### PR TITLE
Ticket 0044: Whitelist model-reply glob via shared loader

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -14,7 +14,7 @@ None
 2. Complete RAG local sweep: 2B/4B scaling curve (branch t21-rag-local-models)
 3. Matching sensitivity sweep (ticket 0035)
 4. Fix empty CSV crash in evaluate (ticket 0045)
-5. Audit JSON globs for .eval.json filtering (ticket 0044)
+5. Whitelist model-reply glob via shared loader (ticket 0044 — doing)
 
 ## North star
 
@@ -41,5 +41,5 @@ Statistical hygiene (ticket 0035) → journal submission (TBD — after conferen
 - 0031 Information regimes sweep (complete)
 - 0035 Matching sensitivity sweep
 - 0038 Reflexive self-prompting experiment
-- 0044 Audit JSON globs for .eval.json filtering
+- 0044 Whitelist model-reply glob via shared loader (doing)
 - 0045 Empty CSV crash in evaluate

--- a/src/aedist/analyze_multiturn_budget.py
+++ b/src/aedist/analyze_multiturn_budget.py
@@ -14,7 +14,7 @@ import json
 import logging
 from pathlib import Path
 
-from .harness import CONTEXT_WINDOW_SAFETY_MARGIN
+from .harness import CONTEXT_WINDOW_SAFETY_MARGIN, iter_model_replies
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 def load_multiturn_results(output_dir: Path) -> list[dict]:
     """Load all JSON results from an experiment output directory."""
     results = []
-    for f in sorted(output_dir.glob("*.json")):
+    for f in iter_model_replies(output_dir):
         with open(f) as fh:
             results.append(json.load(fh))
     return results

--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -20,8 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-from aedist.harness import iter_model_replies
-from aedist.util import parse_number, strip_diacritics
+from .harness import iter_model_replies
+from .util import parse_number, strip_diacritics
 
 log = logging.getLogger(__name__)
 

--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from aedist.harness import iter_model_replies
 from aedist.util import parse_number, strip_diacritics
 
 log = logging.getLogger(__name__)
@@ -358,9 +359,7 @@ def main() -> None:
     if not input_dir.exists() or not input_dir.is_dir():
         raise SystemExit(f"Input dir not found: {input_dir}")
 
-    json_files = sorted(
-        f for f in input_dir.glob("*.json") if not f.name.endswith(".eval.json")
-    )
+    json_files = list(iter_model_replies(input_dir))
     if not json_files:
         raise SystemExit(f"No JSON files in: {input_dir}")
 

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -8,8 +8,10 @@ save/skip logic, and cost computation.
 import json
 import logging
 import os
+import re
 import time
 import tomllib
+from collections.abc import Iterator
 from pathlib import Path
 
 import yaml
@@ -188,6 +190,22 @@ def output_path(output_dir: Path, model_id: str, run: int, prefix: str = "") -> 
 def should_skip(output_dir: Path, model_id: str, run: int, prefix: str = "") -> bool:
     """Return True if the output file already exists."""
     return output_path(output_dir, model_id, run, prefix).exists()
+
+
+_MODEL_REPLY_RE = re.compile(r"^.+-run\d+\.json$")
+
+
+def iter_model_replies(directory: Path) -> Iterator[Path]:
+    """Yield model-reply JSON files from *directory*, sorted by name.
+
+    Matches the canonical naming convention from output_filename():
+    {slug}-run{N}.json or {prefix}-{slug}-run{N}.json.
+    Excludes all derived files (.record.json, _summary.json,
+    tavily_cache.json, etc.) by whitelist, not blacklist.
+    """
+    for f in sorted(directory.glob("*.json")):
+        if _MODEL_REPLY_RE.match(f.name):
+            yield f
 
 
 # ---------------------------------------------------------------------------

--- a/src/aedist/self_consistency.py
+++ b/src/aedist/self_consistency.py
@@ -138,7 +138,12 @@ def plants_to_csv_text(plants: list) -> str:
 
 
 def _group_runs(input_dir: Path) -> dict[str, list[Path]]:
-    """Group JSON files by model name. Returns {model: [run1, run2, run3]}."""
+    """Group JSON files by model name. Returns {model: [run1, run2, run3]}.
+
+    The regex is intentionally equivalent to harness._MODEL_REPLY_RE but
+    uses capture groups to extract the model name and run number for
+    grouping.  See ticket 0044 for the shared whitelist rationale.
+    """
     pattern = re.compile(r"^(.+)-run(\d+)\.json$")
     groups: dict[str, list[tuple[int, Path]]] = defaultdict(list)
     for jf in sorted(input_dir.glob("*.json")):

--- a/tests/test_analyze_multiturn_budget.py
+++ b/tests/test_analyze_multiturn_budget.py
@@ -1,6 +1,12 @@
 """Tests for aedist.analyze_multiturn_budget — token budget extrapolation."""
 
-from aedist.analyze_multiturn_budget import extrapolate_to_n_turns, per_turn_token_usage
+import json
+
+from aedist.analyze_multiturn_budget import (
+    extrapolate_to_n_turns,
+    load_multiturn_results,
+    per_turn_token_usage,
+)
 
 
 def test_per_turn_token_usage_extracts_assistant_turns():
@@ -95,3 +101,18 @@ def test_extrapolate_zero_context_window():
     proj = extrapolate_to_n_turns(per_turn, n_turns=10, context_window=0)
     assert proj["overflow"] is False
     assert proj["projected_pct"] == 0
+
+
+def test_load_multiturn_results_skips_derived_files(tmp_path):
+    """load_multiturn_results only loads model-reply files, not derived files."""
+    record = {"turns": [{"role": "assistant", "content": "x", "turn": 0}]}
+    # Model reply (should be loaded)
+    (tmp_path / "model-run1.json").write_text(json.dumps(record))
+    # Derived files (should be skipped)
+    (tmp_path / "tavily_cache.json").write_text(json.dumps({"query": "test"}))
+    (tmp_path / "self_consistency_summary.json").write_text(json.dumps({"kappa": 0.8}))
+    (tmp_path / "model-run1.record.json").write_text(json.dumps({"f1": 0.5}))
+
+    results = load_multiturn_results(tmp_path)
+    assert len(results) == 1
+    assert results[0] == record

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -16,7 +16,6 @@ from aedist.extract import (
     score_csv_like_block,
     sniff_dialect,
 )
-from aedist.util import strip_diacritics
 
 
 class TestHeaderMapping:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -358,7 +358,7 @@ class TestExtractOne:
         assert res.status is ExtractStatus.FAILED
 
 
-class TestMainSkipsEvalJson:
+class TestMainSkipsDerivedJson:
     def test_eval_json_ignored(self, tmp_path, monkeypatch):
         """main() must not attempt to extract .eval.json files."""
         inp = tmp_path / "inp"
@@ -378,3 +378,24 @@ class TestMainSkipsEvalJson:
         # Only the model reply should produce a CSV
         assert (out / "model-run1.csv").exists()
         assert not (out / "model-run1.eval.csv").exists()
+
+    def test_record_and_summary_json_ignored(self, tmp_path, monkeypatch):
+        """main() skips .record.json, _summary.json, and other non-reply files."""
+        inp = tmp_path / "inp"
+        inp.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        # Real model reply
+        (inp / "model-run1.json").write_text(
+            json.dumps({"response": "```csv\nName,Fuel\nPha Lai,Coal\n```"})
+        )
+        # Derived files that should be skipped (whitelist excludes these)
+        (inp / "model-run1.record.json").write_text(json.dumps({"f1": 0.5}))
+        (inp / "tavily_cache.json").write_text(json.dumps({}))
+        (inp / "self_consistency_summary.json").write_text(json.dumps({}))
+        monkeypatch.setattr("sys.argv", ["extract", "--input", str(inp), "--output", str(out)])
+        main()
+        assert (out / "model-run1.csv").exists()
+        # None of the derived files should produce CSVs
+        csv_files = list(out.glob("*.csv"))
+        assert len(csv_files) == 1, f"Expected 1 CSV, got {[f.name for f in csv_files]}"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -132,3 +132,27 @@ def test_estimate_messages_tokens_missing_content():
 
     messages = [{"role": "user"}]
     assert estimate_messages_tokens(messages) == 0
+
+
+def test_iter_model_replies_filters_derived_files(tmp_path):
+    """iter_model_replies returns only canonical model-reply files."""
+    from aedist.harness import iter_model_replies
+
+    # Model replies (should be returned)
+    (tmp_path / "deepseek-v3.2-run1.json").write_text("{}")
+    (tmp_path / "deepseek-v3.2-run2.json").write_text("{}")
+    (tmp_path / "padme-qwen3.5-122b-run1.json").write_text("{}")
+
+    # Derived files (should be excluded)
+    (tmp_path / "deepseek-v3.2-run1.record.json").write_text("{}")
+    (tmp_path / "deepseek-v3.2-run1.eval.json").write_text("{}")
+    (tmp_path / "tavily_cache.json").write_text("{}")
+    (tmp_path / "self_consistency_summary.json").write_text("{}")
+    (tmp_path / "deepseek-v3.2-run1_summary.json").write_text("{}")
+
+    result = [f.name for f in iter_model_replies(tmp_path)]
+    assert result == [
+        "deepseek-v3.2-run1.json",
+        "deepseek-v3.2-run2.json",
+        "padme-qwen3.5-122b-run1.json",
+    ]

--- a/tickets/0044-eval-json-glob-audit.erg
+++ b/tickets/0044-eval-json-glob-audit.erg
@@ -1,12 +1,15 @@
 %erg v1
 Title: Whitelist model-reply glob via shared loader
-Status: open
+Status: doing
 Created: 2026-04-08
 Author: claude
 
 --- log ---
 2026-04-08T19:30Z claude created from anti-pattern sweep after ticket 0043
 2026-04-09T12:00Z claude status reimagined by IDD phase 1
+2026-04-09T13:00Z claude status planned by IDD phase 2
+2026-04-09T14:00Z claude note verified feasible — all paths, globs, test logic confirmed exact, no API keys needed
+2026-04-09T15:00Z claude status executed by IDD phase 3
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary\n\n- Add `iter_model_replies()` to `harness.py` with compiled regex `^.+-run\\d+\\.json$`\n- Replace blacklist filter in `extract.py` (`.eval.json` exclusion) with whitelist call\n- Replace unfiltered `glob(\"*.json\")` in `analyze_multiturn_budget.py` with whitelist call\n- Document `self_consistency.py` regex equivalence\n\nEliminates entire class of file-confusion bugs (4 independent ad-hoc filters → 1 shared function).\n\n**Milestone:** Pipeline\n**Ticket:** 0044\n\n## Test plan\n\n- [x] `test_iter_model_replies_filters_derived_files` — 8 file types, only 3 valid pass through\n- [x] `test_record_and_summary_json_ignored` — regression test for extract.py\n- [x] `test_load_multiturn_results_skips_derived_files` — regression test for analyze_multiturn_budget.py\n- [x] 590 tests pass, 0 failures\n\nhttps://claude.ai/code/session_01X2rVnbgXZiDfEozyUmqoom"