### PR TITLE
Fix MinerU + complete 3-way converter benchmark (#81, #85, #111)

### DIFF
--- a/experiments/data/converter_test/README.md
+++ b/experiments/data/converter_test/README.md
@@ -28,12 +28,25 @@
 - **Speed**: ~60s per page (173 pages ≈ 3 hours)
 - **Verdict**: Good table quality, but too slow for full documents
 
-### MinerU (not tested — container image not yet pulled)
+### MinerU (localhost:8010, jianjungki/mineru-api:gpu, GPU)
+- **Output**: 695 lines, 50K chars, **0 markdown tables**
+- **Text extraction**: Good — Vietnamese diacritics preserved, document structure detected
+- **Table extraction**: Poor — tables not converted to markdown format
+- **Speed**: Fast (single API call)
+- **Verdict**: Good for text, fails on tables for this document type
 
 ## Conclusion
 
 **Marker is the clear winner** for this document type:
-- 170 extracted tables vs 0 (GROBID) — the only converter that preserves table structure at scale
+
+| Backend | Tables | Table rows | Lines | Size |
+|---------|--------|-----------|-------|------|
+| **Marker** | **170** | **4038** | 4745 | 1.6 MB |
+| GROBID | 0 | 0 | 4961 | 388 KB |
+| MinerU | 0 | 0 | 695 | 58 KB |
+| Gemma 4 vision | good/page | — | — | ~60s/page |
+
+- Marker is the only converter that preserves table structure at scale
 - Full document in one call vs page-by-page (vision)
 - Minor OCR errors on Vietnamese diacritics (fixable in post-processing)
 

--- a/experiments/data/converter_test/mineru/Decision-1509.md
+++ b/experiments/data/converter_test/mineru/Decision-1509.md
@@ -1,0 +1,695 @@
+#  
+
+#  
+
+#  
+
+#  
+
+$\mathbf{v_{\upmu}}$  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/1c140edde667980bfc6e0a09ebbcdc6652dc186809dcdfbe1cfbce8780cfedf6.jpg)  
+
+# BỘ CÔNG THƯƠNG CỘNG HÒA XÃ HỘI CHỦ NGHĨA VIỆT NAM _______________ Độc lập - Tự do - Hạnh phúc  
+
+# KẾ HOẠCH Thực hiện Quy hoạch phát triển điện lực quốc gia thời kỳ 2021 - 2030, tầm nhìn đến năm 2050 điều chỉnh  
+
+(Kèm theo Quyết định số 1509/QĐ-BCT ngày 30 tháng 5 năm 2025 của Bộ Công Thương)  
+
+# I. MỤC ĐÍCH VÀ YÊU CẦU 1. Mục đích  
+
+- Triển khai thực hiện có hiệu quả Quyết định số 768/QĐ-TTg ngày 15 tháng 4 năm 2025 của Thủ tướng Chính phủ phê duyệt Điều chỉnh Quy hoạch phát triển điện lực quốc gia thời kỳ 2021-2030, tầm nhìn tới năm 2050 (Điều chỉnh Quy hoạch điện VIII). Xây dựng lộ trình tổ chức thực hiện có hiệu quả các đề án/dự án đáp ứng các mục tiêu đã đề ra của Điều chỉnh Quy hoạch điện VIII, đáp ứng nhu cầu điện cho phát triển kinh tế - xã hội theo từng thời kỳ, bảo đảm phát triển điện lực đi trước một bước.  
+
+- Xác định các giải pháp thu hút đầu tư phát triển điện lực theo Điều chỉnh Quy hoạch điện VIII trong thời kỳ quy hoạch.  
+
+- Đề ra các nhiệm vụ cho các Bộ, ngành và Ủy ban nhân dân các tỉnh, thành phố trực thuộc trung ương trong việc phối hợp với Bộ Công Thương và các đơn vị liên quan để thực hiện hiệu quả Điều chỉnh Quy hoạch điện VIII.  
+
+# 2. Yêu cầu  
+
+- Kế hoạch thực hiện Quy hoạch điện VIII điều chỉnh phải bám sát quan điểm, mục tiêu, định hướng của Điều chỉnh Quy hoạch điện VIII, cụ thể hóa được các nhiệm vụ được giao tại Quyết định số 768/QĐ-TTg ngày 15 tháng 4 năm 2025 của Thủ tướng Chính phủ và các văn bản quy phạm pháp luật có liên quan.  
+
+- Xác định cụ thể tiến độ, nguồn lực và việc sử dụng nguồn lực thực hiện các đề án/dự án xây dựng và hoàn thiện chính sách, pháp luật; tăng cường năng lực khoa học công nghệ, xây dựng trung tâm nghiên cứu cơ bản, trung tâm phát triển; đào tạo và nâng cao chất lượng nguồn nhân lực của ngành điện trong thời kỳ quy hoạch.  
+
+- Xác định cụ thể tiến độ các dự án nguồn điện, lưới điện theo Điều chỉnh Quy hoạch điện VIII cho từng địa phương tới năm 2030 và giai đoạn 2031-2035; danh mục các dự án đầu tư công, dự án đầu tư sử dụng nguồn vốn khác ngoài vốn đầu tư công, dự án sử dụng nguồn vốn xã hội hóa.  
+
+- Đảm bảo tính tuân thủ, kế thừa, đồng bộ với các quy hoạch ngành/kế hoạch thực hiện quy hoạch cấp quốc gia được duyệt, đảm bảo tính liên kết, thống nhất trong thực hiện.  
+
+# II. NỘI DUNG KẾ HOẠCH THỰC HIỆN QUY HOẠCH ĐIỆN VIII ĐIỀU CHỈNH  
+
+1. Danh mục các dự án nguồn điện quan trọng, ưu tiên đầu tư của ngành tới năm 2030 và giai đoạn 2031-2035  
+
+- Đến năm 2030, tổng công suất nhiệt điện LNG là 22.524 MW. Danh mục các dự án đầu tư xây dựng mới và tiến độ vận hành tại Bảng 1 Phụ lục II.1.  
+
+- Đến năm 2030, tổng công suất nhiệt điện khí trong nước là 14.930 MW. Danh mục các dự án đầu tư xây dựng mới và tiến độ vận hành tại Bảng 6 Phụ lục II.1.  
+
+- Đến năm 2030, tổng công suất nhiệt điện than là 31.055 MW. Danh mục các dự án đầu tư xây dựng mới và tiến độ vận hành tại Bảng 3 Phụ lục II.1.  
+
+- Đến năm 2030, tổng công suất nguồn điện đồng phát, nguồn điện sử dụng nhiệt dư, khí lò cao, sản phẩm phụ của dây chuyền công nghệ là 1.404 MW. Đến năm 2035 tổng công suất nguồn điện đồng phát, nguồn điện sử dụng nhiệt dư, khí lò cao, sản phẩm phụ của dây chuyền công nghệ là 3.204 MW. Danh mục các dự án cần đầu tư xây dựng mới và tiến độ vận hành tại Bảng 5 Phụ lục II.1.  
+
+- Tổng công suất thủy điện là 33.294 - 34.667 MW. Danh mục dự án thủy điện vừa và lớn đầu tư xây dựng mới và tiến độ vận hành tại Bảng 7 Phụ lục II.1. Danh mục các thủy điện có công suất dưới 50 MW đấu nối ở cấp điện áp $220\,\mathrm{kV}$ trở lên đầu tư xây dựng mới và tiến độ vận hành tại Bảng 8 Phụ lục II.1  
+
+- Tổng công suất thủy điện tích năng là 2.400 - 6.000 MW. Danh mục dự án đầu tư xây dựng mới và tiến độ vận hành tại Bảng 9 Phụ lục II.1.  
+
+- Tổng công suất điện hạt nhân là 4.000 - 6.400 MW. Danh mục các dự án điện hạt nhân đầu tư xây dựng mới và tiến độ vận hành tại Bảng 10, Phụ lục II.1.  
+
+- Tổng công suất điện gió trên bờ (điện gió trên đất liền và gần bờ) là 26.066 - 38.029 MW. Danh mục các dự án điện gió trên bờ đầu tư xây dựng mới và tiến độ vận hành tại Bảng 12 và Bảng 13, Phụ lục II.1.  
+
+- Năm 2030, tổng công suất điện gió ngoài khơi phục vụ nhu cầu điện trong nước là 6.000 MW. Đến năm 2035, tổng công suất điện gió ngoài khơi phục vụ nhu cầu điện trong nước đạt 17.032 MW. Công suất điện gió ngoài khơi theo vùng tại Bảng 17, Phụ lục II.1.  
+
+- Tổng công suất điện mặt trời (gồm điện mặt trời tập trung và điện mặt trời mái nhà, không bao gồm các nguồn điện mặt trời theo khoản 5 Điều 10 Luật Điện lực số 61/2024/QH15) là 46.459 - 73.416 MW. Danh mục các dự án điện mặt trời cần đầu tư xây dựng mới và tiến độ vận hành tại Bảng 14, Phụ lục II.1.  
+
+- Tổng công suất điện sinh khối là 1.523 - 2.699 MW. Danh mục các dự án điện sinh khối xây dựng mới tại Bảng 15, Phụ lục II.1.  
+
+- Tổng công suất điện sản xuất từ rác, chất thải rắn là 1.441 - 2.137 MW. Danh mục các dự án điện sản xuất từ rác xây dựng mới tại Bảng 16, Phụ lục II.1.  
+
+- Đến năm 2030, Tổng công suất pin lưu trữ dự kiến đạt khoảng 10.000 - 16.300 MW. Danh mục dự án đầu tư xây dựng mới tại Bảng 11 Phụ lục II.1. Phát triển điện mặt trời tập trung phải kết hợp với lắp đặt pin lưu trữ với tỷ lệ tối thiểu $10\%$ công suất và tích trong 2 giờ.  
+
+# 2. Các loại hình nguồn điện khác tới năm 2035  
+
+- Dự kiến phát triển 2.000-3.000 MW các nguồn điện linh hoạt. Danh mục dự án đầu tư xây dựng mới tại Bảng 19 Phụ lục II.1.  
+
+- Đẩy mạnh nhập khẩu điện từ các nước Đông Nam Á (ASEAN) và Tiểu vùng sông Mê Kông (GMS) có tiềm năng về thủy điện. Quan tâm đầu tư, khai thác các nguồn điện tại nước ngoài để cung ứng điện về Việt Nam. Năm 2030, nhập khẩu khoảng 9.360 - 12.100 MW từ Lào theo Hiệp định giữa hai Chính phủ và tận dụng khả năng nhập khẩu phù hợp với điều kiện đấu nối từ Trung Quốc với quy mô hợp lý. Nếu điều kiện thuận lợi, giá thành hợp lý, có thể tăng thêm quy mô tối đa hoặc đẩy sớm thời gian nhập khẩu điện từ Lào về khu vực miền Bắc.  
+
+- Đến năm 2030, tăng quy mô xuất khẩu điện sang Campuchia lên khoảng 400 MW. Dự kiến đến năm 2035, quy mô công suất xuất khẩu điện sang Singapore, Malaysia và các đối tác khác trong khu vực đạt khoảng 5.000 - 10.000 MW và duy trì với quy mô 10.000 MW đến năm 2050, có thể cao hơn tùy theo nhu cầu của bên nhập khẩu trên cơ sở có hiệu quả kinh tế cao, đảm bảo an ninh năng lượng trong nước và an ninh quốc phòng. Danh mục dự án tiềm năng xuất khẩu điện tại Bảng 19 Phụ lục II.1.  
+
+- Nguồn điện năng lượng tái tạo phục vụ xuất khẩu, sản xuất năng lượng mới như sau:  
+
+$+$ Những vị trí có tiềm năng xuất khẩu điện ra nước ngoài là khu vực miền Trung và miền Nam. Quy mô xuất khẩu từ 5.000 MW đến 10.000 MW. Bộ Công Thương báo cáo các cấp có thẩm quyền xem xét, quyết định chủ trương xuất khẩu điện và phương án lưới điện đấu nối đồng bộ đối với từng trường hợp cụ thể, phù hợp với quy định của pháp luật.  
+
++ Sử dụng năng lượng tái tạo để sản xuất các loại năng lượng mới (như hydro xanh, amoniac xanh) phục vụ nhu cầu trong nước và xuất khẩu: Ưu tiên phát triển tại các khu vực có tiềm năng năng lượng tái tạo tốt, cơ sở hạ tầng lưới điện thuận lợi; quy mô phát triển phấn đấu đạt 15.000 MW (chủ yếu là nguồn điện gió ngoài khơi). Bộ Công Thương báo cáo, kiến nghị Thủ tướng Chính phủ xem xét, quyết định với từng dự án cụ thể khi đã cơ bản đánh giá được tính khả thi về công nghệ và giá thành. Công suất nguồn năng lượng tái tạo để sản xuất năng lượng mới không tính vào cơ cấu nguồn điện cung cấp cho phụ tải hệ thống điện quốc gia.  
+
+# 3. Danh mục các dự án lưới điện truyền tải và liên kết lưới điện khu vực  
+
+Danh mục các dự án lưới điện truyền tải quan trọng, ưu tiên đầu tư, lưới điện liên kết với các nước láng giềng nêu tại Phụ lục II.2.  
+
+Khối lượng “lưới điện dự phòng phát sinh các đường dây và trạm biến áp” có trong Phụ lục Phụ lục II.2 được phép sử dụng để:  
+
+(i) Triển khai các dự án lưới điện truyền tải xây dựng mới hoặc các công trình đầu tư bổ sung mới để nâng cao năng lực lưới điện truyền tải, khả năng điều khiển và vận hành hệ thống điện trong quá trình thực hiện Điều chỉnh Quy hoạch điện VIII, nhưng chưa có danh mục cụ thể tại Quyết định số 768/QĐ-TTg ngày 15 tháng 4 năm 2025.  
+
+(ii) Đấu nối đồng bộ các dự án nguồn điện nhập khẩu (từ Lào, Trung Quốc, Campuchia...) vào hệ thống điện Việt Nam.  
+
+(iii) Đấu nối đồng bộ hoặc điều chỉnh đấu nối các dự án nguồn điện năng lượng tái tạo (điện gió trên bờ và gần bờ, điện mặt trời, điện sinh khối, điện sản xuất từ rác...) trong Điều chỉnh Quy hoạch điện VIII với hệ thống điện quốc gia.  
+
+Bộ Công Thương xem xét, báo cáo Thủ tướng Chính phủ chấp thuận chủ trương triển khai các dự án cụ thể.  
+
+# 4. Chương trình phát triển điện nông thôn, miền núi và hải đảo  
+
+(i) Cấp điện lưới quốc gia hoặc các nguồn điện năng lượng tái tạo khoảng 911.400 hộ dân (trong đó, khoảng 160.000 hộ dân chưa có điện, 751.400 hộ dân cần cải tạo) của 14.676 thôn bản trên địa bàn $3.099\ \mathrm{x}\tilde{\mathrm{a}}$ , trong đó, số xã khu vực biên giới và đặc biệt khó khăn là 1.075 xã (43 tỉnh) thuộc các tỉnh, thành phố Điện Biên, Lào Cai, Yên Bái, Hà Giang, Bắc Giang, Sơn La, Hòa Bình, Phú Thọ, Tuyên Quang, Thái Nguyên, Thanh Hóa, Hà Tĩnh, Quảng Bình, Quảng Nam, Quảng Ngãi, Kon Tum, Đắk Nông, Đắk Lắk, Bạc Liêu, An Giang, Cần Thơ, Cao Bằng, Lai Châu, Bắc Kạn, Lạng Sơn, Nghệ An, TP. Huế, Bình Định, Phú Yên, Gia Lai, Lâm Đồng, Bình Thuận, Bình Phước, Tây Ninh, Bến Tre, Trà Vinh, Kiên Giang, Sóc Trăng, Long An, Tiền Giang, Vĩnh Long, Đồng Tháp, Hậu Giang, Cà Mau; khu vực còn lại là $2.024\times\tilde{\mathbf{a}}$ ;  
+
+(ii) Cấp điện 2.478 trạm bơm quy mô vừa và nhỏ (13 tỉnh) khu vực đồng bằng sông Cửu Long thuộc các tỉnh, thành phố Bến Tre, Trà Vinh, An Giang, Kiên Giang, Cần Thơ, Bạc Liêu, Sóc Trăng, Long An, Tiền Giang, Vĩnh Long, Đồng Tháp, Hậu Giang, Cà Mau, kết hợp cấp điện cho nhân dân;  
+
+(iii) Cấp điện lưới quốc gia hoặc các nguồn điện năng lượng tái tạo cho các đảo còn lại: Đảo Cồn Cỏ tỉnh Quảng Trị; Đảo Thổ Châu, An Sơn - Nam Du tỉnh Kiên Giang; Huyện đảo Côn Đảo, tỉnh Bà Rịa - Vũng Tàu.  
+
+Danh mục các tỉnh/dự án thành phần trong Chương trình nêu tại Phụ lục IV.  
+
+# 5. Kế hoạch phát triển hệ sinh thái công nghiệp và dịch vụ về năng lượng tái tạo  
+
+Nghiên cứu xây dựng 02 trung tâm công nghiệp, dịch vụ năng lượng tái tạo liên vùng trong giai đoạn tới năm 2030 như sau:  
+
+- Trung tâm công nghiệp, dịch vụ năng lượng tái tạo tại Bắc Bộ.  
+
++ Vị trí: Tại khu vực Hải Phòng, Quảng Ninh, Thái Bình, ... Trong tương lai có thể xem xét mở rộng ra các khu vực lân cận.  
+
+$+$ Các nhà máy chế tạo thiết bị phục vụ phát triển năng lượng tái tạo, dịch vụ cảng biển, hậu cần phục vụ xây lắp, vận hành, bảo trì, bảo dưỡng.  
+
+$+$ Các khu công nghiệp xanh, phát thải các bon thấp. $+$ Các cơ sở nghiên cứu, đào tạo.  
+
+- Trung tâm công nghiệp, dịch vụ năng lượng tái tạo liên vùng Nam Trung Bộ - Nam Bộ.  
+
++ Vị trí: Tại khu vực Ninh Thuận, Bình Thuận, Bà Rịa - Vũng Tàu, TP. Hồ Chí Minh, ... Trong tương lai có thể xem xét mở rộng ra các khu vực lân cận.  
+
++ Các nhà máy chế tạo thiết bị phục vụ phát triển năng lượng tái tạo, dịch vụ cảng biển, hậu cần phục vụ xây lắp, vận hành, bảo trì, bảo dưỡng. $+$ Các khu công nghiệp xanh, phát thải các bon thấp. $+$ Các cơ sở nghiên cứu, đào tạo.  
+
+6. Danh mục các đề án/dự án ưu tiên về hoàn thiện chính sách pháp luật và tăng cường năng lực của ngành điện  
+
+Danh mục các đề án/dự án ưu tiên về hoàn thiện chính sách pháp luật và tăng cường năng lực của ngành điện tại các Bảng 1, 2, 3 Phụ lục I.  
+
+# 7. Nhu cầu sử dụng đất tới năm 2030  
+
+Nhu cầu đất cho phát triển cơ sở và kết cấu hạ tầng điện lực khoảng 89,9 - 93,36 nghìn ha trong giai đoạn 2021 - 2030 phù hợp với chỉ tiêu phân bổ đất đai trong Nghị quyết số 39/2021/QH15 ngày 13 tháng 11 năm 2021 của Quốc hội.  
+
+# 8. Nhu cầu vốn đầu tư tới năm 2030  
+
+# - Giai đoạn 2025-2030:  
+
++ Vốn đầu tư nguồn điện là: 2.876.397 nghìn tỷ VNĐ (118,2 tỷ USD), trong đó nhà nước đầu tư là 666.779 nghìn tỷ VNĐ (27,4 tỷ USD), xem xét xã hội hóa là 2.209.618 nghìn tỷ VNĐ (90,8 tỷ USD).  
+
++ Vốn đầu tư lưới truyền tải là 440.464 nghìn tỷ VNĐ (18,1 tỷ USD), trong đó nhà nước đầu tư là 313.922 nghìn tỷ VNĐ (12,9 tỷ USD), xem xét xã hội hóa là 126.542 nghìn tỷ VNĐ (5,2 tỷ USD).  
+
+# - Giai đoạn 2031-2035:  
+
++ Vốn đầu tư nguồn điện là 2.776.624 nghìn tỷ VNĐ (114,1 tỷ USD), trong đó nhà nước đầu tư là 644.878 nghìn tỷ VNĐ (26,5 tỷ USD), xem xét xã hội hóa là 2.131.746 nghìn tỷ VNĐ (87,6 tỷ USD).  
+
++ Vốn đầu tư lưới truyền tải là 386.927 nghìn tỷ VNĐ (15,9 tỷ USD), trong đó nhà nước đầu tư là 289.587 nghìn tỷ VNĐ (11,9 tỷ USD), xem xét xã hội hóa là 97.340 nghìn tỷ VNĐ (4,0 tỷ USD).  
+
+Ghi chú: Tỷ giá áp dụng: 24.355 VND/USD ngày 31/12/2024.  
+
+9. Giải pháp, nguồn lực thực hiện quy hoạch  
+
+Các giải pháp thực hiện quy hoạch bao gồm 11 nhóm nhiệm vụ, giải pháp cụ thể theo Phần VI, Điều 1 của Quyết định số 768/QĐ-TTg ngày 15 tháng 4 năm 2025 của Thủ tướng Chính phủ.  
+
+# III. TỔ CHỨC THỰC HIỆN  
+
+# 1. Bộ Tài chính  
+
+- Phối hợp với Bộ Công Thương xây dựng các chính sách về giá điện theo cơ chế thị trường.  
+
+- Phối hợp với Bộ Công Thương nghiên cứu, xây dựng và ban hành hoặc trình các cấp có thẩm quyền ban hành các cơ chế tài chính, cơ chế giá điện, cơ chế khuyến khích để hỗ trợ thực hiện.  
+
+# 2. Các bộ, ngành  
+
+Thực hiện đầy đủ chức năng, nhiệm vụ, quyền hạn để triển khai đúng tiến độ các dự án trong Điều chỉnh Quy hoạch điện VIII; đề xuất cơ chế, chính sách, các giải pháp tháo gỡ vướng mắc để thực hiện hiệu quả các mục tiêu của quy hoạch, đảm bảo thống nhất, đồng bộ với việc thực hiện các mục tiêu phát triển kinh tế - xã hội của từng ngành và địa phương.  
+
+# 3. Ủy ban nhân dân các tỉnh, thành phố trực thuộc Trung ương  
+
+- Chỉ đạo các sở, ngành liên quan cập nhật danh mục nguồn và lưới điện được xác định trong quy hoạch này vào quy hoạch tỉnh và các quy hoạch có tính kỹ thuật, chuyên ngành như quy hoạch xây dựng, quy hoạch đô thị, quy hoạch nông thôn, quy hoạch sử dụng đất cấp tỉnh, cấp huyện để tổ chức không gian làm cơ sở thực hiện đầu tư xây dựng các dự án điện.  
+
+- Rà soát, điều chỉnh cập nhật trong quy hoạch tỉnh, kế hoạch thực hiện quy hoạch tỉnh theo các quy định của pháp luật về quy hoạch, điện lực (nếu có mâu thuẫn với quy hoạch này), trong đó xác định rõ phạm vi nguồn điện, lưới điện trong phương án cấp điện đã được quy định tại Điều 4 và khoản 1 Điều 24 Nghị định số 56/2025/NĐ-CP ngày 03/3/2025 của Chính phủ Quy định chi tiết một số điều của Luật điện lực về quy hoạch phát triển điện lực, phương án phát triển mạng lưới cấp điện, đầu tư xây dựng dự án điện lực và đấu thầu lựa chọn nhà đầu tư dự án kinh doanh điện lực, đảm bảo phù hợp với nội dung, quy mô phân bổ công suất tăng thêm cho các địa phương trong quy hoạch điện VIII và Điều chỉnh Quy hoạch điện VIII.  
+
+- Tổ chức thực hiện việc lựa chọn chủ đầu tư các dự án điện theo thẩm quyền, bố trí quỹ đất cho phát triển các công trình điện theo quy định của pháp luật; chủ trì, phối hợp chặt chẽ với các chủ đầu tư thực hiện việc giải phóng mặt bằng, bồi thường, di dân, tái định cư cho các dự án nguồn điện, lưới điện theo quy định.  
+
+- Chỉ đạo, giám sát chủ đầu tư thực hiện đúng tiến độ các dự án nguồn và lưới điện trên địa bàn, bảo đảm đưa dự án vào vận hành đúng tiến độ theo quy hoạch.  
+
+- Phối hợp với Bộ Công Thương và các bộ, cơ quan liên quan tổ chức thực hiện $\mathrm{K}\hat{\mathrm{e}}$ hoạch thực hiện Quy hoạch điện VIII điều chỉnh theo chức năng, thẩm quyền.  
+
+# 4. Cục Điện lực  
+
+- Thường xuyên kiểm tra, giám sát tình hình triển khai các dự án nguồn, lưới điện để đề xuất giải pháp, bảo đảm tiến độ theo Điều chỉnh quy hoạch điện VIII được duyệt, xử lý theo thẩm quyền và quy định đối với các dự án chậm tiến độ.  
+
+- Tổ chức đánh giá thực hiện quy hoạch theo quy định của Luật Quy hoạch.  
+
+# 5. Vụ Dầu khí và Than  
+
+- Thường xuyên theo dõi, cập nhật tình hình cấp nhiên liệu (than, khí) cho sản xuất điện; trường hợp có vấn đề phát sinh, ảnh hưởng đến việc cấp nhiên liệu cho các nhà máy điện, kịp thời báo cáo Lãnh đạo Bộ Công Thương để xem xét, chỉ đạo.  
+
+- Giám sát, đôn đốc việc đảm bảo tiến độ các công trình hạ tầng tiếp nhận, cung cấp khí cho sản xuất điện (bao gồm cả LNG), dự án kho cảng LNG và ưu tiên đảm bảo nhiên liệu cho các nhà máy nhiệt điện.  
+
+# 6. Cục Đổi mới sáng tạo, Chuyển đổi xanh và Khuyến công  
+
+- Chủ trì, phối hợp với Cục Điện lực và Tập đoàn Điện lực Việt Nam tăng cường công tác tuyên truyền tiết kiệm điện và lợi ích của việc thực hiện Chương trình quốc gia về sử dụng năng lượng tiết kiệm và hiệu quả, Chương trình quốc gia về quản lý nhu cầu điện và các Chương trình Điều chỉnh phụ tải điện trong phạm vi cả nước.  
+
+- Chủ trì xây dựng trình Quốc hội thông qua Luật Sử dụng năng lượng tiết kiệm và hiệu quả (sửa đổi) để tạo sự chuyển biến mạnh mẽ trong việc giảm cường độ sử dụng năng lượng của nền kinh tế, ban hành chế tài và các tiêu chuẩn, quy chuẩn bắt buộc về sử dụng hiệu quả năng lượng, góp phần đổi mới mô hình tăng trưởng của nền kinh tế.  
+
+- Nghiên cứu áp dụng các tiêu chuẩn, quy chuẩn bắt buộc kèm theo chế tài về sử dụng điện hiệu quả đối với những lĩnh vực, ngành có mức tiêu thụ điện cao.  
+
+# 7. Tập đoàn Điện lực Việt Nam  
+
+- Giữ vai trò chính trong việc đảm bảo cung cấp điện ổn định, an toàn cho phát triển kinh tế - xã hội. Thực hiện đầu tư các dự án nguồn điện và lưới điện truyền tải theo nhiệm vụ được giao.  
+
+- Thường xuyên rà soát, đánh giá cân đối cung - cầu điện, tình trạng vận hành hệ thống điện toàn quốc và khu vực, báo cáo các cấp có thẩm quyền.  
+
+- Thực hiện triệt để các giải pháp đổi mới quản trị doanh nghiệp, nâng cao hiệu quả sản xuất kinh doanh, tăng năng suất lao động, giảm tổn thất điện năng, tiết kiệm chi phí, giảm giá thành.  
+
+- Chủ động phối hợp địa phương thực hiện cập nhật các dự án công trình điện được giao làm chủ đầu tư vào quy hoạch, $\mathrm{k}\hat{\mathrm{e}}$ hoạch thực hiện quy hoạch phát cấp tỉnh, quy hoạch sử dụng đất cấp tỉnh, cấp huyện.  
+
+- Tập trung triển khai nhanh, quyết liệt các dự án nguồn và lưới điện được giao làm chủ đầu tư, đặc biệt là các dự án lưới điện phục vụ nhập khẩu điện từ Lào về Việt Nam và lưới điện giải toả công suất các nguồn điện, bảo đảm tiến độ theo quy hoạch được duyệt. Phối hợp chặt chế với các bộ, ngành, địa phương để tháo gỡ khó khăn trong giải phóng mặt bằng, đấu nối, đầu tư nguồn và lưới điện. Tập đoàn Điện lực Việt Nam chịu trách nhiệm chính nếu các dự án trên chậm tiến độ, không đảm bảo an ninh cung cấp điện.  
+
+- Tích cực phối hợp với các địa phương, tập trung mọi nguồn lực, đẩy nhanh tiến độ các dự án theo Thông báo số 93/TB-VPCP ngày 10  tháng 3 năm 2025 của Văn phòng Chính phủ và các dự án thuộc chương trình, công trình dự án quan trọng quốc gia trọng điểm ngành năng lượng ban hành kèm theo Quyết định số 270/QĐ-TTg ngày 02 tháng 4 năm 2024 của Thủ tướng Chính phủ, đảm bảo tiến độ được duyệt theo quy định; kịp thời đề xuất cấp có thẩm quyền xem xét tháo gỡ các khó khăn, vướng mắc về pháp lý trong triển khai dự án (nếu có).  
+
+- Chủ động, tích cực hơn nữa trong việc đầu mối phát triển các dự án điện gió, điện gió ngoài khơi, điện khí và các loại hình nguồn điện khác khi có điều kiện, cơ hội.  
+
+# 8. Tập đoàn Công nghiệp - Năng lượng Quốc gia Việt Nam  
+
+- Tăng cường tìm kiếm, thăm dò và khai thác các nguồn khí trong nước để cung cấp cho phát điện, phù hợp với nhu cầu phụ tải điện. Triển khai nhanh, có hiệu quả các mỏ khí Lô B, Cá Voi Xanh, Kèn Bầu... theo tiến độ được duyệt.  
+
+- Thực hiện các giải pháp xây dựng cơ sở hạ tầng kho, cảng, kết nối hệ thống khí trong nước và khu vực phục vụ nhập khẩu khí thiên nhiên và LNG để đảm bảo nguồn khí cho các nhà máy điện.  
+
+- Thực hiện đúng tiến độ các dự án nguồn điện được giao.  
+
+- Chủ động, tích cực hơn nữa trong việc đầu mối phát triển các dự án điện gió, điện gió ngoài khơi, điện khí và các loại hình nguồn điện khác khi có điều kiện, cơ hội.  
+
+# 9. Tập đoàn Công nghiệp Than - Khoáng sản Việt Nam, Tổng công ty Đông Bắc  
+
+- Giữ vai trò chính trong việc đảm bảo cung cấp than cho sản xuất điện phù hợp với lộ trình chuyển dịch năng lượng. Trước mắt nâng cao năng lực sản xuất than trong nước, kết hợp với nhập khẩu than để cung cấp nhiên liệu cho các nhà máy điện.  
+
+- Đầu tư các dự án nguồn điện theo nhiệm vụ được giao.  
+
+# Phụ lục I DANH MỤC CÁC ĐỀ ÁN/DỰ ÁN ƯU TIÊN VỀ HOÀN THIỆN CHÍNH SÁCH PHÁP LUẬT VÀ TĂNG CƯỜNG NĂNG LỰC CỦA NGÀNH ĐIỆN  
+
+(Kèm theo Kế hoạch tại Quyết định số 1509/QĐ-BCT ngày 30 tháng 5 năm 2025 của Bộ Công Thương)  
+
+Bảng 1: Các Đề án/dự án xây dựng và hoàn thiện chính sách, pháp luật   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/39ad4bfefe293d3801265ecaa7ed117afaf2f3ec47737b1af88d3550e4406437.jpg)  
+
+Bảng 2: Các Đề án/dự án tăng cường năng lực khoa học công nghệ, xây dựng trung tâm nghiên cứu cơ bản, trung tâm phát triển   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d8981414e5e5016004b648821c48b2cd6090e46484e95a23bc0e4ea70fb3aac3.jpg)  
+
+Bảng 3: Các Đề án/dự án đào tạo và nâng cao chất lượng nguồn nhân lực   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/f0a8cc3deb49836a277cec8ddf229d134180ec2411132c1f9d727e516a63b7a3.jpg)  
+
+# Phụ lục II DANH MỤC VÀ TIẾN ĐỘ DỰ KIẾN CÁC DỰ ÁN NGUỒN, LƯỚI ĐIỆN QUAN TRỌNG QUỐC GIA, DỰ ÁN ƯU TIÊN CỦA NGÀNH ĐIỆN  
+
+# Phụ lục II.1 DANH MỤC VÀ TIẾN ĐỘ DỰ KIẾN CÁC DỰ ÁN NGUỒN ĐIỆN QUAN TRỌNG QUỐC GIA, DỰ ÁN ƯU TIÊN CỦA NGÀNH  
+
+Bảng 1: Danh mục các nhà máy nhiệt điện LNG  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/4080f77b5b44c316bc7a4b9db7dd4a424bc20779b15b15e5f2b8a4a1adf9dff9.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d090cb1f10f9187a5701b9623105bf91561515ab1486737ffbded6cb366769cc.jpg)  
+Ghi chú:  
+
+- Công suất đặt của các nhà máy điện có thể dao động trong phạm $\mathrm{vi}\pm15\%$ và sẽ được chuẩn xác, phù hợp với gam công suất của tổ máy trong $\mathrm{K}\hat{\mathrm{e}}$ hoạch thực hiện quy hoạch, giai đoạn chuẩn bị và thực hiện dự án đầu tư xây dựng.  
+
+(\*): Các dự án cần có giải pháp để bảo đảm tiến độ vận hành theo quy hoạch được duyệt.   
+$(^{**})$ : Các dự án phát triển mới giai đoạn 2031-2035 phục vụ cấp điện khu vực miền Bắc.  
+
+# Bảng 2: Danh mục các nhà máy nhiệt điện LNG dự phòng phát triển  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/9dee52538ae7889295c17b339ff7b99de6d3e4451200b40374535633a56d6e98.jpg)  
+
+Bảng 3: Danh mục các nhà máy nhiệt điện than đang xây dựng   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/25f8eab0352efc3596f6b631d2bd7abd209931c32cdc1680e90bc6a912879f4d.jpg)  
+
+Bảng 4: Danh mục các nhà máy nhiệt điện than đang gặp khó khăn trong triển khai   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/85a8afd8971b353a66f7988c6c08d0200b7f85f0238f208cc2b7a682f74a6b36.jpg)  
+
+Bảng 5: Danh mục nguồn điện đồng phát, nguồn điện sử dụng nhiệt dư, khí lò cao, sản phẩm phụ của dây chuyền công nghệ trong các cơ sở công nghiệp   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e769a67370fc51a971ecbddb7e7c51e912b2a15a2cfea694dce465e506dbb203.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/df9bb0b07dc138b098b0b9398ef4f78b3464fb091e4bce437ed9d8a884c16abb.jpg)  
+
+# Bảng 6: Danh mục các nhà máy nhiệt điện khí trong nước  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6c11cb2210f3bc14d2533ae8d6c379be2d05691b71b5c389897f5f6228c5c333.jpg)  
+Ghi chú: - Công suất đặt của các nhà máy điện có thể dao động trong phạm $\mathrm{vi}\pm15\%$ và sẽ được chuẩn xác, phù hợp với gam công suất của tổ máy trong $\mathrm{K}\hat{\mathrm{e}}$ hoạch thực hiện quy hoạch, giai đoạn chuẩn bị và thực hiện dự án đầu tư xây dựng.  
+
+$(^{*})$ Nhà máy điện hiện có chuyển sang sử dụng khí Lô B.  
+
+# Bảng 7: Danh mục các nguồn thủy điện lớn  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/f56f5c1a8c6233e85b724274263d190812e9ef0e9284356b9070a96e8785291e.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6d4620ef9fc8f79e520c7b55658650463b774f172a035cba0631c40271eedb51.jpg)  
+Ghi chú: $(^{*})$ Các dự án tiềm năng đã được phê duyệt theo Quyết định số 500/QĐ-TTg, cần được xem xét, đánh giá kỹ các tác động về môi trường, đất đai và ảnh hưởng đến rừng của dự án.  
+
+Bảng 8: Danh mục các thủy điện có công suất dưới 50 MW đấu nối ở cấp điện áp ${\bf220\V V}$ trở lên   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e1fb37b098dd9113cae7a2759d326c32dc8749886cff17123149c4e6fbbff200.jpg)  
+
+# Bảng 9: Danh mục các thủy điện tích năng  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/acebe020031e3a58f1358a21459ca590e6a42bb5736e599e51585af64de1c296.jpg)  
+Ghi chú: $(^{*})$ Các dự án được xác định trên cơ sở xét theo thứ tự ưu tiên đối với danh mục đề xuất của các địa phương. Có thể xem xét phát triển với quy mô lớn hơn tuỳ thuộc vào nhu cầu của hệ thống điện. $(^{**})$ : Tổng quy mô dự án là $1.200\;\mathrm{MW}$ .  
+
+# Bảng 10: Danh mục dự kiến các nguồn điện hạt nhân (MW)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/da93dfbb1ca9c14992805c0ceceec97cd80dd4bc70d33f84543d5f8550851663.jpg)  
+
+# Bảng 11: Danh mục dự kiến các dự án pin lưu trữ (MW)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/049a4c598e8d55760bce23a3440d5270bf89f97bdbe86a368ef3b89190c02fc3.jpg)  
+
+# Bảng 12: Danh mục dự kiến các dự án điện gió trên bờ và gần bờ đã được phê duyệt trong Quy hoạch điện VIII, $\mathbf{K}\hat{\mathbf{e}}$ hoạch thực hiện Quy hoạch điện VIII  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c9597e005d11865276649e6bdeaf5d3ba23030ab1ee67eea479d4f27f10208b0.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/12eb83bc9927c54ad415e03632d23e6767dcba1602ea1dce6c23e0c4be1e58e1.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/226d253314783337204053dc670bf3807120aee6579291c9ef9c9c8e0afad2e3.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/08d40e6678d2dcd1905c079bd744c2420109153a6ab8a32b202666056b578af3.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d2db538830112b5a0153c98c9c67eb7bf294b426f6259710174c0ed640cd9037.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5a726f5fef5622990c2be23e0201762914b9d1128623547678c86bdf4e3d57fa.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/1a86aa6c42ead9664061fc9492acafc8c83c2021514d8835d22fea1a6313e067.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e3506e343e59e5aa4594b4d1fab6abe679cf8a29a47bf61b7d2f5315de20ab2b.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d0515b69052e7639b0c1ae3d9a81801f751d2e82247d6b58ce4ced88878bd3c1.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6bbdd93d48ebb08027df37c7ee736f34e654fd95ced460f533db0f7cd73f4740.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6dcf24211cc5fd43ecced8b34c5951121f5074329d2ebca300f58b127e241d13.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/05a5fb2618a1f14673e46fbec7e8dff4397809c238f0ac78a855bf277bacff6a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a52e591045915300aa8b4aef15ae31d3c9fd88f7165c5b3cb184e2d302f871c6.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a74b36a3587c172c05bac7fae32305f38608e164e95cdd820f659907a1daf8c7.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/12bb877ab73043ceff93e4635940910c58ebaff907a720358e5b083e836ae9b0.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/000199d0a2599f7345e36647232c96c36dbb275e8318f2cfe567e390739fa29b.jpg)  
+Ghi chú: -Tiến độ vận hành lưới điện đấu nối đồng bộ với tiến độ nguồn điện.  
+
+# Bảng 13: Danh mục các dự án điện gió trên bờ, gần bờ được phân bổ thêm cho các địa phương theo từng giai đoạn  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/471cec28a202a2082113ed0166963a073f8f1316231d6a0309734e3d13f759a0.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a34a9e5f4e0e26d30ecee64604933727390048100992bd378f91e1b915763739.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/4e243800cc9c7e415d6aec87e5d25ebc0b9045c5c51e3c5dd3e3f26595b1cd78.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d367859fc3b59bcef88ed58f7ed006f4a80550869f4a337ba710c591f89f4eb6.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/8cb20c7c1b9fc8d1e75a7bf135553fc6fd11b73b9271e3e27551cdd866dc9a3f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/1df83802de83b9425242ef29504d7734b4f525fff50acf83a4d61a714fba2020.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/4ec07380266550384d6d5bd0c2f53d1531e2b7bcfe6aa2f4a805a2681897aa4a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/b87bc88695cc4da777593c24c572baeaa1880bf6f0e3c330b5a568bf7bfc94c3.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5fe483bc7505057fcf8659584942a24afa478217da9b9d7da6a065f17eb56ca9.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/8252804a4c93326199bb94ecd463e64cf50bf86d066d12a10e7d3388e68c66c8.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/71940c63b363d5a906a88e148464e3b2eacd7e5e47f739c734f74656cb500bef.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/391c5a2e06f5f0d9998c5bc634ceee0c9d94e62805d5becbe492bb9842ae0f01.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5ef5fae73ad02ef07d7e700826269a661e463ea31b9067e8f5fe8cc26d623d17.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/1b413d28e5b180bad7ab4ba3ccc4f5d15fdb777b3622e5a519722b3c798f0fa5.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5e3dbf316fe65091927a7cc8716495e7e299d4a415a16202bfb68756740d96ff.jpg)  
+Ghi chú: -Tiến độ vận hành lưới điện đấu nối đồng bộ với tiến độ nguồn điện.  
+
+Bảng 14: Danh mục các dự án điện mặt trời tập trung   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/70b3d339afd432441c62953250a6b6f4e91d3e58a130ff6e3d692c4c12a92837.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/2630a8a6e386b2b240dcd5bb03d98635abee5e097d9b6ef865cf77eda374adbc.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/316f562cb1ad948a7d8da9207f19c5403941d2aa59ad81ffed80c575d20777bc.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a9262164e6c213f2809907ff5847e5f7dbfd19f8006a634191ac64ba9e2d0ad8.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d398464812359ad732f338010b138a6dd645234b32eb1dd17ba3b3ef97a285ea.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c0b51e63327692abafd39547c4f5cee2188b790538d5e7e14867c4a6857b0f45.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/66db756abb383faffe44cdb8fb8341b02b7566d1e3620f3fa226ad2877e17a36.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/b71158ba8394f9891b9d4f21bf617831f7b5b7c97f34603e99e7bf79dddbea0b.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/3363bbe211bd4bb0c7867ce9c5ba69c8b22c4aaa135a922c3ecc80dbcfa96ead.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/06745423175270943a968e53ec7efb3d4035f4939ea89ca84b32a8d4e7219415.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/7d7d6d0e59d709ab38f861f46f30002e359fa1485d313ffa04717f47264fa101.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/487edfde8ea173aff82a8afe53eb58111b4ee21883ca7bd381572c27d5895d6e.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/9812da9ec7ff94547df5ccc853405ef9940a10c05e35f473067fda60844741c6.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/ac15eed0d5fe1c30d712899e68d4cc2caa62602afef03653d8493b6b7bb6a5bf.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/639034e1daaab467e8e109dde0cb835f54a1b094ce2b27b7d2f842530b3bc460.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/086cc8acac18c35af482169c1c4cf5abe62b7bcccad9d6c05bfe0fae1e01976b.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/2147a07ffb76ba560589fc92c7f9adf3b7e90b6035080a6428036cd00a3b499f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/dbff41737eb62dd9455f9c2c1d52af977c23e38a6415eb08aad6140bb937e11f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d8ef0481e23602cd0f4a69d51705553a6be410968d6648a136624ebc83ec27c9.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e84e8ee7b648906f903ad8f33a7cccb072134a4d83d1d9df60b2c040b067b675.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/ea0c6cf25d8029f35b1db7bc3efc909e0f8b8f5044be52e880456df9d0656914.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/4d5caf3d77416632bba69f6202e9beac0444a343330bf944c9fac8b31bb8becf.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/f3ff345b16939933e5bb0f7da395d784f98177f6dff91046cc15e3484acb7009.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/aed2675c26f085c9995758b4cecc42e7c308d436281ba66db86eae5fdd9b6f1a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e9f37c21fc9f90ffdad2028fdff353e77a25eaaf61528d3eafb1f6e7db7dcaa6.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/2e524f02babc1582325dc5c97533bf101b2fe5556373977d9db032f77347554b.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/b4ccd2c20abb81a39490cf944156c3c4a357385b2d98aa0543e0ecc98cb8627a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/8b7e398b77c39fe02469cba850a7c4028450eb621e907e6b3958b79238b1f68e.jpg)  
+Ghi chú: -Tiến độ vận hành lưới điện đấu nối đồng bộ với tiến độ nguồn điện.  
+
+# Bảng 15: Danh mục các dự án điện sinh khối có công suất từ 50 MW trở lên và dự án có công suất nhỏ hơn 50 MW đấu nối ở cấp điện áp ${\bf220\V V}$ trở lên  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/8c08054b8ac2e97281594110055c9ca4645733b50f82e8bddf6ad29317003a61.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/9c2b3abdd3637cb366ecc1c72b3af13bdd42dca1f3f808a7fb2d2a8cc83012ab.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d6abc21a33bbf26bae6c578bb504de9ee73551e076a6606fc0cfa6a53cb3c365.jpg)  
+Ghi chú: -Tiến độ vận hành lưới điện đấu nối đồng bộ với tiến độ nguồn điện.  
+
+# Bảng 16: Danh mục các dự án điện sản xuất từ rác có công suất từ 50 MW trở lên và dự án có công suất nhỏ hơn 50 MW đấu nối ở cấp điện áp ${\bf220\V V}$ trở lên  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/031c7b9bf914565071b95b458c5b00700ce53e601efb7f7bd9cc9905e39e7d77.jpg)  
+Ghi chú: -Tiến độ vận hành lưới điện đấu nối đồng bộ với tiến độ nguồn điện.  
+
+# Bảng 17: Danh mục các dự án điện gió ngoài khơi đến năm 2030  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/162ac4e416d046a69980b72023f9034e9a04d822f85aef1c2199bad043ae0986.jpg)  
+- Các dự án cần có giải pháp để bảo đảm tiến độ vận hành theo quy hoạch được duyệt. Việc xác định tọa độ vị trí các dự án ĐGNK tuân thủ các quy định của pháp luật và được xác định $\mathring\upsigma$ giai đoạn chuẩn bị dự án, bảo đảm không chồng lấn với các quy hoạch khác.  
+
+(\*) Dự án điều chuyển từ khu vực Trung Trung Bộ sang Nam Bộ.  
+
+Bảng 18: Danh mục các dự án điện gió ngoài khơi đến năm 2035 (MW)   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6724e7afcc14a68a0adc735ab1d66580c5e09a4d31febec5ad598abd9fd70d17.jpg)  
+Ghi chú: - Việc xác định tọa $\hat{\mathrm{d}}\hat{\mathrm{0}}$ vị trí các dự án ĐGNK tuân thủ các quy định của pháp luật và được xác định ở giai đoạn chuẩn bị dự án, bảo đảm không chồng lấn với các quy hoạch khác. $(^{*})$ Các dự án đã xác định giai đoạn đến năm 2030 tại Bảng 18.  
+
+# Bảng 19: Danh mục dự kiến các dự án nhiệt điện linh hoạt  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/bc6b1fe1ca59cde82eaf89104ae26c16f1853260e7cdb018027547aa40b8eee9.jpg)  
+Ghi chú: (\*) Danh mục dự kiến các dự án nhiệt điện linh hoạt tăng thêm sẽ được làm rõ theo quy định của pháp luật. - Nhiên liệu sử dụng cho các dự án nhiệt điện linh hoạt sẽ chuẩn xác trong giai đoạn chuẩn bị dự án.  
+
+# Bảng 20: Các dự án tiềm năng xuất khẩu điện  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/476b4c04795269a690a86d81f222bcf7af601c21a26bdedc201088f8ba56cece.jpg)  
+
+Ghi chú: Các dự án xuất khẩu điện được phép phát triển trên cơ sở đảm bảo an ninh năng lượng, an ninh quốc phòng và các điều kiện kinh tế, kỹ thuật.  
+
+# Phụ lục II.2 DANH MỤC LƯỚI ĐIỆN TRUYỀN TẢI CẢI TẠO VÀ XÂY DỰNG MỚI ƯU TIÊN ĐẦU TƯ ĐẾN NĂM 2030 VÀ ĐỊNH HƯỚNG NĂM 2035  
+
+Bảng 1: Danh mục các công trình UHVDC giai đoạn 2031-2035   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/1950604bed09cd62075e1b7f98a8e619da0c00c8681f3db410feb77c3be26a0a.jpg)  
+
+Ghi chú:   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/da45d1a81c2772725f0774efce5bc43e96f3b18ebd9ae16e6b225fa986fef772.jpg)  
+
+Các hệ thống HVDC truyền tải liên vùng, khoảng cách truyền tải lớn ( $\operatorname{g}\!{\dot{\operatorname{om}}}$ các đường dây HVDC và các trạm chuyển đổi converter AC-DC, DC-AC) có chi phí đầu tư rất lớn. Cần nghiên cứu kỹ, đánh giá tổng thể khi triển khai thực hiện các hệ thống này căn cứ tiến độ triển khai các dự án nguồn điện (bao gồm nguồn điện nền và nguồn NLTT), gắn với tín hiệu thị trường và cơ chế chính sách.  
+
+Bảng 2: Định hướng các đường dây và trạm biến áp UHVAC $765{\div}1000\,\,\mathbf{k}\mathbf{V}$ giai đoạn 2031-2035   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/ad5c391ce461d11c7691f813cf1011e11d513e4e772af0534ce9446792bd313d.jpg)  
+Ghi chú: Sự xuất hiện của hệ thống truyền tải cực siêu cao UHVAC $765{-}1000\,\mathrm{kV}$ kết nối Nam Trung Bộ - Nam Bộ trong bảng trên gắn với quy mô phát triển nguồn điện tại Nam Trung Bộ (ĐHN Ninh Thuận 3,4, điện mặt trời, điện gió trên bờ, điện gió ngoài khơi), cần có thêm các nghiên cứu về tính khả thi và hiệu quả kinh tế - kỹ thuật tổng thể.  
+
+# Bảng 3: Danh mục các trạm biến áp $500\,\mathrm{kV}$ xây mới và cải tạo khu vực miền Bắc  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/982e8625b7ef226a58aea2dcc0cbc8cb2f742a047c2a44c5482f2c3032eea691.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/918311ca86747cf5621ac0f7e153f4d0def8996d9129db7efe5ae50190440c3f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c4abd70ad81d3ef5ac290b300ee97ea52a4424e07144c221d34c57a6712ad85e.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/57969df2dcb547cd2bbc2c6e503b49929dcd1d58a424a03cd2defdf782cfb614.jpg)  
+
+Bảng 4: Danh mục các đường dây $500~\mathrm{kV}$ xây mới và cải tạo khu vực miền Bắc   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/4a3af3e0f794626b8e3e18b6aab8ff59c88c95a2a436fc224398a6a47934c537.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/590cdea9f954a6e83a50c561a4ec02640fa1e31a3e746db93c0e33fc3b9bdb9a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/f4ec64a1234a6d5f0e207c881a2e05c1cead99772ac64bc5600773a7ded78f46.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/0d9d55977d36b04ac2793327fda646c7ccdd583fd11e15f326ff9ead56346c10.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/9e0deb1af52e6c4991dfbc227d61e86f54cf270fa11a9819589ecc135eba1ac0.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/84dbb534fc6b5da79121ce048076ffddfe3026a26af3ac624484910b380e4873.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5f7658f5d054caeede957bf53fa6502b36ea5dd5df6464b56d929a627bca62d9.jpg)  
+
+# Bảng 5: Danh mục các trạm biến áp ${\bf220\V V}$ và cải tạo khu vực miền Bắc  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/ade4681dbfc9ff34ead722f739f481cdf3203eba7e2a3d68c39d4a7ec3fcbbb7.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/ccbf258e1f917405e752178496ef2bb42e50511a814c343f303240324083c1f2.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a0891663fe2b63ac11a6bd345a0e42aa3303f9b0b01f36e0c20c0008fb345dbb.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/17433bb1e595e0d020bd1a2a0b0b01067429d0308d7c5fc3922e6b88b7f1db1f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a95db3a79822860245f75f108f115b59fa5e1b8c285b1bba53dcc812545eb40e.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/0bfd038524c7a14cdf241fada84f2b61ff846298886e53baff62c07af440c3c3.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/0d14173a558e9c6ff3a52a9e22bcf57140f32efcba9511a694702416cb433678.jpg)  
+
+Bảng 6: Danh mục các đường dây ${\bf220\V V}$ xây mới và cải tạo khu vực miền Bắc   
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/2bde23ae4faebacf35b3ca636d86c21f80c9a5d94962bad2e0d401aaa8350b7f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a301d1aa769715a1876f2c6eabd1f01d3c6c312c36e9867d35a48fbcb00f8ca0.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d68ff7e99bcf3a708ad2d77155ac4ec8f6b0551c28c427450ee94e3612430d03.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/b2c4c8ee46ada434b9a79d0ea6eeb49acbee3175fd03413fc4b3f35c7373d044.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/fed4b2f211362755781146fe5eb3c32fa99f3c19f7b9c85c89ec0994845509a7.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/caf95e4c8bfc8dd7a54ff309b0d04b9210e82d3e1fe1c1d522abdeefcb98a20b.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/74db22a6a3cd42c33b072ab27b32d162d1c861f17e142517f3575c9d217ad5af.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/570df64bdd0db39506f9e627aaffbb5019998bc06396dea7c4084758671bc04d.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/759bf5df856bf7ae6b28c62fd391244f4849711591102ef521ad1b8aff6c4aa4.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/dd0cd8727a039c67468ed013eaded1d1a446d6606116051b629b1f727b7a0a45.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d4d32b23afd12164065d881caf2022dfdb790f73304f948b096762c0962c889d.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/4eaa19d843890fe165089d9b8255a513f318aeae6348113ec82a29caca398b2c.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/bfbc4905a2cad8bce542992c760ae0f63c15a5b389d00822ab0350a26a89f4d0.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e4f645106d0c34ffe9782b9edb1ccb16bf4f2e6e6493fd708ba5cc45ff215224.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/b13b30a7fc9595f74be794663f0c73be0aff9b43510497af8377d07469bd6177.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/aefd87422ee7208406cd91784aff8b68a9e5cfa69e0b01ada87e6c46fc2cdfdc.jpg)  
+
+# Bảng 7: Danh mục các trạm biến áp $500~\mathrm{kV}$ xây mới và cải tạo khu vực miền Trung  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/28c48b7a82683ecdf725f5c6bd9bc7006eb3ce4f07717f5d58f3b0c9a3835c9d.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/0fdd3522f5e6781703dba17cbe8651ea1ed9dc4ff701a85f5b33996df09f3a55.jpg)  
+
+# Bảng 8: Danh mục các đường dây $500~\mathrm{kV}$ và cải tạo khu vực miền Trung  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/ec7cfeed284cafd15e0a152a8f9cfa7a8837f3dd2745bb5ac3e5bbf8cc234905.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/7835b5ebae4e1494d2f65f49d05e0a8450f565f8104dc0c7124f9f6401128da1.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/32778b92d14402720c120d62db21ba274e5076c1ca44101706a0c5c259c5ed58.jpg)  
+
+# Bảng 9: Danh mục các trạm biến áp ${\bf220\V V}$ và cải tạo khu vực miền Trung  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/467c9929c5cba65c3c948eb86e06f45f0903676174da818ff7ef1377abcf560e.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/9ae01c104c3a9c2b87028186697fea96f2bd39fc16f2abce8cba48a16c1df1c9.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/0af515879463051271b47f032c566ab5a09574276fbc6667eda058caf631fcf2.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/37cff74f1ecbf80c7fee1e751e4e5345f31c3a5dd2977f4b1cdacbfcdb7bf348.jpg)  
+
+# Bảng 10: Danh mục các đường dây ${\bf220\V V}$ và cải tạo khu vực miền Trung  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/eb195138fc9fc67ed4e803134bb477d6c816819b785f6a4612b3b28fb778e47a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/cf18b5cbdc829ffc7f35b33a37c6d6bb7d41ecb4f1eea039cfabc6e080e3b045.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c55bb8fc3dea408122857ed1c9bf6d5749efce32508c8fea3e25facf3e57196f.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/b1eeef834f4125f4e26a64910621a886f2dfc1d6fabacb44619094df39d350b4.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/921a6817bd79d5c441bea762af6e011f0f534c759075bd42fb2b73825d4e619b.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d0b2f8b66ad8bc3fef93ddd7e7247989d8865e43486557a004f319fa84631c24.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/85ffba9ab16a2a1dfa85f7a31d58c3b7ce9897f4fafcfe9cb7d4be2db69b7fde.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c55fefec8fa2a1a0f286bb6312632c81816613705cf02f398581cd6ac123e3a3.jpg)  
+
+# Bảng 11: Danh mục các trạm biến áp $500~\mathrm{kV}$ và cải tạo khu vực miền Nam  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/189c893ebb9395a73dd2b454eefbee38584b709e39e2e8d4ca3cc05c0494f16d.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a965cc2d0661129c1c546dd96d001d3e23da2f506f20383ba8aae478260cf767.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d4fc15857c81ce574354b77f7e310f52e78ff3a06680569cf039026169df681f.jpg)  
+
+# Bảng 12: Danh mục các đường dây $500~\mathrm{kV}$ và cải tạo khu vực miền Nam  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/31b057936692b3a748a07b363928f795845db77b6640d1ecf674508fb383bd60.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6eaa39f78a37a9963ffc72533ec9008658f4476e03928edea8dbd40e0fe9e199.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c8bdda9f1990088fe5a5ff2f3a3ff7cda8979fedbc146b16300ce910856e901c.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5f0bc286df15b2eaec251833003f40c431020b153e407ccf41266a9448659492.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/7cdb37ffe20b7696f17833cb364a0d0798e7e7787c49222f5a193d136873b335.jpg)  
+
+# Bảng 13: Danh mục các trạm biến áp ${\bf220\V V}$ xây mới và cải tạo khu vực miền Nam  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e821f3d0110ffa7238145b5389cde5415121d44898e943c4a5f1b5ce660ab298.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/eff3b4150eabfe75137373ca835afeda123a1ad4d8c1dcc188842d1da6c8f556.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/0eea4cad673cb24eaaf478b752173e26dead160af37f3e6ac8f573411b935332.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/642636dfcb9dd31bea4bb1af990a30a1cdee0f26d2d9690cf14d8950b3d5192a.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/a716c45221103da397ce00b3423e7e127bd7d6d3951cdcdd233bf85e22c9d8c7.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/49ce5ba6dde8680aabb85d4efb9bed6ade3bca1582fb3cce423b2dd00f54ee76.jpg)  
+
+# Bảng 14: Danh mục các đường dây ${\bf220\V V}$ xây mới và cải tạo khu vực miền Nam  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/948da3e2999d629ef09812a74013aa84985da74caa6fade2f0ed46ec8a3614bd.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/67cc1064b2743c1a9839dac2221b61dbbe18ba574ffad431240c2b239ba07fda.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/17ac4fb22898d2f221d0662e4b8ba89927cc71965fdb2f3bb0b772fe479980c6.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/8605a12e59f30fd0f6d0f9f8ced4b6b657325fef8590d5708ec79e260177409c.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/7263162d383a5724e2a05884fe897f9da29c3b163bed44c460fbc2d833789072.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/249d151a48397a1a6319f5f47edfa582dd4652bc77d2ed40692a889cbab79cea.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/51859fb11f4e37f8120cdbf851d27fea3c94c4c643658fc282809da98276efaa.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/8d7d6fa97db6fde1da3bc76d7ab6feefac5417fd5a86f912003dd9445384dbe4.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/e4cf77791020b7d9c6f48889ce3acf4ab6dd6943ea2b4da1dc8daf7973fcd877.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/6af54c7c7cb79b54bba6e10e5e6206e7fbee49438902e2b686a3f30f6b440444.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/f33f443c79e00f10f6b8f13735c4dd91d00a9a3569bbde00689137807295a259.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/baf785ee9105c433aa945e99511a3e020b93aa680983b882c61d99ab3dca8cba.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/045b7166fc943dfd1b6f48b17dcc65b43ea36a8eb796becdcdf9500a1a31eaba.jpg)  
+
+Ghi chú:  
+
+1. Đối với trạm biến áp  
+
+- Danh mục trạm biến áp không bao gồm các trạm biến áp nâng áp của các dự án nguồn điện. Trong quá trình chuẩn bị dự án của mỗi giai đoạn, quy mô của trạm biến áp nâng sẽ được lựa chọn phù hợp với nhu cầu phụ tải và giải tỏa công suất nguồn điện.  
+
+(\*) Tiến độ, quy mô và vị trí của các trạm biến áp sẽ được chuẩn xác trong quá trình chuẩn bị dự án, phụ thuộc vào tiềm năng phát triển nguồn và cấu hình lưới điện trong thực tế.  
+
+2. Đối với đường dây - Chiều dài đường dây sẽ được chuẩn xác trong giai đoạn chuẩn bị dự án. (\*) Tiến độ, quy mô của các đường dây sẽ được chuẩn xác trong quá trình chuẩn bị dự án, phụ thuộc vào tiềm năng phát triển nguồn và cấu hình lưới điện trong thực tế.  
+
+3. Đối với đấu nối nguồn năng lượng tái tạo  
+
+Phương án đấu nối chi tiết của các dự án năng lượng tái tạo cần được xem xét kỹ lưỡng trong quá trình triển khai, điều chỉnh phù hợp với điều kiện thực tế (nếu cần), đảm bảo hiệu quả kinh tế và các tiêu chuẩn kỹ thuật vận hành.  
+
+# PHỤ LỤC IV  
+
+# CHƯƠNG TRÌNH CẤP ĐIỆN NÔNG THÔN MIỀN NÚI, HẢI ĐẢO  
+
+(Kèm theo Kế hoạch tại Quyết định số 1509/QĐ-BCT ngày 30 tháng 5 năm 2025 của Bộ Công Thương)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/5898fe8e4a3f1a88138158fd5606a54a3ed36a541a0aeb4b2cc21c28e451ebd8.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/d0fd93881e94c0c0ff51795fe31cc03505241b5a0491d70e9d6599e2c1e56a93.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/be595b505530235c9d504c89ec6a251ad08f00f570bb5533ef1b53a3b3cedff1.jpg)  
+
+![](/tmp/23cdb0fe-5627-4bd3-aa94-5ea77a60c11d/images/c46a3f5cab15f2bdec9aaa303249268059a7c7cf5164ae17b56ac65d10789354.jpg)  

--- a/report/inputs/generated/tab_converter_benchmark.tex
+++ b/report/inputs/generated/tab_converter_benchmark.tex
@@ -4,5 +4,6 @@ Backend & Lines & Tables & Table rows & Vietnamese & Size (KB) \\
 \midrule
 grobid & 4961 & 0 & 0 & 5/5 & 388 \\
 marker & 4745 & 170 & 4038 & 5/5 & 1630 \\
+mineru & 695 & 0 & 0 & 5/5 & 58 \\
 \bottomrule
 \end{tabular}

--- a/src/aedist/pdf2md_mineru.py
+++ b/src/aedist/pdf2md_mineru.py
@@ -33,7 +33,7 @@ def mineru_convert(pdf_path: Path, mineru_url: str = DEFAULT_MINERU_URL) -> str:
     MinerU returns a ZIP containing markdown and images.
     We extract just the markdown content.
     """
-    url = f"{mineru_url}/file_parse"
+    url = f"{mineru_url}/api/parse"
 
     boundary = "----MinerUBoundary"
     pdf_bytes = pdf_path.read_bytes()
@@ -72,6 +72,8 @@ def mineru_convert(pdf_path: Path, mineru_url: str = DEFAULT_MINERU_URL) -> str:
 
     # JSON response
     result = json.loads(raw.decode("utf-8"))
+    if "content" in result:
+        return result["content"]
     if "markdown" in result:
         return result["markdown"]
     if "md_content" in result:


### PR DESCRIPTION
## Summary

- Fix MinerU backend: endpoint `/api/parse`, response field `content`, internal port 3000
- Complete 3-way benchmark on Decision 1509:

| Backend | Tables | Rows | Lines |
|---------|--------|------|-------|
| **Marker** | **170** | **4038** | 4745 |
| GROBID | 0 | 0 | 4961 |
| MinerU | 0 | 0 | 695 |

Marker is the clear winner for scanned Vietnamese PDFs with tables.

Closes #81, closes #111. Partial #85.

## Test plan
- [x] 19 tests pass (mineru + compare_converters)
- [x] MinerU processes Decision 1509 via API
- [x] Benchmark runs across all 3 backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)