### PR TITLE
Add Mistral Large, .env guard, no error files

### DIFF
--- a/experiments/Makefile
+++ b/experiments/Makefile
@@ -13,6 +13,13 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
+# --- Load API key from .env if not already set --------------------------------
+ifeq ($(OPENROUTER_API_KEY),)
+  OPENROUTER_API_KEY := $(shell grep '^OPENROUTER_API_KEY=' ../.env 2>/dev/null | cut -d= -f2-)
+endif
+export OPENROUTER_API_KEY
+$(if $(OPENROUTER_API_KEY),,$(error OPENROUTER_API_KEY not set — export it or add to .env))
+
 # --- Read sweep configs ------------------------------------------------------
 cfg = $(shell python3 -c "import yaml; c=yaml.safe_load(open('sweeps/$(1).yaml')); print(c.get('$(2)',''))")
 

--- a/experiments/models.yaml
+++ b/experiments/models.yaml
@@ -83,12 +83,12 @@
   name: Mistral Large 3
   provider: Mistral
   country: FR
-  architecture: dense
+  architecture: moe
   reasoning: instruct
   context_window: 262144
-  price_per_mtok_in: 2.0
-  price_per_mtok_out: 6.0
-  params: "41B active"
+  price_per_mtok_in: 0.5
+  price_per_mtok_out: 1.5
+  params: "675B MoE (41B active)"
   size_class: frontier
   license: open-apache
 

--- a/src/aedist/query.py
+++ b/src/aedist/query.py
@@ -104,21 +104,6 @@ def main():
                 log.info("  Done. cost=%.6f total=%.6f USD", cost, budget.total_cost)
             except openai.APIError as e:
                 log.error("Error querying %s run %d: %s", label, run, e)
-                filepath = output_path(output_dir, model_id, run)
-                record = {
-                    "model": model_id,
-                    "date": date.today().isoformat(),
-                    "run": run,
-                    "prompt": prompt,
-                    "response": None,
-                    "finish_reason": "error",
-                    "error": str(e),
-                    "usage": None,
-                    "wall_seconds": 0.0,
-                    "cost_usd": 0.0,
-                    "model_metadata": model_metadata(model),
-                }
-                save_json(filepath, record)
 
     log.info("Completed. Total cost: %.6f USD", budget.total_cost)
 


### PR DESCRIPTION
## Summary

- Fix Mistral Large 3 registry entry: MoE 675B (41B active), $0.50/$1.50 per Mtok
- Makefile auto-loads `OPENROUTER_API_KEY` from `.env` when not in environment
- `query.py`: don't persist error records as JSON files — keeps Make targets missing so retry works automatically

Mistral Large census complete: median F1 = 37.8%, 100% precision, $0.006.

## Test plan

- [x] 116 tests pass
- [x] `make sweep1` queries only Mistral Large (incremental)
- [x] Mistral Large 3 runs complete successfully via `.env` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)