### PR TITLE
Ticket 0023: Unify worker dispatch across all 8 Method modes

### DIFF
--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -155,8 +155,8 @@ class Worker:
             )
         elif mode == Method.VERIFICATION:
             raise NotImplementedError(
-                f"verification mode requires external orchestration "
-                f"(use query_verification.py directly)"
+                "verification mode requires external orchestration "
+                "(use query_verification.py directly)"
             )
         else:
             raise ValueError(f"Unsupported mode: {mode!r}")
@@ -275,6 +275,8 @@ class Worker:
                      output_dir, run, pool_label):
         """Execute a web-augmented query."""
         tavily_key = os.environ.get("TAVILY_API_KEY", "")
+        if not tavily_key:
+            log.warning("TAVILY_API_KEY not set — web mode will run without search context")
         web_context, search_log = run_web_searches(tavily_key) if tavily_key else ("", [])
 
         messages = [

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -1,11 +1,9 @@
 """Worker classes with lease semantics for the job board.
 
-Workers poll for pending jobs, acquire exclusive leases via atomic file
-renames, execute the query pipeline, and write results to done/ or failed/.
-
-Subclasses:
-    PadmeWorker  — local Ollama (GPU)
-    OpenRouterWorker — OpenRouter cloud API
+Worker.execute() dispatches on job.mode, routing each job to the correct
+query pipeline (single-turn, RAG, multiturn, web, decomposed).  Subclasses
+override only make_client() to target different endpoints (Ollama vs
+OpenRouter).  All dispatch logic lives in the base class.
 """
 
 import logging
@@ -221,7 +219,12 @@ class Worker:
         if not corpus_dir or not corpus_dir.exists():
             raise ValueError(f"RAG mode requires a valid corpus directory, got {job.corpus!r}")
 
-        corpus_text, corpus_files = load_corpus(corpus_dir)
+        try:
+            corpus_text, corpus_files = load_corpus(corpus_dir)
+        except SystemExit as exc:
+            raise RuntimeError(
+                f"RAG corpus load failed for {corpus_dir}: {exc}"
+            ) from exc
         messages = [
             {"role": "system", "content": corpus_text},
             {"role": "user", "content": prompt},
@@ -276,8 +279,11 @@ class Worker:
         """Execute a web-augmented query."""
         tavily_key = os.environ.get("TAVILY_API_KEY", "")
         if not tavily_key:
-            log.warning("TAVILY_API_KEY not set — web mode will run without search context")
-        web_context, search_log = run_web_searches(tavily_key) if tavily_key else ("", [])
+            raise RuntimeError(
+                "TAVILY_API_KEY is not set — web mode cannot produce valid results "
+                "without search context"
+            )
+        web_context, search_log = run_web_searches(tavily_key)
 
         messages = [
             {"role": "system", "content": (
@@ -301,7 +307,12 @@ class Worker:
         if not corpus_dir or not corpus_dir.exists():
             raise ValueError(f"Decomposed mode requires a valid corpus directory, got {job.corpus!r}")
 
-        corpus_text, corpus_files = load_corpus(corpus_dir)
+        try:
+            corpus_text, corpus_files = load_corpus(corpus_dir)
+        except SystemExit as exc:
+            raise RuntimeError(
+                f"Decomposed corpus load failed for {corpus_dir}: {exc}"
+            ) from exc
         budget = BudgetTracker(job.budget_usd)
 
         log.info("Querying %s run %d (decomposed RAG)...", model_id, run)
@@ -461,7 +472,7 @@ class OpenRouterWorker(Worker):
     """
 
     def __init__(self, jobs_root: Path = Path("jobs")) -> None:
-        super().__init__(worker_id="openrouter", jobs_root=jobs_root)
+        super().__init__(worker_id="", jobs_root=jobs_root)
 
 
 # ---------------------------------------------------------------------------

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -16,6 +16,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 from .harness import (
+    BudgetTracker,
     compute_cost,
     load_models,
     make_client,
@@ -25,9 +26,14 @@ from .harness import (
     save_json,
     should_skip,
 )
+from .query_decomposed import query_decomposed
+from .query_multiturn import run_conversation
+from .query_rag import load_corpus
+from .query_web import run_web_searches
 from .schema import (
     JobSpec,
     LeaseInfo,
+    Method,
     MethodParams,
     ResourceUse,
     RunRecord,
@@ -92,11 +98,255 @@ class Worker:
             expiry_time=expiry,
         )
 
-    # -- execution (abstract) --------------------------------------------------
+    # -- client factory (override in subclasses) --------------------------------
+
+    def make_client(self):
+        """Create an OpenAI-compatible client. Subclasses override for their endpoint."""
+        return make_client()
+
+    # -- mode dispatch ----------------------------------------------------------
 
     def execute(self, job: JobSpec) -> dict:
-        """Subclasses override to call appropriate query pipeline based on job.mode."""
-        raise NotImplementedError
+        """Dispatch to the correct query pipeline based on job.mode.
+
+        Raises ValueError for unrecognized modes. Raises NotImplementedError
+        for modes that require external orchestration (verification).
+        """
+        client = self.make_client()
+        prompt = Path(job.prompt).read_text().strip()
+        models = load_models(job.models_file)
+        output_dir = Path(job.output_dir)
+
+        if job.model_filter:
+            models = [m for m in models if job.model_filter in m["id"]]
+        if not models:
+            raise ValueError(f"No model matched filter {job.model_filter!r}")
+        model_entry = models[0]
+        model_id = model_entry["id"]
+        run = job.run_number
+
+        pool_label = self.worker_id
+        if should_skip(output_dir, model_id, run, pool_label):
+            log.info("Skip %s run %d (cached)", model_id, run)
+            return {"wall_seconds": 0, "cost_usd": 0, "tokens_in": 0,
+                    "tokens_out": 0, "result_file": None}
+
+        mode = job.mode
+        if mode in (Method.SINGLE, Method.FRONTIER, Method.SOURCED):
+            return self._execute_single(
+                client, model_id, model_entry, prompt, output_dir, run, pool_label,
+            )
+        elif mode == Method.RAG:
+            return self._execute_rag(
+                client, model_id, model_entry, prompt, output_dir, run, pool_label, job,
+            )
+        elif mode == Method.MULTITURN:
+            return self._execute_multiturn(
+                client, model_id, model_entry, prompt, output_dir, run, pool_label, job,
+            )
+        elif mode == Method.WEB:
+            return self._execute_web(
+                client, model_id, model_entry, prompt, output_dir, run, pool_label,
+            )
+        elif mode == Method.DECOMPOSED:
+            return self._execute_decomposed(
+                client, model_id, model_entry, prompt, output_dir, run, pool_label, job,
+            )
+        elif mode == Method.VERIFICATION:
+            raise NotImplementedError(
+                f"verification mode requires external orchestration "
+                f"(use query_verification.py directly)"
+            )
+        else:
+            raise ValueError(f"Unsupported mode: {mode!r}")
+
+    # -- per-mode handlers -----------------------------------------------------
+
+    def _execute_single(self, client, model_id, model_entry, prompt,
+                        output_dir, run, pool_label):
+        """Execute a single-turn query."""
+        log.info("Querying %s run %d ...", model_id, run)
+        result = query_single_turn(
+            client, model_id, [{"role": "user", "content": prompt}],
+        )
+        usage = result.get("usage") or {}
+        cost = compute_cost(usage, model_entry)
+
+        filepath = output_path(output_dir, model_id, run, pool_label)
+        save_json(filepath, {
+            "model": model_id,
+            "date": date.today().isoformat(),
+            "run": run,
+            "prompt": prompt,
+            "response": result["content"],
+            "finish_reason": result["finish_reason"],
+            "usage": usage,
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "model_metadata": model_metadata(model_entry),
+        })
+        return {
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "tokens_in": usage.get("prompt_tokens", 0),
+            "tokens_out": usage.get("completion_tokens", 0),
+            "result_file": str(filepath),
+        }
+
+    def _execute_rag(self, client, model_id, model_entry, prompt,
+                     output_dir, run, pool_label, job):
+        """Execute a RAG query: corpus as system context + prompt as user."""
+        corpus_dir = Path(job.corpus) if job.corpus else None
+        if not corpus_dir or not corpus_dir.exists():
+            raise ValueError(f"RAG mode requires a valid corpus directory, got {job.corpus!r}")
+
+        corpus_text, corpus_files = load_corpus(corpus_dir)
+        messages = [
+            {"role": "system", "content": corpus_text},
+            {"role": "user", "content": prompt},
+        ]
+
+        log.info("Querying %s run %d (RAG %s)...", model_id, run, job.strategy or "wholesale")
+        result = query_single_turn(client, model_id, messages)
+        usage = result.get("usage") or {}
+        cost = compute_cost(usage, model_entry)
+
+        filepath = output_path(output_dir, model_id, run, pool_label)
+        save_json(filepath, {
+            "model": model_id,
+            "run": run,
+            "date": date.today().isoformat(),
+            "strategy": job.strategy or "wholesale",
+            "corpus_files": corpus_files,
+            "prompt": prompt,
+            "response": result["content"],
+            "finish_reason": result["finish_reason"],
+            "usage": usage,
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "model_metadata": model_metadata(model_entry),
+        })
+        return {
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "tokens_in": usage.get("prompt_tokens", 0),
+            "tokens_out": usage.get("completion_tokens", 0),
+            "result_file": str(filepath),
+        }
+
+    def _execute_multiturn(self, client, model_id, model_entry, prompt,
+                           output_dir, run, pool_label, job):
+        """Execute a multi-turn conversation."""
+        followups_path = Path(job.followups) if job.followups else None
+        if not followups_path or not followups_path.exists():
+            raise ValueError(f"Multiturn mode requires a valid followups file, got {job.followups!r}")
+
+        followups = [
+            line.strip() for line in followups_path.read_text().splitlines() if line.strip()
+        ]
+        budget = BudgetTracker(job.budget_usd)
+
+        log.info("Querying %s run %d (multiturn, %d followups)...", model_id, run, len(followups))
+        conv = run_conversation(client, model_id, prompt, followups, model_entry, budget)
+        if conv is None:
+            raise RuntimeError(f"Multiturn conversation failed for {model_id} run {run}")
+
+        filepath = output_path(output_dir, model_id, run, pool_label)
+        save_json(filepath, {
+            "model": model_id,
+            "run": run,
+            "date": date.today().isoformat(),
+            "model_metadata": model_metadata(model_entry),
+            **conv,
+        })
+        return {
+            "wall_seconds": conv.get("total_wall_seconds", 0),
+            "cost_usd": conv.get("total_cost_usd", 0),
+            "tokens_in": 0,
+            "tokens_out": 0,
+            "result_file": str(filepath),
+        }
+
+    def _execute_web(self, client, model_id, model_entry, prompt,
+                     output_dir, run, pool_label):
+        """Execute a web-augmented query."""
+        import os
+        tavily_key = os.environ.get("TAVILY_API_KEY", "")
+        web_context, search_log = run_web_searches(tavily_key) if tavily_key else ("", [])
+
+        messages = [
+            {"role": "system", "content": (
+                "Use the following web search results as context "
+                "to answer the user's question.\n\n" + web_context
+            )},
+            {"role": "user", "content": prompt},
+        ]
+
+        log.info("Querying %s run %d (web-augmented)...", model_id, run)
+        result = query_single_turn(client, model_id, messages)
+        usage = result.get("usage") or {}
+        cost = compute_cost(usage, model_entry)
+
+        filepath = output_path(output_dir, model_id, run, pool_label)
+        save_json(filepath, {
+            "model": model_id,
+            "run": run,
+            "date": date.today().isoformat(),
+            "prompt": prompt,
+            "response": result["content"],
+            "finish_reason": result["finish_reason"],
+            "usage": usage,
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "web_searches": search_log,
+            "model_metadata": model_metadata(model_entry),
+        })
+        return {
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "tokens_in": usage.get("prompt_tokens", 0),
+            "tokens_out": usage.get("completion_tokens", 0),
+            "result_file": str(filepath),
+        }
+
+    def _execute_decomposed(self, client, model_id, model_entry, prompt,
+                            output_dir, run, pool_label, job):
+        """Execute decomposed sub-queries by fuel type."""
+        corpus_dir = Path(job.corpus) if job.corpus else None
+        if not corpus_dir or not corpus_dir.exists():
+            raise ValueError(f"Decomposed mode requires a valid corpus directory, got {job.corpus!r}")
+
+        corpus_text, corpus_files = load_corpus(corpus_dir)
+        budget = BudgetTracker(job.budget_usd)
+
+        log.info("Querying %s run %d (decomposed RAG)...", model_id, run)
+        decomposed = query_decomposed(client, model_id, corpus_text, budget, model_entry)
+        if decomposed is None:
+            raise RuntimeError(f"Decomposed query failed for {model_id} run {run}")
+
+        filepath = output_path(output_dir, model_id, run, pool_label)
+        save_json(filepath, {
+            "model": model_id,
+            "run": run,
+            "date": date.today().isoformat(),
+            "strategy": "decomposed",
+            "corpus_files": corpus_files,
+            "prompt": prompt,
+            "response": decomposed.get("merged_csv", ""),
+            "finish_reason": "merged",
+            "usage": decomposed.get("total_usage", {}),
+            "wall_seconds": decomposed.get("total_wall_seconds", 0),
+            "cost_usd": decomposed.get("total_cost_usd", 0),
+            "model_metadata": model_metadata(model_entry),
+            "n_merged_plants": decomposed.get("n_merged_plants", 0),
+        })
+        return {
+            "wall_seconds": decomposed.get("total_wall_seconds", 0),
+            "cost_usd": decomposed.get("total_cost_usd", 0),
+            "tokens_in": decomposed.get("total_usage", {}).get("prompt_tokens", 0),
+            "tokens_out": decomposed.get("total_usage", {}).get("completion_tokens", 0),
+            "result_file": str(filepath),
+        }
 
     # -- completion ------------------------------------------------------------
 
@@ -195,7 +445,7 @@ class PadmeWorker(Worker):
     """Worker for local GPU execution via Ollama.
 
     Executes jobs sequentially (one model at a time) using the local
-    Ollama endpoint.
+    Ollama endpoint.  Dispatch logic is inherited from Worker.execute().
     """
 
     def __init__(
@@ -206,63 +456,9 @@ class PadmeWorker(Worker):
         super().__init__(worker_id="padme", jobs_root=jobs_root)
         self.base_url = base_url
 
-    def execute(self, job: JobSpec) -> dict:
-        """Run a single query against Ollama.
-
-        Each job targets exactly one model (via model_filter) and one run
-        (repeat=1).  The manager handles fan-out.
-        """
-        client = make_client(self.base_url)
-        prompt = Path(job.prompt).read_text().strip()
-        models = load_models(job.models_file)
-        output_dir = Path(job.output_dir)
-
-        if job.model_filter:
-            models = [m for m in models if job.model_filter in m["id"]]
-        if not models:
-            raise ValueError(f"No model matched filter {job.model_filter!r}")
-        model_entry = models[0]
-        model_id = model_entry["id"]
-
-        run = job.run_number
-
-        if should_skip(output_dir, model_id, run, "padme"):
-            log.info("Skip %s run %d (cached)", model_id, run)
-            return {"wall_seconds": 0, "cost_usd": 0, "tokens_in": 0,
-                    "tokens_out": 0, "result_file": None}
-
-        log.info("Querying %s run %d ...", model_id, run)
-        result = query_single_turn(
-            client, model_id, [{"role": "user", "content": prompt}],
-        )
-
-        usage = result.get("usage") or {}
-        cost = compute_cost(usage, model_entry)
-
-        filepath = output_path(output_dir, model_id, run, "padme")
-        save_json(
-            filepath,
-            {
-                "model": model_id,
-                "date": date.today().isoformat(),
-                "run": run,
-                "prompt": prompt,
-                "response": result["content"],
-                "finish_reason": result["finish_reason"],
-                "usage": usage,
-                "wall_seconds": result["wall_seconds"],
-                "cost_usd": cost,
-                "model_metadata": model_metadata(model_entry),
-            },
-        )
-
-        return {
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "tokens_in": usage.get("prompt_tokens", 0),
-            "tokens_out": usage.get("completion_tokens", 0),
-            "result_file": str(filepath),
-        }
+    def make_client(self):
+        """Create an OpenAI-compatible client for Ollama."""
+        return make_client(self.base_url)
 
 
 # ---------------------------------------------------------------------------
@@ -276,64 +472,11 @@ class OpenRouterWorker(Worker):
     """Worker for execution via OpenRouter cloud API.
 
     Each job is a single (model, run) pair — the manager handles fan-out.
+    Dispatch logic is inherited from Worker.execute().
     """
 
     def __init__(self, jobs_root: Path = Path("jobs")) -> None:
         super().__init__(worker_id="openrouter", jobs_root=jobs_root)
-
-    def execute(self, job: JobSpec) -> dict:
-        """Run a single query via OpenRouter."""
-        client = make_client()
-        prompt = Path(job.prompt).read_text().strip()
-        models = load_models(job.models_file)
-        output_dir = Path(job.output_dir)
-
-        if job.model_filter:
-            models = [m for m in models if job.model_filter in m["id"]]
-        if not models:
-            raise ValueError(f"No model matched filter {job.model_filter!r}")
-        model_entry = models[0]
-        model_id = model_entry["id"]
-
-        run = job.run_number
-
-        if should_skip(output_dir, model_id, run):
-            log.info("Skip %s run %d (cached)", model_id, run)
-            return {"wall_seconds": 0, "cost_usd": 0, "tokens_in": 0,
-                    "tokens_out": 0, "result_file": None}
-
-        log.info("Querying %s run %d ...", model_id, run)
-        result = query_single_turn(
-            client, model_id, [{"role": "user", "content": prompt}],
-        )
-
-        usage = result.get("usage") or {}
-        cost = compute_cost(usage, model_entry)
-
-        filepath = output_path(output_dir, model_id, run)
-        save_json(
-            filepath,
-            {
-                "model": model_id,
-                "date": date.today().isoformat(),
-                "run": run,
-                "prompt": prompt,
-                "response": result["content"],
-                "finish_reason": result["finish_reason"],
-                "usage": usage,
-                "wall_seconds": result["wall_seconds"],
-                "cost_usd": cost,
-                "model_metadata": model_metadata(model_entry),
-            },
-        )
-
-        return {
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "tokens_in": usage.get("prompt_tokens", 0),
-            "tokens_out": usage.get("completion_tokens", 0),
-            "result_file": str(filepath),
-        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -9,6 +9,7 @@ Subclasses:
 """
 
 import logging
+import os
 import re
 import signal
 import traceback
@@ -162,29 +163,10 @@ class Worker:
 
     # -- per-mode handlers -----------------------------------------------------
 
-    def _execute_single(self, client, model_id, model_entry, prompt,
-                        output_dir, run, pool_label):
-        """Execute a single-turn query."""
-        log.info("Querying %s run %d ...", model_id, run)
-        result = query_single_turn(
-            client, model_id, [{"role": "user", "content": prompt}],
-        )
+    @staticmethod
+    def _build_result(result: dict, cost: float, filepath: Path) -> dict:
+        """Build the standard return dict from a query_single_turn result."""
         usage = result.get("usage") or {}
-        cost = compute_cost(usage, model_entry)
-
-        filepath = output_path(output_dir, model_id, run, pool_label)
-        save_json(filepath, {
-            "model": model_id,
-            "date": date.today().isoformat(),
-            "run": run,
-            "prompt": prompt,
-            "response": result["content"],
-            "finish_reason": result["finish_reason"],
-            "usage": usage,
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "model_metadata": model_metadata(model_entry),
-        })
         return {
             "wall_seconds": result["wall_seconds"],
             "cost_usd": cost,
@@ -192,6 +174,45 @@ class Worker:
             "tokens_out": usage.get("completion_tokens", 0),
             "result_file": str(filepath),
         }
+
+    def _query_and_save(self, client, model_id, model_entry, messages,
+                        output_dir, run, pool_label, extra_fields=None):
+        """Run query_single_turn, save JSON, return standard result dict.
+
+        Common path for single, RAG, and web modes that all use
+        query_single_turn with different message lists.
+        """
+        result = query_single_turn(client, model_id, messages)
+        usage = result.get("usage") or {}
+        cost = compute_cost(usage, model_entry)
+
+        filepath = output_path(output_dir, model_id, run, pool_label)
+        record = {
+            "model": model_id,
+            "date": date.today().isoformat(),
+            "run": run,
+            "response": result["content"],
+            "finish_reason": result["finish_reason"],
+            "usage": usage,
+            "wall_seconds": result["wall_seconds"],
+            "cost_usd": cost,
+            "model_metadata": model_metadata(model_entry),
+        }
+        if extra_fields:
+            record.update(extra_fields)
+        save_json(filepath, record)
+        return self._build_result(result, cost, filepath)
+
+    def _execute_single(self, client, model_id, model_entry, prompt,
+                        output_dir, run, pool_label):
+        """Execute a single-turn query."""
+        log.info("Querying %s run %d ...", model_id, run)
+        messages = [{"role": "user", "content": prompt}]
+        return self._query_and_save(
+            client, model_id, model_entry, messages,
+            output_dir, run, pool_label,
+            extra_fields={"prompt": prompt},
+        )
 
     def _execute_rag(self, client, model_id, model_entry, prompt,
                      output_dir, run, pool_label, job):
@@ -207,32 +228,15 @@ class Worker:
         ]
 
         log.info("Querying %s run %d (RAG %s)...", model_id, run, job.strategy or "wholesale")
-        result = query_single_turn(client, model_id, messages)
-        usage = result.get("usage") or {}
-        cost = compute_cost(usage, model_entry)
-
-        filepath = output_path(output_dir, model_id, run, pool_label)
-        save_json(filepath, {
-            "model": model_id,
-            "run": run,
-            "date": date.today().isoformat(),
-            "strategy": job.strategy or "wholesale",
-            "corpus_files": corpus_files,
-            "prompt": prompt,
-            "response": result["content"],
-            "finish_reason": result["finish_reason"],
-            "usage": usage,
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "model_metadata": model_metadata(model_entry),
-        })
-        return {
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "tokens_in": usage.get("prompt_tokens", 0),
-            "tokens_out": usage.get("completion_tokens", 0),
-            "result_file": str(filepath),
-        }
+        return self._query_and_save(
+            client, model_id, model_entry, messages,
+            output_dir, run, pool_label,
+            extra_fields={
+                "prompt": prompt,
+                "strategy": job.strategy or "wholesale",
+                "corpus_files": corpus_files,
+            },
+        )
 
     def _execute_multiturn(self, client, model_id, model_entry, prompt,
                            output_dir, run, pool_label, job):
@@ -270,7 +274,6 @@ class Worker:
     def _execute_web(self, client, model_id, model_entry, prompt,
                      output_dir, run, pool_label):
         """Execute a web-augmented query."""
-        import os
         tavily_key = os.environ.get("TAVILY_API_KEY", "")
         web_context, search_log = run_web_searches(tavily_key) if tavily_key else ("", [])
 
@@ -283,31 +286,11 @@ class Worker:
         ]
 
         log.info("Querying %s run %d (web-augmented)...", model_id, run)
-        result = query_single_turn(client, model_id, messages)
-        usage = result.get("usage") or {}
-        cost = compute_cost(usage, model_entry)
-
-        filepath = output_path(output_dir, model_id, run, pool_label)
-        save_json(filepath, {
-            "model": model_id,
-            "run": run,
-            "date": date.today().isoformat(),
-            "prompt": prompt,
-            "response": result["content"],
-            "finish_reason": result["finish_reason"],
-            "usage": usage,
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "web_searches": search_log,
-            "model_metadata": model_metadata(model_entry),
-        })
-        return {
-            "wall_seconds": result["wall_seconds"],
-            "cost_usd": cost,
-            "tokens_in": usage.get("prompt_tokens", 0),
-            "tokens_out": usage.get("completion_tokens", 0),
-            "result_file": str(filepath),
-        }
+        return self._query_and_save(
+            client, model_id, model_entry, messages,
+            output_dir, run, pool_label,
+            extra_fields={"prompt": prompt, "web_searches": search_log},
+        )
 
     def _execute_decomposed(self, client, model_id, model_entry, prompt,
                             output_dir, run, pool_label, job):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13,6 +13,9 @@ def _make_job(
     mode: str = "single",
     timeout_seconds: int = 600,
     model_filter: str | None = "openai/gpt-4o",
+    corpus: str | None = None,
+    followups: str | None = None,
+    strategy: str | None = None,
 ) -> JobSpec:
     """Create a minimal JobSpec for testing."""
     return JobSpec(
@@ -24,6 +27,9 @@ def _make_job(
         model_filter=model_filter,
         output_dir="outputs/test",
         timeout_seconds=timeout_seconds,
+        corpus=corpus,
+        followups=followups,
+        strategy=strategy,
     )
 
 
@@ -431,3 +437,234 @@ def test_openrouter_full_lifecycle(tmp_path: Path) -> None:
     assert record is not None
     assert record.method == Method.SINGLE
     assert (jobs_root / "done" / "or-lc.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# Mode dispatch tests (Ticket 0023)
+# ---------------------------------------------------------------------------
+
+
+def _canned_single_result():
+    """Canned result dict from query_single_turn."""
+    return {
+        "content": "Plant A,coal,operational",
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 50, "completion_tokens": 100},
+        "wall_seconds": 3.5,
+    }
+
+
+def _dispatch_patches(tmp_path):
+    """Patches for dispatch tests — mocks make_client and all harness fns."""
+    return {
+        "make_client": MagicMock(return_value=MagicMock()),
+        "load_models": MagicMock(return_value=[{"id": "qwen3:8b"}]),
+        "compute_cost": MagicMock(return_value=0.0),
+        "model_metadata": MagicMock(return_value={}),
+        "save_json": MagicMock(),
+        "should_skip": MagicMock(return_value=False),
+        "output_path": MagicMock(return_value=tmp_path / "out" / "r.json"),
+        "query_single_turn": MagicMock(return_value=_canned_single_result()),
+    }
+
+
+def test_rag_job_dispatches_to_rag_pipeline(tmp_path: Path) -> None:
+    """A job with mode=rag must call RAG query functions, not single-turn."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc1.md").write_text("Some corpus content")
+
+    job = _make_job(
+        mode="rag",
+        corpus=str(corpus_dir),
+        strategy="wholesale",
+        model_filter="qwen3:8b",
+    )
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        result = worker.execute(job)
+
+    # RAG path should build system+user messages with corpus, not just user message
+    call_args = patches["query_single_turn"].call_args
+    messages = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("messages")
+    assert len(messages) == 2  # system (corpus) + user (prompt)
+    assert messages[0]["role"] == "system"
+    assert "corpus" in messages[0]["content"].lower() or "Some corpus content" in messages[0]["content"]
+    assert result["wall_seconds"] == 3.5
+
+
+def test_multiturn_job_dispatches_to_multiturn(tmp_path: Path) -> None:
+    """A job with mode=multiturn must run a multi-turn conversation."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+    followups_file = tmp_path / "followups.txt"
+    followups_file.write_text("What about gas plants?\nAny LNG?")
+
+    job = _make_job(mode="multiturn", followups=str(followups_file), model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        result = worker.execute(job)
+
+    # Multiturn should call query_single_turn multiple times (initial + followups)
+    assert patches["query_single_turn"].call_count >= 2  # initial + at least 1 followup
+    assert "wall_seconds" in result
+
+
+def test_web_job_dispatches_to_web(tmp_path: Path) -> None:
+    """A job with mode=web must run web-augmented queries."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(mode="web", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch("aedist.worker.run_web_searches", return_value=("web context", [])):
+        with patch.multiple("aedist.worker", **patches):
+            result = worker.execute(job)
+
+    # Web path builds system message with web search context
+    call_args = patches["query_single_turn"].call_args
+    messages = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("messages")
+    assert messages[0]["role"] == "system"
+    assert result["wall_seconds"] == 3.5
+
+
+def test_decomposed_job_dispatches_to_decomposed(tmp_path: Path) -> None:
+    """A job with mode=decomposed must run decomposed sub-queries."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc1.md").write_text("Some corpus content")
+
+    job = _make_job(mode="decomposed", corpus=str(corpus_dir), model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        result = worker.execute(job)
+
+    # Decomposed runs 3 sub-queries (coal, gas, other)
+    assert patches["query_single_turn"].call_count == 3
+    assert "wall_seconds" in result
+
+
+def test_single_job_dispatches_to_single(tmp_path: Path) -> None:
+    """A job with mode=single still calls query_single_turn."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(mode="single", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        result = worker.execute(job)
+
+    patches["query_single_turn"].assert_called_once()
+    assert result["wall_seconds"] == 3.5
+
+
+def test_unknown_mode_raises(tmp_path: Path) -> None:
+    """An unrecognized mode must raise, not silently fall back to single-turn."""
+    import pytest
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    # We can't construct a JobSpec with an invalid enum, so test via internal dispatch
+    job = _make_job(mode="single", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    # Monkey-patch mode to an unknown value to test the dispatch guard
+    object.__setattr__(job, "mode", "nonexistent_mode")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        with pytest.raises(ValueError, match="Unsupported mode"):
+            worker.execute(job)
+
+
+def test_dispatch_shared_between_padme_and_openrouter(tmp_path: Path) -> None:
+    """PadmeWorker and OpenRouterWorker share the same dispatch logic."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc1.md").write_text("Some corpus content")
+
+    job = _make_job(mode="rag", corpus=str(corpus_dir), strategy="wholesale", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+
+    for WorkerCls in [PadmeWorker, OpenRouterWorker]:
+        worker = WorkerCls(jobs_root=tmp_path / f"jobs-{WorkerCls.__name__}")
+        patches = _dispatch_patches(tmp_path)
+        with patch.multiple("aedist.worker", **patches):
+            result = worker.execute(job)
+        # Both workers should dispatch RAG the same way
+        call_args = patches["query_single_turn"].call_args
+        messages = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("messages")
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+
+
+def test_verification_job_raises_not_implemented(tmp_path: Path) -> None:
+    """Verification mode requires special handling not available in worker dispatch."""
+    import pytest
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(mode="verification", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        with pytest.raises(NotImplementedError, match="verification"):
+            worker.execute(job)
+
+
+def test_frontier_job_dispatches_like_single(tmp_path: Path) -> None:
+    """Frontier mode dispatches through query_single_turn like single mode."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(mode="frontier", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        result = worker.execute(job)
+
+    patches["query_single_turn"].assert_called_once()
+    assert result["wall_seconds"] == 3.5
+
+
+def test_sourced_job_dispatches_like_single(tmp_path: Path) -> None:
+    """Sourced mode dispatches through query_single_turn (same as single)."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(mode="sourced", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _dispatch_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        result = worker.execute(job)
+
+    patches["query_single_turn"].assert_called_once()
+    assert result["wall_seconds"] == 3.5

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -509,13 +509,19 @@ def test_multiturn_job_dispatches_to_multiturn(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
+    mock_conv_result = {
+        "turns": [{"role": "user", "content": "List thermal plants", "turn": 0}],
+        "total_cost_usd": 0.01,
+        "total_wall_seconds": 5.0,
+        "context_overflow": False,
+    }
     patches = _dispatch_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
-        result = worker.execute(job)
+        with patch("aedist.worker.run_conversation", return_value=mock_conv_result) as mock_run:
+            result = worker.execute(job)
 
-    # Multiturn should call query_single_turn multiple times (initial + followups)
-    assert patches["query_single_turn"].call_count >= 2  # initial + at least 1 followup
-    assert "wall_seconds" in result
+    mock_run.assert_called_once()
+    assert result["wall_seconds"] == 5.0
 
 
 def test_web_job_dispatches_to_web(tmp_path: Path) -> None:
@@ -551,13 +557,23 @@ def test_decomposed_job_dispatches_to_decomposed(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
+    mock_decomposed_result = {
+        "strategy": "decomposed",
+        "sub_queries": {},
+        "merged_csv": "name,fuel\nPlant A,coal",
+        "n_merged_plants": 1,
+        "total_cost_usd": 0.03,
+        "total_wall_seconds": 10.0,
+        "total_usage": {"prompt_tokens": 150, "completion_tokens": 300},
+    }
     patches = _dispatch_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
-        result = worker.execute(job)
+        with patch("aedist.worker.query_decomposed", return_value=mock_decomposed_result) as mock_dec:
+            result = worker.execute(job)
 
-    # Decomposed runs 3 sub-queries (coal, gas, other)
-    assert patches["query_single_turn"].call_count == 3
-    assert "wall_seconds" in result
+    mock_dec.assert_called_once()
+    assert result["wall_seconds"] == 10.0
+    assert result["tokens_in"] == 150
 
 
 def test_single_job_dispatches_to_single(tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -609,11 +609,11 @@ def test_dispatch_shared_between_padme_and_openrouter(tmp_path: Path) -> None:
     job = _make_job(mode="rag", corpus=str(corpus_dir), strategy="wholesale", model_filter="qwen3:8b")
     job = job.model_copy(update={"prompt": str(prompt_file)})
 
-    for WorkerCls in [PadmeWorker, OpenRouterWorker]:
-        worker = WorkerCls(jobs_root=tmp_path / f"jobs-{WorkerCls.__name__}")
+    for worker_cls in [PadmeWorker, OpenRouterWorker]:
+        worker = worker_cls(jobs_root=tmp_path / f"jobs-{worker_cls.__name__}")
         patches = _harness_patches(tmp_path)
         with patch.multiple("aedist.worker", **patches):
-            result = worker.execute(job)
+            worker.execute(job)
         # Both workers should dispatch RAG the same way
         call_args = patches["query_single_turn"].call_args
         messages = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("messages")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from aedist.schema import JobSpec, Method
 from aedist.worker import OpenRouterWorker, PadmeWorker, Worker
 
@@ -292,19 +294,25 @@ def test_padme_worker_custom_base_url(tmp_path: Path) -> None:
     assert worker.base_url == "http://gpu:8080/v1"
 
 
-def _harness_patches(tmp_path):
-    """Context manager dict for patching harness functions in aedist.worker."""
+def _canned_single_result():
+    """Canned result dict from query_single_turn."""
     return {
-        "make_client": MagicMock(),
+        "content": "Plant A,coal,operational",
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 50, "completion_tokens": 100},
+        "wall_seconds": 3.5,
+    }
+
+
+def _harness_patches(tmp_path):
+    """Patch dict for all harness functions used in aedist.worker.
+
+    Shared by lifecycle tests, PadmeWorker tests, and dispatch tests.
+    """
+    return {
+        "make_client": MagicMock(return_value=MagicMock()),
         "load_models": MagicMock(return_value=[{"id": "qwen3:8b"}]),
-        "query_single_turn": MagicMock(
-            return_value={
-                "content": "Plant A,coal,operational",
-                "finish_reason": "stop",
-                "usage": {"prompt_tokens": 50, "completion_tokens": 100},
-                "wall_seconds": 3.5,
-            }
-        ),
+        "query_single_turn": MagicMock(return_value=_canned_single_result()),
         "compute_cost": MagicMock(return_value=0.0),
         "model_metadata": MagicMock(return_value={}),
         "save_json": MagicMock(),
@@ -376,9 +384,9 @@ def test_padme_full_lifecycle(tmp_path: Path) -> None:
 
 
 def test_openrouter_worker_id(tmp_path: Path) -> None:
-    """OpenRouterWorker always has worker_id='openrouter'."""
+    """OpenRouterWorker uses empty worker_id to avoid filename prefix."""
     worker = OpenRouterWorker(jobs_root=tmp_path / "jobs")
-    assert worker.worker_id == "openrouter"
+    assert worker.worker_id == ""
 
 
 def test_openrouter_worker_execute(tmp_path: Path) -> None:
@@ -444,30 +452,6 @@ def test_openrouter_full_lifecycle(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _canned_single_result():
-    """Canned result dict from query_single_turn."""
-    return {
-        "content": "Plant A,coal,operational",
-        "finish_reason": "stop",
-        "usage": {"prompt_tokens": 50, "completion_tokens": 100},
-        "wall_seconds": 3.5,
-    }
-
-
-def _dispatch_patches(tmp_path):
-    """Patches for dispatch tests — mocks make_client and all harness fns."""
-    return {
-        "make_client": MagicMock(return_value=MagicMock()),
-        "load_models": MagicMock(return_value=[{"id": "qwen3:8b"}]),
-        "compute_cost": MagicMock(return_value=0.0),
-        "model_metadata": MagicMock(return_value={}),
-        "save_json": MagicMock(),
-        "should_skip": MagicMock(return_value=False),
-        "output_path": MagicMock(return_value=tmp_path / "out" / "r.json"),
-        "query_single_turn": MagicMock(return_value=_canned_single_result()),
-    }
-
-
 def test_rag_job_dispatches_to_rag_pipeline(tmp_path: Path) -> None:
     """A job with mode=rag must call RAG query functions, not single-turn."""
     prompt_file = tmp_path / "prompt.txt"
@@ -485,7 +469,7 @@ def test_rag_job_dispatches_to_rag_pipeline(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         result = worker.execute(job)
 
@@ -515,7 +499,7 @@ def test_multiturn_job_dispatches_to_multiturn(tmp_path: Path) -> None:
         "total_wall_seconds": 5.0,
         "context_overflow": False,
     }
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         with patch("aedist.worker.run_conversation", return_value=mock_conv_result) as mock_run:
             result = worker.execute(job)
@@ -524,8 +508,10 @@ def test_multiturn_job_dispatches_to_multiturn(tmp_path: Path) -> None:
     assert result["wall_seconds"] == 5.0
 
 
-def test_web_job_dispatches_to_web(tmp_path: Path) -> None:
+def test_web_job_dispatches_to_web(tmp_path: Path, monkeypatch) -> None:
     """A job with mode=web must run web-augmented queries."""
+    monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+
     prompt_file = tmp_path / "prompt.txt"
     prompt_file.write_text("List thermal plants")
 
@@ -533,7 +519,7 @@ def test_web_job_dispatches_to_web(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch("aedist.worker.run_web_searches", return_value=("web context", [])):
         with patch.multiple("aedist.worker", **patches):
             result = worker.execute(job)
@@ -566,7 +552,7 @@ def test_decomposed_job_dispatches_to_decomposed(tmp_path: Path) -> None:
         "total_wall_seconds": 10.0,
         "total_usage": {"prompt_tokens": 150, "completion_tokens": 300},
     }
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         with patch("aedist.worker.query_decomposed", return_value=mock_decomposed_result) as mock_dec:
             result = worker.execute(job)
@@ -585,7 +571,7 @@ def test_single_job_dispatches_to_single(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         result = worker.execute(job)
 
@@ -595,7 +581,6 @@ def test_single_job_dispatches_to_single(tmp_path: Path) -> None:
 
 def test_unknown_mode_raises(tmp_path: Path) -> None:
     """An unrecognized mode must raise, not silently fall back to single-turn."""
-    import pytest
     prompt_file = tmp_path / "prompt.txt"
     prompt_file.write_text("List thermal plants")
 
@@ -607,7 +592,7 @@ def test_unknown_mode_raises(tmp_path: Path) -> None:
     # Monkey-patch mode to an unknown value to test the dispatch guard
     object.__setattr__(job, "mode", "nonexistent_mode")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         with pytest.raises(ValueError, match="Unsupported mode"):
             worker.execute(job)
@@ -626,7 +611,7 @@ def test_dispatch_shared_between_padme_and_openrouter(tmp_path: Path) -> None:
 
     for WorkerCls in [PadmeWorker, OpenRouterWorker]:
         worker = WorkerCls(jobs_root=tmp_path / f"jobs-{WorkerCls.__name__}")
-        patches = _dispatch_patches(tmp_path)
+        patches = _harness_patches(tmp_path)
         with patch.multiple("aedist.worker", **patches):
             result = worker.execute(job)
         # Both workers should dispatch RAG the same way
@@ -638,7 +623,6 @@ def test_dispatch_shared_between_padme_and_openrouter(tmp_path: Path) -> None:
 
 def test_verification_job_raises_not_implemented(tmp_path: Path) -> None:
     """Verification mode requires special handling not available in worker dispatch."""
-    import pytest
     prompt_file = tmp_path / "prompt.txt"
     prompt_file.write_text("List thermal plants")
 
@@ -646,7 +630,7 @@ def test_verification_job_raises_not_implemented(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         with pytest.raises(NotImplementedError, match="verification"):
             worker.execute(job)
@@ -661,7 +645,7 @@ def test_frontier_job_dispatches_like_single(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         result = worker.execute(job)
 
@@ -678,9 +662,71 @@ def test_sourced_job_dispatches_like_single(tmp_path: Path) -> None:
     job = job.model_copy(update={"prompt": str(prompt_file)})
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
 
-    patches = _dispatch_patches(tmp_path)
+    patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         result = worker.execute(job)
 
     patches["query_single_turn"].assert_called_once()
     assert result["wall_seconds"] == 3.5
+
+
+# ---------------------------------------------------------------------------
+# pool_label / filename prefix tests (Ticket 0023 review fix 1)
+# ---------------------------------------------------------------------------
+
+
+def test_padme_pool_label_is_padme(tmp_path: Path) -> None:
+    """PadmeWorker uses 'padme' as pool_label, producing prefixed filenames."""
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+    assert worker.worker_id == "padme"
+
+
+def test_openrouter_pool_label_is_empty(tmp_path: Path) -> None:
+    """OpenRouterWorker uses empty pool_label, producing unprefixed filenames."""
+    worker = OpenRouterWorker(jobs_root=tmp_path / "jobs")
+    assert worker.worker_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Web mode without API key must raise (Ticket 0023 review fix 2)
+# ---------------------------------------------------------------------------
+
+
+def test_web_mode_raises_without_tavily_key(tmp_path: Path, monkeypatch) -> None:
+    """Web mode must raise RuntimeError when TAVILY_API_KEY is unset."""
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(mode="web", model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        with pytest.raises(RuntimeError, match="TAVILY_API_KEY"):
+            worker.execute(job)
+
+
+# ---------------------------------------------------------------------------
+# RAG SystemExit catch (Ticket 0023 review fix 3)
+# ---------------------------------------------------------------------------
+
+
+def test_rag_empty_corpus_raises_runtime_error(tmp_path: Path) -> None:
+    """RAG mode converts SystemExit from load_corpus into RuntimeError."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+    corpus_dir = tmp_path / "empty_corpus"
+    corpus_dir.mkdir()
+    # No .md files => load_corpus raises SystemExit
+
+    job = _make_job(mode="rag", corpus=str(corpus_dir), model_filter="qwen3:8b")
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        with pytest.raises(RuntimeError, match="RAG corpus load failed"):
+            worker.execute(job)

--- a/tickets/0023-smart-worker-dispatch.erg
+++ b/tickets/0023-smart-worker-dispatch.erg
@@ -5,11 +5,11 @@ Created: 2026-04-08
 Author: claude
 
 --- log ---
-2026-04-09T16:00Z claude status executed by IDD phase 3
-2026-04-09T12:00Z claude status reimagined by IDD phase 1
-2026-04-08T13:00Z claude note unblocked — 0011 merged (PR #188)
 2026-04-08T06:16Z claude created
 2026-04-08T06:16Z claude note Design from review of ticket 0011
+2026-04-08T13:00Z claude note unblocked — 0011 merged (PR #188)
+2026-04-09T12:00Z claude status reimagined by IDD phase 1
+2026-04-09T16:00Z claude status executed by IDD phase 3
 
 --- body ---
 ## Context

--- a/tickets/0023-smart-worker-dispatch.erg
+++ b/tickets/0023-smart-worker-dispatch.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Workers self-select jobs by capability, not pool field
-Status: open
+Status: doing
 Created: 2026-04-08
 Author: claude
 
@@ -10,6 +10,8 @@ Author: claude
 2026-04-08T13:00Z claude note unblocked — 0011 merged (PR #188)
 2026-04-09T12:00Z claude status reimagined by IDD phase 1
 2026-04-09T16:00Z claude status executed by IDD phase 3
+2026-04-09T18:00Z claude status doing — review fixes in progress
+2026-04-09T18:00Z claude note scope expanded from 3 modes (single/rag/multiturn) to 7 modes (single/frontier/sourced/rag/multiturn/web/decomposed)
 
 --- body ---
 ## Context

--- a/tickets/0023-smart-worker-dispatch.erg
+++ b/tickets/0023-smart-worker-dispatch.erg
@@ -5,6 +5,7 @@ Created: 2026-04-08
 Author: claude
 
 --- log ---
+2026-04-09T16:00Z claude status executed by IDD phase 3
 2026-04-09T12:00Z claude status reimagined by IDD phase 1
 2026-04-08T13:00Z claude note unblocked — 0011 merged (PR #188)
 2026-04-08T06:16Z claude created


### PR DESCRIPTION
## Summary\n\n- Move `Worker.execute()` from abstract to concrete dispatcher across all 8 `Method` enum values\n- New `make_client()` factory: PadmeWorker passes Ollama URL, OpenRouterWorker uses default\n- Delete 120+ lines of duplicated `execute()` from both subclasses\n- Extract `_query_and_save()` helper for the common query/save/return pattern\n- Verification mode raises `NotImplementedError` (requires external orchestration)\n- Unknown modes raise `ValueError` (no silent fallback to single-turn)\n\n**Fixes silent bug**: workers previously ignored `job.mode` and hardcoded `query_single_turn` for all modes.\n\n**Milestone:** Pipeline\n**Ticket:** 0023\n\n## Test plan\n\n- [x] 10 new dispatch tests covering all 8 enum values\n- [x] Unknown mode raises ValueError\n- [x] Verification raises NotImplementedError\n- [x] PadmeWorker and OpenRouterWorker share dispatch logic\n- [x] 584 tests pass, 0 failures\n\nhttps://claude.ai/code/session_01X2rVnbgXZiDfEozyUmqoom