### PR TITLE
Phase 1: self-consistency analysis of sweep2_rag (closes #96 Phase 1)

### DIFF
--- a/src/aedist/self_consistency.py
+++ b/src/aedist/self_consistency.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import csv
+import io
 import json
 import logging
 import re
@@ -23,7 +24,7 @@ from .extract import extract_one
 from .metrics import BenchmarkMetrics, compute_metrics
 from .reconcile import reconcile
 from .runner import _DEFAULT_REF, load_plants_csv
-from .schema import Plant
+from .schema import FuelType, Plant, PlantStatus
 
 log = logging.getLogger(__name__)
 
@@ -109,10 +110,6 @@ def union_vote(run_plant_lists: list[list]) -> list:
 
 def plants_to_csv_text(plants: list) -> str:
     """Serialize a list of Plant objects to canonical CSV text."""
-    import io
-
-    from .schema import FuelType, PlantStatus
-
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow(["name", "fuel", "status", "cod", "province", "capacity_mwe"])


### PR DESCRIPTION
## Summary

- Implements `aedist.self_consistency`: majority-vote and union-vote aggregation across 3 runs per model
- Runs Phase 1 of #96 at zero cost (reprocesses existing sweep2_rag data)
- **Finding: majority vote is the wrong strategy; union vote is better for truncation-prone models**

## Results (5 models × 3 runs each)

| Model | Med F1 | Maj F1 | Union F1 | Maj Δ | Union Δ |
|---|---|---|---|---|---|
| deepseek-v3.2 | 60.1% | 38.6% | **95.5%** | -21.5% | **+35.4%** |
| gemini-2.5-flash-lite | 96.7% | 61.3% | 51.8% | -35.5% | -44.9% |
| gpt-5.4 | 77.0% | 63.0% | 78.5% | -14.0% | +1.6% |
| mistral-large-2512 | 72.2% | 52.5% | 81.5% | -19.7% | +9.3% |
| mistral-small-2603 | 86.4% | 36.2% | 72.4% | -50.2% | -14.0% |

**Avg majority vote: -28% F1. Avg union vote: -2.5% F1.**

## Diagnosis

The bottleneck is **recall, not hallucinations**. Models truncate outputs inconsistently: deepseek gives 33/70/85 plants across 3 runs (163 in reference), while mistral-small gives 85/124/126. Majority vote amplifies truncation by keeping only the intersection. Union vote recovers more plants but trades precision.

gemini is the outlier: run1 outputs 399 plants (2.4× reference, many hallucinated), run2 outputs 174 at 96.7% F1. Union of those two is worse than run2 alone.

## Implications for April 11

**Priority shift**: the unstable, truncated outputs are the core problem. The right next move is Phase 2 from #96: **task decomposition by fuel type** (3 sub-queries: coal / gas+LNG / other). This reduces per-query scope and forces completeness. Expected to be highest-impact, lowest-cost intervention.

Self-consistency (majority) is **not** a useful strategy here. The issue's framing of it as "free wins" turns out to be wrong for this data — the runs are inconsistent in what they *include*, not in what they *hallucinate*.

**Best result seen**: gemini-2.5-flash-lite run2 at 96.7% F1 — but this is unstable (run1 is 58%). Understanding what makes run2 different from run1 is worth investigating before April 11.

## Test plan

- [x] `make check-fast` passes (182 tests, 4 skipped)
- [ ] Run `python -m aedist.self_consistency --input experiments/outputs/sweep2_rag --output experiments/outputs/sweep2_rag_consistency`

🤖 Generated with [Claude Code](https://claude.com/claude-code)