### PR TITLE
Fix mangled test names in test_query_decomposed.py

### DIFF
--- a/tests/test_query_decomposed.py
+++ b/tests/test_query_decomposed.py
@@ -5,7 +5,7 @@ from aedist.query_decomposed import extract_csv_text, merge_csvs
 # --- merge_csvs ---
 
 
-def testmerge_csvs_deduplicates_by_name():
+def test_merge_csvs_deduplicates_by_name():
     csv1 = "name,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\n"
     csv2 = "name,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\nVung Ang,coal,planned,,Ha Tinh,1200\n"
     merged = merge_csvs([csv1, csv2])
@@ -13,7 +13,7 @@ def testmerge_csvs_deduplicates_by_name():
     assert len(lines) == 3  # header + 2 unique plants
 
 
-def testmerge_csvs_case_insensitive_dedup():
+def test_merge_csvs_case_insensitive_dedup():
     csv1 = "name,fuel,status,cod,province,capacity_mwe\nPHA LAI,coal,,,Hai Duong,600\n"
     csv2 = "name,fuel,status,cod,province,capacity_mwe\npha lai,coal,,,Hai Duong,600\n"
     merged = merge_csvs([csv1, csv2])
@@ -21,17 +21,17 @@ def testmerge_csvs_case_insensitive_dedup():
     assert len(lines) == 2  # header + 1 plant (deduped)
 
 
-def testmerge_csvs_preserves_header():
+def test_merge_csvs_preserves_header():
     csv1 = "name,fuel,status,cod,province,capacity_mwe\nPlant A,coal,,,Hanoi,100\n"
     merged = merge_csvs([csv1])
     assert merged.startswith("name,fuel,status,cod,province,capacity_mwe")
 
 
-def testmerge_csvs_empty_input():
+def test_merge_csvs_empty_input():
     assert merge_csvs([]) == ""
 
 
-def testmerge_csvs_skips_empty_names():
+def test_merge_csvs_skips_empty_names():
     csv1 = (
         "name,fuel,status,cod,province,capacity_mwe\n,coal,,,Hanoi,100\nPlant B,gas,,,HCMC,200\n"
     )
@@ -40,7 +40,7 @@ def testmerge_csvs_skips_empty_names():
     assert len(lines) == 2  # header + Plant B only
 
 
-def testmerge_csvs_multiple_fuels():
+def test_merge_csvs_multiple_fuels():
     coal = "name,fuel,status,cod,province,capacity_mwe\nPlant A,coal,,,Hanoi,100\nPlant B,coal,,,HCMC,200\n"
     gas = "name,fuel,status,cod,province,capacity_mwe\nPlant C,gas,,,Da Nang,300\n"
     other = "name,fuel,status,cod,province,capacity_mwe\nPlant D,oil,,,Hue,50\n"
@@ -52,19 +52,19 @@ def testmerge_csvs_multiple_fuels():
 # --- extract_csv_text ---
 
 
-def testextract_csv_text_fenced_block():
+def test_extract_csv_text_fenced_block():
     response = "Here are the plants:\n\n```csv\nname,fuel,status,cod,province,capacity_mwe\nPha Lai,coal,operational,,Hai Duong,600\n```\n"
     result = extract_csv_text(response)
     assert result is not None
     assert "Pha Lai" in result
 
 
-def testextract_csv_text_no_csv():
+def test_extract_csv_text_no_csv():
     result = extract_csv_text("I don't have that information.")
     assert result is None
 
 
-def testextract_csv_text_inline_csv():
+def test_extract_csv_text_inline_csv():
     response = "Results:\nname,fuel,status,cod,province,capacity_mwe\nVung Ang,coal,planned,,Ha Tinh,1200\n\nEnd of data."
     result = extract_csv_text(response)
     assert result is not None


### PR DESCRIPTION
## Summary

PR #159 did a find-replace of `_merge_csvs` → `merge_csvs` and `_extract_csv_text` → `extract_csv_text` that also stripped the underscore from 9 test function names (e.g. `test_merge_csvs_deduplicates_by_name` → `testmerge_csvs_deduplicates_by_name`).

Tests still ran (pytest discovers `test*` prefixed functions) but names lost readability and deviated from project conventions.

## Test plan
- [x] `pytest tests/test_query_decomposed.py -v` — 9 tests pass with corrected names

🤖 Generated with [Claude Code](https://claude.com/claude-code)