### PR TITLE
Fix 4 review nits from PR #165

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,7 @@ ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: spawns subprocesses or uses sleep-based timing",
+    "slow: requires network access or real data",
+]

--- a/tests/test_measurements_adapter.py
+++ b/tests/test_measurements_adapter.py
@@ -5,7 +5,6 @@ RunRecords and back via the adapter must reproduce the original dicts exactly
 (for the fields the reporting scripts consume).
 """
 
-import json
 from pathlib import Path
 
 import pytest
@@ -163,6 +162,29 @@ class TestRoundTrip:
         recovered = records_to_metrics(records)
         assert recovered[0]["cost_usd"] == 0.015
         assert recovered[0]["wall_seconds"] == 24.5
+
+
+class TestRoundTripRealData:
+    """Round-trip with real measurements.jsonl data."""
+
+    @pytest.fixture
+    def real_records(self):
+        path = Path("measurements.jsonl")
+        if not path.exists():
+            pytest.skip("Real measurements.jsonl not available")
+        return RunRecord.load_jsonl(path)
+
+    @pytest.mark.slow
+    def test_real_data_roundtrip(self, real_records):
+        metrics = records_to_metrics(real_records)
+        recovered = metrics_to_records(metrics)
+        roundtripped = records_to_metrics(recovered)
+        assert len(roundtripped) == len(metrics)
+        for orig, rec in zip(metrics, roundtripped):
+            for field in _CONSUMED_FIELDS:
+                assert orig.get(field) == rec.get(field), (
+                    f"Field {field!r}: {orig.get(field)} != {rec.get(field)} for {orig['label']}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plot_census.py
+++ b/tests/test_plot_census.py
@@ -1,11 +1,10 @@
 """Tests for aedist.plot_census — CSV bar-chart data from metrics JSON."""
 
 import csv
-import json
-from pathlib import Path
+
+from conftest import write_measurements
 
 from aedist.plot_census import build_census_rows
-
 
 SAMPLE_METRICS = [
     {"label": "sweep1_census/gpt-5.4-run1", "f1": 0.70},
@@ -43,22 +42,22 @@ def test_output_is_sorted_descending():
     assert f1_values == sorted(f1_values, reverse=True)
 
 
-from conftest import write_measurements
-
-
 def test_main_writes_csv(tmp_path):
     """CLI writes well-formed CSV with header."""
     input_path = tmp_path / "measurements.jsonl"
     write_measurements(input_path, SAMPLE_METRICS)
     output_path = tmp_path / "census_bars.csv"
 
-    from aedist.plot_census import main
     import sys
+
+    from aedist.plot_census import main
 
     sys.argv = [
         "plot_census",
-        "--measurements", str(input_path),
-        "--output", str(output_path),
+        "--measurements",
+        str(input_path),
+        "--output",
+        str(output_path),
     ]
     main()
 

--- a/tests/test_plot_pareto.py
+++ b/tests/test_plot_pareto.py
@@ -1,10 +1,10 @@
 """Tests for aedist.plot_pareto — Pareto CSV from metrics JSON."""
 
 import csv
-import json
+
+from conftest import write_measurements
 
 from aedist.plot_pareto import build_pareto_rows, load_costs
-
 
 SAMPLE_METRICS = [
     {"label": "sweep1_census/gpt-5.4-run1", "f1": 0.70},
@@ -55,9 +55,6 @@ def test_local_flag():
     assert by_model["padme-qwen3.5-27b"]["local"] == 1
 
 
-from conftest import write_measurements
-
-
 def test_main_writes_csv(tmp_path):
     """CLI writes well-formed CSV with cost data."""
     input_path = tmp_path / "measurements.jsonl"
@@ -66,14 +63,18 @@ def test_main_writes_csv(tmp_path):
     costs_path.write_text(SUMMARY_CSV)
     output_path = tmp_path / "pareto.csv"
 
-    from aedist.plot_pareto import main
     import sys
+
+    from aedist.plot_pareto import main
 
     sys.argv = [
         "plot_pareto",
-        "--measurements", str(input_path),
-        "--costs", str(costs_path),
-        "--output", str(output_path),
+        "--measurements",
+        str(input_path),
+        "--costs",
+        str(costs_path),
+        "--output",
+        str(output_path),
     ]
     main()
 
@@ -92,13 +93,16 @@ def test_main_without_costs(tmp_path):
     write_measurements(input_path, SAMPLE_METRICS)
     output_path = tmp_path / "pareto.csv"
 
-    from aedist.plot_pareto import main
     import sys
+
+    from aedist.plot_pareto import main
 
     sys.argv = [
         "plot_pareto",
-        "--measurements", str(input_path),
-        "--output", str(output_path),
+        "--measurements",
+        str(input_path),
+        "--output",
+        str(output_path),
     ]
     main()
 

--- a/tests/test_tabulate_census.py
+++ b/tests/test_tabulate_census.py
@@ -1,6 +1,6 @@
 """Tests for aedist.tabulate_census — generate census results LaTeX table."""
 
-import json
+from conftest import write_measurements
 
 from aedist.tabulate_census import generate_census_table
 from aedist.tabulate_utils import format_model_name, group_and_summarize, strip_label
@@ -204,9 +204,6 @@ def test_generate_census_table_matched_over_total():
 
 
 # --- CLI integration via file ---
-
-
-from conftest import write_measurements
 
 
 def test_main_writes_output(tmp_path):

--- a/tests/test_tabulate_comparaison.py
+++ b/tests/test_tabulate_comparaison.py
@@ -1,7 +1,8 @@
 """Tests for aedist.tabulate_comparaison — generate RAG comparison LaTeX table."""
 
-import json
 import logging
+
+from conftest import write_measurements
 
 from aedist.tabulate_comparaison import (
     generate_comparaison_table,
@@ -155,7 +156,18 @@ def test_generate_table_sorted_by_f1_rag_desc():
     latex, _ = generate_comparaison_table(SAMPLE_METRICS)
     # GPT-5.4 RAG F1=0.720 > padme RAG F1=0.410, so GPT row comes first
     lines = latex.splitlines()
-    data_lines = [l for l in lines if "\\\\" in l and "toprule" not in l and "midrule" not in l and "endhead" not in l and "bottomrule" not in l and "endlastfoot" not in l and "caption" not in l and "Model &" not in l]
+    data_lines = [
+        l
+        for l in lines
+        if "\\\\" in l
+        and "toprule" not in l
+        and "midrule" not in l
+        and "endhead" not in l
+        and "bottomrule" not in l
+        and "endlastfoot" not in l
+        and "caption" not in l
+        and "Model &" not in l
+    ]
     gpt_line = next((i for i, l in enumerate(data_lines) if "GPT-5.4" in l), None)
     padme_line = next((i for i, l in enumerate(data_lines) if "(L)" in l), None)
     assert gpt_line is not None and padme_line is not None
@@ -237,9 +249,6 @@ def test_empty_intersection_no_data_rows():
 
 
 # --- CLI integration ---
-
-
-from conftest import write_measurements
 
 
 def test_main_writes_output(tmp_path):

--- a/tests/test_tabulate_macros.py
+++ b/tests/test_tabulate_macros.py
@@ -1,11 +1,8 @@
 """Tests for aedist.tabulate_macros — LaTeX macro generation from metrics JSON."""
 
-import json
-import textwrap
-from pathlib import Path
+from conftest import write_measurements
 
 from aedist.tabulate_macros import generate_macros, load_and_summarize
-
 
 SAMPLE_METRICS = [
     {"label": "sweep1_census/gpt-5.4-run1", "f1": 0.70, "coverage": 0.8, "precision": 0.62},
@@ -14,12 +11,42 @@ SAMPLE_METRICS = [
     {"label": "sweep1_census/claude-4-run1", "f1": 0.65, "coverage": 0.75, "precision": 0.58},
     {"label": "sweep1_census/claude-4-run2", "f1": 0.63, "coverage": 0.73, "precision": 0.56},
     {"label": "sweep1_census/claude-4-run3", "f1": 0.67, "coverage": 0.77, "precision": 0.60},
-    {"label": "sweep1_census/padme-qwen3.5-27b-run1", "f1": 0.50, "coverage": 0.60, "precision": 0.43},
-    {"label": "sweep1_census/padme-qwen3.5-27b-run2", "f1": 0.52, "coverage": 0.62, "precision": 0.45},
-    {"label": "sweep1_census/padme-qwen3.5-27b-run3", "f1": 0.48, "coverage": 0.58, "precision": 0.41},
-    {"label": "sweep1_census/padme-mistral-small3.2-run1", "f1": 0.40, "coverage": 0.50, "precision": 0.33},
-    {"label": "sweep1_census/padme-mistral-small3.2-run2", "f1": 0.42, "coverage": 0.52, "precision": 0.35},
-    {"label": "sweep1_census/padme-mistral-small3.2-run3", "f1": 0.38, "coverage": 0.48, "precision": 0.31},
+    {
+        "label": "sweep1_census/padme-qwen3.5-27b-run1",
+        "f1": 0.50,
+        "coverage": 0.60,
+        "precision": 0.43,
+    },
+    {
+        "label": "sweep1_census/padme-qwen3.5-27b-run2",
+        "f1": 0.52,
+        "coverage": 0.62,
+        "precision": 0.45,
+    },
+    {
+        "label": "sweep1_census/padme-qwen3.5-27b-run3",
+        "f1": 0.48,
+        "coverage": 0.58,
+        "precision": 0.41,
+    },
+    {
+        "label": "sweep1_census/padme-mistral-small3.2-run1",
+        "f1": 0.40,
+        "coverage": 0.50,
+        "precision": 0.33,
+    },
+    {
+        "label": "sweep1_census/padme-mistral-small3.2-run2",
+        "f1": 0.42,
+        "coverage": 0.52,
+        "precision": 0.35,
+    },
+    {
+        "label": "sweep1_census/padme-mistral-small3.2-run3",
+        "f1": 0.38,
+        "coverage": 0.48,
+        "precision": 0.31,
+    },
 ]
 
 
@@ -63,22 +90,22 @@ def test_slug_strips_run_and_dir():
     assert len(summary) == 1
 
 
-from conftest import write_measurements
-
-
 def test_main_writes_file(tmp_path):
     """CLI writes macros.tex from a measurements.jsonl file."""
     input_path = tmp_path / "measurements.jsonl"
     write_measurements(input_path, SAMPLE_METRICS)
     output_path = tmp_path / "macros.tex"
 
-    from aedist.tabulate_macros import main
     import sys
+
+    from aedist.tabulate_macros import main
 
     sys.argv = [
         "tabulate_macros",
-        "--measurements", str(input_path),
-        "--output", str(output_path),
+        "--measurements",
+        str(input_path),
+        "--output",
+        str(output_path),
     ]
     main()
     content = output_path.read_text()

--- a/tests/test_tabulate_relances.py
+++ b/tests/test_tabulate_relances.py
@@ -1,6 +1,6 @@
 """Tests for aedist.tabulate_relances — generate multi-turn relances LaTeX table."""
 
-import json
+from conftest import write_measurements
 
 from aedist.tabulate_relances import (
     _generate_per_turn_table,
@@ -15,39 +15,225 @@ from aedist.tabulate_relances import (
 # Per-turn entries (with "turn" field) for two models, 3 runs each, turns 0-2.
 SAMPLE_PER_TURN_METRICS = [
     # gpt-5.4 run1
-    {"label": "sweep2_multiturn/gpt-5.4-run1", "turn": 0, "f1": 0.40, "precision": 0.90, "coverage": 0.30, "n_reference": 163, "n_matched": 49},
-    {"label": "sweep2_multiturn/gpt-5.4-run1", "turn": 1, "f1": 0.55, "precision": 0.92, "coverage": 0.45, "n_reference": 163, "n_matched": 73},
-    {"label": "sweep2_multiturn/gpt-5.4-run1", "turn": 2, "f1": 0.65, "precision": 0.95, "coverage": 0.50, "n_reference": 163, "n_matched": 82},
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run1",
+        "turn": 0,
+        "f1": 0.40,
+        "precision": 0.90,
+        "coverage": 0.30,
+        "n_reference": 163,
+        "n_matched": 49,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run1",
+        "turn": 1,
+        "f1": 0.55,
+        "precision": 0.92,
+        "coverage": 0.45,
+        "n_reference": 163,
+        "n_matched": 73,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run1",
+        "turn": 2,
+        "f1": 0.65,
+        "precision": 0.95,
+        "coverage": 0.50,
+        "n_reference": 163,
+        "n_matched": 82,
+    },
     # gpt-5.4 run2
-    {"label": "sweep2_multiturn/gpt-5.4-run2", "turn": 0, "f1": 0.42, "precision": 0.91, "coverage": 0.32, "n_reference": 163, "n_matched": 52},
-    {"label": "sweep2_multiturn/gpt-5.4-run2", "turn": 1, "f1": 0.57, "precision": 0.93, "coverage": 0.47, "n_reference": 163, "n_matched": 77},
-    {"label": "sweep2_multiturn/gpt-5.4-run2", "turn": 2, "f1": 0.67, "precision": 0.96, "coverage": 0.52, "n_reference": 163, "n_matched": 85},
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run2",
+        "turn": 0,
+        "f1": 0.42,
+        "precision": 0.91,
+        "coverage": 0.32,
+        "n_reference": 163,
+        "n_matched": 52,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run2",
+        "turn": 1,
+        "f1": 0.57,
+        "precision": 0.93,
+        "coverage": 0.47,
+        "n_reference": 163,
+        "n_matched": 77,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run2",
+        "turn": 2,
+        "f1": 0.67,
+        "precision": 0.96,
+        "coverage": 0.52,
+        "n_reference": 163,
+        "n_matched": 85,
+    },
     # gpt-5.4 run3
-    {"label": "sweep2_multiturn/gpt-5.4-run3", "turn": 0, "f1": 0.38, "precision": 0.89, "coverage": 0.28, "n_reference": 163, "n_matched": 46},
-    {"label": "sweep2_multiturn/gpt-5.4-run3", "turn": 1, "f1": 0.53, "precision": 0.91, "coverage": 0.43, "n_reference": 163, "n_matched": 70},
-    {"label": "sweep2_multiturn/gpt-5.4-run3", "turn": 2, "f1": 0.63, "precision": 0.94, "coverage": 0.48, "n_reference": 163, "n_matched": 78},
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run3",
+        "turn": 0,
+        "f1": 0.38,
+        "precision": 0.89,
+        "coverage": 0.28,
+        "n_reference": 163,
+        "n_matched": 46,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run3",
+        "turn": 1,
+        "f1": 0.53,
+        "precision": 0.91,
+        "coverage": 0.43,
+        "n_reference": 163,
+        "n_matched": 70,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run3",
+        "turn": 2,
+        "f1": 0.63,
+        "precision": 0.94,
+        "coverage": 0.48,
+        "n_reference": 163,
+        "n_matched": 78,
+    },
     # padme-qwen3.5-122b run1
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run1", "turn": 0, "f1": 0.20, "precision": 0.80, "coverage": 0.15, "n_reference": 163, "n_matched": 24},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run1", "turn": 1, "f1": 0.30, "precision": 0.82, "coverage": 0.22, "n_reference": 163, "n_matched": 36},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run1", "turn": 2, "f1": 0.38, "precision": 0.85, "coverage": 0.28, "n_reference": 163, "n_matched": 46},
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run1",
+        "turn": 0,
+        "f1": 0.20,
+        "precision": 0.80,
+        "coverage": 0.15,
+        "n_reference": 163,
+        "n_matched": 24,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run1",
+        "turn": 1,
+        "f1": 0.30,
+        "precision": 0.82,
+        "coverage": 0.22,
+        "n_reference": 163,
+        "n_matched": 36,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run1",
+        "turn": 2,
+        "f1": 0.38,
+        "precision": 0.85,
+        "coverage": 0.28,
+        "n_reference": 163,
+        "n_matched": 46,
+    },
     # padme-qwen3.5-122b run2
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run2", "turn": 0, "f1": 0.22, "precision": 0.81, "coverage": 0.17, "n_reference": 163, "n_matched": 28},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run2", "turn": 1, "f1": 0.32, "precision": 0.83, "coverage": 0.24, "n_reference": 163, "n_matched": 39},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run2", "turn": 2, "f1": 0.40, "precision": 0.86, "coverage": 0.30, "n_reference": 163, "n_matched": 49},
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run2",
+        "turn": 0,
+        "f1": 0.22,
+        "precision": 0.81,
+        "coverage": 0.17,
+        "n_reference": 163,
+        "n_matched": 28,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run2",
+        "turn": 1,
+        "f1": 0.32,
+        "precision": 0.83,
+        "coverage": 0.24,
+        "n_reference": 163,
+        "n_matched": 39,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run2",
+        "turn": 2,
+        "f1": 0.40,
+        "precision": 0.86,
+        "coverage": 0.30,
+        "n_reference": 163,
+        "n_matched": 49,
+    },
     # padme-qwen3.5-122b run3
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run3", "turn": 0, "f1": 0.18, "precision": 0.79, "coverage": 0.13, "n_reference": 163, "n_matched": 21},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run3", "turn": 1, "f1": 0.28, "precision": 0.81, "coverage": 0.20, "n_reference": 163, "n_matched": 33},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run3", "turn": 2, "f1": 0.36, "precision": 0.84, "coverage": 0.26, "n_reference": 163, "n_matched": 43},
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run3",
+        "turn": 0,
+        "f1": 0.18,
+        "precision": 0.79,
+        "coverage": 0.13,
+        "n_reference": 163,
+        "n_matched": 21,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run3",
+        "turn": 1,
+        "f1": 0.28,
+        "precision": 0.81,
+        "coverage": 0.20,
+        "n_reference": 163,
+        "n_matched": 33,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run3",
+        "turn": 2,
+        "f1": 0.36,
+        "precision": 0.84,
+        "coverage": 0.26,
+        "n_reference": 163,
+        "n_matched": 43,
+    },
 ]
 
 # Summary entries (no "turn" field) for fallback table.
 SAMPLE_SUMMARY_METRICS = [
-    {"label": "sweep2_multiturn/gpt-5.4-run1", "f1": 0.658, "precision": 1.0, "coverage": 0.491, "n_reference": 163, "n_matched": 80},
-    {"label": "sweep2_multiturn/gpt-5.4-run2", "f1": 0.660, "precision": 0.980, "coverage": 0.500, "n_reference": 163, "n_matched": 82},
-    {"label": "sweep2_multiturn/gpt-5.4-run3", "f1": 0.640, "precision": 0.990, "coverage": 0.470, "n_reference": 163, "n_matched": 77},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run1", "f1": 0.436, "precision": 0.800, "coverage": 0.300, "n_reference": 163, "n_matched": 49},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run2", "f1": 0.465, "precision": 0.850, "coverage": 0.320, "n_reference": 163, "n_matched": 52},
-    {"label": "sweep2_multiturn/padme-qwen3.5-122b-run3", "f1": 0.450, "precision": 0.820, "coverage": 0.310, "n_reference": 163, "n_matched": 51},
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run1",
+        "f1": 0.658,
+        "precision": 1.0,
+        "coverage": 0.491,
+        "n_reference": 163,
+        "n_matched": 80,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run2",
+        "f1": 0.660,
+        "precision": 0.980,
+        "coverage": 0.500,
+        "n_reference": 163,
+        "n_matched": 82,
+    },
+    {
+        "label": "sweep2_multiturn/gpt-5.4-run3",
+        "f1": 0.640,
+        "precision": 0.990,
+        "coverage": 0.470,
+        "n_reference": 163,
+        "n_matched": 77,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run1",
+        "f1": 0.436,
+        "precision": 0.800,
+        "coverage": 0.300,
+        "n_reference": 163,
+        "n_matched": 49,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run2",
+        "f1": 0.465,
+        "precision": 0.850,
+        "coverage": 0.320,
+        "n_reference": 163,
+        "n_matched": 52,
+    },
+    {
+        "label": "sweep2_multiturn/padme-qwen3.5-122b-run3",
+        "f1": 0.450,
+        "precision": 0.820,
+        "coverage": 0.310,
+        "n_reference": 163,
+        "n_matched": 51,
+    },
 ]
 
 
@@ -57,7 +243,14 @@ SAMPLE_SUMMARY_METRICS = [
 def test_generate_relances_table_no_multiturn_entries():
     """When no sweep2_multiturn entries exist, returns empty summary table."""
     non_mt = [
-        {"label": "sweep1_census/gpt-5.4-run1", "f1": 0.65, "precision": 1.0, "coverage": 0.49, "n_reference": 163, "n_matched": 80},
+        {
+            "label": "sweep1_census/gpt-5.4-run1",
+            "f1": 0.65,
+            "precision": 1.0,
+            "coverage": 0.49,
+            "n_reference": 163,
+            "n_matched": 80,
+        },
     ]
     latex = generate_relances_table(non_mt)
     assert "\\begin{longtable}" in latex
@@ -65,7 +258,18 @@ def test_generate_relances_table_no_multiturn_entries():
     assert "\\label{tab:relances}" in latex
     # Table should have no data rows (only boilerplate)
     lines = latex.splitlines()
-    data_lines = [l for l in lines if "\\\\" in l and "toprule" not in l and "midrule" not in l and "endhead" not in l and "bottomrule" not in l and "endlastfoot" not in l and "caption" not in l and "Model &" not in l]
+    data_lines = [
+        l
+        for l in lines
+        if "\\\\" in l
+        and "toprule" not in l
+        and "midrule" not in l
+        and "endhead" not in l
+        and "bottomrule" not in l
+        and "endlastfoot" not in l
+        and "caption" not in l
+        and "Model &" not in l
+    ]
     assert len(data_lines) == 0
 
 
@@ -117,7 +321,18 @@ def test_generate_per_turn_table_sorted_by_final_turn_f1():
     """Models sorted by final-turn F1 descending (GPT before padme)."""
     latex = _generate_per_turn_table(SAMPLE_PER_TURN_METRICS)
     lines = latex.splitlines()
-    data_lines = [l for l in lines if "\\\\" in l and "toprule" not in l and "midrule" not in l and "endhead" not in l and "bottomrule" not in l and "endlastfoot" not in l and "caption" not in l and "Model &" not in l]
+    data_lines = [
+        l
+        for l in lines
+        if "\\\\" in l
+        and "toprule" not in l
+        and "midrule" not in l
+        and "endhead" not in l
+        and "bottomrule" not in l
+        and "endlastfoot" not in l
+        and "caption" not in l
+        and "Model &" not in l
+    ]
     gpt_line = next((i for i, l in enumerate(data_lines) if "GPT-5.4" in l), None)
     padme_line = next((i for i, l in enumerate(data_lines) if "(L)" in l), None)
     assert gpt_line is not None and padme_line is not None
@@ -168,8 +383,19 @@ def test_generate_summary_table_used_when_no_turn_field():
 
 def test_group_by_model_and_turn_skips_entries_without_turn():
     mixed = [
-        {"label": "sweep2_multiturn/gpt-5.4-run1", "f1": 0.65, "n_reference": 163, "n_matched": 80},
-        {"label": "sweep2_multiturn/gpt-5.4-run1", "turn": 0, "f1": 0.40, "n_reference": 163, "n_matched": 49},
+        {
+            "label": "sweep2_multiturn/gpt-5.4-run1",
+            "f1": 0.65,
+            "n_reference": 163,
+            "n_matched": 80,
+        },
+        {
+            "label": "sweep2_multiturn/gpt-5.4-run1",
+            "turn": 0,
+            "f1": 0.40,
+            "n_reference": 163,
+            "n_matched": 49,
+        },
     ]
     grouped = group_by_model_and_turn(mixed)
     assert "gpt-5.4" in grouped
@@ -186,8 +412,18 @@ def test_group_by_model_and_turn_empty_input():
 
 def test_group_by_model_and_turn_all_without_turn():
     entries = [
-        {"label": "sweep2_multiturn/gpt-5.4-run1", "f1": 0.65, "n_reference": 163, "n_matched": 80},
-        {"label": "sweep2_multiturn/gpt-5.4-run2", "f1": 0.66, "n_reference": 163, "n_matched": 82},
+        {
+            "label": "sweep2_multiturn/gpt-5.4-run1",
+            "f1": 0.65,
+            "n_reference": 163,
+            "n_matched": 80,
+        },
+        {
+            "label": "sweep2_multiturn/gpt-5.4-run2",
+            "f1": 0.66,
+            "n_reference": 163,
+            "n_matched": 82,
+        },
     ]
     grouped = group_by_model_and_turn(entries)
     assert grouped == {}
@@ -208,7 +444,9 @@ def test_group_by_model_and_turn_groups_correctly():
 
 def test_single_run_per_turn_table():
     """Model with only one run should still produce valid per-turn output."""
-    single_run = [e for e in SAMPLE_PER_TURN_METRICS if e["label"] == "sweep2_multiturn/gpt-5.4-run1"]
+    single_run = [
+        e for e in SAMPLE_PER_TURN_METRICS if e["label"] == "sweep2_multiturn/gpt-5.4-run1"
+    ]
     latex = _generate_per_turn_table(single_run)
     assert "\\begin{longtable}" in latex
     assert "GPT-5.4" in latex
@@ -224,9 +462,6 @@ def test_single_run_summary_table():
 
 
 # --- CLI integration ---
-
-
-from conftest import write_measurements
 
 
 def test_main_writes_output(tmp_path):

--- a/tickets/0004-retire-patchwork.erg
+++ b/tickets/0004-retire-patchwork.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Retire all_metrics.json and per-sweep summary paths
-Status: pending
+Status: closed
 Created: 2026-04-04
 Author: claude
 Blocked-by: 0003
@@ -12,6 +12,7 @@ Blocked-by: 0003
 2026-04-06T17:36Z claude status doing
 2026-04-06T17:50Z claude status closed — all_metrics.json retired, 8 scripts on measurements.jsonl only, 392 tests pass
 2026-04-06T17:52Z claude status pending — awaiting PR review, simplify, re-review, merge
+2026-04-06T22:00Z claude status closed — PR #165 merged, review nits fixed in fix/pr165-nits
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Hoist `from conftest import write_measurements` to top-of-file in 6 test files (ruff then reformatted long dict literals — cosmetic noise)
- Add `TestRoundTripRealData` integration test against live `measurements.jsonl`, replacing the deleted `all_metrics.json` round-trip
- Close ticket 0004 (PR #165 merged) — unblocks ticket 0020
- Register `slow` / `integration` pytest markers in `pyproject.toml`

## Test plan

- [x] `make check-fast` — 423 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)