### PR TITLE
Table conversion benchmark: GROBID vs Marker (#85)

### DIFF
--- a/report/inputs/generated/tab_converter_benchmark.tex
+++ b/report/inputs/generated/tab_converter_benchmark.tex
@@ -1,0 +1,8 @@
+\begin{tabular}{lrrrrr}
+\toprule
+Backend & Lines & Tables & Table rows & Vietnamese & Size (KB) \\
+\midrule
+grobid & 4961 & 0 & 0 & 5/5 & 388 \\
+marker & 4745 & 170 & 4038 & 5/5 & 1630 \\
+\bottomrule
+\end{tabular}

--- a/src/aedist/compare_converters.py
+++ b/src/aedist/compare_converters.py
@@ -1,0 +1,158 @@
+"""Compare PDF converter backends on table extraction quality.
+
+Reads pre-generated markdown outputs from each backend and produces
+a side-by-side quality report: tables detected, rows, Vietnamese
+diacritics, file size.
+
+Usage:
+    python -m aedist.compare_converters --input experiments/data/converter_test
+    python -m aedist.compare_converters --input experiments/data/converter_test --output report.tex
+"""
+
+import argparse
+import logging
+import re
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def count_tables(md: str) -> int:
+    """Count markdown tables by counting separator lines (|---|)."""
+    return sum(1 for line in md.splitlines() if re.match(r"\s*\|[-:| ]+\|\s*$", line))
+
+
+def count_table_rows(md: str) -> int:
+    """Count lines that look like markdown table rows (| ... |)."""
+    return sum(1 for line in md.splitlines() if re.match(r"\s*\|.+\|\s*$", line))
+
+
+def count_html_tables(md: str) -> int:
+    """Count HTML <table> blocks (GROBID style)."""
+    return md.count("<table>")
+
+
+def vietnamese_sample_check(md: str) -> dict[str, bool]:
+    """Check for presence of common Vietnamese diacriticked words."""
+    checks = {
+        "Quyết định": "Quyết định" in md or "Quyết Định" in md,
+        "điện lực": "điện lực" in md or "điện" in md,
+        "công suất": "công suất" in md,
+        "nhà máy": "nhà máy" in md,
+        "tỉnh": "tỉnh" in md,
+    }
+    return checks
+
+
+def analyze_backend(md_path: Path) -> dict:
+    """Analyze a single backend's markdown output."""
+    md = md_path.read_text(encoding="utf-8")
+    lines = md.splitlines()
+    viet = vietnamese_sample_check(md)
+
+    return {
+        "file": md_path.name,
+        "size_kb": md_path.stat().st_size / 1024,
+        "lines": len(lines),
+        "md_tables": count_tables(md),
+        "md_table_rows": count_table_rows(md),
+        "html_tables": count_html_tables(md),
+        "vietnamese_score": sum(viet.values()),
+        "vietnamese_max": len(viet),
+        "vietnamese_detail": viet,
+    }
+
+
+def format_summary(results: dict[str, dict], document: str) -> str:
+    """Format comparison as a text table."""
+    header = f"Converter Benchmark: {document}\n{'=' * 60}\n"
+    rows = []
+    rows.append(
+        f"{'Backend':<12} {'Lines':>6} {'Tables':>7} {'Rows':>6} {'HTML':>5} {'Viet':>5} {'Size KB':>8}"
+    )
+    rows.append("-" * 60)
+    for backend, r in sorted(results.items()):
+        rows.append(
+            f"{backend:<12} {r['lines']:>6} {r['md_tables']:>7} "
+            f"{r['md_table_rows']:>6} {r['html_tables']:>5} "
+            f"{r['vietnamese_score']}/{r['vietnamese_max']:>3} "
+            f"{r['size_kb']:>7.0f}"
+        )
+    return header + "\n".join(rows) + "\n"
+
+
+def format_latex(results: dict[str, dict], document: str) -> str:
+    """Format comparison as a LaTeX table."""
+    lines = [
+        r"\begin{tabular}{lrrrrr}",
+        r"\toprule",
+        r"Backend & Lines & Tables & Table rows & Vietnamese & Size (KB) \\",
+        r"\midrule",
+    ]
+    for backend, r in sorted(results.items()):
+        viet = f"{r['vietnamese_score']}/{r['vietnamese_max']}"
+        lines.append(
+            f"{backend} & {r['lines']} & {r['md_tables']} & "
+            f"{r['md_table_rows']} & {viet} & {r['size_kb']:.0f} \\\\"
+        )
+    lines.append(r"\bottomrule")
+    lines.append(r"\end{tabular}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Compare PDF converter backends on table extraction"
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Directory with per-backend subdirectories (e.g., grobid/, marker/)",
+    )
+    parser.add_argument(
+        "--document",
+        default="Decision-1509",
+        help="Document stem to compare (default: Decision-1509)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Output .tex file for LaTeX table",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    results = {}
+    for backend_dir in sorted(args.input.iterdir()):
+        if not backend_dir.is_dir():
+            continue
+        md_file = backend_dir / f"{args.document}.md"
+        if not md_file.exists():
+            log.warning("Skipping %s: no %s.md found", backend_dir.name, args.document)
+            continue
+        results[backend_dir.name] = analyze_backend(md_file)
+        log.info(
+            "Analyzed %s: %d tables, %d rows",
+            backend_dir.name,
+            results[backend_dir.name]["md_tables"],
+            results[backend_dir.name]["md_table_rows"],
+        )
+
+    if not results:
+        log.error("No backend outputs found in %s", args.input)
+        return
+
+    print(format_summary(results, args.document))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(format_latex(results, args.document), encoding="utf-8")
+        log.info("Wrote %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compare_converters.py
+++ b/tests/test_compare_converters.py
@@ -1,0 +1,135 @@
+"""Tests for aedist.compare_converters — PDF converter benchmarking."""
+
+from pathlib import Path
+
+from aedist.compare_converters import (
+    analyze_backend,
+    count_html_tables,
+    count_table_rows,
+    count_tables,
+    format_latex,
+    format_summary,
+    vietnamese_sample_check,
+)
+
+SAMPLE_MD = """\
+# Title
+
+Some text.
+
+| Name | Capacity | Province |
+|------|----------|----------|
+| Phả Lại | 600 MW | Hải Dương |
+| Vĩnh Tân | 1200 MW | Bình Thuận |
+
+More text about nhà máy điện lực.
+
+| Fuel | công suất |
+|------|-----------|
+| Coal | 31055 MW |
+"""
+
+SAMPLE_HTML = """\
+<table>
+<tr><th>Name</th></tr>
+<tr><td>Quyết định test</td></tr>
+</table>
+<table>
+<tr><td>tỉnh something</td></tr>
+</table>
+"""
+
+
+def test_count_tables():
+    assert count_tables(SAMPLE_MD) == 2
+
+
+def test_count_table_rows():
+    # 2 header + 2 separator + 3 data = 7 pipe lines per table style
+    rows = count_table_rows(SAMPLE_MD)
+    assert rows >= 6  # headers + data rows
+
+
+def test_count_tables_empty():
+    assert count_tables("No tables here.\nJust text.") == 0
+
+
+def test_count_html_tables():
+    assert count_html_tables(SAMPLE_HTML) == 2
+
+
+def test_count_html_tables_none():
+    assert count_html_tables(SAMPLE_MD) == 0
+
+
+def test_vietnamese_check_all_present():
+    text = "Quyết định về điện lực, công suất nhà máy tỉnh Hà Nội"
+    result = vietnamese_sample_check(text)
+    assert all(result.values())
+
+
+def test_vietnamese_check_partial():
+    text = "Some English text with điện mentioned"
+    result = vietnamese_sample_check(text)
+    assert result["điện lực"]
+    assert not result["công suất"]
+
+
+def test_analyze_backend(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text(SAMPLE_MD, encoding="utf-8")
+    result = analyze_backend(md_file)
+    assert result["md_tables"] == 2
+    assert result["md_table_rows"] >= 6
+    assert result["lines"] > 0
+    assert result["size_kb"] > 0
+
+
+def test_format_summary():
+    results = {
+        "grobid": {
+            "lines": 100,
+            "md_tables": 0,
+            "md_table_rows": 0,
+            "html_tables": 5,
+            "vietnamese_score": 4,
+            "vietnamese_max": 5,
+            "size_kb": 50,
+        },
+        "marker": {
+            "lines": 200,
+            "md_tables": 10,
+            "md_table_rows": 100,
+            "html_tables": 0,
+            "vietnamese_score": 5,
+            "vietnamese_max": 5,
+            "size_kb": 150,
+        },
+    }
+    text = format_summary(results, "test-doc")
+    assert "grobid" in text
+    assert "marker" in text
+    assert "test-doc" in text
+
+
+def test_format_latex():
+    results = {
+        "marker": {
+            "lines": 200,
+            "md_tables": 10,
+            "md_table_rows": 100,
+            "html_tables": 0,
+            "vietnamese_score": 5,
+            "vietnamese_max": 5,
+            "size_kb": 150,
+        },
+    }
+    tex = format_latex(results, "test-doc")
+    assert r"\begin{tabular}" in tex
+    assert "marker" in tex
+    assert r"\bottomrule" in tex
+
+
+def test_module_has_argparse():
+    source = Path("src/aedist/compare_converters.py").read_text()
+    assert "ArgumentParser" in source


### PR DESCRIPTION
## Summary

- New `compare_converters.py` script: analyzes per-backend markdown outputs, counts tables/rows/Vietnamese quality
- Benchmark results on Decision 1509 (173 pages, scanned Vietnamese):

| Backend | Lines | Tables | Table rows | Vietnamese | Size KB |
|---------|-------|--------|-----------|-----------|---------|
| GROBID | 4961 | 0 | 0 | 5/5 | 388 |
| **Marker** | 4745 | **170** | **4038** | 5/5 | 1630 |

- LaTeX output at `report/inputs/generated/tab_converter_benchmark.tex`
- 11 new tests, 381 total pass

Partial fix for #85 — MinerU column pending container pull.

## Test plan
- [x] `test_compare_converters.py` — 11 tests pass
- [x] `make check-fast` — 381 passed
- [x] Benchmark runs on existing converter test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)