### PR TITLE
Implement observer for lease monitoring and job board status

### DIFF
--- a/src/aedist/observer.py
+++ b/src/aedist/observer.py
@@ -1,0 +1,141 @@
+"""Observer for lease monitoring and job board status.
+
+Scans job directories, detects stale leases, requeues expired jobs,
+and reports pipeline status. Read-only by default.
+
+Usage:
+    python -m aedist.observer                  # status report
+    python -m aedist.observer --requeue        # also requeue expired leases
+    python -m aedist.observer --json           # machine-readable output
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_LEASE_RE = re.compile(r"^(.+)-lease-(\d{8}T\d{6}Z)\.yaml$")
+
+
+def _parse_expiry(filename: str) -> tuple[str, datetime] | None:
+    """Extract job_id and expiry from a running/ filename."""
+    m = _LEASE_RE.match(filename)
+    if not m:
+        return None
+    job_id = m.group(1)
+    expiry = datetime.strptime(m.group(2), "%Y%m%dT%H%M%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    return job_id, expiry
+
+
+def find_expired(
+    jobs_root: Path, now: datetime | None = None,
+) -> list[tuple[str, Path, datetime]]:
+    """Find running jobs with expired leases.
+
+    Returns list of (job_id, path, expiry) for expired jobs.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    expired = []
+    running_dir = jobs_root / "running"
+    if not running_dir.exists():
+        return expired
+    for path in running_dir.glob("*.yaml"):
+        parsed = _parse_expiry(path.name)
+        if parsed is None:
+            continue
+        job_id, expiry = parsed
+        if now > expiry:
+            expired.append((job_id, path, expiry))
+    return expired
+
+
+def requeue_expired(
+    jobs_root: Path, now: datetime | None = None,
+) -> list[str]:
+    """Move expired running jobs back to pending/.
+
+    Returns list of requeued job IDs.
+    """
+    expired = find_expired(jobs_root, now)
+    requeued = []
+    pending_dir = jobs_root / "pending"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    for job_id, path, _expiry in expired:
+        dst = pending_dir / f"000-{job_id}.yaml"
+        path.rename(dst)
+        requeued.append(job_id)
+        log.info("Requeued expired job: %s", job_id)
+    return requeued
+
+
+def status_report(jobs_root: Path) -> dict:
+    """Generate a status report of the job board."""
+    dirs = ("pending", "running", "done", "failed")
+    counts: dict[str, int] = {}
+    for d in dirs:
+        p = jobs_root / d
+        counts[d] = len(list(p.glob("*.yaml"))) if p.exists() else 0
+
+    now = datetime.now(timezone.utc)
+    expired = find_expired(jobs_root, now)
+
+    return {
+        "counts": counts,
+        "expired_leases": len(expired),
+        "expired_jobs": [job_id for job_id, _, _ in expired],
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Monitor job board and detect expired leases"
+    )
+    parser.add_argument(
+        "--jobs-root", type=Path, default=Path("jobs"),
+        help="Root directory for job board (default: jobs/)",
+    )
+    parser.add_argument(
+        "--requeue", action="store_true",
+        help="Move expired running jobs back to pending/",
+    )
+    parser.add_argument(
+        "--json", action="store_true", dest="json_output",
+        help="Output status as JSON",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if args.requeue:
+        requeued = requeue_expired(args.jobs_root)
+        if requeued:
+            log.info("Requeued %d expired jobs: %s", len(requeued), requeued)
+        else:
+            log.info("No expired leases to requeue.")
+
+    report = status_report(args.jobs_root)
+
+    if args.json_output:
+        print(json.dumps(report, indent=2))
+    else:
+        c = report["counts"]
+        log.info("Job board: %s", args.jobs_root)
+        log.info("  Pending:  %d", c.get("pending", 0))
+        log.info("  Running:  %d", c.get("running", 0))
+        log.info("  Done:     %d", c.get("done", 0))
+        log.info("  Failed:   %d", c.get("failed", 0))
+        if report["expired_leases"]:
+            log.info("  Expired:  %d — %s", report["expired_leases"],
+                     report["expired_jobs"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,108 @@
+"""Tests for aedist.observer — lease monitoring and job board status."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from aedist.observer import find_expired, requeue_expired, status_report
+
+
+def _make_running(jobs_root: Path, job_id: str, expiry: datetime) -> Path:
+    """Create a running job file with a lease timestamp."""
+    running_dir = jobs_root / "running"
+    running_dir.mkdir(parents=True, exist_ok=True)
+    expiry_str = expiry.strftime("%Y%m%dT%H%M%SZ")
+    path = running_dir / f"{job_id}-lease-{expiry_str}.yaml"
+    path.write_text(f"job_id: {job_id}\n")
+    return path
+
+
+def _make_pending(jobs_root: Path, job_id: str) -> Path:
+    """Create a pending job file."""
+    pending_dir = jobs_root / "pending"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    path = pending_dir / f"050-{job_id}.yaml"
+    path.write_text(f"job_id: {job_id}\n")
+    return path
+
+
+def _make_done(jobs_root: Path, job_id: str) -> Path:
+    """Create a done job file."""
+    done_dir = jobs_root / "done"
+    done_dir.mkdir(parents=True, exist_ok=True)
+    path = done_dir / f"{job_id}.yaml"
+    path.write_text(f"job_id: {job_id}\n")
+    return path
+
+
+class TestFindExpired:
+    def test_no_running_dir(self, tmp_path):
+        assert find_expired(tmp_path) == []
+
+    def test_no_expired(self, tmp_path):
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        _make_running(tmp_path, "job1", future)
+        assert find_expired(tmp_path) == []
+
+    def test_detects_expired(self, tmp_path):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        _make_running(tmp_path, "job1", past)
+        expired = find_expired(tmp_path)
+        assert len(expired) == 1
+        assert expired[0][0] == "job1"
+
+    def test_mixed_expired_and_active(self, tmp_path):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        _make_running(tmp_path, "expired-job", past)
+        _make_running(tmp_path, "active-job", future)
+        expired = find_expired(tmp_path)
+        assert len(expired) == 1
+        assert expired[0][0] == "expired-job"
+
+
+class TestRequeueExpired:
+    def test_requeues_to_pending(self, tmp_path):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        _make_running(tmp_path, "stale", past)
+
+        requeued = requeue_expired(tmp_path)
+
+        assert requeued == ["stale"]
+        assert not list((tmp_path / "running").glob("*.yaml"))
+        assert list((tmp_path / "pending").glob("*stale*"))
+
+    def test_no_expired_to_requeue(self, tmp_path):
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        _make_running(tmp_path, "active", future)
+
+        requeued = requeue_expired(tmp_path)
+        assert requeued == []
+        assert list((tmp_path / "running").glob("*.yaml"))
+
+
+class TestStatusReport:
+    def test_empty_board(self, tmp_path):
+        report = status_report(tmp_path)
+        assert report["counts"] == {"pending": 0, "running": 0, "done": 0, "failed": 0}
+        assert report["expired_leases"] == 0
+
+    def test_counts_all_dirs(self, tmp_path):
+        _make_pending(tmp_path, "p1")
+        _make_pending(tmp_path, "p2")
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        _make_running(tmp_path, "r1", future)
+        _make_done(tmp_path, "d1")
+
+        report = status_report(tmp_path)
+        assert report["counts"]["pending"] == 2
+        assert report["counts"]["running"] == 1
+        assert report["counts"]["done"] == 1
+        assert report["counts"]["failed"] == 0
+
+    def test_reports_expired(self, tmp_path):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        _make_running(tmp_path, "stale", past)
+
+        report = status_report(tmp_path)
+        assert report["expired_leases"] == 1
+        assert "stale" in report["expired_jobs"]

--- a/tickets/0010-observer.erg
+++ b/tickets/0010-observer.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Implement observer for lease monitoring and status
-Status: open
+Status: closed
 Created: 2026-04-04
 Author: claude
 Blocked-by: 0007
 
 --- log ---
 2026-04-04T12:51Z claude created
+2026-04-04T16:45Z claude status closed — observer with expired lease detection, requeue, status report, 9 tests
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- `observer.py`: expired lease detection, requeue to pending/, status report
- CLI: `python -m aedist.observer [--requeue] [--json]`
- Closes ticket 0010

## Test plan
- 9 tests: empty board, no expired, detect expired, mixed, requeue, counts, reports
- 311 passed, 0 failures across full suite

https://claude.ai/code/session_016fUi1drtr4G4u1TB17neag