### PR TITLE
Fix post-merge review findings (#148, #149)

### DIFF
--- a/src/aedist/analyze_multiturn_budget.py
+++ b/src/aedist/analyze_multiturn_budget.py
@@ -69,7 +69,9 @@ def extrapolate_to_n_turns(
     avg_growth = sum(deltas) / len(deltas)
     last_prompt = per_turn[-1]["prompt_tokens"]
     last_turn = per_turn[-1]["turn"]
-    remaining = n_turns - 1 - last_turn  # turns beyond what we observed
+    # Turns are 0-indexed: turn 0 is the initial prompt, turn 1 is first relance, etc.
+    # So n_turns=10 means turns 0..9, and remaining = 9 - last_observed_turn.
+    remaining = n_turns - 1 - last_turn
     projected = last_prompt + max(0, remaining) * avg_growth
 
     limit = int(context_window * CONTEXT_WINDOW_SAFETY_MARGIN)

--- a/src/aedist/query_decomposed.py
+++ b/src/aedist/query_decomposed.py
@@ -74,7 +74,7 @@ _FUEL_PROMPTS = {
 }
 
 
-def _extract_csv_text(response: str) -> str | None:
+def extract_csv_text(response: str) -> str | None:
     """Extract and canonicalize CSV from a model response."""
     blocks = extract_fenced_blocks(response)
     if not blocks:
@@ -92,7 +92,7 @@ def _extract_csv_text(response: str) -> str | None:
         return None
 
 
-def _merge_csvs(csv_texts: list[str]) -> str:
+def merge_csvs(csv_texts: list[str]) -> str:
     """Merge multiple canonical CSVs, deduplicating by name."""
     seen_names: set[str] = set()
     merged_rows: list[list[str]] = []
@@ -173,7 +173,7 @@ def query_decomposed(
     # Merge CSV outputs
     csv_texts = []
     for fuel in _FUEL_PROMPTS:
-        csv_text = _extract_csv_text(sub_results[fuel]["response"])
+        csv_text = extract_csv_text(sub_results[fuel]["response"])
         if csv_text:
             csv_texts.append(csv_text)
             lines = csv_text.strip().split("\n")
@@ -181,7 +181,7 @@ def query_decomposed(
         else:
             log.warning("    %s: no CSV extracted", fuel)
 
-    merged_csv = _merge_csvs(csv_texts) if csv_texts else ""
+    merged_csv = merge_csvs(csv_texts) if csv_texts else ""
     merged_lines = merged_csv.strip().split("\n") if merged_csv else []
     n_merged = len(merged_lines) - 1 if len(merged_lines) > 1 else 0
     log.info("  Merged: %d unique plants from %d sub-queries", n_merged, len(csv_texts))

--- a/src/aedist/query_multiturn.py
+++ b/src/aedist/query_multiturn.py
@@ -20,8 +20,10 @@ from pathlib import Path
 import openai
 
 from .harness import (
+    CONTEXT_WINDOW_SAFETY_MARGIN,
     BudgetTracker,
     compute_cost,
+    estimate_messages_tokens,
     load_models,
     make_client,
     model_metadata,
@@ -36,7 +38,6 @@ log = logging.getLogger(__name__)
 
 def _check_context(messages: list[dict], model: dict, turn: int) -> bool:
     """Return True if estimated tokens fit within model context window."""
-    from .harness import CONTEXT_WINDOW_SAFETY_MARGIN, estimate_messages_tokens
 
     ctx_window = model.get("context_window", 0)
     if not ctx_window:

--- a/tests/test_query_decomposed.py
+++ b/tests/test_query_decomposed.py
@@ -1,71 +1,71 @@
 """Tests for aedist.query_decomposed — CSV merging and extraction."""
 
-from aedist.query_decomposed import _extract_csv_text, _merge_csvs
+from aedist.query_decomposed import extract_csv_text, merge_csvs
 
-# --- _merge_csvs ---
+# --- merge_csvs ---
 
 
-def test_merge_csvs_deduplicates_by_name():
+def testmerge_csvs_deduplicates_by_name():
     csv1 = "name,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\n"
     csv2 = "name,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\nVung Ang,coal,planned,,Ha Tinh,1200\n"
-    merged = _merge_csvs([csv1, csv2])
+    merged = merge_csvs([csv1, csv2])
     lines = merged.strip().split("\n")
     assert len(lines) == 3  # header + 2 unique plants
 
 
-def test_merge_csvs_case_insensitive_dedup():
+def testmerge_csvs_case_insensitive_dedup():
     csv1 = "name,fuel,status,cod,province,capacity_mwe\nPHA LAI,coal,,,Hai Duong,600\n"
     csv2 = "name,fuel,status,cod,province,capacity_mwe\npha lai,coal,,,Hai Duong,600\n"
-    merged = _merge_csvs([csv1, csv2])
+    merged = merge_csvs([csv1, csv2])
     lines = merged.strip().split("\n")
     assert len(lines) == 2  # header + 1 plant (deduped)
 
 
-def test_merge_csvs_preserves_header():
+def testmerge_csvs_preserves_header():
     csv1 = "name,fuel,status,cod,province,capacity_mwe\nPlant A,coal,,,Hanoi,100\n"
-    merged = _merge_csvs([csv1])
+    merged = merge_csvs([csv1])
     assert merged.startswith("name,fuel,status,cod,province,capacity_mwe")
 
 
-def test_merge_csvs_empty_input():
-    assert _merge_csvs([]) == ""
+def testmerge_csvs_empty_input():
+    assert merge_csvs([]) == ""
 
 
-def test_merge_csvs_skips_empty_names():
+def testmerge_csvs_skips_empty_names():
     csv1 = (
         "name,fuel,status,cod,province,capacity_mwe\n,coal,,,Hanoi,100\nPlant B,gas,,,HCMC,200\n"
     )
-    merged = _merge_csvs([csv1])
+    merged = merge_csvs([csv1])
     lines = merged.strip().split("\n")
     assert len(lines) == 2  # header + Plant B only
 
 
-def test_merge_csvs_multiple_fuels():
+def testmerge_csvs_multiple_fuels():
     coal = "name,fuel,status,cod,province,capacity_mwe\nPlant A,coal,,,Hanoi,100\nPlant B,coal,,,HCMC,200\n"
     gas = "name,fuel,status,cod,province,capacity_mwe\nPlant C,gas,,,Da Nang,300\n"
     other = "name,fuel,status,cod,province,capacity_mwe\nPlant D,oil,,,Hue,50\n"
-    merged = _merge_csvs([coal, gas, other])
+    merged = merge_csvs([coal, gas, other])
     lines = merged.strip().split("\n")
     assert len(lines) == 5  # header + 4 plants
 
 
-# --- _extract_csv_text ---
+# --- extract_csv_text ---
 
 
-def test_extract_csv_text_fenced_block():
+def testextract_csv_text_fenced_block():
     response = "Here are the plants:\n\n```csv\nname,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\n```\n"
-    result = _extract_csv_text(response)
+    result = extract_csv_text(response)
     assert result is not None
     assert "Pha Lai" in result
 
 
-def test_extract_csv_text_no_csv():
-    result = _extract_csv_text("I don't have that information.")
+def testextract_csv_text_no_csv():
+    result = extract_csv_text("I don't have that information.")
     assert result is None
 
 
-def test_extract_csv_text_inline_csv():
+def testextract_csv_text_inline_csv():
     response = "Results:\nname,fuel,status,cod,province,capacity_mwe\nVung Ang,coal,planned,,Ha Tinh,1200\n\nEnd of data."
-    result = _extract_csv_text(response)
+    result = extract_csv_text(response)
     assert result is not None
     assert "Vung Ang" in result


### PR DESCRIPTION
## Summary

Fixes all actionable findings from post-merge reviews:

**From #148 (multi-turn token budget):**
- Move deferred import to top-level in `query_multiturn.py`
- Add comment explaining 0-indexed turn formula in `extrapolate_to_n_turns`

**From #149 (public API for extract helpers):**
- `_extract_csv_text` → `extract_csv_text` (public, tested directly)
- `_merge_csvs` → `merge_csvs` (public, tested directly)
- Update test imports to match

## Test plan
- [x] `make check-fast` — 370 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)