### PR TITLE
Raise ruff bar: fix bug-class violations, enable B/PERF/PGH rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ target-version = "py311"
 line-length = 99
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "PERF", "PGH", "PIE810", "RUF012"]
 ignore = ["E501"]
 
 [tool.pytest.ini_options]

--- a/src/aedist/build_corpus.py
+++ b/src/aedist/build_corpus.py
@@ -140,15 +140,11 @@ def parse_reference_titles(readme_path: Path) -> list[str]:
     from the report/inputs/README.md format.
     """
     text = readme_path.read_text(encoding="utf-8")
-    titles = []
-
     # Match \emph{...} titles (government documents)
-    for m in re.finditer(r"\\emph\{([^}]+)\}", text):
-        titles.append(m.group(1).strip())
+    titles = [m.group(1).strip() for m in re.finditer(r"\\emph\{([^}]+)\}", text)]
 
     # Match backtick-quoted titles (articles)
-    for m in re.finditer(r"`([^']+)'", text):
-        titles.append(m.group(1).strip())
+    titles.extend(m.group(1).strip() for m in re.finditer(r"`([^']+)'", text))
 
     return titles
 

--- a/src/aedist/cleaner/cleaner.py
+++ b/src/aedist/cleaner/cleaner.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 import unicodedata
 from pathlib import Path
+from typing import ClassVar
 
 import pandas as pd
 
@@ -19,7 +20,7 @@ class PowerPlantDataframeCleaner:
     columns 'name', 'province', 'fuel', 'capacity', and 'status'.
     """
 
-    REQUIRED_COLUMNS: set[str] = {"name", "province", "fuel", "capacity", "status"}
+    REQUIRED_COLUMNS: ClassVar[set[str]] = {"name", "province", "fuel", "capacity", "status"}
 
     def __init__(self, config_path: str | None = None) -> None:
         """

--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -51,13 +51,12 @@ LENGTH_BONUS_CAP_LINES = 50.0
 def extract_fenced_blocks(text: str) -> list[str]:
     # Capture content in ```csv ...``` or ``` ... ```
     # Use \r?\n to handle both LF and CRLF line endings.
-    blocks: list[str] = []
-    for m in re.finditer(
-        r"```(?:csv)?\s*\r?\n(.*?)\r?\n```", text, flags=re.IGNORECASE | re.DOTALL
-    ):
-        # Strip any remaining \r from captured content (CRLF inside block)
-        blocks.append(m.group(1).replace("\r", ""))
-    return blocks
+    return [
+        m.group(1).replace("\r", "")
+        for m in re.finditer(
+            r"```(?:csv)?\s*\r?\n(.*?)\r?\n```", text, flags=re.IGNORECASE | re.DOTALL
+        )
+    ]
 
 
 def score_csv_like_block(block: str) -> float:

--- a/src/aedist/matching/lp.py
+++ b/src/aedist/matching/lp.py
@@ -260,17 +260,18 @@ def _extract_results(
     x_vars = context["x_vars"]  # type: dict[tuple[int, int], LpVariable]
     u_vars = context["u_vars"]  # type: dict[int, LpVariable]
     v_vars = context["v_vars"]  # type: dict[int, LpVariable]
-    sim_thresh: int = config["similarity_threshold"]  # type: ignore
+    sim_thresh: int = config["similarity_threshold"]  # type: ignore[assignment]
     cap_tol: float = float(config["capacity_tolerance"])
 
     results: list[dict[str, object]] = []
     indices1: list[int] = list(df1.index)
     indices2: list[int] = list(df2.index)
-    matched_pairs: list[tuple[int, int]] = []
-    for i in indices1:
-        for j in indices2:
-            if x_vars[(i, j)].varValue >= 0.5:
-                matched_pairs.append((i, j))
+    matched_pairs: list[tuple[int, int]] = [
+        (i, j)
+        for i in indices1
+        for j in indices2
+        if x_vars[(i, j)].varValue >= 0.5
+    ]
     unmatched_df1: list[int] = [i for i in indices1 if u_vars[i].varValue >= 0.5]
     unmatched_df2: list[int] = [j for j in indices2 if v_vars[j].varValue >= 0.5]
 
@@ -292,11 +293,8 @@ def _extract_results(
                 status = "Mismatched"
         results.append(build_result_row(df1.loc[i], df2.loc[j], status, similarity_score=score))
 
-    for i in unmatched_df1:
-        results.append(build_result_row(df1.loc[i], None, "Only in file1"))
-
-    for j in unmatched_df2:
-        results.append(build_result_row(None, df2.loc[j], "Only in file2"))
+    results.extend(build_result_row(df1.loc[i], None, "Only in file1") for i in unmatched_df1)
+    results.extend(build_result_row(None, df2.loc[j], "Only in file2") for j in unmatched_df2)
 
     return results
 

--- a/src/aedist/query_verification.py
+++ b/src/aedist/query_verification.py
@@ -275,12 +275,12 @@ def main():
     tavily_key = os.environ.get("TAVILY_API_KEY")
 
     # Enumerate conditions
-    conditions = []
-    for base in base_configs:
-        for mode in modes:
-            runs = 1 if mode in _DETERMINISTIC_MODES else repeat
-            for run in range(1, runs + 1):
-                conditions.append((base, mode, run))
+    conditions = [
+        (base, mode, run)
+        for base in base_configs
+        for mode in modes
+        for run in range(1, (1 if mode in _DETERMINISTIC_MODES else repeat) + 1)
+    ]
 
     if args.dry_run:
         log.info("Verification: %d conditions", len(conditions))

--- a/src/aedist/query_web.py
+++ b/src/aedist/query_web.py
@@ -88,8 +88,7 @@ def run_web_searches(
         try:
             results = tavily_search(query, api_key)
             search_log.append({"query": query, "results": results})
-            for r in results:
-                context_parts.append(f"## {r['title']}\n{r['content']}")
+            context_parts.extend(f"## {r['title']}\n{r['content']}" for r in results)
         except httpx.HTTPError as e:
             log.error("Search failed for '%s': %s", query, e)
             search_log.append({"query": query, "error": str(e), "results": []})

--- a/src/aedist/reconcile.py
+++ b/src/aedist/reconcile.py
@@ -33,16 +33,17 @@ def plants_to_dataframe(plants: list[Plant]) -> pd.DataFrame:
     The LP matcher expects columns: name, name_clean, capacity_clean.
     We also preserve province, fuel, status for attribute-level metrics.
     """
-    rows = []
-    for p in plants:
-        rows.append({
+    rows = [
+        {
             "name": p.name,
             "province": p.province or "",
             "fuel": p.fuel.value if p.fuel else "",
             "capacity": str(p.capacity_mwe) if p.capacity_mwe is not None else "",
             "status": p.status.value if p.status else "",
             "source_ref": p.source_ref or "",
-        })
+        }
+        for p in plants
+    ]
     df = pd.DataFrame(rows)
     if df.empty:
         # Return a zero-row DataFrame with all raw + cleaned columns so

--- a/src/aedist/self_consistency.py
+++ b/src/aedist/self_consistency.py
@@ -203,7 +203,7 @@ def run_analysis(
         run_metrics, csv_paths = evaluate_single_runs(run_paths, work_dir, reference)
 
         # Pair metrics with source paths, drop failed runs, sort by F1
-        paired = [(m, p) for m, p in zip(run_metrics, run_paths) if m is not None]
+        paired = [(m, p) for m, p in zip(run_metrics, run_paths, strict=True) if m is not None]
         if not paired:
             log.warning("No valid runs for %s — skipping", model)
             continue

--- a/src/aedist/stats.py
+++ b/src/aedist/stats.py
@@ -65,7 +65,7 @@ def paired_bootstrap_test(
         return 1.0
 
     rng = random.Random(seed)
-    diffs = [ai - bi for ai, bi in zip(a, b)]
+    diffs = [ai - bi for ai, bi in zip(a, b, strict=True)]
     observed = abs(sum(diffs) / len(diffs))
 
     # Resample under H0 by randomly flipping signs of differences

--- a/tests/test_jobspec.py
+++ b/tests/test_jobspec.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from aedist.schema import (
     JobSpec,
@@ -64,7 +65,7 @@ class TestJobSpecConstruction:
         assert j.followups == "prompts/followups.txt"
 
     def test_invalid_mode_rejected(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             _make_jobspec(mode="bogus")
 
 
@@ -161,5 +162,5 @@ class TestLeaseInfo:
         assert lease.start_time.tzinfo is not None
 
     def test_expiry_required(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             LeaseInfo(job_id="job_003", worker_id="w1")

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -143,21 +143,19 @@ class TestOutputEquivalence:
 
     def _records_from_metrics(self, metrics_list):
         """Build RunRecords matching the fixture data."""
-        records = []
-        for m in metrics_list:
-            records.append(
-                _make_record(
-                    m["label"],
-                    tp=m["n_matched"],
-                    fp=m["n_hallucinated"],
-                    fn=m["n_missed"],
-                    f1=m["f1"],
-                    fuel_accuracy=m.get("fuel_accuracy"),
-                    status_accuracy=m.get("status_accuracy"),
-                    province_accuracy=m.get("province_accuracy"),
-                )
+        return [
+            _make_record(
+                m["label"],
+                tp=m["n_matched"],
+                fp=m["n_hallucinated"],
+                fn=m["n_missed"],
+                f1=m["f1"],
+                fuel_accuracy=m.get("fuel_accuracy"),
+                status_accuracy=m.get("status_accuracy"),
+                province_accuracy=m.get("province_accuracy"),
             )
-        return records
+            for m in metrics_list
+        ]
 
     def test_census_table_equivalence(self):
         from aedist.tabulate_census import generate_census_table

--- a/tests/test_pdf2md_grobid.py
+++ b/tests/test_pdf2md_grobid.py
@@ -121,7 +121,7 @@ def test_no_print_calls():
     lines = text.splitlines()
     for i, line in enumerate(lines, 1):
         stripped = line.lstrip()
-        if stripped.startswith("#") or stripped.startswith('"'):
+        if stripped.startswith(("#", '"')):
             continue
         assert not re.match(r".*\bprint\s*\(", stripped), (
             f"Found print() call at line {i}: {line.strip()}"

--- a/tests/test_pdf2md_mistral_ocr.py
+++ b/tests/test_pdf2md_mistral_ocr.py
@@ -91,7 +91,7 @@ def test_no_print_calls():
     lines = text.splitlines()
     for i, line in enumerate(lines, 1):
         stripped = line.lstrip()
-        if stripped.startswith("#") or stripped.startswith('"'):
+        if stripped.startswith(("#", '"')):
             continue
         assert not re.match(r".*\bprint\s*\(", stripped), (
             f"Found print() call at line {i}: {line.strip()}"

--- a/tests/test_pdf2md_ollama.py
+++ b/tests/test_pdf2md_ollama.py
@@ -22,7 +22,7 @@ def test_no_print_calls():
     lines = text.splitlines()
     for i, line in enumerate(lines, 1):
         stripped = line.lstrip()
-        if stripped.startswith("#") or stripped.startswith('"'):
+        if stripped.startswith(("#", '"')):
             continue
         assert not re.match(r".*\bprint\s*\(", stripped), (
             f"Found print() call at line {i}: {line.strip()}"

--- a/tests/test_pdf2md_openrouter.py
+++ b/tests/test_pdf2md_openrouter.py
@@ -68,7 +68,7 @@ def test_no_print_calls():
     lines = text.splitlines()
     for i, line in enumerate(lines, 1):
         stripped = line.lstrip()
-        if stripped.startswith("#") or stripped.startswith('"'):
+        if stripped.startswith(("#", '"')):
             continue
         assert not re.match(r".*\bprint\s*\(", stripped), (
             f"Found print() call at line {i}: {line.strip()}"

--- a/tests/test_pdf2md_openrouter_doc.py
+++ b/tests/test_pdf2md_openrouter_doc.py
@@ -53,7 +53,7 @@ def test_no_print_calls():
     lines = text.splitlines()
     for i, line in enumerate(lines, 1):
         stripped = line.lstrip()
-        if stripped.startswith("#") or stripped.startswith('"'):
+        if stripped.startswith(("#", '"')):
             continue
         assert not re.match(r".*\bprint\s*\(", stripped), (
             f"Found print() call at line {i}: {line.strip()}"

--- a/tests/test_runrecord.py
+++ b/tests/test_runrecord.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from aedist.schema import (
     Method,
@@ -75,7 +76,7 @@ class TestRunRecordConstruction:
             assert r.method == m
 
     def test_invalid_method_rejected(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             RunRecord(
                 method="invalid",
                 method_params=MethodParams(model="test/model"),

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -2,6 +2,8 @@
 
 import random
 
+import pytest
+
 from aedist.stats import bootstrap_ci, paired_bootstrap_test
 
 # --- bootstrap_ci ---
@@ -76,11 +78,8 @@ def test_paired_test_empty():
 
 def test_paired_test_length_mismatch():
     """Mismatched lengths → ValueError."""
-    try:
+    with pytest.raises(ValueError, match="equal-length"):
         paired_bootstrap_test([0.9, 0.91], [0.5])
-        assert False, "Should have raised ValueError"
-    except ValueError:
-        pass
 
 
 def test_paired_test_deterministic_with_seed():

--- a/tests/test_variance_decomposition.py
+++ b/tests/test_variance_decomposition.py
@@ -109,12 +109,13 @@ def test_balanced_subdesign_selection():
     """
     from aedist.variance_decomposition import variance_decomposition
 
-    records = []
     # 3 models x 2 methods, 2 replicates each
-    for model in ["A", "B", "C"]:
-        for method in ["rag", "single"]:
-            for f1 in [0.70, 0.80]:
-                records.append(make_record(model, method, f1))
+    records = [
+        make_record(model, method, f1)
+        for model in ["A", "B", "C"]
+        for method in ["rag", "single"]
+        for f1 in [0.70, 0.80]
+    ]
     # 4th model in only 1 method — should be excluded from the cross
     records.append(make_record("D", "rag", 0.60))
     records.append(make_record("D", "rag", 0.65))
@@ -208,11 +209,12 @@ def test_subdesign_composition_in_output():
     """Variance decomposition output includes sub-design composition."""
     from aedist.variance_decomposition import variance_decomposition
 
-    records = []
-    for model in ["A", "B"]:
-        for method in ["rag", "single"]:
-            for f1 in [0.70, 0.80]:
-                records.append(make_record(model, method, f1))
+    records = [
+        make_record(model, method, f1)
+        for model in ["A", "B"]
+        for method in ["rag", "single"]
+        for f1 in [0.70, 0.80]
+    ]
     result = variance_decomposition(records)
     assert "models_included" in result
     assert "methods_included" in result
@@ -225,11 +227,12 @@ def test_omega_squared_in_decomposition():
     """Variance decomposition output includes omega-squared."""
     from aedist.variance_decomposition import variance_decomposition
 
-    records = []
-    for model in ["A", "B"]:
-        for method in ["rag", "single"]:
-            for f1 in [0.70, 0.80]:
-                records.append(make_record(model, method, f1))
+    records = [
+        make_record(model, method, f1)
+        for model in ["A", "B"]
+        for method in ["rag", "single"]
+        for f1 in [0.70, 0.80]
+    ]
     result = variance_decomposition(records)
     assert "omega_sq_model" in result
     assert "omega_sq_method" in result


### PR DESCRIPTION
## Summary

- Expand ruff lint rules: add `B` (bugbear), `PERF`, `PGH`, `PIE810`, `RUF012` to `pyproject.toml`
- Fix 6 bug-class violations: `zip()` without `strict=` (B905), overly broad `pytest.raises(Exception)` (B017), `assert False` (B011), blanket `type: ignore` (PGH003), mutable class default (RUF012)
- Fix 13 PERF401 loop-append → comprehension/extend
- Fix 5 PIE810 multiple `.startswith()` → tuple form

## Test plan

- [x] `ruff check .` passes with expanded rule set (0 violations)
- [x] 635 tests pass
- [x] No behavioral changes — all fixes are mechanical

https://claude.ai/code/session_01Lz28JdsXMoj3AReARnh2TH