### PR TITLE
refactor: extract magic numbers to named constants

### DIFF
--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -26,6 +26,11 @@ from typing import Any, cast
 log = logging.getLogger(__name__)
 
 
+# Bonus per recognized header keyword in CSV scoring
+HEADER_KEYWORD_BONUS = 0.2
+# Cap for length bonus normalization (number of lines)
+LENGTH_BONUS_CAP_LINES = 50.0
+
 _DATE_DIR_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -62,10 +67,10 @@ def _score_csv_like_block(block: str) -> float:
     header_bonus = 0.0
     for token in ["name", "plant", "fuel", "status", "stage", "cod", "connection", "province", "capacity"]:
         if token in header:
-            header_bonus += 0.2
+            header_bonus += HEADER_KEYWORD_BONUS
 
     # Prefer longer blocks and those with many delimited lines
-    length_bonus = min(len(lines) / 50.0, 1.0)  # cap
+    length_bonus = min(len(lines) / LENGTH_BONUS_CAP_LINES, 1.0)  # cap
     return (delimiter_hits / max(len(lines), 1)) + header_bonus + length_bonus
 
 

--- a/src/aedist/query_rag.py
+++ b/src/aedist/query_rag.py
@@ -35,6 +35,12 @@ from .harness import (
 
 log = logging.getLogger(__name__)
 
+# Approximate characters per token for English text (actual varies 3-5)
+CHARS_PER_TOKEN = 4
+
+# Fraction of model context window to use (safety margin)
+CONTEXT_WINDOW_SAFETY_MARGIN = 0.8
+
 
 def load_corpus(corpus_dir: Path) -> tuple[str, list[str]]:
     """Load all .md files from corpus directory, return (text, filenames)."""
@@ -53,7 +59,7 @@ def load_corpus(corpus_dir: Path) -> tuple[str, list[str]]:
 
 def estimate_tokens(text: str) -> int:
     """Rough token estimate: ~4 chars per token for English text."""
-    return len(text) // 4
+    return len(text) // CHARS_PER_TOKEN
 
 
 def main():
@@ -88,7 +94,7 @@ def main():
     if args.dry_run:
         for model in models:
             ctx = model.get("context_window", 0)
-            fits = "OK" if corpus_tokens < ctx * 0.8 else "SKIP (too large)"
+            fits = "OK" if corpus_tokens < ctx * CONTEXT_WINDOW_SAFETY_MARGIN else "SKIP (too large)"
             for run in range(1, args.repeat + 1):
                 log.info("Would query %s run %d [%s]", model["id"], run, fits)
         return
@@ -102,7 +108,7 @@ def main():
         ctx_window = model.get("context_window", 0)
 
         # Context window guard
-        if corpus_tokens > ctx_window * 0.8:
+        if corpus_tokens > ctx_window * CONTEXT_WINDOW_SAFETY_MARGIN:
             log.warning(
                 "Skip %s: corpus ~%d tokens exceeds 80%% of context window (%d)",
                 label, corpus_tokens, ctx_window,

--- a/src/aedist/query_web.py
+++ b/src/aedist/query_web.py
@@ -34,6 +34,9 @@ from .harness import (
 
 log = logging.getLogger(__name__)
 
+# Tavily API timeout in seconds
+TAVILY_TIMEOUT_SECONDS = 30.0
+
 # Predefined search queries for Vietnam thermal power plants
 _SEARCH_QUERIES = [
     "Vietnam thermal power plants list coal gas LNG 2024 2025",
@@ -52,7 +55,7 @@ def tavily_search(query: str, api_key: str) -> list[dict]:
             "search_depth": "advanced",
             "max_results": 5,
         },
-        timeout=30.0,
+        timeout=TAVILY_TIMEOUT_SECONDS,
     )
     resp.raise_for_status()
     data = resp.json()

--- a/src/aedist/verify.py
+++ b/src/aedist/verify.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 _DEFAULT_REF = Path(__file__).parent.parent.parent / "data" / "reference" / "gem_thermal.csv"
 
 # Similarity threshold for fuzzy name matching
-_SIMILARITY_THRESHOLD = 70.0
+SIMILARITY_THRESHOLD = 70.0
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +99,7 @@ def fuzzy_match_gem(plant_name: str, gem_plants: list[dict]) -> dict | None:
             best_score = score
             best_match = gem
 
-    if best_score >= _SIMILARITY_THRESHOLD:
+    if best_score >= SIMILARITY_THRESHOLD:
         return best_match
     return None
 


### PR DESCRIPTION
## Summary\n- Replace hardcoded numeric values with descriptive module-level constants in `extract.py`, `query_rag.py`, `query_web.py`, and `verify.py`\n- Constants: `HEADER_KEYWORD_BONUS`, `LENGTH_BONUS_CAP_LINES`, `CHARS_PER_TOKEN`, `CONTEXT_WINDOW_SAFETY_MARGIN`, `TAVILY_TIMEOUT_SECONDS`, `SIMILARITY_THRESHOLD`\n\nCloses #36\n\n## Test plan\n- [x] `uv run pytest` — all tests pass\n- [x] `uv run ruff check` — no lint errors\n\nhttps://claude.ai/code/session_01FrTYAJT7tZPFXELZBsQkgx