### PR TITLE
fix(plot_census): remove unused slug_from_label import

### DIFF
--- a/src/aedist/plot_census.py
+++ b/src/aedist/plot_census.py
@@ -16,7 +16,7 @@ import json
 import logging
 from pathlib import Path
 
-from .tabulate_macros import slug_from_label, load_and_summarize
+from .tabulate_macros import load_and_summarize
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Remove unused `slug_from_label` import from `plot_census.py` (flagged by ruff linter)
- Import was left over from a previous refactoring

Closes #73

## Test plan
- [x] `uv run pytest tests/test_plot_census.py` passes
- [x] `uv run ruff check src/aedist/plot_census.py` passes

https://claude.ai/code/session_01FrTYAJT7tZPFXELZBsQkgx