### PR TITLE
Wire cost data into Pareto chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,11 @@ $(SLIDE_GEN)/census_bars.csv: $(METRICS)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_census --input $< --output $@
 
-$(SLIDE_GEN)/pareto.csv: $(METRICS)
+SWEEP1_SUMMARY := results/summary/sweep1_summary.csv
+
+$(SLIDE_GEN)/pareto.csv: $(METRICS) $(SWEEP1_SUMMARY)
 	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_pareto --input $< --output $@
+	uv run python -m aedist.plot_pareto --input $< --costs $(SWEEP1_SUMMARY) --output $@
 
 # --- Publications -------------------------------------------------------------
 

--- a/src/aedist/plot_pareto.py
+++ b/src/aedist/plot_pareto.py
@@ -6,6 +6,7 @@ sorted by f1 descending.
 Usage:
     uv run python -m aedist.plot_pareto \\
         --input results/summary/all_metrics.json \\
+        --costs results/summary/sweep1_summary.csv \\
         --output slides/inputs/generated/pareto.csv
 """
 
@@ -20,20 +21,37 @@ from .tabulate_macros import load_and_summarize
 log = logging.getLogger(__name__)
 
 
-def build_pareto_rows(metrics: list[dict]) -> list[dict]:
+def load_costs(csv_path: Path) -> dict[str, float]:
+    """Load per-run cost from sweep summary CSV.
+
+    Returns {model_slug: cost_per_run} where cost_per_run = total_cost / n_runs.
+    """
+    costs: dict[str, float] = {}
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            n_runs = int(row["n_runs"])
+            total = float(row["total_cost_usd"])
+            costs[row["model"]] = total / n_runs if n_runs > 0 else 0.0
+    return costs
+
+
+def build_pareto_rows(
+    metrics: list[dict],
+    costs: dict[str, float] | None = None,
+) -> list[dict]:
     """Build rows for the Pareto chart.
 
     Returns list of dicts with keys: model, f1, cost_usd, local.
     Sorted by f1 descending.
     """
+    if costs is None:
+        costs = {}
     summary = load_and_summarize(metrics)
     rows = [
         {
             "model": slug,
             "f1": info["median_f1"],
-            # TODO: extract cost from query JSONs (usage.total_cost or
-            # prompt_tokens * price). For now placeholder 0.0.
-            "cost_usd": 0.0,
+            "cost_usd": round(costs.get(slug, 0.0), 6),
             "local": 1 if info["is_local"] else 0,
         }
         for slug, info in summary.items()
@@ -48,16 +66,22 @@ def main() -> None:
         description="Generate Pareto-front CSV from metrics JSON",
     )
     parser.add_argument("--input", required=True, help="Path to all_metrics.json")
+    parser.add_argument("--costs", default=None, help="Path to sweep summary CSV with cost data")
     parser.add_argument("--output", required=True, help="Path to write pareto.csv")
     args = parser.parse_args()
 
     input_path = Path(args.input)
     output_path = Path(args.output)
 
+    costs = None
+    if args.costs:
+        costs = load_costs(Path(args.costs))
+        log.info("Loaded costs for %d models from %s", len(costs), args.costs)
+
     with open(input_path) as f:
         metrics = json.load(f)
 
-    rows = build_pareto_rows(metrics)
+    rows = build_pareto_rows(metrics, costs)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", newline="") as f:

--- a/tests/test_plot_pareto.py
+++ b/tests/test_plot_pareto.py
@@ -3,7 +3,7 @@
 import csv
 import json
 
-from aedist.plot_pareto import build_pareto_rows
+from aedist.plot_pareto import build_pareto_rows, load_costs
 
 
 SAMPLE_METRICS = [
@@ -15,6 +15,12 @@ SAMPLE_METRICS = [
     {"label": "sweep1_census/padme-qwen3.5-27b-run3", "f1": 0.48},
 ]
 
+SUMMARY_CSV = """\
+model,n_runs,median_f1,median_coverage,median_precision,median_fuel_accuracy,median_n_plants,total_cost_usd,median_latency_s
+gpt-5.4,3,0.7000,0.8000,0.9000,0.5000,10,0.045000,2.5
+padme-qwen3.5-27b,3,0.5000,0.6000,0.7000,0.4000,8,0.000000,5.0
+"""
+
 
 def test_build_pareto_rows():
     """Rows have model, f1, cost_usd, local columns."""
@@ -23,11 +29,22 @@ def test_build_pareto_rows():
     assert all(set(r.keys()) == {"model", "f1", "cost_usd", "local"} for r in rows)
 
 
-def test_cost_placeholder():
-    """Cost is 0.0 as placeholder until query cost data is integrated."""
+def test_cost_without_csv():
+    """Cost defaults to 0.0 when no cost data provided."""
     rows = build_pareto_rows(SAMPLE_METRICS)
     for row in rows:
         assert row["cost_usd"] == 0.0
+
+
+def test_cost_from_csv(tmp_path):
+    """Cost is per-run (total_cost / n_runs) when CSV provided."""
+    csv_path = tmp_path / "summary.csv"
+    csv_path.write_text(SUMMARY_CSV)
+    costs = load_costs(csv_path)
+    rows = build_pareto_rows(SAMPLE_METRICS, costs)
+    by_model = {r["model"]: r for r in rows}
+    assert by_model["gpt-5.4"]["cost_usd"] == 0.015  # 0.045 / 3
+    assert by_model["padme-qwen3.5-27b"]["cost_usd"] == 0.0
 
 
 def test_local_flag():
@@ -39,7 +56,35 @@ def test_local_flag():
 
 
 def test_main_writes_csv(tmp_path):
-    """CLI writes well-formed CSV."""
+    """CLI writes well-formed CSV with cost data."""
+    input_path = tmp_path / "all_metrics.json"
+    input_path.write_text(json.dumps(SAMPLE_METRICS))
+    costs_path = tmp_path / "summary.csv"
+    costs_path.write_text(SUMMARY_CSV)
+    output_path = tmp_path / "pareto.csv"
+
+    from aedist.plot_pareto import main
+    import sys
+
+    sys.argv = [
+        "plot_pareto",
+        "--input", str(input_path),
+        "--costs", str(costs_path),
+        "--output", str(output_path),
+    ]
+    main()
+
+    content = output_path.read_text()
+    reader = csv.DictReader(content.splitlines())
+    rows = list(reader)
+    assert len(rows) == 2
+    assert set(reader.fieldnames) == {"model", "f1", "cost_usd", "local"}
+    by_model = {r["model"]: r for r in rows}
+    assert float(by_model["gpt-5.4"]["cost_usd"]) == 0.015
+
+
+def test_main_without_costs(tmp_path):
+    """CLI works without --costs (backward compatible)."""
     input_path = tmp_path / "all_metrics.json"
     input_path.write_text(json.dumps(SAMPLE_METRICS))
     output_path = tmp_path / "pareto.csv"
@@ -58,4 +103,3 @@ def test_main_writes_csv(tmp_path):
     reader = csv.DictReader(content.splitlines())
     rows = list(reader)
     assert len(rows) == 2
-    assert set(reader.fieldnames) == {"model", "f1", "cost_usd", "local"}


### PR DESCRIPTION
## Summary
- `plot_pareto.py` now reads per-model cost from `sweep1_summary.csv` via `--costs` flag
- Computes per-run cost (`total_cost_usd / n_runs`) and joins by model slug
- Backward compatible: without `--costs`, falls back to 0.0
- Makefile updated to pass the summary CSV as a dependency

Closes #59

## Test plan
- [x] 6 unit tests pass (including cost lookup, backward compat, CLI with/without `--costs`)
- [x] Full suite: 114 passed, 4 skipped
- [ ] Verify `make figures` produces non-zero costs in `pareto.csv` after `make sweep1-summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)