### PR TITLE
extract: add tests and shared constant for #152

### DIFF
--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -28,6 +28,22 @@ log = logging.getLogger(__name__)
 
 # Bonus per recognized header keyword in CSV scoring
 HEADER_KEYWORD_BONUS = 0.2
+
+# Keywords that signal a CSV header row about power plants.
+# Shared between score_csv_block() and fallback_extract_inline_csv()
+# to prevent the two lists from drifting apart.
+_HEADER_KEYWORDS = (
+    "name",
+    "plant",
+    "project",
+    "fuel",
+    "status",
+    "stage",
+    "cod",
+    "connection",
+    "province",
+    "capacity",
+)
 # Cap for length bonus normalization (number of lines)
 LENGTH_BONUS_CAP_LINES = 50.0
 
@@ -65,17 +81,7 @@ def score_csv_like_block(block: str) -> float:
 
     header = lines[0].lower()
     header_bonus = 0.0
-    for token in [
-        "name",
-        "plant",
-        "fuel",
-        "status",
-        "stage",
-        "cod",
-        "connection",
-        "province",
-        "capacity",
-    ]:
+    for token in _HEADER_KEYWORDS:
         if token in header:
             header_bonus += HEADER_KEYWORD_BONUS
 
@@ -118,7 +124,7 @@ def fallback_extract_inline_csv(text: str) -> str | None:
             continue
         low = stripped.lower()
         if ("," in stripped or ";" in stripped or "\t" in stripped) and any(
-            kw in low for kw in ("name", "plant", "project", "fuel", "capacity", "province")
+            kw in low for kw in _HEADER_KEYWORDS
         ):
             header_idx = i
             break

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -23,6 +23,10 @@ class TestHeaderMapping:
         """Gemini-2.5-flash-lite run3 used quoted 'Power Plant' header."""
         assert map_header_to_canonical(norm_header("Power Plant")) == "name"
 
+    def test_project_header(self):
+        """Some models use 'Project' as the name column header."""
+        assert map_header_to_canonical(norm_header("Project")) == "name"
+
     def test_generation_capacity(self):
         assert map_header_to_canonical(norm_header("Generation Capacity (MWe)")) == "capacity_mwe"
 
@@ -52,3 +56,48 @@ class TestPipeTable:
         result = _extract_pipe_table(text)
         lines = result.strip().splitlines()
         assert not any("---" in ln for ln in lines)
+
+
+class TestFallbackInlineCSV:
+    """fallback_extract_inline_csv detects CSV-like regions in plain text."""
+
+    def test_classic_name_header(self):
+        from aedist.extract import fallback_extract_inline_csv
+
+        text = "Here are the plants:\nName,Fuel,Province\nPha Lai,Coal,Hai Duong\n"
+        result = fallback_extract_inline_csv(text)
+        assert result is not None
+        assert "Name,Fuel,Province" in result
+        assert "Pha Lai" in result
+
+    def test_project_header_detected(self):
+        """PR #152: 'Project' keyword triggers header detection."""
+        from aedist.extract import fallback_extract_inline_csv
+
+        text = "Project,Fuel,Capacity\nSon My 1,Coal,150\nVung Ang 2,Coal,600\n"
+        result = fallback_extract_inline_csv(text)
+        assert result is not None
+        assert "Project,Fuel,Capacity" in result
+
+    def test_fuel_keyword_detected(self):
+        from aedist.extract import fallback_extract_inline_csv
+
+        text = "Some intro.\nFuel,Status,Province\nCoal,Operational,Quang Ninh\n"
+        result = fallback_extract_inline_csv(text)
+        assert result is not None
+        assert "Fuel,Status,Province" in result
+
+    def test_no_csv_returns_none(self):
+        from aedist.extract import fallback_extract_inline_csv
+
+        text = "This is just a paragraph about power plants in Vietnam."
+        assert fallback_extract_inline_csv(text) is None
+
+    def test_stops_at_double_blank(self):
+        """CSV region ends at two consecutive blank lines."""
+        from aedist.extract import fallback_extract_inline_csv
+
+        text = "Name,Fuel\nPha Lai,Coal\n\n\nUnrelated text here"
+        result = fallback_extract_inline_csv(text)
+        assert result is not None
+        assert "Unrelated" not in result


### PR DESCRIPTION
## Summary
- Add missing test coverage for PR #152 changes (merged without tests)
- Test `map_header_to_canonical("Project")` → `"name"` mapping
- Add 5 tests for `fallback_extract_inline_csv` (previously zero coverage)
- Extract `_HEADER_KEYWORDS` constant shared between `score_csv_block()` and `fallback_extract_inline_csv()`, replacing three overlapping inline keyword lists that could drift apart

## Test plan
- [x] `make check-fast` — 370 tests pass
- [x] All 14 extract tests pass (6 header + 3 pipe table + 5 inline CSV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)