### PR TITLE
fix(Makefile): make OPENROUTER_API_KEY guard conditional on sweep targets

### DIFF
--- a/experiments/Makefile
+++ b/experiments/Makefile
@@ -18,7 +18,11 @@ ifeq ($(OPENROUTER_API_KEY),)
   OPENROUTER_API_KEY := $(shell grep '^OPENROUTER_API_KEY=' ../.env 2>/dev/null | cut -d= -f2-)
 endif
 export OPENROUTER_API_KEY
-$(if $(OPENROUTER_API_KEY),,$(error OPENROUTER_API_KEY not set — export it or add to .env))
+# Guard: only require OPENROUTER_API_KEY for targets that actually need it
+_NEEDS_OPENROUTER := sweep1 sweep1-openrouter sweep1-padme sweep1-summary sweep2 sweep2-multiturn sweep2-rag sweep2-web
+ifneq ($(filter $(_NEEDS_OPENROUTER),$(MAKECMDGOALS)),)
+  $(if $(OPENROUTER_API_KEY),,$(error OPENROUTER_API_KEY not set — export it or add to .env))
+endif
 
 # --- Read sweep configs ------------------------------------------------------
 cfg = $(shell python3 -c "import yaml; c=yaml.safe_load(open('sweeps/$(1).yaml')); print(c.get('$(2)',''))")


### PR DESCRIPTION
## Summary\n- Replace the unconditional `OPENROUTER_API_KEY` guard in `experiments/Makefile` with a conditional one that only triggers for targets that actually need it (`sweep1`, `sweep2`, etc.)\n- Unrelated targets like `build-corpus`, `help`, and `pdf2md` are no longer blocked when the API key is absent\n\n## Test plan\n- [ ] Run `make help` (or another non-sweep target) without `OPENROUTER_API_KEY` set — should succeed\n- [ ] Run `make sweep1` without `OPENROUTER_API_KEY` set — should error with the guard message\n\nCloses #75\n\nhttps://claude.ai/code/session_01FrTYAJT7tZPFXELZBsQkgx