### PR TITLE
Multi-turn token budget: context guard, stateless mode, analysis (#113)

### DIFF
--- a/src/aedist/analyze_multiturn_budget.py
+++ b/src/aedist/analyze_multiturn_budget.py
@@ -1,0 +1,136 @@
+"""Analyze multi-turn token budget from existing sweep outputs.
+
+Reads JSON results from sweep2_multiturn and extrapolates token growth
+to N turns, reporting which models would overflow their context window.
+
+Usage:
+    python -m aedist.analyze_multiturn_budget \
+        --input experiments/outputs/sweep2_multiturn \
+        --turns 10
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from .harness import CONTEXT_WINDOW_SAFETY_MARGIN
+
+log = logging.getLogger(__name__)
+
+
+def load_multiturn_results(output_dir: Path) -> list[dict]:
+    """Load all JSON results from a sweep directory."""
+    results = []
+    for f in sorted(output_dir.glob("*.json")):
+        with open(f) as fh:
+            results.append(json.load(fh))
+    return results
+
+
+def per_turn_token_usage(record: dict) -> list[dict]:
+    """Extract per-turn prompt_tokens and completion_tokens from assistant turns."""
+    return [
+        {
+            "turn": t["turn"],
+            "prompt_tokens": t.get("usage", {}).get("prompt_tokens", 0) or 0,
+            "completion_tokens": t.get("usage", {}).get("completion_tokens", 0) or 0,
+        }
+        for t in record.get("turns", [])
+        if t["role"] == "assistant"
+    ]
+
+
+def extrapolate_to_n_turns(
+    per_turn: list[dict],
+    n_turns: int,
+    context_window: int,
+) -> dict:
+    """Extrapolate token growth to n_turns. Returns projection dict."""
+    if len(per_turn) < 2:
+        last_prompt = per_turn[0]["prompt_tokens"] if per_turn else 0
+        return {
+            "observed_turns": len(per_turn),
+            "last_prompt_tokens": last_prompt,
+            "avg_growth_per_turn": 0,
+            "projected_prompt_at_n": last_prompt,
+            "context_window": context_window,
+            "limit_80pct": int(context_window * CONTEXT_WINDOW_SAFETY_MARGIN),
+            "projected_pct": last_prompt / context_window * 100 if context_window else 0,
+            "overflow": False,
+        }
+
+    # Growth per turn = delta in prompt_tokens between consecutive turns
+    deltas = []
+    for i in range(1, len(per_turn)):
+        delta = per_turn[i]["prompt_tokens"] - per_turn[i - 1]["prompt_tokens"]
+        deltas.append(delta)
+
+    avg_growth = sum(deltas) / len(deltas)
+    last_prompt = per_turn[-1]["prompt_tokens"]
+    last_turn = per_turn[-1]["turn"]
+    remaining = n_turns - 1 - last_turn  # turns beyond what we observed
+    projected = last_prompt + max(0, remaining) * avg_growth
+
+    limit = int(context_window * CONTEXT_WINDOW_SAFETY_MARGIN)
+
+    return {
+        "observed_turns": len(per_turn),
+        "last_prompt_tokens": last_prompt,
+        "avg_growth_per_turn": round(avg_growth),
+        "projected_prompt_at_n": round(projected),
+        "context_window": context_window,
+        "limit_80pct": limit,
+        "projected_pct": projected / context_window * 100 if context_window else 0,
+        "overflow": projected > limit if context_window else False,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze multi-turn token budget")
+    parser.add_argument("--input", required=True, help="Sweep output directory")
+    parser.add_argument("--turns", type=int, default=10, help="Target number of turns")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    results = load_multiturn_results(Path(args.input))
+    if not results:
+        raise SystemExit(f"No JSON files found in {args.input}")
+
+    log.info(
+        "%-35s %4s  %6s  %6s  %8s  %10s  %6s  %s",
+        "model",
+        "run",
+        "turns",
+        "growth",
+        "last_pt",
+        "proj@" + str(args.turns),
+        "pct",
+        "overflow",
+    )
+    log.info("-" * 100)
+
+    for record in results:
+        model = record.get("model", "?")
+        run = record.get("run", "?")
+        ctx = record.get("model_metadata", {}).get("context_window", 0)
+
+        per_turn = per_turn_token_usage(record)
+        proj = extrapolate_to_n_turns(per_turn, args.turns, ctx)
+
+        log.info(
+            "%-35s %4s  %6d  %6d  %8d  %10d  %5.1f%%  %s",
+            model,
+            run,
+            proj["observed_turns"],
+            proj["avg_growth_per_turn"],
+            proj["last_prompt_tokens"],
+            proj["projected_prompt_at_n"],
+            proj["projected_pct"],
+            "OVERFLOW" if proj["overflow"] else "ok",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 # Model loading
 # ---------------------------------------------------------------------------
 
+
 def load_models(path: str) -> list[dict]:
     """Load model registry from YAML file."""
     with open(path) as f:
@@ -57,6 +58,7 @@ def compute_cost(usage: dict, model: dict) -> float:
 # Budget tracking
 # ---------------------------------------------------------------------------
 
+
 class BudgetTracker:
     """Track cumulative spend and stop when budget exceeded."""
 
@@ -78,15 +80,38 @@ class BudgetTracker:
         if self.exceeded:
             log.warning(
                 "Budget exceeded (%.4f >= %.4f USD). Stopping.",
-                self.total_cost, self.budget_usd,
+                self.total_cost,
+                self.budget_usd,
             )
             return False
         return True
 
 
 # ---------------------------------------------------------------------------
+# Token estimation
+# ---------------------------------------------------------------------------
+
+# Approximate characters per token for English text (actual varies 3-5)
+CHARS_PER_TOKEN = 4
+
+# Fraction of model context window to use (safety margin)
+CONTEXT_WINDOW_SAFETY_MARGIN = 0.8
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate based on character count."""
+    return len(text) // CHARS_PER_TOKEN
+
+
+def estimate_messages_tokens(messages: list[dict]) -> int:
+    """Estimate total tokens across a message list."""
+    return sum(estimate_tokens(m.get("content", "")) for m in messages)
+
+
+# ---------------------------------------------------------------------------
 # OpenAI client
 # ---------------------------------------------------------------------------
+
 
 def make_client(base_url: str | None = None) -> OpenAI:
     """Create an OpenAI-compatible client.
@@ -109,6 +134,7 @@ def make_client(base_url: str | None = None) -> OpenAI:
 # ---------------------------------------------------------------------------
 # File naming and skip logic
 # ---------------------------------------------------------------------------
+
 
 def output_filename(model_id: str, run: int, prefix: str = "") -> str:
     """Generate output filename: {prefix}{short_name}-run{n}.json."""
@@ -133,6 +159,7 @@ def should_skip(output_dir: Path, model_id: str, run: int, prefix: str = "") -> 
 # Save helpers
 # ---------------------------------------------------------------------------
 
+
 def save_json(filepath: Path, record: dict) -> None:
     """Write a JSON record to file."""
     filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -144,6 +171,7 @@ def save_json(filepath: Path, record: dict) -> None:
 # ---------------------------------------------------------------------------
 # Single-turn query helper
 # ---------------------------------------------------------------------------
+
 
 def query_single_turn(
     client: OpenAI,

--- a/src/aedist/query_multiturn.py
+++ b/src/aedist/query_multiturn.py
@@ -34,6 +34,27 @@ from .harness import (
 log = logging.getLogger(__name__)
 
 
+def _check_context(messages: list[dict], model: dict, turn: int) -> bool:
+    """Return True if estimated tokens fit within model context window."""
+    from .harness import CONTEXT_WINDOW_SAFETY_MARGIN, estimate_messages_tokens
+
+    ctx_window = model.get("context_window", 0)
+    if not ctx_window:
+        return True
+    est = estimate_messages_tokens(messages)
+    limit = int(ctx_window * CONTEXT_WINDOW_SAFETY_MARGIN)
+    if est > limit:
+        log.warning(
+            "Context overflow: ~%d tokens > %d (80%% of %d). Stopping at turn %d.",
+            est,
+            limit,
+            ctx_window,
+            turn,
+        )
+        return False
+    return True
+
+
 def run_conversation(
     client,
     model_id: str,
@@ -41,12 +62,14 @@ def run_conversation(
     followups: list[str],
     model: dict,
     budget: BudgetTracker,
+    stateless: bool = False,
 ) -> dict | None:
     """Run a multi-turn conversation. Returns record dict or None if budget exceeded."""
     messages: list[dict] = []
     turns: list[dict] = []
     total_cost = 0.0
     total_wall = 0.0
+    context_overflow = False
 
     # Initial prompt
     messages.append({"role": "user", "content": prompt})
@@ -54,6 +77,14 @@ def run_conversation(
 
     if not budget.check_or_warn():
         return None
+
+    if not _check_context(messages, model, 0):
+        return {
+            "turns": turns,
+            "total_cost_usd": 0.0,
+            "total_wall_seconds": 0.0,
+            "context_overflow": True,
+        }
 
     result = query_single_turn(client, model_id, messages)
     usage = result.get("usage") or {}
@@ -63,22 +94,32 @@ def run_conversation(
     total_wall += result["wall_seconds"]
 
     messages.append({"role": "assistant", "content": result["content"]})
-    turns.append({
-        "role": "assistant",
-        "content": result["content"],
-        "turn": 0,
-        "wall_seconds": result["wall_seconds"],
-        "usage": usage,
-        "cost_usd": cost,
-    })
+    turns.append(
+        {
+            "role": "assistant",
+            "content": result["content"],
+            "turn": 0,
+            "wall_seconds": result["wall_seconds"],
+            "usage": usage,
+            "cost_usd": cost,
+        }
+    )
 
     # Followups
     for i, followup in enumerate(followups, start=1):
         if not budget.check_or_warn():
             break
 
-        messages.append({"role": "user", "content": followup})
+        if stateless:
+            messages = [{"role": "user", "content": prompt + "\n\n" + followup}]
+        else:
+            messages.append({"role": "user", "content": followup})
+
         turns.append({"role": "user", "content": followup, "turn": i})
+
+        if not _check_context(messages, model, i):
+            context_overflow = True
+            break
 
         result = query_single_turn(client, model_id, messages)
         usage = result.get("usage") or {}
@@ -88,19 +129,22 @@ def run_conversation(
         total_wall += result["wall_seconds"]
 
         messages.append({"role": "assistant", "content": result["content"]})
-        turns.append({
-            "role": "assistant",
-            "content": result["content"],
-            "turn": i,
-            "wall_seconds": result["wall_seconds"],
-            "usage": usage,
-            "cost_usd": cost,
-        })
+        turns.append(
+            {
+                "role": "assistant",
+                "content": result["content"],
+                "turn": i,
+                "wall_seconds": result["wall_seconds"],
+                "usage": usage,
+                "cost_usd": cost,
+            }
+        )
 
     return {
         "turns": turns,
         "total_cost_usd": total_cost,
         "total_wall_seconds": total_wall,
+        "context_overflow": context_overflow,
     }
 
 
@@ -112,17 +156,24 @@ def main():
     parser.add_argument("--output", required=True, help="Output directory for results")
     parser.add_argument("--model", help="Query only this model (OpenRouter ID)")
     parser.add_argument("--repeat", type=int, default=1, help="Number of runs per model")
-    parser.add_argument("--budget-usd", type=float, default=None, help="Stop if cumulative cost exceeds budget")
-    parser.add_argument("--dry-run", action="store_true", help="List what would be queried, don't call API")
+    parser.add_argument(
+        "--budget-usd", type=float, default=None, help="Stop if cumulative cost exceeds budget"
+    )
+    parser.add_argument(
+        "--stateless",
+        action="store_true",
+        help="Stateless batch mode: each followup sent independently (no accumulated history)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="List what would be queried, don't call API"
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     prompt = Path(args.prompt).read_text().strip()
     followups = [
-        line.strip()
-        for line in Path(args.followups).read_text().splitlines()
-        if line.strip()
+        line.strip() for line in Path(args.followups).read_text().splitlines() if line.strip()
     ]
     models = load_models(args.models)
     output_dir = Path(args.output)
@@ -153,11 +204,24 @@ def main():
                 log.info("Skip %s run %d (cached)", label, run)
                 continue
 
-            log.info("Querying %s run %d/%d (multiturn, %d followups)...",
-                     label, run, args.repeat, len(followups))
+            log.info(
+                "Querying %s run %d/%d (multiturn, %d followups)...",
+                label,
+                run,
+                args.repeat,
+                len(followups),
+            )
 
             try:
-                conv = run_conversation(client, model_id, prompt, followups, model, budget)
+                conv = run_conversation(
+                    client,
+                    model_id,
+                    prompt,
+                    followups,
+                    model,
+                    budget,
+                    stateless=args.stateless,
+                )
                 if conv is None:
                     return
 
@@ -172,8 +236,9 @@ def main():
                     **conv,
                 }
                 save_json(filepath, record)
-                log.info("  Done. cost=%.6f total=%.6f USD",
-                         conv["total_cost_usd"], budget.total_cost)
+                log.info(
+                    "  Done. cost=%.6f total=%.6f USD", conv["total_cost_usd"], budget.total_cost
+                )
             except openai.APIError as e:
                 log.error("Error querying %s run %d: %s", label, run, e)
 

--- a/src/aedist/query_rag.py
+++ b/src/aedist/query_rag.py
@@ -22,8 +22,10 @@ from pathlib import Path
 import openai
 
 from .harness import (
+    CONTEXT_WINDOW_SAFETY_MARGIN,
     BudgetTracker,
     compute_cost,
+    estimate_tokens,
     load_models,
     make_client,
     model_metadata,
@@ -34,12 +36,6 @@ from .harness import (
 )
 
 log = logging.getLogger(__name__)
-
-# Approximate characters per token for English text (actual varies 3-5)
-CHARS_PER_TOKEN = 4
-
-# Fraction of model context window to use (safety margin)
-CONTEXT_WINDOW_SAFETY_MARGIN = 0.8
 
 
 def load_corpus(corpus_dir: Path) -> tuple[str, list[str]]:
@@ -57,23 +53,26 @@ def load_corpus(corpus_dir: Path) -> tuple[str, list[str]]:
     return "\n---\n".join(parts), names
 
 
-def estimate_tokens(text: str) -> int:
-    """Rough token estimate based on CHARS_PER_TOKEN ratio for English text."""
-    return len(text) // CHARS_PER_TOKEN
-
-
 def main():
     parser = argparse.ArgumentParser(description="RAG queries via OpenRouter")
     parser.add_argument("--prompt", required=True, help="Path to prompt text file")
     parser.add_argument("--corpus", required=True, help="Directory containing .md corpus files")
-    parser.add_argument("--strategy", default="wholesale", choices=["wholesale"],
-                        help="RAG strategy (currently only 'wholesale')")
+    parser.add_argument(
+        "--strategy",
+        default="wholesale",
+        choices=["wholesale"],
+        help="RAG strategy (currently only 'wholesale')",
+    )
     parser.add_argument("--models", required=True, help="Path to models.yaml")
     parser.add_argument("--output", required=True, help="Output directory for results")
     parser.add_argument("--model", help="Query only this model (OpenRouter ID)")
     parser.add_argument("--repeat", type=int, default=1, help="Number of runs per model")
-    parser.add_argument("--budget-usd", type=float, default=None, help="Stop if cumulative cost exceeds budget")
-    parser.add_argument("--dry-run", action="store_true", help="List what would be queried, don't call API")
+    parser.add_argument(
+        "--budget-usd", type=float, default=None, help="Stop if cumulative cost exceeds budget"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="List what would be queried, don't call API"
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -94,7 +93,9 @@ def main():
     if args.dry_run:
         for model in models:
             ctx = model.get("context_window", 0)
-            fits = "OK" if corpus_tokens < ctx * CONTEXT_WINDOW_SAFETY_MARGIN else "SKIP (too large)"
+            fits = (
+                "OK" if corpus_tokens < ctx * CONTEXT_WINDOW_SAFETY_MARGIN else "SKIP (too large)"
+            )
             for run in range(1, args.repeat + 1):
                 log.info("Would query %s run %d [%s]", model["id"], run, fits)
         return
@@ -111,7 +112,9 @@ def main():
         if corpus_tokens > ctx_window * CONTEXT_WINDOW_SAFETY_MARGIN:
             log.warning(
                 "Skip %s: corpus ~%d tokens exceeds 80%% of context window (%d)",
-                label, corpus_tokens, ctx_window,
+                label,
+                corpus_tokens,
+                ctx_window,
             )
             continue
 
@@ -123,8 +126,7 @@ def main():
                 log.info("Skip %s run %d (cached)", label, run)
                 continue
 
-            log.info("Querying %s run %d/%d (RAG %s)...",
-                     label, run, args.repeat, args.strategy)
+            log.info("Querying %s run %d/%d (RAG %s)...", label, run, args.repeat, args.strategy)
 
             try:
                 messages = [

--- a/tests/test_analyze_multiturn_budget.py
+++ b/tests/test_analyze_multiturn_budget.py
@@ -1,0 +1,97 @@
+"""Tests for aedist.analyze_multiturn_budget — token budget extrapolation."""
+
+from aedist.analyze_multiturn_budget import extrapolate_to_n_turns, per_turn_token_usage
+
+
+def test_per_turn_token_usage_extracts_assistant_turns():
+    record = {
+        "turns": [
+            {"role": "user", "content": "hi", "turn": 0},
+            {
+                "role": "assistant",
+                "content": "resp",
+                "turn": 0,
+                "usage": {"prompt_tokens": 100, "completion_tokens": 200},
+            },
+            {"role": "user", "content": "more", "turn": 1},
+            {
+                "role": "assistant",
+                "content": "resp2",
+                "turn": 1,
+                "usage": {"prompt_tokens": 400, "completion_tokens": 300},
+            },
+        ]
+    }
+    result = per_turn_token_usage(record)
+    assert len(result) == 2
+    assert result[0] == {"turn": 0, "prompt_tokens": 100, "completion_tokens": 200}
+    assert result[1] == {"turn": 1, "prompt_tokens": 400, "completion_tokens": 300}
+
+
+def test_per_turn_token_usage_handles_missing_usage():
+    record = {
+        "turns": [
+            {"role": "assistant", "content": "x", "turn": 0},
+        ]
+    }
+    result = per_turn_token_usage(record)
+    assert result[0]["prompt_tokens"] == 0
+    assert result[0]["completion_tokens"] == 0
+
+
+def test_extrapolate_linear_growth():
+    """Linear extrapolation with constant growth rate."""
+    per_turn = [
+        {"turn": 0, "prompt_tokens": 100, "completion_tokens": 200},
+        {"turn": 1, "prompt_tokens": 400, "completion_tokens": 200},
+        {"turn": 2, "prompt_tokens": 700, "completion_tokens": 200},
+        {"turn": 3, "prompt_tokens": 1000, "completion_tokens": 200},
+    ]
+    # Growth: 300, 300, 300 → avg 300
+    # Last prompt at turn 3: 1000
+    # Project to turn 9 (n_turns=10): 1000 + (9-3)*300 = 2800
+    proj = extrapolate_to_n_turns(per_turn, n_turns=10, context_window=5000)
+    assert proj["observed_turns"] == 4
+    assert proj["avg_growth_per_turn"] == 300
+    assert proj["projected_prompt_at_n"] == 2800
+    assert proj["limit_80pct"] == 4000
+    assert proj["overflow"] is False
+    assert abs(proj["projected_pct"] - 56.0) < 0.1
+
+
+def test_extrapolate_overflow():
+    """Detects overflow when projection exceeds 80% of context window."""
+    per_turn = [
+        {"turn": 0, "prompt_tokens": 1000, "completion_tokens": 500},
+        {"turn": 1, "prompt_tokens": 5000, "completion_tokens": 500},
+        {"turn": 2, "prompt_tokens": 9000, "completion_tokens": 500},
+        {"turn": 3, "prompt_tokens": 13000, "completion_tokens": 500},
+    ]
+    # Growth: 4000 avg. Last: 13000. Project to turn 9: 13000 + 6*4000 = 37000
+    # Context 40000 → limit 32000. 37000 > 32000 → overflow
+    proj = extrapolate_to_n_turns(per_turn, n_turns=10, context_window=40000)
+    assert proj["overflow"] is True
+    assert proj["projected_prompt_at_n"] == 37000
+
+
+def test_extrapolate_single_turn():
+    """Single turn: no growth data, returns last prompt as projection."""
+    per_turn = [
+        {"turn": 0, "prompt_tokens": 500, "completion_tokens": 200},
+    ]
+    proj = extrapolate_to_n_turns(per_turn, n_turns=10, context_window=100000)
+    assert proj["observed_turns"] == 1
+    assert proj["avg_growth_per_turn"] == 0
+    assert proj["projected_prompt_at_n"] == 500
+    assert proj["overflow"] is False
+
+
+def test_extrapolate_zero_context_window():
+    """Zero context window: no overflow possible, pct is 0."""
+    per_turn = [
+        {"turn": 0, "prompt_tokens": 100, "completion_tokens": 50},
+        {"turn": 1, "prompt_tokens": 200, "completion_tokens": 50},
+    ]
+    proj = extrapolate_to_n_turns(per_turn, n_turns=10, context_window=0)
+    assert proj["overflow"] is False
+    assert proj["projected_pct"] == 0

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,6 +1,5 @@
 """Tests for aedist.harness — shared query utilities."""
 
-
 from aedist.harness import (
     BudgetTracker,
     compute_cost,
@@ -99,10 +98,37 @@ def test_compute_cost_missing_pricing():
 def test_make_client_custom_base_url():
     """make_client with base_url doesn't require OPENROUTER_API_KEY."""
     from unittest.mock import patch
+
     with patch("aedist.harness.OpenAI") as mock_cls:
         from aedist.harness import make_client
+
         make_client(base_url="http://localhost:11434/v1")
         mock_cls.assert_called_once_with(
             base_url="http://localhost:11434/v1",
             api_key="ollama",
         )
+
+
+def test_estimate_tokens():
+    from aedist.harness import estimate_tokens
+
+    # 20 chars / 4 chars_per_token = 5
+    assert estimate_tokens("a" * 20) == 5
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_messages_tokens():
+    from aedist.harness import estimate_messages_tokens
+
+    messages = [
+        {"role": "user", "content": "a" * 40},  # 10 tokens
+        {"role": "assistant", "content": "b" * 80},  # 20 tokens
+    ]
+    assert estimate_messages_tokens(messages) == 30
+
+
+def test_estimate_messages_tokens_missing_content():
+    from aedist.harness import estimate_messages_tokens
+
+    messages = [{"role": "user"}]
+    assert estimate_messages_tokens(messages) == 0

--- a/tests/test_query_multiturn.py
+++ b/tests/test_query_multiturn.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
-def _make_mock_response(content="name,fuel\nPlant A,coal", prompt_tokens=100, completion_tokens=200):
+def _make_mock_response(
+    content="name,fuel\nPlant A,coal", prompt_tokens=100, completion_tokens=200
+):
     resp = MagicMock()
     resp.choices = [MagicMock()]
     resp.choices[0].message.content = content
@@ -57,14 +59,23 @@ def test_multiturn_produces_correct_turn_structure(mock_openai_cls, tmp_path):
     prompt, followups, models, output = _setup_files(tmp_path)
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query_multiturn",
-            "--prompt", str(prompt),
-            "--followups", str(followups),
-            "--models", str(models),
-            "--output", str(output),
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query_multiturn",
+                "--prompt",
+                str(prompt),
+                "--followups",
+                str(followups),
+                "--models",
+                str(models),
+                "--output",
+                str(output),
+            ],
+        ):
             from aedist.query_multiturn import main
+
             main()
 
     json_files = list(output.rglob("*.json"))
@@ -109,14 +120,23 @@ def test_multiturn_followups_parsed_from_file(mock_openai_cls, tmp_path):
     prompt, followups, models, output = _setup_files(tmp_path)
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query_multiturn",
-            "--prompt", str(prompt),
-            "--followups", str(followups),
-            "--models", str(models),
-            "--output", str(output),
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query_multiturn",
+                "--prompt",
+                str(prompt),
+                "--followups",
+                str(followups),
+                "--models",
+                str(models),
+                "--output",
+                str(output),
+            ],
+        ):
             from aedist.query_multiturn import main
+
             main()
 
     # 3 API calls: initial + 2 followups
@@ -136,16 +156,27 @@ def test_multiturn_budget_guard(mock_openai_cls, tmp_path):
 
     # Budget 0.0008 allows 1 call but not 2
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query_multiturn",
-            "--prompt", str(prompt),
-            "--followups", str(followups),
-            "--models", str(models),
-            "--output", str(output),
-            "--repeat", "3",
-            "--budget-usd", "0.0008",
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query_multiturn",
+                "--prompt",
+                str(prompt),
+                "--followups",
+                str(followups),
+                "--models",
+                str(models),
+                "--output",
+                str(output),
+                "--repeat",
+                "3",
+                "--budget-usd",
+                "0.0008",
+            ],
+        ):
             from aedist.query_multiturn import main
+
             main()
 
     json_files = list(output.rglob("*.json"))
@@ -163,16 +194,156 @@ def test_multiturn_repeat(mock_openai_cls, tmp_path):
     prompt, followups, models, output = _setup_files(tmp_path)
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query_multiturn",
-            "--prompt", str(prompt),
-            "--followups", str(followups),
-            "--models", str(models),
-            "--output", str(output),
-            "--repeat", "2",
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query_multiturn",
+                "--prompt",
+                str(prompt),
+                "--followups",
+                str(followups),
+                "--models",
+                str(models),
+                "--output",
+                str(output),
+                "--repeat",
+                "2",
+            ],
+        ):
             from aedist.query_multiturn import main
+
             main()
 
     json_files = list(output.rglob("*.json"))
     assert len(json_files) == 2
+
+
+def _make_mock_client():
+    """Create a mock client whose create() returns incrementing responses."""
+    client = MagicMock()
+    call_count = {"n": 0}
+
+    def side_effect(*args, **kwargs):
+        call_count["n"] += 1
+        return _make_mock_response(f"Response {call_count['n']}")
+
+    client.chat.completions.create.side_effect = side_effect
+    return client
+
+
+def test_context_overflow_guard():
+    """run_conversation stops when estimated tokens exceed context window."""
+    from aedist.harness import BudgetTracker
+    from aedist.query_multiturn import run_conversation
+
+    client = _make_mock_client()
+    # context_window=50 tokens → limit=40 (80%).
+    # Prompt "a"*200 = 50 estimated tokens > 40 limit → overflow on turn 0.
+    model = {"context_window": 50, "price_per_mtok_in": 0, "price_per_mtok_out": 0}
+    budget = BudgetTracker(budget_usd=None)
+
+    result = run_conversation(
+        client,
+        "test/model",
+        "a" * 200,
+        ["followup1"],
+        model,
+        budget,
+    )
+    assert result is not None
+    assert result["context_overflow"] is True
+    # Should not have called the API at all
+    assert client.chat.completions.create.call_count == 0
+
+
+def test_context_overflow_mid_conversation():
+    """Context guard triggers mid-conversation after responses accumulate."""
+    from aedist.harness import BudgetTracker
+    from aedist.query_multiturn import run_conversation
+
+    client = _make_mock_client()
+    # context_window=100 tokens → limit=80.
+    # Initial prompt "List plants." = 3 tokens, fits.
+    # Response "Response 1" ~2 tokens.
+    # Followup "a"*400 = 100 tokens → total ~105 > 80 → overflow.
+    model = {"context_window": 100, "price_per_mtok_in": 0, "price_per_mtok_out": 0}
+    budget = BudgetTracker(budget_usd=None)
+
+    result = run_conversation(
+        client,
+        "test/model",
+        "List plants.",
+        ["a" * 400, "more?"],
+        model,
+        budget,
+    )
+    assert result is not None
+    assert result["context_overflow"] is True
+    # Initial call should succeed, overflow at followup
+    assert client.chat.completions.create.call_count == 1
+    asst_turns = [t for t in result["turns"] if t["role"] == "assistant"]
+    assert len(asst_turns) == 1
+
+
+def test_stateless_mode_resets_messages():
+    """In stateless mode, each API call receives only 1 message (no history)."""
+    from aedist.harness import BudgetTracker
+    from aedist.query_multiturn import run_conversation
+
+    client = _make_mock_client()
+    model = {"context_window": 100000, "price_per_mtok_in": 0, "price_per_mtok_out": 0}
+    budget = BudgetTracker(budget_usd=None)
+
+    result = run_conversation(
+        client,
+        "test/model",
+        "List plants.",
+        ["Any missing?", "Check LNG?"],
+        model,
+        budget,
+        stateless=True,
+    )
+    assert result is not None
+    assert result["context_overflow"] is False
+
+    # 3 API calls: initial + 2 followups
+    assert client.chat.completions.create.call_count == 3
+
+    # In stateless mode, each followup creates a fresh messages list.
+    # However, call_args captures references that get mutated by later
+    # .append(). Verify correctness via the result: each followup call
+    # should NOT accumulate prior responses. The last call's messages
+    # list (calls[2]) was created fresh and then had 1 response appended,
+    # so it has 2 entries — but the user message should be prompt+followup,
+    # not the full history.
+    calls = client.chat.completions.create.call_args_list
+    last_call_msgs = calls[2].kwargs["messages"]
+    # Should contain only the combined prompt+followup as user, plus appended response
+    assert len(last_call_msgs) == 2  # user + appended assistant
+    assert "List plants." in last_call_msgs[0]["content"]
+    assert "Check LNG?" in last_call_msgs[0]["content"]
+    # Critically: should NOT contain earlier followup responses
+    assert "Response 2" not in last_call_msgs[0]["content"]
+
+
+def test_no_context_window_skips_guard():
+    """Models without context_window field skip the guard entirely."""
+    from aedist.harness import BudgetTracker
+    from aedist.query_multiturn import run_conversation
+
+    client = _make_mock_client()
+    model = {"price_per_mtok_in": 0, "price_per_mtok_out": 0}  # no context_window
+    budget = BudgetTracker(budget_usd=None)
+
+    result = run_conversation(
+        client,
+        "test/model",
+        "a" * 10000,
+        ["followup"],
+        model,
+        budget,
+    )
+    assert result is not None
+    assert result["context_overflow"] is False
+    assert client.chat.completions.create.call_count == 2


### PR DESCRIPTION
## Summary

- **Context window guard** in `run_conversation()`: estimates tokens before each API call, stops early at 80% of context window. Prevents silent overflow for small-context models like DeepSeek V3.2 (164K).
- **`--stateless` flag** for `query_multiturn.py`: sends each followup independently (no accumulated history). Token usage stays constant per turn.
- **`analyze_multiturn_budget.py`**: reads existing sweep outputs, extrapolates token growth to N turns. Key finding: DeepSeek V3.2 run1 projects to 123% overflow at 15 turns; all other models safe.
- Moved `estimate_tokens()` and constants from `query_rag.py` to `harness.py` for reuse.

## Test plan

- [x] `make check-fast` — 336 pass, 0 fail
- [x] `uv run python -m aedist.analyze_multiturn_budget --input experiments/outputs/sweep2_multiturn --turns 10` — DeepSeek run1 at 79%, others 1-14%
- [x] Context overflow guard tested with mock (tiny context window)
- [x] Stateless mode tested: followup calls contain only prompt+followup, no history

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)