### PR TITLE
Add Gemma 4 (26B, 31B) to Padme model registry

### DIFF
--- a/experiments/models_padme.yaml
+++ b/experiments/models_padme.yaml
@@ -89,3 +89,25 @@
   price_per_mtok_out: 0.0
   size_class: small
   license: open-apache
+
+- id: gemma4:26b
+  name: Gemma 4 26B (local)
+  provider: Ollama/Padme
+  country: US
+  architecture: dense
+  context_window: 131072
+  price_per_mtok_in: 0.0
+  price_per_mtok_out: 0.0
+  size_class: medium
+  license: open-other
+
+- id: gemma4:31b
+  name: Gemma 4 31B (local)
+  provider: Ollama/Padme
+  country: US
+  architecture: dense
+  context_window: 131072
+  price_per_mtok_in: 0.0
+  price_per_mtok_out: 0.0
+  size_class: medium
+  license: open-other


### PR DESCRIPTION
## Summary

- Add `gemma4:26b` and `gemma4:31b` to `experiments/models_padme.yaml`
- Ollama 0.20.0 upgrade confirmed, both models pulled and smoke-tested on Padme

Closes #77

## Test plan

- [x] `test_models.py` — 3 tests pass (schema, coverage, unique IDs)
- [x] Smoke test: `gemma4:26b` responds via Ollama API on Padme

🤖 Generated with [Claude Code](https://claude.com/claude-code)