### PR TITLE
fix(slides): suppress XeTeX font scan warnings

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -8,8 +8,8 @@
 \pgfplotsset{compat=1.18}
 \usepackage{pgfplotstable}
 
+\usepackage[no-math]{fontspec}
 \usetheme[numbering=fraction]{metropolis}
-% Note: XeTeX scans system fonts (~1000 harmless warnings). Builds fine.
 
 \InputIfFileExists{inputs/generated/macros}{}{}
 


### PR DESCRIPTION
## Summary\n- Load `fontspec` with `no-math` option before metropolis theme\n- Prevents full font enumeration that caused ~1175 XeTeX warnings\n\nCloses #62\n\n## Test plan\n- [x] `make slides` produces zero font scan warnings\n\nhttps://claude.ai/code/session_01FrTYAJT7tZPFXELZBsQkgx