### PR TITLE
Ticket 0047: fix insincere tests — tiers 1-4

### DIFF
--- a/tests/test_build_corpus.py
+++ b/tests/test_build_corpus.py
@@ -21,9 +21,11 @@ def test_split_by_page_markers():
         "Content of section A.\n"
     )
     sections = split_into_sections(md)
-    assert len(sections) >= 2
-    assert any(s["page"] == 1 for s in sections)
-    assert any(s["page"] == 2 for s in sections)
+    assert len(sections) == 2
+    assert sections[0]["page"] == 1
+    assert "Document Title" in sections[0]["text"]
+    assert sections[1]["page"] == 2
+    assert "Section A" in sections[1]["text"]
 
 
 def test_split_preserves_table_content():

--- a/tests/test_compare_converters.py
+++ b/tests/test_compare_converters.py
@@ -137,6 +137,23 @@ def test_format_summary():
     assert "test-doc" in text
 
 
+def _data_rows(tex):
+    """Extract data rows (between midrule and bottomrule) from a tabular."""
+    rows = []
+    in_data = False
+    for line in tex.splitlines():
+        stripped = line.strip()
+        if r"\midrule" in stripped:
+            in_data = True
+            continue
+        if r"\bottomrule" in stripped:
+            break
+        if in_data and "&" in stripped:
+            cells = [c.strip().rstrip("\\").strip() for c in stripped.split("&")]
+            rows.append(cells)
+    return rows
+
+
 def test_format_latex_without_meta():
     results = {
         "marker": {
@@ -148,10 +165,14 @@ def test_format_latex_without_meta():
         },
     }
     tex = format_latex(results)
-    assert r"\begin{tabular}" in tex
-    assert "marker" in tex
-    assert r"\bottomrule" in tex
-    assert "Tableaux" in tex  # French headers
+    rows = _data_rows(tex)
+    assert len(rows) == 1
+    # Columns: Backend, Tableaux, Lignes, Taille, Temps, Diacritiques
+    assert rows[0][0] == "marker"
+    assert rows[0][1] == "170"
+    assert "4" in rows[0][2] and "038" in rows[0][2]  # 4\,038
+    assert rows[0][4] == "--"  # no timing without meta
+    assert rows[0][5] == "5/5"
 
 
 def test_format_latex_with_meta():
@@ -172,9 +193,12 @@ def test_format_latex_with_meta():
         },
     }
     tex = format_latex(results, meta)
-    assert "Marker (local, GPU)" in tex
-    assert "45" in tex
-    assert "complets" in tex
+    rows = _data_rows(tex)
+    assert len(rows) == 1
+    assert rows[0][0] == "Marker (local, GPU)"
+    assert rows[0][1] == "170"
+    assert rows[0][4] == "45"
+    assert rows[0][5] == "complets"
 
 
 def test_format_latex_rows_na():
@@ -197,7 +221,12 @@ def test_format_latex_rows_na():
         },
     }
     tex = format_latex(results, meta)
-    assert "-- &" in tex
+    rows = _data_rows(tex)
+    assert len(rows) == 1
+    assert rows[0][0] == "GROBID (local)"
+    assert rows[0][1] == "45"
+    assert rows[0][2] == "--"  # rows_na suppresses row count
+    assert rows[0][4] == "20"
 
 
 def test_format_latex_thousands_separator():

--- a/tests/test_empty_csv.py
+++ b/tests/test_empty_csv.py
@@ -20,14 +20,12 @@ class TestPlantsToDataframeEmpty:
         plus the auxiliary cleaned columns. No exception raised."""
         df = plants_to_dataframe([])
         assert len(df) == 0
-        # LP matcher requires these three columns
-        assert "name" in df.columns
-        assert "name_clean" in df.columns
-        assert "capacity_clean" in df.columns
-        # Auxiliary columns from cleaner
-        assert "province_clean" in df.columns
-        assert "fuel_clean" in df.columns
-        assert "status_clean" in df.columns
+        expected_columns = {
+            "name", "province", "fuel", "capacity", "status", "source_ref",
+            "name_clean", "province_clean", "fuel_clean", "capacity_clean",
+            "status_clean",
+        }
+        assert set(df.columns) == expected_columns
 
 
 class TestReconcileEmptySystem:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -78,6 +78,10 @@ def test_coverage(models):
     size_classes = {m["size_class"] for m in models}
 
     assert len(models) >= 45, f"Expected >= 45 models, got {len(models)}"
+    # Spot-check that every model has required pricing fields
+    for m in models:
+        assert m.get("price_per_mtok_in") is not None, f"{m['id']}: missing price_per_mtok_in"
+        assert m.get("price_per_mtok_out") is not None, f"{m['id']}: missing price_per_mtok_out"
     assert "US" in countries
     assert "CN" in countries
     assert {"frontier", "large", "medium", "small", "edge"} <= size_classes, (

--- a/tests/test_plot_pareto.py
+++ b/tests/test_plot_pareto.py
@@ -17,10 +17,15 @@ SAMPLE_METRICS = [
 
 
 def test_build_pareto_rows():
-    """Rows have model, f1, cost_usd, local columns."""
+    """Rows have correct models with median f1 and local flag."""
     rows = build_pareto_rows(SAMPLE_METRICS)
     assert len(rows) == 2
     assert all(set(r.keys()) == {"model", "f1", "cost_usd", "local"} for r in rows)
+    by_model = {r["model"]: r for r in rows}
+    assert by_model["gpt-5.4"]["f1"] == 0.70  # median of [0.68, 0.70, 0.72]
+    assert by_model["gpt-5.4"]["local"] == 0
+    assert by_model["padme-qwen3.5-27b"]["f1"] == 0.50  # median of [0.48, 0.50, 0.52]
+    assert by_model["padme-qwen3.5-27b"]["local"] == 1
 
 
 def test_cost_without_explicit_data():

--- a/tests/test_query_rag.py
+++ b/tests/test_query_rag.py
@@ -134,7 +134,6 @@ def test_rag_output_metadata(mock_openai_cls, tmp_path):
     assert len(json_files) == 1
     record = json.loads(json_files[0].read_text())
     assert record["strategy"] == "wholesale"
-    assert "corpus_files" in record
-    assert len(record["corpus_files"]) == 2
-    assert "corpus_tokens" in record
-    assert record["corpus_tokens"] > 0
+    assert sorted(record["corpus_files"]) == ["doc1.md", "doc2.md"]
+    assert isinstance(record["corpus_tokens"], int)
+    assert record["corpus_tokens"] > 10  # both docs have real content

--- a/tests/test_runrecord.py
+++ b/tests/test_runrecord.py
@@ -63,6 +63,7 @@ class TestRunRecordConstruction:
             method_params=MethodParams(model="anthropic/claude-sonnet-4-20250514"),
         )
         assert len(r.run_id) == 12
+        assert r.run_id.isalnum()  # hex chars only, not arbitrary
         assert r.resource_use.wall_s is None
         assert r.result_summary.status == "ok"
         assert r.justification is None

--- a/tests/test_tabulate_macros.py
+++ b/tests/test_tabulate_macros.py
@@ -6,7 +6,7 @@ from aedist.tabulate_macros import generate_macros, load_and_summarize
 
 SAMPLE_METRICS = [
     {"label": "census/gpt-5.4-run1", "f1": 0.70, "coverage": 0.8, "precision": 0.62},
-    {"label": "census/gpt-5.4-run2", "f1": 0.68, "coverage": 0.78, "precision": 0.60},
+    {"label": "census/gpt-5.4-run2", "f1": 0.60, "coverage": 0.78, "precision": 0.60},
     {"label": "census/gpt-5.4-run3", "f1": 0.72, "coverage": 0.82, "precision": 0.64},
     {"label": "census/claude-4-run1", "f1": 0.65, "coverage": 0.75, "precision": 0.58},
     {"label": "census/claude-4-run2", "f1": 0.63, "coverage": 0.73, "precision": 0.56},
@@ -54,7 +54,7 @@ def test_load_and_summarize():
     """Model slugs are extracted and median F1 computed per model."""
     summary = load_and_summarize(SAMPLE_METRICS)
     assert len(summary) == 4
-    # gpt-5.4 median of [0.68, 0.70, 0.72] = 0.70
+    # gpt-5.4 median of [0.60, 0.70, 0.72] = 0.70 (mean would be ~0.673)
     assert summary["gpt-5.4"]["median_f1"] == 0.70
     # claude-4 median of [0.63, 0.65, 0.67] = 0.65
     assert summary["claude-4"]["median_f1"] == 0.65

--- a/tests/test_tabulate_variance.py
+++ b/tests/test_tabulate_variance.py
@@ -44,13 +44,38 @@ def test_table_has_label():
     assert "\\label{tab:variance}" in latex
 
 
+def _variance_data_rows(latex):
+    """Extract data rows from the variance longtable."""
+    rows = []
+    in_data = False
+    for line in latex.splitlines():
+        stripped = line.strip()
+        if r"\endhead" in stripped:
+            in_data = True
+            continue
+        if r"\midrule" in stripped and in_data:
+            continue
+        if r"\end{longtable}" in stripped:
+            break
+        if in_data and "&" in stripped:
+            cells = [c.strip().rstrip("\\").strip() for c in stripped.split("&")]
+            rows.append(cells)
+    return rows
+
+
 def test_table_has_all_sources():
-    """All four variance sources appear in the table."""
+    """All four variance sources appear as rows with correct values."""
     latex = generate_variance_table(SAMPLE_ANOVA)
-    assert "Model" in latex
-    assert "Method" in latex
-    assert "Interaction" in latex or "Model $\\times$ Method" in latex
-    assert "Residual" in latex
+    rows = _variance_data_rows(latex)
+    sources = [r[0] for r in rows]
+    assert "Model" in sources
+    assert "Method" in sources
+    assert "Residual" in sources
+    # Verify Model row has correct SS and F values
+    model_row = rows[sources.index("Model")]
+    assert model_row[1] == "1.2340"  # SS
+    assert model_row[2] == "4"  # df
+    assert model_row[3] == "10.05"  # F
 
 
 def test_table_has_eta_squared():
@@ -76,9 +101,14 @@ def test_table_has_f_statistics():
 
 
 def test_table_has_p_values():
-    """p-values appear in the table."""
+    """p-values in correct cells for each source row."""
     latex = generate_variance_table(SAMPLE_ANOVA)
-    assert "$<$0.001" in latex or "0.001" in latex
+    rows = _variance_data_rows(latex)
+    sources = [r[0] for r in rows]
+    model_row = rows[sources.index("Model")]
+    method_row = rows[sources.index("Method")]
+    assert model_row[4] == "0.001"  # p_a
+    assert method_row[4] == "0.003"  # p_b
 
 
 def test_table_has_omega_squared():

--- a/tests/test_variance_decomposition.py
+++ b/tests/test_variance_decomposition.py
@@ -44,6 +44,8 @@ def test_variance_decomposition_perfect_separation():
         make_record(model="B", method="rag", f1=0.51),
     ]
     result = variance_decomposition(records)
+    # Model effect should dominate — A≈0.90, B≈0.50 are far apart
+    assert result["eta_sq_model"] > 0.90
     assert result["eta_sq_residual"] < 0.05
 
 
@@ -201,8 +203,9 @@ def test_large_f_gives_small_p():
         ("B", "y"): [1.0, 2.0],
     }
     result = two_way_anova(data)
-    assert result["f_a"] > 10
-    assert result["p_a"] < 0.05
+    # A vs B means differ by ~99, residual variance ~0.5 → F >> 100
+    assert result["f_a"] > 100
+    assert result["p_a"] < 0.01
 
 
 def test_subdesign_composition_in_output():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -341,12 +341,20 @@ def test_padme_worker_execute(tmp_path: Path) -> None:
         budget_usd=1.0,
     )
 
-    with patch.multiple("aedist.worker", **_harness_patches(tmp_path)):
-        result = worker.execute(job)
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
 
-    assert result["wall_seconds"] == 3.5
-    assert result["tokens_in"] == 50
-    assert result["tokens_out"] == 100
+    # Verify model ID and message structure passed to query_single_turn
+    call_args = patches["query_single_turn"].call_args[0]
+    assert call_args[1] == "qwen3:8b"  # model_id
+    messages = call_args[2]
+    assert len(messages) == 1
+    assert messages[0] == {"role": "user", "content": "List thermal plants"}
+    # Verify save_json was called with the model reply record
+    saved = patches["save_json"].call_args[0][1]
+    assert saved["model"] == "qwen3:8b"
+    assert saved["response"] == "Plant A,coal,operational"
 
 
 def test_padme_full_lifecycle(tmp_path: Path) -> None:
@@ -376,6 +384,11 @@ def test_padme_full_lifecycle(tmp_path: Path) -> None:
     assert record is not None
     assert record.method == Method.SINGLE
     assert (jobs_root / "done" / "padme-lc.yaml").exists()
+    # Verify resource_use captured from execute() return value
+    assert record.resource_use.wall_s == 3.5
+    assert record.resource_use.tokens_in == 50
+    assert record.resource_use.tokens_out == 100
+    assert record.resource_use.cost_usd == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -409,13 +422,20 @@ def test_openrouter_worker_execute(tmp_path: Path) -> None:
         budget_usd=10.0,
     )
 
-    with patch.multiple("aedist.worker", **_harness_patches(tmp_path)):
-        result = worker.execute(job)
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
 
-    # 1 model x 1 run = 1 query
-    assert result["wall_seconds"] == 3.5
-    assert result["tokens_in"] == 50
-    assert result["tokens_out"] == 100
+    # Verify model ID and message structure passed to query_single_turn
+    call_args = patches["query_single_turn"].call_args[0]
+    assert call_args[1] == "qwen3:8b"
+    messages = call_args[2]
+    assert len(messages) == 1
+    assert messages[0] == {"role": "user", "content": "List thermal plants"}
+    # Verify save_json was called with the model reply record
+    saved = patches["save_json"].call_args[0][1]
+    assert saved["model"] == "qwen3:8b"
+    assert saved["response"] == "Plant A,coal,operational"
 
 
 def test_openrouter_full_lifecycle(tmp_path: Path) -> None:
@@ -445,6 +465,10 @@ def test_openrouter_full_lifecycle(tmp_path: Path) -> None:
     assert record is not None
     assert record.method == Method.SINGLE
     assert (jobs_root / "done" / "or-lc.yaml").exists()
+    # Verify resource_use captured from execute() return value
+    assert record.resource_use.wall_s == 3.5
+    assert record.resource_use.tokens_in == 50
+    assert record.resource_use.tokens_out == 100
 
 
 # ---------------------------------------------------------------------------
@@ -471,15 +495,18 @@ def test_rag_job_dispatches_to_rag_pipeline(tmp_path: Path) -> None:
 
     patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
-        result = worker.execute(job)
+        worker.execute(job)
 
     # RAG path should build system+user messages with corpus, not just user message
     call_args = patches["query_single_turn"].call_args
     messages = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("messages")
     assert len(messages) == 2  # system (corpus) + user (prompt)
     assert messages[0]["role"] == "system"
-    assert "corpus" in messages[0]["content"].lower() or "Some corpus content" in messages[0]["content"]
-    assert result["wall_seconds"] == 3.5
+    assert "Some corpus content" in messages[0]["content"]
+    assert messages[1] == {"role": "user", "content": "List thermal plants"}
+    # Verify saved record includes RAG-specific fields
+    saved = patches["save_json"].call_args[0][1]
+    assert saved["strategy"] == "wholesale"
 
 
 def test_multiturn_job_dispatches_to_multiturn(tmp_path: Path) -> None:
@@ -502,10 +529,14 @@ def test_multiturn_job_dispatches_to_multiturn(tmp_path: Path) -> None:
     patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         with patch("aedist.worker.run_conversation", return_value=mock_conv_result) as mock_run:
-            result = worker.execute(job)
+            worker.execute(job)
 
     mock_run.assert_called_once()
-    assert result["wall_seconds"] == 5.0
+    # Verify run_conversation received the correct arguments
+    args = mock_run.call_args
+    assert args[0][1] == "qwen3:8b"  # model_id
+    assert args[0][2] == "List thermal plants"  # prompt
+    assert args[0][3] == ["What about gas plants?", "Any LNG?"]  # followups
 
 
 def test_web_job_dispatches_to_web(tmp_path: Path, monkeypatch) -> None:
@@ -522,13 +553,14 @@ def test_web_job_dispatches_to_web(tmp_path: Path, monkeypatch) -> None:
     patches = _harness_patches(tmp_path)
     with patch("aedist.worker.run_web_searches", return_value=("web context", [])):
         with patch.multiple("aedist.worker", **patches):
-            result = worker.execute(job)
+            worker.execute(job)
 
     # Web path builds system message with web search context
     call_args = patches["query_single_turn"].call_args
     messages = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("messages")
     assert messages[0]["role"] == "system"
-    assert result["wall_seconds"] == 3.5
+    assert "web context" in messages[0]["content"]
+    assert messages[1] == {"role": "user", "content": "List thermal plants"}
 
 
 def test_decomposed_job_dispatches_to_decomposed(tmp_path: Path) -> None:
@@ -555,11 +587,17 @@ def test_decomposed_job_dispatches_to_decomposed(tmp_path: Path) -> None:
     patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
         with patch("aedist.worker.query_decomposed", return_value=mock_decomposed_result) as mock_dec:
-            result = worker.execute(job)
+            worker.execute(job)
 
     mock_dec.assert_called_once()
-    assert result["wall_seconds"] == 10.0
-    assert result["tokens_in"] == 150
+    # Verify query_decomposed received corpus text and model ID
+    dec_args = mock_dec.call_args[0]
+    assert dec_args[1] == "qwen3:8b"  # model_id
+    assert "Some corpus content" in dec_args[2]  # corpus_text
+    # Verify saved record includes decomposed-specific fields
+    saved = patches["save_json"].call_args[0][1]
+    assert saved["strategy"] == "decomposed"
+    assert saved["n_merged_plants"] == 1
 
 
 def test_single_job_dispatches_to_single(tmp_path: Path) -> None:
@@ -573,10 +611,12 @@ def test_single_job_dispatches_to_single(tmp_path: Path) -> None:
 
     patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
-        result = worker.execute(job)
+        worker.execute(job)
 
     patches["query_single_turn"].assert_called_once()
-    assert result["wall_seconds"] == 3.5
+    call_args = patches["query_single_turn"].call_args[0]
+    assert call_args[1] == "qwen3:8b"
+    assert call_args[2] == [{"role": "user", "content": "List thermal plants"}]
 
 
 def test_unknown_mode_raises(tmp_path: Path) -> None:
@@ -647,10 +687,12 @@ def test_frontier_job_dispatches_like_single(tmp_path: Path) -> None:
 
     patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
-        result = worker.execute(job)
+        worker.execute(job)
 
     patches["query_single_turn"].assert_called_once()
-    assert result["wall_seconds"] == 3.5
+    call_args = patches["query_single_turn"].call_args[0]
+    assert call_args[1] == "qwen3:8b"
+    assert call_args[2] == [{"role": "user", "content": "List thermal plants"}]
 
 
 def test_sourced_job_dispatches_like_single(tmp_path: Path) -> None:
@@ -664,10 +706,12 @@ def test_sourced_job_dispatches_like_single(tmp_path: Path) -> None:
 
     patches = _harness_patches(tmp_path)
     with patch.multiple("aedist.worker", **patches):
-        result = worker.execute(job)
+        worker.execute(job)
 
     patches["query_single_turn"].assert_called_once()
-    assert result["wall_seconds"] == 3.5
+    call_args = patches["query_single_turn"].call_args[0]
+    assert call_args[1] == "qwen3:8b"
+    assert call_args[2] == [{"role": "user", "content": "List thermal plants"}]
 
 
 # ---------------------------------------------------------------------------

--- a/tickets/0047-test-sincerity.erg
+++ b/tickets/0047-test-sincerity.erg
@@ -1,11 +1,13 @@
 %erg v1
 Title: Fix 34 insincere tests across 5 anti-pattern tiers
-Status: open
+Status: doing
 Created: 2026-04-09
 Author: claude
 
 --- log ---
 2026-04-09T20:00Z claude created from test sincerity audit
+2026-04-09T21:00Z claude claimed
+2026-04-09T21:30Z claude note tier 1 (11 circular mocks) + tier 2 (asymmetric fixtures) done
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

### Tier 1 — Circular mocks (11 tests in test_worker.py)
- Replace passthrough value assertions (`assert result["wall_seconds"] == 3.5`) with argument-structure assertions: verify model ID, message roles/content, saved record fields
- Add `resource_use` assertions to 2 lifecycle tests that test the full `execute→complete→RunRecord` pipeline

### Tier 2 — Tautological fixtures (test_tabulate_macros.py)
- Make gpt-5.4 fixture asymmetric (`[0.60, 0.70, 0.72]`) so median ≠ mean

### Tier 3 — String-contains → row-level verification (3 files)
- `test_compare_converters.py`: add `_data_rows()` parser, verify each LaTeX cell by column index
- `test_tabulate_variance.py`: add `_variance_data_rows()` parser, verify SS/df/F/p in correct cells
- `test_query_rag.py`: assert exact corpus filenames and meaningful token count

### Tier 4 — Shape-only / loose bounds (6 files)
- `test_plot_pareto.py`: verify actual f1 values and local flags per model
- `test_empty_csv.py`: assert exact column set instead of membership checks
- `test_runrecord.py`: assert run_id is alphanumeric, not just length==12
- `test_build_corpus.py`: assert exact section count and page/content mapping
- `test_variance_decomposition.py`: tighten bounds (eta_sq_model > 0.90, F > 100)
- `test_models.py`: add pricing field validation for every model entry

## Mutation test

Before: zeroing `wall_seconds` in `worker._build_result` → 0 test failures
After: → 2 lifecycle test failures

## Test plan

- [x] `ruff check .` clean
- [x] 635 tests pass
- [x] Mutation `wall_seconds * 0` in `_build_result` caught by lifecycle tests
- [x] Swapping a LaTeX column value now fails
- [x] Returning mean instead of median now fails (asymmetric fixture)

**Ticket:** 0047

https://claude.ai/code/session_01Lz28JdsXMoj3AReARnh2TH