### PR TITLE
Rename select_top → select_sweep2, models_top5 → models_sweep2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ sweep1-summary:
 	$(MAKE) -C experiments sweep1-summary
 
 # Stage 4a: model selection (computed from census, not hardcoded)
-experiments/models_top5.yaml: $(METRICS) experiments/models.yaml experiments/models_padme.yaml
-	uv run python -m aedist.select_top \
+experiments/models_sweep2.yaml: $(METRICS) experiments/models.yaml experiments/models_padme.yaml
+	uv run python -m aedist.select_sweep2 \
 	    --input $< --registry experiments/models.yaml \
 	    --padme experiments/models_padme.yaml \
 	    --output $@ --n 1
 
-select: experiments/models_top5.yaml
+select: experiments/models_sweep2.yaml
 
 # Stage 4b: tables for report
 tables: $(GEN)/tab_census.tex $(GEN)/macros.tex

--- a/experiments/sweeps/sweep2_multiturn.yaml
+++ b/experiments/sweeps/sweep2_multiturn.yaml
@@ -2,7 +2,7 @@
 mode: multiturn
 prompt: prompts/prompt_structured.txt
 followups: prompts/followups.txt
-models: models_top5.yaml
+models: models_sweep2.yaml
 repeat: 3
 budget_usd: 10
 output: outputs/sweep2_multiturn

--- a/experiments/sweeps/sweep2_rag.yaml
+++ b/experiments/sweeps/sweep2_rag.yaml
@@ -3,7 +3,7 @@ mode: rag
 prompt: prompts/prompt_structured.txt
 corpus: data/rag_corpus
 strategy: wholesale
-models: models_top5.yaml
+models: models_sweep2.yaml
 repeat: 3
 budget_usd: 10
 output: outputs/sweep2_rag

--- a/experiments/sweeps/sweep2_web.yaml
+++ b/experiments/sweeps/sweep2_web.yaml
@@ -1,7 +1,7 @@
 # Sweep 2: Web-augmented queries
 mode: web
 prompt: prompts/prompt_structured.txt
-models: models_top5.yaml
+models: models_sweep2.yaml
 repeat: 3
 budget_usd: 10
 output: outputs/sweep2_web

--- a/src/aedist/select_sweep2.py
+++ b/src/aedist/select_sweep2.py
@@ -5,11 +5,11 @@ ranks by median F1, and selects top N ensuring diversity across
 geography, provider type, and price tier.
 
 Usage:
-    uv run python -m aedist.select_top \
+    uv run python -m aedist.select_sweep2 \
         --input results/summary/all_metrics.json \
         --registry experiments/models.yaml \
         --padme experiments/models_padme.yaml \
-        --output experiments/models_top5.yaml \
+        --output experiments/models_sweep2.yaml \
         --n 8
 """
 
@@ -86,7 +86,7 @@ def load_registry(models: list[dict], *, is_padme: bool = False) -> dict[str, di
 # Selection
 # ---------------------------------------------------------------------------
 
-def select_top(
+def select_sweep2(
     rankings: dict[str, float],
     cloud_registry: dict[str, dict],
     local_registry: dict[str, dict],
@@ -137,7 +137,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     parser = argparse.ArgumentParser(
-        prog="aedist.select_top",
+        prog="aedist.select_sweep2",
         description="Select top models from census evaluation metrics",
     )
     parser.add_argument(
@@ -187,7 +187,7 @@ def main() -> None:
         log.info("  %s  %.1f%%%s", slug.ljust(35), f1 * 100, marker)
 
     # Select
-    selected = select_top(rankings, cloud_reg, padme_reg, n=args.n)
+    selected = select_sweep2(rankings, cloud_reg, padme_reg, n=args.n)
 
     # Write output
     # Strip internal fields and write clean YAML

--- a/tests/test_select_sweep2.py
+++ b/tests/test_select_sweep2.py
@@ -1,12 +1,12 @@
-"""Tests for select_top — model selection from census metrics."""
+"""Tests for select_sweep2 — model selection from census metrics."""
 
 import pytest
 
-from aedist.select_top import (
+from aedist.select_sweep2 import (
     extract_slug,
     group_median_f1,
     load_registry,
-    select_top,
+    select_sweep2,
 )
 
 # ---------------------------------------------------------------------------
@@ -75,15 +75,15 @@ class TestGroupMedianF1:
 
 
 # ---------------------------------------------------------------------------
-# select_top — N cloud + N local
+# select_sweep2 — N cloud + N local
 # ---------------------------------------------------------------------------
 
-class TestSelectTop:
+class TestSelectSweep2:
     def _select(self, n=1):
         rankings = group_median_f1(SAMPLE_METRICS)
         cloud = load_registry(SAMPLE_CLOUD, is_padme=False)
         local = load_registry(SAMPLE_PADME, is_padme=True)
-        return select_top(rankings, cloud, local, n=n)
+        return select_sweep2(rankings, cloud, local, n=n)
 
     def test_n1_gives_two_models(self):
         """--n 1 → 1 cloud + 1 local = 2 total."""


### PR DESCRIPTION
## Summary

- Rename module `select_top` → `select_sweep2` (name describes purpose, not count)
- Rename output `models_top5.yaml` → `models_sweep2.yaml` across Makefile and sweep configs
- `--n` controls how many per tier; filename stays correct regardless of N

## Test plan

- [x] `uv run --with pytest python -m pytest` — 116 passed
- [x] `make -n select` shows `select_sweep2` and `models_sweep2.yaml`
- [x] `grep -r select_top` and `grep -r models_top5` return no hits outside `.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)