### PR TITLE
Ticket 0045: Fix empty CSV crash in reconcile pipeline

### DIFF
--- a/experiments/Makefile
+++ b/experiments/Makefile
@@ -174,7 +174,7 @@ derived/%.record.json: derived/%.csv $(REFERENCE)
 
 .PHONY: evaluate-all-records
 evaluate-all-records:
-	-@$(MAKE) --no-print-directory -k -j$$(nproc) \
+	@$(MAKE) --no-print-directory -j$$(nproc) \
 	    $$(find outputs derived -name '*.csv' ! -name 'reconciliation_*' | sed 's/\.csv$$/.record.json/')
 	@shopt -s nullglob; \
 	for f in outputs/*/*-run*.json derived/*/*-run*.json; do \

--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -279,6 +279,11 @@ def _evaluate_csv_file(
         label = f"{system_path.parent.name}/{system_path.stem}"
         record = _metrics_to_runrecord(metrics, label, _rel_path(system_path))
 
+        # Mark empty system CSVs so they appear as status="empty" in the
+        # measurements table rather than the default "ok".
+        if len(system) == 0:
+            record.result_summary.status = "empty"
+
         json_companion = system_path.with_suffix(".json")
         if json_companion.exists():
             _backfill_resource_use(record, json_companion)

--- a/src/aedist/reconcile.py
+++ b/src/aedist/reconcile.py
@@ -45,7 +45,17 @@ def plants_to_dataframe(plants: list[Plant]) -> pd.DataFrame:
         })
     df = pd.DataFrame(rows)
     if df.empty:
-        df = pd.DataFrame(columns=["name", "province", "fuel", "capacity", "status", "source_ref"])
+        # Return a zero-row DataFrame with all raw + cleaned columns so
+        # downstream consumers (LP matcher, metrics) see the schema they
+        # expect.  Bypass the cleaner — its validate_dataframe raises on
+        # empty input, and there is nothing to clean anyway.
+        return pd.DataFrame(
+            columns=[
+                "name", "province", "fuel", "capacity", "status", "source_ref",
+                "name_clean", "province_clean", "fuel_clean", "capacity_clean",
+                "status_clean",
+            ]
+        )
 
     # Use the existing cleaner for normalization
     cleaner = PowerPlantDataframeCleaner(config_path=str(_CLEANER_CONFIG))

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -23,3 +23,30 @@ class TestPlantsToDataframeEmpty:
         assert "province_clean" in df.columns
         assert "fuel_clean" in df.columns
         assert "status_clean" in df.columns
+
+
+class TestReconcileEmptySystem:
+    """reconcile(reference, []) produces all-REFERENCE_ONLY entries."""
+
+    @pytest.fixture
+    def three_reference_plants(self):
+        return [
+            Plant(name="Pha Lai", fuel=FuelType.COAL, capacity_mwe=600),
+            Plant(name="Uong Bi", fuel=FuelType.COAL, capacity_mwe=300),
+            Plant(name="Ninh Binh", fuel=FuelType.COAL, capacity_mwe=100),
+        ]
+
+    def test_all_entries_are_reference_only(self, three_reference_plants):
+        entries = reconcile(three_reference_plants, [])
+        assert len(entries) == 3
+        for e in entries:
+            assert e.match_type == MatchType.REFERENCE_ONLY
+
+    def test_empty_system_metrics_are_zero(self, three_reference_plants):
+        from aedist.metrics import compute_metrics
+        entries = reconcile(three_reference_plants, [])
+        m = compute_metrics(entries)
+        assert m.f1 == 0.0
+        assert m.n_matched == 0
+        assert m.n_missed == 3
+        assert m.n_hallucinated == 0

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -1,6 +1,9 @@
 # tests/test_empty_csv.py
 """Tests for empty CSV / empty plant list handling in the reconciliation pipeline."""
 
+import json
+from pathlib import Path
+
 import pytest
 from aedist.reconcile import plants_to_dataframe, reconcile
 from aedist.schema import MatchType, Plant, FuelType, PlantStatus
@@ -50,3 +53,33 @@ class TestReconcileEmptySystem:
         assert m.n_matched == 0
         assert m.n_missed == 3
         assert m.n_hallucinated == 0
+
+
+class TestEvaluateEmptyCsv:
+    """_evaluate_csv_file on a header-only CSV produces status='empty' record."""
+
+    def test_header_only_csv_produces_empty_record(self, tmp_path):
+        # Create a header-only CSV (valid headers, zero data rows)
+        csv_path = tmp_path / "census" / "empty-model-run1.csv"
+        csv_path.parent.mkdir(parents=True)
+        csv_path.write_text("name,fuel,status,capacity\n", encoding="utf-8")
+
+        ref_path = Path(__file__).parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
+        if not ref_path.exists():
+            pytest.skip("Reference CSV not available")
+
+        import argparse
+        from aedist.evaluate import _evaluate_csv_file
+        args = argparse.Namespace(output=str(tmp_path / "out"), reference=None)
+        _evaluate_csv_file(csv_path, ref_path, args)
+
+        record_path = tmp_path / "out" / "empty-model-run1.record.json"
+        assert record_path.exists()
+
+        record = json.loads(record_path.read_text())
+        assert record["result_summary"]["status"] == "empty"
+        assert record["result_summary"]["f1"] == 0.0
+        assert record["result_summary"]["fn"] == 163  # N_reference
+        assert record["result_summary"]["tp"] == 0
+        assert record["result_summary"]["fp"] == 0
+        assert record["result_summary"]["n_plants"] == 0

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 import pytest
+from aedist.evaluate import load_plants_csv
 from aedist.reconcile import plants_to_dataframe, reconcile
 from aedist.schema import MatchType, Plant, FuelType
 
@@ -77,9 +78,13 @@ class TestEvaluateEmptyCsv:
         assert record_path.exists()
 
         record = json.loads(record_path.read_text())
+        # Derive expected false-negative count from the actual reference file
+        # so the test adapts if the reference dataset changes.
+        n_reference = len(load_plants_csv(ref_path))
+        assert n_reference > 0, "Reference CSV yielded no plants — check data/reference/"
         assert record["result_summary"]["status"] == "empty"
         assert record["result_summary"]["f1"] == 0.0
-        assert record["result_summary"]["fn"] == 163  # N_reference
+        assert record["result_summary"]["fn"] == n_reference
         assert record["result_summary"]["tp"] == 0
         assert record["result_summary"]["fp"] == 0
         assert record["result_summary"]["n_plants"] == 0

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -5,9 +5,10 @@ import json
 from pathlib import Path
 
 import pytest
+
 from aedist.evaluate import load_plants_csv
 from aedist.reconcile import plants_to_dataframe, reconcile
-from aedist.schema import MatchType, Plant, FuelType
+from aedist.schema import FuelType, MatchType, Plant
 
 
 class TestPlantsToDataframeEmpty:
@@ -70,6 +71,7 @@ class TestEvaluateEmptyCsv:
             pytest.skip("Reference CSV not available")
 
         import argparse
+
         from aedist.evaluate import _evaluate_csv_file
         args = argparse.Namespace(output=str(tmp_path / "out"), reference=None)
         _evaluate_csv_file(csv_path, ref_path, args)

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from aedist.reconcile import plants_to_dataframe, reconcile
-from aedist.schema import MatchType, Plant, FuelType, PlantStatus
+from aedist.schema import MatchType, Plant, FuelType
 
 
 class TestPlantsToDataframeEmpty:

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -1,0 +1,25 @@
+# tests/test_empty_csv.py
+"""Tests for empty CSV / empty plant list handling in the reconciliation pipeline."""
+
+import pytest
+from aedist.reconcile import plants_to_dataframe, reconcile
+from aedist.schema import MatchType, Plant, FuelType, PlantStatus
+
+
+class TestPlantsToDataframeEmpty:
+    """plants_to_dataframe must return a valid cleaned DataFrame for empty input."""
+
+    def test_empty_list_returns_dataframe_with_cleaned_columns(self):
+        """plants_to_dataframe([]) returns a zero-row DataFrame with the
+        columns that the LP matcher requires (name, name_clean, capacity_clean)
+        plus the auxiliary cleaned columns. No exception raised."""
+        df = plants_to_dataframe([])
+        assert len(df) == 0
+        # LP matcher requires these three columns
+        assert "name" in df.columns
+        assert "name_clean" in df.columns
+        assert "capacity_clean" in df.columns
+        # Auxiliary columns from cleaner
+        assert "province_clean" in df.columns
+        assert "fuel_clean" in df.columns
+        assert "status_clean" in df.columns

--- a/tickets/0045-empty-csv-crash.erg
+++ b/tickets/0045-empty-csv-crash.erg
@@ -8,6 +8,9 @@ Author: claude
 2026-04-08T22:00Z claude created
 2026-04-08T22:00Z claude note found during ticket 0036 rebuild
 2026-04-09T12:00Z claude status reimagined by IDD phase 1
+2026-04-09T13:00Z claude status planned by IDD phase 2
+2026-04-09T14:00Z claude note verified feasible — Plant() default enum works, no API keys needed
+2026-04-09T15:00Z claude status executed by IDD phase 3
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary\n\n- Fix crash in `reconcile.py:plants_to_dataframe` — detects empty DataFrame then ignores its own check, falls through to cleaner which raises ValueError\n- Short-circuit with zero-row DataFrame preserving all 11 columns\n- Set `status=\"empty\"` in evaluate.py for zero-row system CSVs (empty CSVs are data with F1=0, not errors)\n- Remove `-k` flag and error suppression from experiments/Makefile\n\n**Milestone:** Pipeline\n**Ticket:** 0045\n\n## Test plan\n\n- [x] `test_empty_list_returns_dataframe_with_cleaned_columns` — plants_to_dataframe([]) returns valid zero-row DataFrame\n- [x] `test_reconcile_empty_system` — reconcile produces REFERENCE_ONLY entries with f1=0\n- [x] `test_evaluate_empty_csv` — status set to \"empty\" not \"ok\"\n- [x] 584/589 pass (5 pre-existing failures in test_score_provenance.py — unrelated)\n\nhttps://claude.ai/code/session_01X2rVnbgXZiDfEozyUmqoom"