### PR TITLE
fix(extract): handle multiturn JSON format with turns[].content

### DIFF
--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -250,6 +250,12 @@ def extract_one(json_path: Path, output_dir: Path, overwrite: bool) -> ExtractRe
         return ExtractResult(False, None, f"{json_path.name}: invalid JSON ({e})")
 
     response = record.get("response")
+    # Handle multiturn JSON format: extract from turns[-1]["content"]
+    if (not response or not isinstance(response, str)) and "turns" in record:
+        turns = record["turns"]
+        assistant_turns = [t for t in turns if t.get("role") == "assistant"]
+        if assistant_turns:
+            response = assistant_turns[-1].get("content", "")
     if not isinstance(response, str) or not response.strip():
         return ExtractResult(False, None, f"{json_path.name}: no response text")
 


### PR DESCRIPTION
## Summary\n- Extract response text from the last assistant turn when the standard `response` field is absent\n- Unblocks evaluation of 15 Sweep 2 multiturn JSON files that were producing \"no response text\" errors\n\nCloses #94\n\n## Test plan\n- [x] `uv run pytest tests/test_extract.py` passes\n\nhttps://claude.ai/code/session_01FrTYAJT7tZPFXELZBsQkgx