### PR TITLE
simplify: public API for extract helpers, add decomposed tests

### DIFF
--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -49,7 +49,7 @@ def extract_fenced_blocks(text: str) -> list[str]:
     return blocks
 
 
-def _score_csv_like_block(block: str) -> float:
+def score_csv_like_block(block: str) -> float:
     lines = [ln.strip() for ln in block.splitlines() if ln.strip()]
     if not lines:
         return -1.0
@@ -216,7 +216,7 @@ class ExtractResult:
     message: str
 
 
-def _parse_and_canonicalize(csv_text: str) -> str:
+def parse_and_canonicalize(csv_text: str) -> str:
     csv_text = csv_text.strip()
     if csv_text.lower().startswith("sep="):
         csv_text = "\n".join(csv_text.splitlines()[1:]).lstrip()
@@ -295,9 +295,9 @@ def extract_one(json_path: Path, output_dir: Path, overwrite: bool) -> ExtractRe
     if not candidates:
         return ExtractResult(False, None, f"{json_path.name}: no CSV found")
 
-    best = max(candidates, key=_score_csv_like_block)
+    best = max(candidates, key=score_csv_like_block)
     try:
-        canonical_csv = _parse_and_canonicalize(best)
+        canonical_csv = parse_and_canonicalize(best)
     except Exception as e:
         return ExtractResult(False, None, f"{json_path.name}: CSV parse failed ({e})")
 

--- a/src/aedist/query_decomposed.py
+++ b/src/aedist/query_decomposed.py
@@ -27,7 +27,12 @@ from pathlib import Path
 
 import openai
 
-from .extract import _parse_and_canonicalize, extract_fenced_blocks, fallback_extract_inline_csv
+from .extract import (
+    extract_fenced_blocks,
+    fallback_extract_inline_csv,
+    parse_and_canonicalize,
+    score_csv_like_block,
+)
 from .harness import (
     BudgetTracker,
     compute_cost,
@@ -79,10 +84,9 @@ def _extract_csv_text(response: str) -> str | None:
     if not blocks:
         return None
 
-    # Pick the longest block (most data)
-    best = max(blocks, key=lambda b: b.count("\n"))
+    best = max(blocks, key=score_csv_like_block)
     try:
-        return _parse_and_canonicalize(best)
+        return parse_and_canonicalize(best)
     except Exception as e:
         log.warning("CSV parse failed: %s", e)
         return None
@@ -124,7 +128,6 @@ def query_decomposed(
     client,
     model_id: str,
     corpus_text: str,
-    base_prompt: str,
     budget: BudgetTracker,
     model: dict,
 ) -> dict | None:
@@ -253,7 +256,6 @@ def main():
                 client,
                 model_id,
                 corpus_text,
-                base_prompt,
                 budget,
                 model,
             )

--- a/tests/test_query_decomposed.py
+++ b/tests/test_query_decomposed.py
@@ -1,0 +1,71 @@
+"""Tests for aedist.query_decomposed — CSV merging and extraction."""
+
+from aedist.query_decomposed import _extract_csv_text, _merge_csvs
+
+# --- _merge_csvs ---
+
+
+def test_merge_csvs_deduplicates_by_name():
+    csv1 = "name,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\n"
+    csv2 = "name,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\nVung Ang,coal,planned,,Ha Tinh,1200\n"
+    merged = _merge_csvs([csv1, csv2])
+    lines = merged.strip().split("\n")
+    assert len(lines) == 3  # header + 2 unique plants
+
+
+def test_merge_csvs_case_insensitive_dedup():
+    csv1 = "name,fuel,status,cod,province,capacity_mwe\nPHA LAI,coal,,,Hai Duong,600\n"
+    csv2 = "name,fuel,status,cod,province,capacity_mwe\npha lai,coal,,,Hai Duong,600\n"
+    merged = _merge_csvs([csv1, csv2])
+    lines = merged.strip().split("\n")
+    assert len(lines) == 2  # header + 1 plant (deduped)
+
+
+def test_merge_csvs_preserves_header():
+    csv1 = "name,fuel,status,cod,province,capacity_mwe\nPlant A,coal,,,Hanoi,100\n"
+    merged = _merge_csvs([csv1])
+    assert merged.startswith("name,fuel,status,cod,province,capacity_mwe")
+
+
+def test_merge_csvs_empty_input():
+    assert _merge_csvs([]) == ""
+
+
+def test_merge_csvs_skips_empty_names():
+    csv1 = (
+        "name,fuel,status,cod,province,capacity_mwe\n,coal,,,Hanoi,100\nPlant B,gas,,,HCMC,200\n"
+    )
+    merged = _merge_csvs([csv1])
+    lines = merged.strip().split("\n")
+    assert len(lines) == 2  # header + Plant B only
+
+
+def test_merge_csvs_multiple_fuels():
+    coal = "name,fuel,status,cod,province,capacity_mwe\nPlant A,coal,,,Hanoi,100\nPlant B,coal,,,HCMC,200\n"
+    gas = "name,fuel,status,cod,province,capacity_mwe\nPlant C,gas,,,Da Nang,300\n"
+    other = "name,fuel,status,cod,province,capacity_mwe\nPlant D,oil,,,Hue,50\n"
+    merged = _merge_csvs([coal, gas, other])
+    lines = merged.strip().split("\n")
+    assert len(lines) == 5  # header + 4 plants
+
+
+# --- _extract_csv_text ---
+
+
+def test_extract_csv_text_fenced_block():
+    response = "Here are the plants:\n\n```csv\nname,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\n```\n"
+    result = _extract_csv_text(response)
+    assert result is not None
+    assert "Pha Lai" in result
+
+
+def test_extract_csv_text_no_csv():
+    result = _extract_csv_text("I don't have that information.")
+    assert result is None
+
+
+def test_extract_csv_text_inline_csv():
+    response = "Results:\nname,fuel,status,cod,province,capacity_mwe\nVung Ang,coal,planned,,Ha Tinh,1200\n\nEnd of data."
+    result = _extract_csv_text(response)
+    assert result is not None
+    assert "Vung Ang" in result


### PR DESCRIPTION
Review fixes for #146, landed after merge.

- Make `parse_and_canonicalize` and `score_csv_like_block` public in extract.py
- Remove unused `base_prompt` parameter from `query_decomposed()`
- Use `score_csv_like_block` instead of divergent line-count heuristic
- Add 9 tests for `_merge_csvs` and `_extract_csv_text`

364 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)