### PR TITLE
Implement OpenRouterWorker with parallel execution

### DIFF
--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -286,6 +286,119 @@ class PadmeWorker(Worker):
 
 
 # ---------------------------------------------------------------------------
+# OpenRouterWorker — cloud API with parallel execution
+# ---------------------------------------------------------------------------
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_CONCURRENCY = 8
+
+
+class OpenRouterWorker(Worker):
+    """Worker for parallel execution via OpenRouter cloud API.
+
+    Processes multiple model/run combinations concurrently using a
+    thread pool, with rate limiting and budget controls.
+    """
+
+    def __init__(
+        self,
+        jobs_root: Path = Path("jobs"),
+        concurrency: int = DEFAULT_CONCURRENCY,
+    ) -> None:
+        super().__init__(worker_id="openrouter", jobs_root=jobs_root)
+        self.concurrency = concurrency
+
+    def execute(self, job: JobSpec) -> dict:
+        """Run queries in parallel via OpenRouter."""
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        from .harness import BudgetTracker
+
+        client = make_client()
+        prompt = Path(job.prompt).read_text().strip()
+        models = load_models(job.models_file)
+        output_dir = Path(job.output_dir)
+
+        if job.model_filter:
+            models = [m for m in models if job.model_filter in m["id"]]
+
+        budget = BudgetTracker(job.budget_usd)
+        total_wall = 0.0
+        total_in = 0
+        total_out = 0
+        result_files: list[str] = []
+
+        # Build work items: (model_entry, run_number)
+        work_items = [
+            (model_entry, run)
+            for model_entry in models
+            for run in range(1, job.repeat + 1)
+            if not should_skip(output_dir, model_entry["id"], run)
+        ]
+
+        def _run_query(model_entry: dict, run: int) -> dict | None:
+            if budget.exceeded:
+                return None
+            model_id = model_entry["id"]
+            log.info("Querying %s run %d/%d...", model_id, run, job.repeat)
+            try:
+                result = query_single_turn(
+                    client, model_id,
+                    [{"role": "user", "content": prompt}],
+                )
+            except openai.APIError as e:
+                log.error("Error querying %s run %d: %s", model_id, run, e)
+                return None
+
+            usage = result.get("usage") or {}
+            cost = compute_cost(usage, model_entry)
+            budget.add(cost)
+
+            filepath = output_path(output_dir, model_id, run)
+            save_json(filepath, {
+                "model": model_id,
+                "date": date.today().isoformat(),
+                "run": run,
+                "prompt": prompt,
+                "response": result["content"],
+                "finish_reason": result["finish_reason"],
+                "usage": usage,
+                "wall_seconds": result["wall_seconds"],
+                "cost_usd": cost,
+                "model_metadata": model_metadata(model_entry),
+            })
+            return {
+                "filepath": str(filepath),
+                "wall_seconds": result["wall_seconds"],
+                "cost_usd": cost,
+                "tokens_in": usage.get("prompt_tokens", 0),
+                "tokens_out": usage.get("completion_tokens", 0),
+            }
+
+        with ThreadPoolExecutor(max_workers=self.concurrency) as pool:
+            futures = {
+                pool.submit(_run_query, m, r): (m, r)
+                for m, r in work_items
+            }
+            for future in as_completed(futures):
+                res = future.result()
+                if res is None:
+                    continue
+                total_wall += res["wall_seconds"]
+                total_in += res["tokens_in"]
+                total_out += res["tokens_out"]
+                result_files.append(res["filepath"])
+
+        return {
+            "wall_seconds": total_wall,
+            "cost_usd": budget.total_cost,
+            "tokens_in": total_in,
+            "tokens_out": total_out,
+            "result_file": result_files[0] if result_files else None,
+        }
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
 
@@ -295,8 +408,8 @@ def main(argv=None):
 
     parser = argparse.ArgumentParser(description="Run an AEDIST worker")
     parser.add_argument(
-        "pool", choices=["padme"],
-        help="Worker pool to run (padme for local Ollama)",
+        "pool", choices=["padme", "openrouter"],
+        help="Worker pool to run",
     )
     parser.add_argument(
         "--jobs-root", type=Path, default=Path("jobs"),
@@ -307,6 +420,10 @@ def main(argv=None):
         help=f"Ollama API base URL (default: {OLLAMA_BASE_URL})",
     )
     parser.add_argument(
+        "--concurrency", type=int, default=DEFAULT_CONCURRENCY,
+        help=f"Max parallel queries for openrouter (default: {DEFAULT_CONCURRENCY})",
+    )
+    parser.add_argument(
         "--loop", action="store_true",
         help="Run continuously, polling for jobs",
     )
@@ -315,6 +432,7 @@ def main(argv=None):
 
     workers = {
         "padme": lambda: PadmeWorker(jobs_root=args.jobs_root, base_url=args.base_url),
+        "openrouter": lambda: OpenRouterWorker(jobs_root=args.jobs_root, concurrency=args.concurrency),
     }
     worker = workers[args.pool]()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from aedist.schema import JobSpec, Method
-from aedist.worker import PadmeWorker, Worker
+from aedist.worker import OpenRouterWorker, PadmeWorker, Worker
 
 
 def _make_job(
@@ -362,3 +362,84 @@ def test_padme_full_lifecycle(tmp_path: Path) -> None:
     assert record is not None
     assert record.method == Method.SINGLE
     assert (jobs_root / "done" / "padme-lc.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# OpenRouterWorker tests
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_worker_id(tmp_path: Path) -> None:
+    """OpenRouterWorker always has worker_id='openrouter'."""
+    worker = OpenRouterWorker(jobs_root=tmp_path / "jobs")
+    assert worker.worker_id == "openrouter"
+
+
+def test_openrouter_worker_concurrency(tmp_path: Path) -> None:
+    """OpenRouterWorker uses default concurrency of 8."""
+    worker = OpenRouterWorker(jobs_root=tmp_path / "jobs")
+    assert worker.concurrency == 8
+
+
+def test_openrouter_worker_custom_concurrency(tmp_path: Path) -> None:
+    """OpenRouterWorker accepts custom concurrency."""
+    worker = OpenRouterWorker(jobs_root=tmp_path / "jobs", concurrency=4)
+    assert worker.concurrency == 4
+
+
+def test_openrouter_worker_execute(tmp_path: Path) -> None:
+    """OpenRouterWorker.execute() processes models in parallel."""
+    jobs_root = tmp_path / "jobs"
+    worker = OpenRouterWorker(jobs_root=jobs_root, concurrency=2)
+
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = JobSpec(
+        job_id="or-test",
+        priority=50,
+        mode=Method.SINGLE,
+        prompt=str(prompt_file),
+        models_file="models.yaml",
+        model_filter="qwen3:8b",
+        output_dir=str(tmp_path / "out"),
+        repeat=2,
+        budget_usd=10.0,
+    )
+
+    with patch.multiple("aedist.worker", **_harness_patches(tmp_path)):
+        result = worker.execute(job)
+
+    # 1 model x 2 runs = 2 queries, each 3.5s wall
+    assert result["wall_seconds"] == 7.0
+    assert result["tokens_in"] == 100
+    assert result["tokens_out"] == 200
+
+
+def test_openrouter_full_lifecycle(tmp_path: Path) -> None:
+    """OpenRouterWorker full lifecycle: poll -> run_one with mocked harness."""
+    jobs_root = tmp_path / "jobs"
+    worker = OpenRouterWorker(jobs_root=jobs_root, concurrency=2)
+
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = JobSpec(
+        job_id="or-lc",
+        priority=50,
+        mode=Method.SINGLE,
+        prompt=str(prompt_file),
+        models_file="models.yaml",
+        model_filter="qwen3:8b",
+        output_dir=str(tmp_path / "out"),
+        repeat=1,
+        budget_usd=10.0,
+    )
+    _write_pending(jobs_root, job)
+
+    with patch.multiple("aedist.worker", **_harness_patches(tmp_path)):
+        record = worker.run_one()
+
+    assert record is not None
+    assert record.method == Method.SINGLE
+    assert (jobs_root / "done" / "or-lc.yaml").exists()

--- a/tickets/0009-openrouter-worker.erg
+++ b/tickets/0009-openrouter-worker.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Implement OpenRouter worker with parallel execution
-Status: open
+Status: closed
 Created: 2026-04-04
 Author: claude
 Blocked-by: 0007
 
 --- log ---
 2026-04-04T12:51Z claude created
+2026-04-04T16:30Z claude status closed — OpenRouterWorker with ThreadPoolExecutor, BudgetTracker, 5 tests
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- `OpenRouterWorker` with ThreadPoolExecutor for parallel API queries
- Configurable concurrency (default 8), BudgetTracker integration
- APIError handling per query (skip and continue)
- CLI: `python -m aedist.worker openrouter --concurrency 8`
- Closes ticket 0009

## Test plan
- 5 new OpenRouterWorker tests (id, concurrency, custom, execute, lifecycle)
- 302 passed, 0 failures across full suite

https://claude.ai/code/session_016fUi1drtr4G4u1TB17neag