### PR TITLE
Ticket 0038: prompt composition and ablation experiment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MEASUREMENTS := measurements.jsonl
 GEN          := report/inputs/generated
 SLIDE_GEN    := slides/inputs/generated
 
-.PHONY: test check-fast check census census-summary
+.PHONY: test check-fast check census census-summary show-prompts
 
 # --- Tests --------------------------------------------------------------------
 
@@ -19,6 +19,17 @@ test:
 check-fast: test
 
 check: test
+
+# --- Prompt inspection -------------------------------------------------------
+
+show-prompts:
+	@uv run python -c "\
+	from aedist.harness import assemble_prompt; \
+	from pathlib import Path; \
+	d = Path('experiments/prompts/modules'); \
+	ALL = ['persona','overview','sourcing','narratives','bibliography','statistics']; \
+	configs = [('base', []), ('composite', ALL)] + [(m, [m]) for m in ALL]; \
+	[print(f'=== {n} ({len(assemble_prompt(d,ms).split(chr(10)))} lines) ===\n{assemble_prompt(d,ms)}\n') for n,ms in configs]"
 
 # --- Measurements (materialized view of all outputs) -------------------------
 #

--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -122,6 +122,13 @@ model_ids = [
     "deepseek/deepseek-v3.2",
 ]
 
+# Ablation experiment — model set TBD after selection phase
+# Populated with prompt-sensitive models from ablation_select runs
+[sets.ablation]
+model_ids = [
+    "anthropic/claude-opus-4.6",
+]
+
 # ---------------------------------------------------------------------------
 # Sweep configurations — experimental conditions
 # ---------------------------------------------------------------------------
@@ -258,3 +265,181 @@ model_set = "frontier_3best"
 repeat = 1
 budget_usd = 20
 output = "qualitative/skill_plans"
+
+# --- Prompt composition and ablation (ticket 0038) ---
+# Prompts assembled at runtime from modules in prompts/modules/.
+# "modules" key lists which modules to include; base.txt is always included.
+# Module ordering is handled by assemble_prompt() in harness.py.
+#
+# Phase 1: selection — base vs composite on all census models (1 rep)
+# Phase 2: full matrix on selected models (5 reps)
+#
+# All modules: persona, overview, sourcing, narratives, bibliography, statistics
+
+[sweeps.ablation_select_base]
+mode = "single"
+prompt_modules = []
+models = "models.yaml"
+model_set = "census_cloud"
+repeat = 1
+budget_usd = 15
+output = "outputs/ablation/select_base"
+
+[sweeps.ablation_select_composite]
+mode = "single"
+prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
+models = "models.yaml"
+model_set = "census_cloud"
+repeat = 1
+budget_usd = 15
+output = "outputs/ablation/select_composite"
+
+# Phase 2 — Composition arm: base + one module
+
+[sweeps.ablation_base]
+mode = "single"
+prompt_modules = []
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/base"
+
+[sweeps.ablation_persona]
+mode = "single"
+prompt_modules = ["persona"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/persona"
+
+[sweeps.ablation_overview]
+mode = "single"
+prompt_modules = ["overview"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/overview"
+
+[sweeps.ablation_narratives]
+mode = "single"
+prompt_modules = ["narratives"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/narratives"
+
+[sweeps.ablation_bibliography]
+mode = "single"
+prompt_modules = ["bibliography"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/bibliography"
+
+[sweeps.ablation_statistics]
+mode = "single"
+prompt_modules = ["statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/statistics"
+
+[sweeps.ablation_sourcing]
+mode = "single"
+prompt_modules = ["sourcing"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/sourcing"
+
+# Anchors
+
+[sweeps.ablation_composite]
+mode = "single"
+prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/composite"
+
+[sweeps.ablation_frontier]
+mode = "single"
+prompt = "prompts/prompt_frontier.txt"
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/frontier"
+
+[sweeps.ablation_census]
+mode = "single"
+prompt = "prompts/prompt_structured.txt"
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/census"
+
+# Ablation arm: composite minus one module
+
+[sweeps.ablation_no_persona]
+mode = "single"
+prompt_modules = ["overview", "sourcing", "narratives", "bibliography", "statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/no_persona"
+
+[sweeps.ablation_no_overview]
+mode = "single"
+prompt_modules = ["persona", "sourcing", "narratives", "bibliography", "statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/no_overview"
+
+[sweeps.ablation_no_narratives]
+mode = "single"
+prompt_modules = ["persona", "overview", "sourcing", "bibliography", "statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/no_narratives"
+
+[sweeps.ablation_no_bibliography]
+mode = "single"
+prompt_modules = ["persona", "overview", "sourcing", "narratives", "statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/no_bibliography"
+
+[sweeps.ablation_no_statistics]
+mode = "single"
+prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/no_statistics"
+
+[sweeps.ablation_no_sourcing]
+mode = "single"
+prompt_modules = ["persona", "overview", "narratives", "bibliography", "statistics"]
+models = "models.yaml"
+model_set = "ablation"
+repeat = 5
+budget_usd = 10
+output = "outputs/ablation/no_sourcing"

--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -271,28 +271,31 @@ output = "qualitative/skill_plans"
 # "modules" key lists which modules to include; base.txt is always included.
 # Module ordering is handled by assemble_prompt() in harness.py.
 #
-# Phase 1: selection — base vs composite on all census models (3 reps)
-# Phase 2: full matrix on selected models (5 reps)
+# Pilot: 2 reps per condition.  Paper upgrade: 5 reps, more models.
+# Temperature: provider-recommended for structured extraction (0.0–0.3).
+# DeepSeek note: API temp 1.0 maps internally to 0.3 (their recommended).
 #
 # All modules: persona, overview, sourcing, narratives, bibliography, statistics
 
-[sweeps.ablation_select_base]
+# Phase 1 — Selection: base vs composite on all census models
+
+[sweeps.ablation_p1_base]
 mode = "single"
 prompt_modules = []
 models = "models.yaml"
 model_set = "census_cloud"
-repeat = 3
-budget_usd = 30
-output = "outputs/ablation/select_base"
+repeat = 2
+budget_usd = 20
+output = "outputs/ablation/p1_base"
 
-[sweeps.ablation_select_composite]
+[sweeps.ablation_p1_composite]
 mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "census_cloud"
-repeat = 3
-budget_usd = 30
-output = "outputs/ablation/select_composite"
+repeat = 2
+budget_usd = 20
+output = "outputs/ablation/p1_composite"
 
 # Phase 2 — Composition arm: base + one module
 
@@ -301,8 +304,8 @@ mode = "single"
 prompt_modules = []
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/base"
 
 [sweeps.ablation_persona]
@@ -310,8 +313,8 @@ mode = "single"
 prompt_modules = ["persona"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/persona"
 
 [sweeps.ablation_overview]
@@ -319,8 +322,8 @@ mode = "single"
 prompt_modules = ["overview"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/overview"
 
 [sweeps.ablation_narratives]
@@ -328,8 +331,8 @@ mode = "single"
 prompt_modules = ["narratives"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/narratives"
 
 [sweeps.ablation_bibliography]
@@ -337,8 +340,8 @@ mode = "single"
 prompt_modules = ["bibliography"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/bibliography"
 
 [sweeps.ablation_statistics]
@@ -346,8 +349,8 @@ mode = "single"
 prompt_modules = ["statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/statistics"
 
 [sweeps.ablation_sourcing]
@@ -355,8 +358,8 @@ mode = "single"
 prompt_modules = ["sourcing"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/sourcing"
 
 # Anchors
@@ -366,8 +369,8 @@ mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/composite"
 
 [sweeps.ablation_frontier]
@@ -375,8 +378,8 @@ mode = "single"
 prompt = "prompts/prompt_frontier.txt"
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/frontier"
 
 [sweeps.ablation_census]
@@ -384,8 +387,8 @@ mode = "single"
 prompt = "prompts/prompt_structured.txt"
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/census"
 
 # Ablation arm: composite minus one module
@@ -395,8 +398,8 @@ mode = "single"
 prompt_modules = ["overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/no_persona"
 
 [sweeps.ablation_no_overview]
@@ -404,8 +407,8 @@ mode = "single"
 prompt_modules = ["persona", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/no_overview"
 
 [sweeps.ablation_no_narratives]
@@ -413,8 +416,8 @@ mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/no_narratives"
 
 [sweeps.ablation_no_bibliography]
@@ -422,8 +425,8 @@ mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/no_bibliography"
 
 [sweeps.ablation_no_statistics]
@@ -431,8 +434,8 @@ mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/no_statistics"
 
 [sweeps.ablation_no_sourcing]
@@ -440,6 +443,6 @@ mode = "single"
 prompt_modules = ["persona", "overview", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "ablation"
-repeat = 5
-budget_usd = 10
+repeat = 2
+budget_usd = 5
 output = "outputs/ablation/no_sourcing"

--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -271,7 +271,7 @@ output = "qualitative/skill_plans"
 # "modules" key lists which modules to include; base.txt is always included.
 # Module ordering is handled by assemble_prompt() in harness.py.
 #
-# Phase 1: selection — base vs composite on all census models (1 rep)
+# Phase 1: selection — base vs composite on all census models (3 reps)
 # Phase 2: full matrix on selected models (5 reps)
 #
 # All modules: persona, overview, sourcing, narratives, bibliography, statistics
@@ -281,8 +281,8 @@ mode = "single"
 prompt_modules = []
 models = "models.yaml"
 model_set = "census_cloud"
-repeat = 1
-budget_usd = 15
+repeat = 3
+budget_usd = 30
 output = "outputs/ablation/select_base"
 
 [sweeps.ablation_select_composite]
@@ -290,8 +290,8 @@ mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
 model_set = "census_cloud"
-repeat = 1
-budget_usd = 15
+repeat = 3
+budget_usd = 30
 output = "outputs/ablation/select_composite"
 
 # Phase 2 — Composition arm: base + one module

--- a/experiments/prompts/modules/README.md
+++ b/experiments/prompts/modules/README.md
@@ -1,0 +1,25 @@
+# Prompt modules
+
+Each `.txt` file is a self-contained prompt component.
+`base.txt` is always included. Other modules are optional.
+
+## Assembly
+
+`harness.assemble_prompt(modules_dir, module_names)` composes the final
+prompt. Module ordering is deterministic:
+
+1. **persona** (prepended before base)
+2. **base** (always present)
+3. **overview** (appended)
+4. **sourcing** (appended)
+5. **narratives** (appended)
+6. **bibliography** (appended)
+7. **statistics** (appended)
+
+The order is defined in `_MODULE_ORDER` in `src/aedist/harness.py`.
+To add a new module: create the `.txt` file here and add its name to
+`_MODULE_ORDER` at the appropriate position.
+
+## Inspection
+
+`make show-prompts` prints all composition variants with line counts.

--- a/experiments/prompts/modules/base.txt
+++ b/experiments/prompts/modules/base.txt
@@ -1,0 +1,34 @@
+Produce a comprehensive CSV table listing ALL thermal power plants in
+Vietnam with capacity of 30 MWe or above, at every stage from early
+proposal through decommissioning. Include grid-connected utility plants,
+captive (self-generation) plants, and industrial cogeneration facilities.
+
+Columns:
+- Name_VI: plant name in Vietnamese
+- Name_EN: plant name in English
+- Fuel: the primary fuel — e.g. Coal, Domestic gas, Imported LNG, Oil.
+  Exclude biomass and waste-to-energy plants (tracked separately).
+- Technology: Subcritical / Supercritical / USC / CCGT / OCGT / CFB
+- Status: current stage of the project, e.g. Operational, Under construction,
+  Proposed, Permitted, Financed, Suspended, Cancelled, Decommissioned.
+  Use the most specific term that applies. Projects may have been proposed
+  by investors, provincial authorities, international partners, or national
+  planners — capture all regardless of which authority originated them.
+- COD: actual or expected commercial operation date
+- Province: location
+- Capacity_MWe: current or as-built net generation capacity in MWe.
+  If the plant was proposed at a different capacity, note the difference.
+- Owner: key investors or controlling entities — e.g. "EVN/GENCO 1",
+  "Marubeni + KEPCO (BOT)", "Formosa Plastics". Skip single-purpose
+  project vehicles.
+- Note: additional context — e.g. original proposed capacity if different
+  from as-built, unit breakdowns, phase information, ownership changes.
+
+Be exhaustive. Cover every thermal power plant you know of, whether it
+appeared in a national power development plan, regulatory filing,
+investment proposal, international agreement, news report, or any other
+source. Include cancelled projects, suspended proposals, and plants that
+were planned but never built. Missing plants reduces the value of this
+inventory.
+
+Format the response as CSV with a header row.

--- a/experiments/prompts/modules/bibliography.txt
+++ b/experiments/prompts/modules/bibliography.txt
@@ -1,0 +1,5 @@
+After completing the inventory, list every source you relied on as an
+annotated bibliography organized by category (government decisions, power
+development plans, utility reports, company filings, news). For each source:
+full citation, URL if known ("URL not verified" if unsure), and one sentence
+on what information was drawn from it.

--- a/experiments/prompts/modules/narratives.txt
+++ b/experiments/prompts/modules/narratives.txt
@@ -1,0 +1,5 @@
+After the CSV table, provide a sourced paragraph for each plant complex
+covering: development history and timeline, notable issues (delays,
+financing changes, ownership transfers, technology changes), and status
+confidence (HIGH = government decision or company report, MEDIUM = multiple
+news sources, LOW = older plans only, status uncertain).

--- a/experiments/prompts/modules/overview.txt
+++ b/experiments/prompts/modules/overview.txt
@@ -1,0 +1,5 @@
+Before the CSV table, provide a sector overview covering: Vietnam's
+electricity generation mix (installed capacity, generation shares by fuel),
+key policy documents and their thermal targets, fuel supply landscape
+(domestic coal, domestic gas, LNG import projects), and key institutional
+actors (state utilities, gas companies, BOT investors, provincial authorities).

--- a/experiments/prompts/modules/persona.txt
+++ b/experiments/prompts/modules/persona.txt
@@ -1,0 +1,1 @@
+You are a senior energy analyst.

--- a/experiments/prompts/modules/sourcing.txt
+++ b/experiments/prompts/modules/sourcing.txt
@@ -1,0 +1,4 @@
+For each row, include Source_1 and Source_2 columns citing the primary
+source for that plant's data. After the table, list all cited sources
+with full citations. Do not fabricate URLs — write "URL not verified"
+if unsure of the exact address.

--- a/experiments/prompts/modules/statistics.txt
+++ b/experiments/prompts/modules/statistics.txt
@@ -1,0 +1,4 @@
+After the inventory, produce cross-tabulation summary tables:
+a) Capacity by fuel x status (total MWe per cell, with row and column totals)
+b) Top 15 provinces by total thermal capacity, broken down by fuel
+c) Timeline of capacity additions by period and fuel type

--- a/report/inputs/plan_ablation.tex
+++ b/report/inputs/plan_ablation.tex
@@ -1,0 +1,234 @@
+% Experimental plan: prompt composition and ablation
+% Included from report.tex, Chapter 2
+
+\section{Expérience~3~: composition et ablation de prompts}\label{sec:exp3}
+
+L'expérience~1 utilise un prompt minimaliste de 40~mots~; l'expérience frontier
+un prompt de 1\,200~mots intégrant cadrage sectoriel, narratifs par centrale,
+statistiques croisées et bibliographie annotée. Or Opus obtient F1\,=\,0,64
+avec le prompt court et F1\,=\,0,54 avec le prompt long~: la métacognition
+supplémentaire \emph{dégrade} l'extraction structurée. Quel composant est
+responsable~?
+
+Deux approches symétriques isolent les effets~:
+
+\begin{description}
+\item[Composition] Partir d'un prompt de base optimisé pour l'extraction CSV,
+  puis ajouter un module à la fois. Mesure~: quel ajout améliore ou dégrade le
+  score~?
+\item[Ablation] Partir du prompt complet (base + tous les modules), puis
+  retirer un module à la fois. Mesure~: quel retrait améliore ou dégrade le
+  score~?
+\end{description}
+
+\noindent La comparaison des deux bras révèle les \emph{effets d'interaction}~:
+un module peut aider seul mais nuire en combinaison, ou inversement.
+
+\subsection{Prompt de base}\label{sec:prompt-base}
+
+Le prompt de base a été conçu par itérations successives avec les critères
+suivants~: (a)~demander un CSV structuré avec colonnes nommées correspondant
+au parseur d'évaluation, (b)~spécifier un seuil d'inclusion (30~MWe),
+(c)~couvrir tout le cycle de vie des projets (proposition à démantèlement),
+(d)~inclure les centrales captives et de cogénération industrielle,
+(e)~exclure explicitement la biomasse et les déchets (suivis séparément),
+(f)~utiliser un vocabulaire de statut ouvert reflétant la multiplicité des
+autorités décisionnaires (investisseurs, provinces, ministère, accords
+internationaux), (g)~ne pas inclure de persona (la littérature sur le
+\emph{role prompting} suggère un effet négatif sur l'extraction structurée),
+(h)~ne pas révéler le nombre attendu de résultats.
+
+\medskip
+\noindent La terminologie est alignée sur l'Open Energy Ontology (OEO)
+avec trois divergences délibérées~: inclusion des centrales hors réseau
+(l'OEO exige la connexion au réseau), distinction gaz domestique / GNL
+importé (l'OEO ne distingue pas la provenance), et regroupement «~thermique~»
+par usage commun plutôt que par classe OEO formelle.
+
+\begin{Prompt}\label{prompt:base}
+Produce a comprehensive CSV table listing ALL thermal power plants in
+Vietnam with capacity of 30 MWe or above, at every stage from early
+proposal through decommissioning. Include grid-connected utility plants,
+captive (self-generation) plants, and industrial cogeneration facilities.
+
+Columns:
+- Name_VI: plant name in Vietnamese
+- Name_EN: plant name in English
+- Fuel: the primary fuel — e.g. Coal, Domestic gas, Imported LNG, Oil.
+  Exclude biomass and waste-to-energy plants (tracked separately).
+- Technology: Subcritical / Supercritical / USC / CCGT / OCGT / CFB
+- Status: current stage of the project, e.g. Operational, Under
+  construction, Proposed, Permitted, Financed, Suspended, Cancelled,
+  Decommissioned. Use the most specific term that applies. Projects may
+  have been proposed by investors, provincial authorities, international
+  partners, or national planners — capture all regardless of which
+  authority originated them.
+- COD: actual or expected commercial operation date
+- Province: location
+- Capacity_MWe: current or as-built net generation capacity in MWe.
+  If the plant was proposed at a different capacity, note the difference.
+- Owner: key investors or controlling entities — e.g. "EVN/GENCO 1",
+  "Marubeni + KEPCO (BOT)", "Formosa Plastics". Skip single-purpose
+  project vehicles.
+- Note: additional context — e.g. original proposed capacity if different
+  from as-built, unit breakdowns, phase information, ownership changes.
+
+Be exhaustive. Cover every thermal power plant you know of, whether it
+appeared in a national power development plan, regulatory filing,
+investment proposal, international agreement, news report, or any other
+source. Include cancelled projects, suspended proposals, and plants that
+were planned but never built. Missing plants reduces the value of this
+inventory.
+
+Format the response as CSV with a header row.
+\end{Prompt}
+
+\subsection{Modules}\label{sec:modules}
+
+Six modules sont testés. Chacun est un paragraphe ajouté à la fin du prompt
+de base.
+
+\paragraph{Persona} Ajoute une consigne de rôle en tête du prompt.
+\begin{Prompt}\label{prompt:mod-persona}
+You are a senior energy analyst.
+\end{Prompt}
+
+\paragraph{Cadrage sectoriel} Demande un paragraphe introductif avant le CSV.
+\begin{Prompt}\label{prompt:mod-overview}
+Before the CSV table, provide a sector overview covering: Vietnam's
+electricity generation mix (installed capacity, generation shares by
+fuel), key policy documents and their thermal targets, fuel supply
+landscape (domestic coal, domestic gas, LNG import projects), and key
+institutional actors (state utilities, gas companies, BOT investors,
+provincial authorities).
+\end{Prompt}
+
+\paragraph{Narratifs par centrale} Demande un commentaire sourcé après le CSV.
+\begin{Prompt}\label{prompt:mod-narratives}
+After the CSV table, provide a sourced paragraph for each plant complex
+covering: development history and timeline, notable issues (delays,
+financing changes, ownership transfers, technology changes), and status
+confidence (HIGH = government decision or company report, MEDIUM =
+multiple news sources, LOW = older plans only, status uncertain).
+\end{Prompt}
+
+\paragraph{Bibliographie} Demande une liste annotée de sources.
+\begin{Prompt}\label{prompt:mod-bibliography}
+After completing the inventory, list every source you relied on as an
+annotated bibliography organized by category (government decisions,
+power development plans, utility reports, company filings, news). For
+each source: full citation, URL if known ("URL not verified" if
+unsure), and one sentence on what information was drawn from it.
+\end{Prompt}
+
+\paragraph{Tableaux statistiques} Demande des tableaux croisés récapitulatifs.
+\begin{Prompt}\label{prompt:mod-statistics}
+After the inventory, produce cross-tabulation summary tables:
+a) Capacity by fuel x status (total MWe per cell, with row and column
+   totals)
+b) Top 15 provinces by total thermal capacity, broken down by fuel
+c) Timeline of capacity additions by period and fuel type
+\end{Prompt}
+
+\paragraph{Sourçage} Demande des colonnes de citation par ligne et une liste
+de références.
+\begin{Prompt}\label{prompt:mod-sourcing}
+For each row, include Source_1 and Source_2 columns citing the primary
+source for that plant's data. After the table, list all cited sources
+with full citations. Do not fabricate URLs — write "URL not verified"
+if unsure of the exact address.
+\end{Prompt}
+
+\subsection{Plan de mesures}\label{sec:plan-mesures}
+
+Le design expérimental comporte deux bras symétriques et trois points d'ancrage.
+
+\paragraph{Points d'ancrage}
+
+\begin{description}
+\item[Census] Le Prompt~1 original (40~mots), point de référence bas.
+\item[Base] Le prompt de base (section~\ref{sec:prompt-base}), point de
+  référence intermédiaire.
+\item[Complet] Le prompt de base + les 6 modules, point de référence haut.
+\item[Frontier] Le prompt frontier existant (1\,200~mots), contrôle externe.
+\end{description}
+
+\paragraph{Bras composition} À partir du prompt de base, ajouter un seul module
+à la fois (6~variantes).
+
+\paragraph{Bras ablation} À partir du prompt complet, retirer un seul module
+à la fois (6~variantes).
+
+\medskip
+\noindent Soit 16~prompts au total~:
+
+\begin{center}
+\small
+\begin{tabular}{rllc}
+\toprule
+\textbf{\#} & \textbf{Prompt} & \textbf{Bras} & \textbf{Modules} \\
+\midrule
+ 0 & Census (Prompt~1 existant) & Ancrage  & -- \\
+ 1 & Base                       & Ancrage  & $\emptyset$ \\
+ 2 & Base + persona             & Composition & \{P\} \\
+ 3 & Base + cadrage             & Composition & \{O\} \\
+ 4 & Base + narratifs           & Composition & \{N\} \\
+ 5 & Base + bibliographie       & Composition & \{B\} \\
+ 6 & Base + statistiques        & Composition & \{T\} \\
+ 7 & Base + sourçage            & Composition & \{S\} \\
+ 8 & Complet                    & Ancrage  & \{P,O,N,B,T,S\} \\
+ 9 & Complet $-$ persona        & Ablation & \{O,N,B,T,S\} \\
+10 & Complet $-$ cadrage        & Ablation & \{P,N,B,T,S\} \\
+11 & Complet $-$ narratifs      & Ablation & \{P,O,B,T,S\} \\
+12 & Complet $-$ bibliographie  & Ablation & \{P,O,N,T,S\} \\
+13 & Complet $-$ statistiques   & Ablation & \{P,O,N,B,S\} \\
+14 & Complet $-$ sourçage       & Ablation & \{P,O,N,B,T\} \\
+15 & Frontier (existant)        & Contrôle & -- \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\subsection{Protocole}\label{sec:protocole-ablation}
+
+\paragraph{Phase de sélection} Les prompts~1 (base) et~8 (complet) sont
+exécutés sur l'ensemble des modèles du census (25+ modèles cloud) avec 1~run
+chacun. On retient les $k$~modèles qui montrent une différence significative
+entre les deux conditions (test de permutation sur le F1). Ce sont les modèles
+\emph{sensibles au prompt}~: les seuls pour lesquels l'ablation peut révéler
+quelque chose.
+
+\paragraph{Phase de mesure} Les 16~prompts sont exécutés sur les $k$~modèles
+retenus, avec 5~répétitions chacun ($16 \times k \times 5$ runs). Température
+fixée à 0. Chaque run produit un CSV évalué contre l'inventaire de référence
+(163~centrales, matching par nom exact et approximatif).
+
+\paragraph{Analyse}
+\begin{itemize}
+\item \textbf{Effets principaux}~: pour chaque module $m$, comparer
+  F1(base) \emph{vs} F1(base+$m$) (composition) et F1(complet) \emph{vs}
+  F1(complet$-m$) (ablation). Les intervalles de confiance bootstrap à 95\,\%
+  sur le $\Delta$F1 déterminent la significativité.
+\item \textbf{Effets d'interaction}~: si un module aide en composition mais
+  nuit en ablation (ou inversement), il interagit avec les autres modules.
+  L'asymétrie composition/ablation quantifie cet effet.
+\item \textbf{Coût de la confiance}~: le module sourçage est non négociable
+  pour le pipeline de production (section~\ref{chap:conclusion}). Son
+  $\Delta$F1 mesure le prix, en points d'extraction, de la traçabilité.
+\end{itemize}
+
+\paragraph{Budget prévisionnel} Avec $k=5$ modèles~: $16 \times 5 \times 5
+= 400$~runs + 50~runs de sélection $= 450$~runs. Au coût moyen de
+0,02--0,05\,\$ par run (Opus)~: 10--25\,\$. Les modèles open-weight réduisent
+ce budget d'un facteur~10.
+
+\subsection{Lien avec la vérification multi-agents}\label{sec:lien-verification}
+
+Cette expérience mesure l'effet du prompt sur l'extraction en un seul tour. La
+vérification --- un agent indépendant contrôle la sortie d'un autre ---
+constitue une expérience séparée. La littérature sur la self-consistency
+et les protocoles de débat montre que la vérification par
+agents multiples et indépendants est plus efficace que l'auto-révision par le
+même modèle. Le module sourçage (colonnes Source\_1, Source\_2) est conçu pour
+alimenter cette phase~: chaque ligne du CSV porte ses propres références,
+permettant à un agent vérificateur de contrôler la provenance sans accéder au
+prompt original.

--- a/report/inputs/plan_ablation.tex
+++ b/report/inputs/plan_ablation.tex
@@ -6,9 +6,11 @@
 L'expérience~1 utilise un prompt minimaliste de 40~mots~; l'expérience frontier
 un prompt de 1\,200~mots intégrant cadrage sectoriel, narratifs par centrale,
 statistiques croisées et bibliographie annotée. Or Opus obtient F1\,=\,0,64
-avec le prompt court et F1\,=\,0,54 avec le prompt long~: la métacognition
-supplémentaire \emph{dégrade} l'extraction structurée. Quel composant est
-responsable~?
+avec le prompt court et F1\,=\,0,54 avec le prompt long~: davantage
+d'instructions \emph{dégrade} l'extraction structurée. Plutôt que de
+diagnostiquer ce prompt existant, nous concevons une famille de prompts
+modulaires pour déterminer quels composants améliorent ou dégradent
+l'extraction~:
 
 Deux approches symétriques isolent les effets~:
 
@@ -191,11 +193,13 @@ Le design expérimental comporte deux bras symétriques et trois points d'ancrag
 \subsection{Protocole}\label{sec:protocole-ablation}
 
 \paragraph{Phase de sélection} Les prompts~1 (base) et~8 (complet) sont
-exécutés sur l'ensemble des modèles du census (25+ modèles cloud) avec 1~run
-chacun. On retient les $k$~modèles qui montrent une différence significative
-entre les deux conditions (test de permutation sur le F1). Ce sont les modèles
-\emph{sensibles au prompt}~: les seuls pour lesquels l'ablation peut révéler
-quelque chose.
+exécutés sur l'ensemble des modèles du census (25+ modèles cloud) avec 3~runs
+chacun. On retient les $k$~modèles dont le $|\Delta\text{F1}|$ moyen entre
+les deux conditions dépasse 0,05 (5~points). Ce seuil élimine les modèles
+insensibles au prompt, pour lesquels l'ablation ne peut rien révéler.
+Trois répétitions suffisent à distinguer un effet réel de la variance
+stochastique du LLM (écart-type typique de 2--3 points F1 d'après les
+mesures de l'expérience~1).
 
 \paragraph{Phase de mesure} Les 16~prompts sont exécutés sur les $k$~modèles
 retenus, avec 5~répétitions chacun ($16 \times k \times 5$ runs). Température
@@ -216,10 +220,24 @@ fixée à 0. Chaque run produit un CSV évalué contre l'inventaire de référen
   $\Delta$F1 mesure le prix, en points d'extraction, de la traçabilité.
 \end{itemize}
 
-\paragraph{Budget prévisionnel} Avec $k=5$ modèles~: $16 \times 5 \times 5
-= 400$~runs + 50~runs de sélection $= 450$~runs. Au coût moyen de
-0,02--0,05\,\$ par run (Opus)~: 10--25\,\$. Les modèles open-weight réduisent
-ce budget d'un facteur~10.
+\paragraph{Budget prévisionnel} Sélection~: $2 \times 25 \times 3 = 150$~runs.
+Mesure avec $k=5$ modèles~: $16 \times 5 \times 5 = 400$~runs.
+Total~: 550~runs. Au coût moyen de 0,02--0,05\,\$ par run~: 10--30\,\$.
+Les modèles open-weight réduisent ce budget d'un facteur~10.
+
+\paragraph{Limites du design}
+\begin{itemize}
+\item \textbf{Requête directe uniquement.} L'expérience teste les prompts
+  en requête single-shot, sans RAG ni décomposition. L'interaction entre
+  le design du prompt et le contexte RAG constitue une expérience séparée~:
+  un module qui nuit en single-shot (cadrage sectoriel gaspillant des tokens)
+  pourrait aider en RAG (amorçage de la récupération documentaire).
+\item \textbf{Plan fractionnaire (résolution~III).} Le design teste les
+  effets principaux de 6~modules (16~prompts) mais pas les $\binom{6}{2}=15$
+  interactions par paires (qui nécessiteraient un plan factoriel $2^6=64$
+  prompts). L'asymétrie composition/ablation détecte la \emph{présence}
+  d'interactions mais ne les attribue pas à un couple spécifique.
+\end{itemize}
 
 \subsection{Lien avec la vérification multi-agents}\label{sec:lien-verification}
 

--- a/report/inputs/plan_ablation.tex
+++ b/report/inputs/plan_ablation.tex
@@ -193,18 +193,21 @@ Le design expérimental comporte deux bras symétriques et trois points d'ancrag
 \subsection{Protocole}\label{sec:protocole-ablation}
 
 \paragraph{Phase de sélection} Les prompts~1 (base) et~8 (complet) sont
-exécutés sur l'ensemble des modèles du census (25+ modèles cloud) avec 3~runs
+exécutés sur l'ensemble des modèles du census (25+ modèles cloud) avec 2~runs
 chacun. On retient les $k$~modèles dont le $|\Delta\text{F1}|$ moyen entre
 les deux conditions dépasse 0,05 (5~points). Ce seuil élimine les modèles
 insensibles au prompt, pour lesquels l'ablation ne peut rien révéler.
-Trois répétitions suffisent à distinguer un effet réel de la variance
-stochastique du LLM (écart-type typique de 2--3 points F1 d'après les
-mesures de l'expérience~1).
 
 \paragraph{Phase de mesure} Les 16~prompts sont exécutés sur les $k$~modèles
-retenus, avec 5~répétitions chacun ($16 \times k \times 5$ runs). Température
-fixée à 0. Chaque run produit un CSV évalué contre l'inventaire de référence
-(163~centrales, matching par nom exact et approximatif).
+retenus, avec 2~répétitions chacun ($16 \times k \times 2$ runs). Température
+réglée selon les recommandations du fournisseur pour l'extraction structurée
+(0,0--0,3 selon les modèles~; pour DeepSeek, la température API 1,0
+correspond à une température interne de 0,3 via un mécanisme de mapping
+documenté). Le nombre total de tokens générés est mesuré par condition pour
+contrôler l'effet de budget de sortie (un prompt demandant des narratifs
+produit mécaniquement plus de tokens, ce qui peut réduire la place disponible
+pour l'inventaire). Chaque run produit un CSV évalué contre l'inventaire de
+référence (163~centrales, matching par nom exact et approximatif).
 
 \paragraph{Analyse}
 \begin{itemize}
@@ -220,10 +223,12 @@ fixée à 0. Chaque run produit un CSV évalué contre l'inventaire de référen
   $\Delta$F1 mesure le prix, en points d'extraction, de la traçabilité.
 \end{itemize}
 
-\paragraph{Budget prévisionnel} Sélection~: $2 \times 25 \times 3 = 150$~runs.
-Mesure avec $k=5$ modèles~: $16 \times 5 \times 5 = 400$~runs.
-Total~: 550~runs. Au coût moyen de 0,02--0,05\,\$ par run~: 10--30\,\$.
-Les modèles open-weight réduisent ce budget d'un facteur~10.
+\paragraph{Budget prévisionnel (pilote)} Sélection~: $2 \times 25 \times 2
+= 100$~runs. Mesure avec $k=5$ modèles~: $16 \times 5 \times 2 = 160$~runs.
+Total~: 260~runs $\approx$ 5--15\,\$. Les modèles open-weight réduisent ce
+budget d'un facteur~10. Pour une publication, augmenter à 5~répétitions,
+élargir le panel de modèles, et pré-enregistrer les hypothèses directionnelles
+par module (voir section~\ref{sec:lien-verification}).
 
 \paragraph{Limites du design}
 \begin{itemize}

--- a/report/report.tex
+++ b/report/report.tex
@@ -190,7 +190,7 @@ Les résultats confirment que les modèles ne révèlent qu'un tiers de leur con
 
 L'approche conversationnelle soulève cependant une contrainte technique~: l'accumulation du contexte. À chaque tour, le modèle reçoit l'historique complet de la conversation~; les tokens de prompt croissent linéairement. L'analyse des données de Sweep~2 (4~tours, 7~modèles, 3~runs chacun) montre que la plupart des modèles n'utilisent que 1 à 7\% de leur fenêtre de contexte. L'exception notable est DeepSeek~V3.2~: lors d'un run, ses réponses particulièrement verbeuses ont consommé 53\% de sa fenêtre de 164K tokens en seulement 4~tours. L'extrapolation linéaire prédit un dépassement à 15~tours. Pour les modèles à fenêtre réduite, un mode «~sans état~» --- où chaque relance est envoyée indépendamment, sans historique --- garantit un budget token constant par tour, au prix de la perte de raffinement itératif.
 
-Plusieurs techniques d'amélioration existent~: prompt engineering avancé, Chain of Thought, Few-shot learning, Self-Consistency, ou encore optimisation automatique des prompts via DSPy \citep{ATRGAC9J}. Le Retrieval-Augmented Generation (RAG) \citep{2U9Y8AJK} enrichit les capacités du modèle en intégrant des documents de référence \citep{JNKUDLN8,Y95UBRJ9}.
+Plusieurs techniques d'amélioration existent~: prompt engineering avancé, Chain of Thought, Few-shot learning, Self-Consistency, ou encore optimisation automatique des prompts via DSPy \citep{ATRGAC9J}. Le Retrieval-Augmented Generation (RAG) \citep{2U9Y8AJK} enrichit les capacités du modèle en intégrant des documents de référence \citep{JNKUDLN8,Y95UBRJ9}. L'expérience~3 (section~\ref{sec:exp3}) isole systématiquement l'effet de chaque composant du prompt sur la qualité de l'extraction.
 
 Deux limites fondamentales demeurent~:
 
@@ -200,6 +200,8 @@ Deux limites fondamentales demeurent~:
 \end{itemize}
 
 La technique RAG a le potentiel d'assurer la traçabilité des résultats et de connaître le pedigree des données.
+
+\input{inputs/plan_ablation}
 
 \chapter{Documents sources et RAG}\label{chap:rag}
 

--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -87,6 +87,8 @@ def load_plants_csv(path: Path) -> list[Plant]:
             return plants
         col_map = {c.strip().lower().replace(" ", "_"): c for c in reader.fieldnames}
         for row in reader:
+            # Preference order: name > name_vi > name_en.  Vietnamese names
+            # match the reference dataset better (diacritics aid fuzzy matching).
             name = _get(row, col_map, ["name", "name_vi", "name_en", "plant_name", "plant"])
             if not name:
                 continue

--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -87,7 +87,7 @@ def load_plants_csv(path: Path) -> list[Plant]:
             return plants
         col_map = {c.strip().lower().replace(" ", "_"): c for c in reader.fieldnames}
         for row in reader:
-            name = _get(row, col_map, ["name", "plant_name", "plant"])
+            name = _get(row, col_map, ["name", "name_vi", "name_en", "plant_name", "plant"])
             if not name:
                 continue
             fuel_raw = _get(row, col_map, ["fuel", "fuel_type"])
@@ -201,9 +201,7 @@ def _write_record(record: RunRecord, out: Path, stem: str) -> Path:
     """Write a RunRecord to {out}/{stem}.record.json, return the path."""
     record_path = out / f"{stem}.record.json"
     record_path.parent.mkdir(parents=True, exist_ok=True)
-    record_path.write_text(
-        record.model_dump_json(indent=2, exclude_none=True), encoding="utf-8"
-    )
+    record_path.write_text(record.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     return record_path
 
 
@@ -261,9 +259,7 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
         _evaluate_csv_file(system_path, ref_path, args)
 
 
-def _evaluate_csv_file(
-    system_path: Path, ref_path: Path, args: argparse.Namespace
-) -> None:
+def _evaluate_csv_file(system_path: Path, ref_path: Path, args: argparse.Namespace) -> None:
     """Evaluate a CSV system output and write record + reconciliation."""
     reference = load_plants_csv(ref_path)
     system = load_plants_csv(system_path)

--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -197,12 +197,24 @@ def norm_header(h: str) -> str:
     return h.strip("_")
 
 
-_CANON = ["name", "fuel", "status", "cod", "province", "capacity_mwe", "source_1", "source_2", "note"]
+_CANON = [
+    "name",
+    "fuel",
+    "status",
+    "cod",
+    "province",
+    "capacity_mwe",
+    "source_1",
+    "source_2",
+    "note",
+]
 
 
 def map_header_to_canonical(norm: str) -> str | None:
     if norm in {
         "name",
+        "name_vi",
+        "name_en",
         "plant",
         "plant_name",
         "plantname",
@@ -336,7 +348,9 @@ def extract_one(json_path: Path, output_dir: Path, overwrite: bool) -> ExtractRe
     try:
         canonical_csv = parse_and_canonicalize(best)
     except Exception as e:
-        return ExtractResult(ExtractStatus.FAILED, None, f"{json_path.name}: CSV parse failed ({e})")
+        return ExtractResult(
+            ExtractStatus.FAILED, None, f"{json_path.name}: CSV parse failed ({e})"
+        )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path.write_text(canonical_csv, encoding="utf-8")

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -132,6 +132,37 @@ def load_experiments(path: str) -> dict:
         return tomllib.load(f)
 
 
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+# Module ordering: persona is prepended, all others appended in this order.
+_MODULE_ORDER = ["overview", "sourcing", "narratives", "bibliography", "statistics"]
+
+
+def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
+    """Assemble a prompt from base + named modules.
+
+    *modules_dir* contains ``base.txt`` and one file per module
+    (e.g. ``persona.txt``, ``overview.txt``).  The *module_names* list
+    selects which modules to include.  ``persona`` is prepended before
+    the base; all others are appended in a fixed order.
+    """
+    base = (modules_dir / "base.txt").read_text().strip()
+    parts_before: list[str] = []
+    parts_after: list[str] = []
+    # Sort requested modules into fixed order for reproducibility.
+    ordered = [m for m in ["persona"] + _MODULE_ORDER if m in module_names]
+    for name in ordered:
+        text = (modules_dir / f"{name}.txt").read_text().strip()
+        if name == "persona":
+            parts_before.append(text)
+        else:
+            parts_after.append(text)
+    sections = parts_before + [base] + parts_after
+    return "\n\n".join(sections)
+
+
 def make_client(base_url: str | None = None) -> OpenAI:
     """Create an OpenAI-compatible client (legacy interface).
 

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -138,6 +138,7 @@ def load_experiments(path: str) -> dict:
 
 # Module ordering: persona is prepended, all others appended in this order.
 _MODULE_ORDER = ["overview", "sourcing", "narratives", "bibliography", "statistics"]
+KNOWN_MODULES = frozenset(["persona"] + _MODULE_ORDER)
 
 
 def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
@@ -147,7 +148,12 @@ def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
     (e.g. ``persona.txt``, ``overview.txt``).  The *module_names* list
     selects which modules to include.  ``persona`` is prepended before
     the base; all others are appended in a fixed order.
+
+    Raises ``ValueError`` if *module_names* contains unknown names.
     """
+    unknown = set(module_names) - KNOWN_MODULES
+    if unknown:
+        raise ValueError(f"Unknown prompt modules: {sorted(unknown)}. Known: {sorted(KNOWN_MODULES)}")
     base = (modules_dir / "base.txt").read_text().strip()
     parts_before: list[str] = []
     parts_after: list[str] = []

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -312,6 +312,35 @@ class TestParseAndCanonicalize:
         assert fields[-1].strip() == ""  # note
 
 
+class TestAblationPromptColumns:
+    """Columns from the ablation prompt (Name_VI, Name_EN, extra Source columns)."""
+
+    def test_name_vi_maps_to_canonical_name(self):
+        assert map_header_to_canonical(norm_header("Name_VI")) == "name"
+
+    def test_name_en_maps_to_canonical_name(self):
+        assert map_header_to_canonical(norm_header("Name_EN")) == "name"
+
+    def test_name_vi_column_parsed_by_canonicalize(self):
+        csv_text = "Name_VI,Name_EN,Fuel,Status\nPhả Lại,Pha Lai,Coal,Operational\n"
+        result = parse_and_canonicalize(csv_text)
+        assert "Phả Lại" in result
+
+    def test_extra_columns_ignored_by_evaluator(self, tmp_path):
+        """load_plants_csv silently ignores columns it doesn't map."""
+        from aedist.evaluate import load_plants_csv
+
+        csv_text = (
+            "Name_VI,Fuel,Status,Province,Capacity_MWe,Source_1,Source_2\n"
+            "Phả Lại,Coal,Operational,Hải Dương,600,Decision 123,EVN Report\n"
+        )
+        tmp = tmp_path / "ablation_test.csv"
+        tmp.write_text(csv_text, encoding="utf-8")
+        plants = load_plants_csv(tmp)
+        assert len(plants) == 1
+        assert plants[0].name == "Phả Lại"
+
+
 class TestHeaderVariantsProvenance:
     """Header variant mappings for provenance columns."""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,9 +52,7 @@ def test_schema_validation(models):
         assert model["license"] in VALID_LICENSES, (
             f"{model_id}: invalid license {model['license']}"
         )
-        assert model["router"] in VALID_ROUTERS, (
-            f"{model_id}: invalid router {model['router']}"
-        )
+        assert model["router"] in VALID_ROUTERS, f"{model_id}: invalid router {model['router']}"
         assert isinstance(model["context_window"], int), f"{model_id}: context_window must be int"
         assert isinstance(model["price_per_mtok_in"], (int, float)), (
             f"{model_id}: price_per_mtok_in must be numeric"
@@ -67,9 +65,7 @@ def test_schema_validation(models):
 def test_router_model_matches_id(models):
     """In Phase A, router_model == id for every entry (scaffolding for Phase B)."""
     for model in models:
-        assert model["router_model"] == model["id"], (
-            f"{model['id']}: router_model mismatch"
-        )
+        assert model["router_model"] == model["id"], f"{model['id']}: router_model mismatch"
 
 
 def test_coverage(models):
@@ -129,7 +125,8 @@ def test_experiments_routers(experiments):
 # ---------------------------------------------------------------------------
 
 VALID_MODES = set(Method)
-SWEEP_REQUIRED_FIELDS = {"mode", "prompt", "models", "repeat", "budget_usd", "output"}
+SWEEP_REQUIRED_FIELDS = {"mode", "models", "repeat", "budget_usd", "output"}
+# Each sweep needs either "prompt" (file path) or "prompt_modules" (list of module names).
 # verification is special — no mode/prompt/models at top level
 SWEEP4_REQUIRED_FIELDS = {"repeat", "budget_usd", "output", "verification_modes", "base_configs"}
 
@@ -141,14 +138,41 @@ def test_sweeps_section_exists(experiments):
 
 
 def test_sweep_count(experiments):
-    """All 11 sweeps are present."""
-    expected = {
-        "census", "census_local",
-        "multiturn", "web",
-        "rag", "decomposed",
-        "verification", "sourced",
-        "frontier", "frontier_scenarios", "frontier_skill",
+    """All sweeps are present."""
+    required = {
+        "census",
+        "census_local",
+        "multiturn",
+        "web",
+        "rag",
+        "decomposed",
+        "verification",
+        "sourced",
+        "frontier",
+        "frontier_scenarios",
+        "frontier_skill",
     }
+    ablation = {
+        "ablation_select_base",
+        "ablation_select_composite",
+        "ablation_base",
+        "ablation_persona",
+        "ablation_overview",
+        "ablation_narratives",
+        "ablation_bibliography",
+        "ablation_statistics",
+        "ablation_sourcing",
+        "ablation_composite",
+        "ablation_frontier",
+        "ablation_census",
+        "ablation_no_persona",
+        "ablation_no_overview",
+        "ablation_no_narratives",
+        "ablation_no_bibliography",
+        "ablation_no_statistics",
+        "ablation_no_sourcing",
+    }
+    expected = required | ablation
     assert set(experiments["sweeps"].keys()) == expected
 
 
@@ -159,9 +183,9 @@ def test_standard_sweep_fields(experiments):
             continue
         missing = SWEEP_REQUIRED_FIELDS - set(sweep.keys())
         assert not missing, f"sweeps.{name} missing fields: {missing}"
-        assert sweep["mode"] in VALID_MODES, (
-            f"sweeps.{name}: invalid mode '{sweep['mode']}'"
-        )
+        has_prompt = "prompt" in sweep or "prompt_modules" in sweep
+        assert has_prompt, f"sweeps.{name} needs 'prompt' or 'prompt_modules'"
+        assert sweep["mode"] in VALID_MODES, f"sweeps.{name}: invalid mode '{sweep['mode']}'"
         assert isinstance(sweep["repeat"], int) and sweep["repeat"] >= 1, (
             f"sweeps.{name}: repeat must be int >= 1"
         )
@@ -202,9 +226,7 @@ def test_sweep_model_set_ids_in_registry(models, experiments):
             continue
         model_set = experiments["sets"][set_name]
         for mid in model_set["model_ids"]:
-            assert mid in registry_ids, (
-                f"sweeps.{name} → sets.{set_name}: '{mid}' not in registry"
-            )
+            assert mid in registry_ids, f"sweeps.{name} → sets.{set_name}: '{mid}' not in registry"
 
 
 def test_sweep_prompts_exist(experiments):
@@ -213,9 +235,35 @@ def test_sweep_prompts_exist(experiments):
         if "prompt" not in sweep:
             continue
         prompt_path = EXPERIMENTS_DIR / sweep["prompt"]
-        assert prompt_path.exists(), (
-            f"sweeps.{name}: prompt file missing: {prompt_path}"
-        )
+        assert prompt_path.exists(), f"sweeps.{name}: prompt file missing: {prompt_path}"
+
+
+def test_sweep_prompt_modules_exist(experiments):
+    """Module files referenced by prompt_modules exist on disk."""
+    modules_dir = EXPERIMENTS_DIR / "prompts" / "modules"
+    assert (modules_dir / "base.txt").exists(), "modules/base.txt missing"
+    for name, sweep in experiments["sweeps"].items():
+        for mod in sweep.get("prompt_modules", []):
+            mod_path = modules_dir / f"{mod}.txt"
+            assert mod_path.exists(), f"sweeps.{name}: module file missing: {mod_path}"
+
+
+def test_assemble_prompt():
+    """assemble_prompt composes base + modules correctly."""
+    from aedist.harness import assemble_prompt
+
+    modules_dir = EXPERIMENTS_DIR / "prompts" / "modules"
+    # Base only
+    base = assemble_prompt(modules_dir, [])
+    assert "Produce a comprehensive CSV table" in base
+    assert "senior energy analyst" not in base
+    # With persona (prepended)
+    with_persona = assemble_prompt(modules_dir, ["persona"])
+    assert with_persona.startswith("You are a senior energy analyst")
+    assert "Produce a comprehensive CSV table" in with_persona
+    # With overview (appended)
+    with_overview = assemble_prompt(modules_dir, ["overview"])
+    assert with_overview.index("sector overview") > with_overview.index("CSV table")
 
 
 def test_sweep_output_dirs_unique(experiments):
@@ -229,9 +277,7 @@ def test_sweep_output_dirs_unique(experiments):
             # census and census_local share output dir by design
             pair = {name, outputs[out]}
             if pair != {"census", "census_local"}:
-                pytest.fail(
-                    f"sweeps.{name} and sweeps.{outputs[out]} share output '{out}'"
-                )
+                pytest.fail(f"sweeps.{name} and sweeps.{outputs[out]} share output '{out}'")
         outputs[out] = name
 
 
@@ -246,12 +292,17 @@ def test_list_models_helper(experiments):
 
     result = subprocess.run(
         [
-            "python3", str(EXPERIMENTS_DIR / "_list_models.py"),
+            "python3",
+            str(EXPERIMENTS_DIR / "_list_models.py"),
             str(MODELS_PATH),
-            "--set", "census_cloud",
-            "--experiments", str(EXPERIMENTS_PATH),
+            "--set",
+            "census_cloud",
+            "--experiments",
+            str(EXPERIMENTS_PATH),
         ],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     )
     shorts = set(result.stdout.strip().split())
     cloud_ids = experiments["sets"]["census_cloud"]["model_ids"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -153,8 +153,8 @@ def test_sweep_count(experiments):
         "frontier_skill",
     }
     ablation = {
-        "ablation_select_base",
-        "ablation_select_composite",
+        "ablation_p1_base",
+        "ablation_p1_composite",
         "ablation_base",
         "ablation_persona",
         "ablation_overview",
@@ -264,6 +264,15 @@ def test_assemble_prompt():
     # With overview (appended)
     with_overview = assemble_prompt(modules_dir, ["overview"])
     assert with_overview.index("sector overview") > with_overview.index("CSV table")
+
+
+def test_assemble_prompt_unknown_module_raises():
+    """assemble_prompt raises ValueError on unknown module names."""
+    from aedist.harness import assemble_prompt
+
+    modules_dir = EXPERIMENTS_DIR / "prompts" / "modules"
+    with pytest.raises(ValueError, match="Unknown prompt modules"):
+        assemble_prompt(modules_dir, ["personaa"])  # typo
 
 
 def test_sweep_output_dirs_unique(experiments):

--- a/tickets/0038-skill-reflexive-multiturn.erg
+++ b/tickets/0038-skill-reflexive-multiturn.erg
@@ -1,6 +1,6 @@
 %erg v1
-Title: Prompt ablation and self-repair: isolate what helps extraction
-Status: open
+Title: Prompt composition and ablation: isolate what helps extraction
+Status: doing
 Created: 2026-04-08
 Author: claude
 
@@ -8,86 +8,78 @@ Author: claude
 2026-04-08T14:00Z claude created
 2026-04-08T16:30Z claude note rewritten after reviewing actual frontier_skill outputs and prompts
 2026-04-09T12:00Z claude status reimagined by IDD phase 1
+2026-04-10T18:00Z claude status doing — redesigned as symmetric composition+ablation experiment; Phase B (self-repair) moved to ticket 0048
 
 --- body ---
 ## Context
-The original ticket proposed "reflexive self-prompting" — a plan-then-execute
-two-turn protocol to improve inventory completeness. That hypothesis is
-backwards. The frontier data already refutes it: Opus census (40-word prompt)
-scores F1=0.64 while Opus frontier (1200-word prompt with sourcing, narratives,
-and bibliography) drops to F1=0.54. More metacognition in the prompt
-*degraded* extraction. Adding a planning turn on top of that is compounding
-the mistake.
+The frontier data shows that Opus scores F1=0.64 with a 40-word census
+prompt and F1=0.54 with the 1200-word frontier prompt. More metacognition
+in the prompt *degraded* extraction. Which component is responsible?
 
-Two sharper questions replace the original:
+Two symmetric approaches isolate the effects:
 
-1. **Prompt ablation**: Which components of the frontier prompt cause the F1
-   drop? Is it the bibliography request? The per-plant narratives? The sector
-   overview? Isolating the damage tells us what NOT to include in production
-   prompts — a direct input to Phase 3 pipeline design.
+1. **Composition**: start from an optimized extraction base prompt, add one
+   module at a time. Measures what each addition does to F1.
+2. **Ablation**: start from the full composite (base + all modules), remove
+   one module at a time. Measures what each removal does to F1.
 
-2. **Self-repair**: Can a model improve its own CSV by reviewing it against
-   an expected plant count? This is the production-relevant capability: not
-   "think before you act" but "critique and fix what you produced." Human
-   analysts do exactly this iterative loop.
+Comparing both arms reveals interaction effects: a module may help alone
+but hurt in combination, or vice versa.
 
-Both use existing infrastructure. No new query modules. No new storage
-conventions. Just new prompt files and sweep configs for `query_frontier`
-and `query_multiturn`.
+## Prompt design
 
-## Phase A — Prompt ablation (pre-conference, ~1h, ~$2)
+The base prompt was designed iteratively (HITL) with these criteria:
+- Structured CSV output matching the evaluator's column parser
+- 30 MWe inclusion threshold
+- Full project lifecycle (proposal through decommissioning)
+- Captive and cogeneration plants included
+- Biomass/waste explicitly excluded (tracked separately)
+- Open status vocabulary (multi-authority, not centrally-planned)
+- No persona (literature suggests negative effect on structured extraction)
+- No numeric hints (avoids anchoring)
+- OEO-aligned terminology with three deliberate divergences documented
 
-Single model (Opus), 5 single-shot runs via `query_frontier.py`:
+Six modules tested: persona, sector overview, per-plant narratives,
+annotated bibliography, cross-tabulation statistics, per-row sourcing.
 
-| Run | Prompt variant | What's removed |
-|-----|---------------|----------------|
-| 1 | census (baseline) | Everything — just "list all plants as CSV" |
-| 2 | frontier minus bibliography | No §4 (annotated bibliography) |
-| 3 | frontier minus narratives | No per-plant discussion paragraphs |
-| 4 | frontier minus overview | No §1 (sector overview) |
-| 5 | frontier full (control) | Nothing — the 1200-word prompt as-is |
+Full experimental plan in report: `report/inputs/plan_ablation.tex`
+Module files in: `experiments/prompts/modules/` (base + 6 modules)
+Assembler in: `src/aedist/harness.py` (assemble_prompt)
+Sweep configs in: `experiments/experiments.toml` (sweeps.ablation_*)
 
-Output: one comparison row in a table. Slide-ready finding for the methods
-framing: "elaborate prompts degrade structured extraction by X% — here's
-which component is responsible."
+## Measurement plan
 
-Storage: `outputs/ablation/` — standard .json/.csv/.eval.json per run.
+16 prompts total (census anchor, base, 6 composition, composite anchor,
+6 ablation, frontier control). Two-phase protocol:
 
-## Phase B — Self-repair protocol (post-conference, ~$5)
+Phase 1 (selection): base and composite on all census_cloud models (1 rep).
+Retain models showing significant base-vs-composite difference.
 
-5 models, using `query_multiturn.py` with 1 followup:
-
-Turn 1: Standard census prompt (prompt_structured.txt).
-Turn 2 (followup): "You produced {N} plants. Vietnam has approximately 163
-  thermal power plants across 50+ complexes. Review your table: identify
-  plants you likely missed (check LNG terminals, plants under PDP7/PDP8,
-  cancelled projects). Produce a corrected and complete CSV table."
-
-The followup is templated — {N} is extracted from turn 1's CSV row count
-at runtime. This requires a minor extension to `run_conversation`: allow
-a followup to reference turn-1 output. If that's too invasive, hardcode
-the followup without {N} and just say "review your table for gaps."
-
-Models: Opus, o3, DeepSeek R1, Tongyi DeepResearch, Kimi K2 Thinking
-(same 5 from original ticket — they have frontier baselines).
-
-Evaluation: extract CSV from turn-2 response, standard evaluate against
-reference. Comparison: single-shot F1 vs self-repair F1 vs cost delta.
-
-Storage: `outputs/self_repair/` — standard multiturn JSON with both turns.
+Phase 2 (measurement): 16 prompts × k models × 5 repeats. Bootstrap CIs
+on delta-F1 per module.
 
 ## Actions
-1. Write 4 ablated prompt variants in experiments/prompts/
-2. Add [sweeps.ablation] to experiments.toml — mode "single", model Opus, 5 prompts
-3. Run Phase A ablation sweep and evaluate (pre-conference if time permits)
-4. Write prompt_self_repair_followup.txt for Phase B
-5. Add [sweeps.self_repair] to experiments.toml — mode "multiturn", 1 followup
-6. Run Phase B after conference, evaluate, produce comparison table
+1. [x] Design base prompt (HITL review)
+2. [x] Write 7 module files + assembler (DRY, no repeated base text)
+3. [x] Add 18 sweep configs to experiments.toml (prompt_modules key)
+4. [x] Add name_vi/name_en aliases to extract.py and evaluate.py
+5. [x] Write experimental plan in report (plan_ablation.tex)
+6. [x] Integrate plan into report.tex
+7. [ ] Wire prompt_modules in runner: query_frontier.py must read
+       prompt_modules from sweep config, call assemble_prompt(), use
+       assembled text instead of --prompt file. Fallback to --prompt
+       when prompt_modules is absent (existing sweeps unchanged).
+8. [ ] Run Phase 1 selection sweeps
+9. [ ] Analyze selection results, populate ablation model set
+10. [ ] Run Phase 2 measurement sweeps
+11. [ ] Evaluate, produce comparison tables, write results section
 
 ## Test
-Phase A first test: `python -m aedist.query_frontier --prompt prompts/prompt_frontier_no_bibliography.txt --model anthropic/claude-opus-4.6 --output outputs/ablation/ --dry-run` succeeds.
+All 856 tests pass with new sweep configs and evaluator aliases.
 
 ## Exit criteria
-- Phase A: 5 ablation runs evaluated, table showing F1 delta per removed component
-- Phase B: 5 models × 1 self-repair run, comparison table: census F1 vs repair F1 vs cost
-- Finding stated: which prompt components help/hurt extraction, and whether self-repair closes the recall gap
+- 16 prompt variants evaluated on k models with 5 repeats each
+- Table showing delta-F1 per module (composition and ablation arms)
+- Interaction effects quantified (composition vs ablation asymmetry)
+- Cost of sourcing stated (delta-F1 for the traceability module)
+- Finding integrated into report

--- a/tickets/0038-skill-reflexive-multiturn.erg
+++ b/tickets/0038-skill-reflexive-multiturn.erg
@@ -58,25 +58,25 @@ Retain models showing significant base-vs-composite difference.
 Phase 2 (measurement): 16 prompts × k models × 5 repeats. Bootstrap CIs
 on delta-F1 per module.
 
-## Actions
+## Actions (all complete — this is a design ticket)
 1. [x] Design base prompt (HITL review)
 2. [x] Write 7 module files + assembler (DRY, no repeated base text)
 3. [x] Add 18 sweep configs to experiments.toml (prompt_modules key)
 4. [x] Add name_vi/name_en aliases to extract.py and evaluate.py
 5. [x] Write experimental plan in report (plan_ablation.tex)
 6. [x] Integrate plan into report.tex
-7. [ ] Wire prompt_modules in runner (ticket 0049)
-8. [ ] Run Phase 1 selection sweeps (3 reps, blocked by 0049)
-9. [ ] Analyze selection results, populate ablation model set
-10. [ ] Run Phase 2 measurement sweeps
-11. [ ] Evaluate, produce comparison tables, write results section
+
+## Downstream tickets
+- 0049: Wire prompt_modules in runner (infra)
+- 0050: Preregister directional hypotheses (blocks paper-grade runs)
+- 0051: Analyze base-vs-census gap (analysis, no extra API calls)
+- 0052: Run ablation sweeps + analyze (execution, blocked by 0049+0044)
+- 0053: Run multi-agent verification (execution, blocked by 0048+0052)
 
 ## Test
-All 856 tests pass with new sweep configs and evaluator aliases.
+862 tests pass with sweep configs, assembler guard, and evaluator aliases.
 
 ## Exit criteria
-- 16 prompt variants evaluated on k models with 5 repeats each
-- Table showing delta-F1 per module (composition and ablation arms)
-- Interaction effects quantified (composition vs ablation asymmetry)
-- Cost of sourcing stated (delta-F1 for the traceability module)
-- Finding integrated into report
+- Experimental plan reviewed and integrated into report ✓
+- Prompt modules, assembler, sweep configs, evaluator aliases merged ✓
+- Downstream tickets created for execution, preregistration, analysis ✓

--- a/tickets/0038-skill-reflexive-multiturn.erg
+++ b/tickets/0038-skill-reflexive-multiturn.erg
@@ -65,11 +65,8 @@ on delta-F1 per module.
 4. [x] Add name_vi/name_en aliases to extract.py and evaluate.py
 5. [x] Write experimental plan in report (plan_ablation.tex)
 6. [x] Integrate plan into report.tex
-7. [ ] Wire prompt_modules in runner: query_frontier.py must read
-       prompt_modules from sweep config, call assemble_prompt(), use
-       assembled text instead of --prompt file. Fallback to --prompt
-       when prompt_modules is absent (existing sweeps unchanged).
-8. [ ] Run Phase 1 selection sweeps
+7. [ ] Wire prompt_modules in runner (ticket 0049)
+8. [ ] Run Phase 1 selection sweeps (3 reps, blocked by 0049)
 9. [ ] Analyze selection results, populate ablation model set
 10. [ ] Run Phase 2 measurement sweeps
 11. [ ] Evaluate, produce comparison tables, write results section

--- a/tickets/0048-multi-agent-verification.erg
+++ b/tickets/0048-multi-agent-verification.erg
@@ -49,19 +49,32 @@ sourcing module as the verification substrate.
 - The existing `extract_csv_rows()` utility handles CSV extraction from
   responses.
 
-## Actions
-1. Design verification protocol (choose among candidates above)
-2. Implement multi-agent verification mode in query_verification.py
-3. Run verification on best ablation prompt outputs (ticket 0038 results)
-4. Evaluate: verified F1 vs unverified F1 vs cost delta
-5. Write results section in report
+## Actions — Phase A: design (this ticket)
+1. Review candidate protocols against infrastructure constraints
+2. Choose one protocol and specify: which models, how many agents,
+   what constitutes agreement/disagreement, how to handle ties
+3. Write experimental plan section for report (like plan_ablation.tex)
+
+## Actions — Phase B: execution (separate ticket, blocked by this one)
+4. Implement chosen protocol in query_verification.py
+5. Run verification on best ablation prompt outputs (ticket 0038 results)
+6. Evaluate: verified F1 vs unverified F1 vs cost delta
+7. Write results section in report
 
 ## Test
-First test: run cross-model verification on one Opus extraction output
-with DeepSeek as verifier. Compare verified vs unverified F1.
+Phase A deliverable: a written protocol spec with concrete parameters
+(model pairs, decision rule, cost estimate), reviewed by author.
 
-## Exit criteria
-- At least one multi-agent verification protocol implemented and evaluated
+Phase B first test: run chosen protocol on one Opus extraction output.
+Compare verified vs unverified F1.
+
+## Exit criteria (Phase A)
+- Protocol chosen and specified with concrete parameters
+- Experimental plan section drafted for report
+- Phase B ticket created with clear actions
+
+## Exit criteria (Phase B — separate ticket)
+- Protocol implemented and evaluated on k models
 - Comparison table: unverified F1 vs verified F1 vs cost
 - Finding stated: does independent verification improve extraction, and at
   what cost?

--- a/tickets/0048-multi-agent-verification.erg
+++ b/tickets/0048-multi-agent-verification.erg
@@ -1,0 +1,67 @@
+%erg v1
+Title: Multi-agent verification of extraction outputs
+Status: open
+Created: 2026-04-10
+Author: claude
+Blocked-by: 0038
+
+--- log ---
+2026-04-10T18:00Z claude created
+2026-04-10T18:00Z claude note split from ticket 0038 Phase B; single-model self-repair deemed too weak
+
+--- body ---
+## Context
+Ticket 0038 originally included a "self-repair" Phase B where a single model
+reviews its own CSV output and produces a corrected version. Investigation
+showed this is the weakest form of verification — the same model has the same
+blind spots. The self-consistency literature (Wang et al. 2023) and debate
+protocols show that verification by multiple independent agents is
+substantially more effective.
+
+This ticket implements multi-agent verification as a separate experiment,
+using the per-row Source_1/Source_2 columns from the ablation prompt's
+sourcing module as the verification substrate.
+
+## Design principles
+1. **Independence**: verifying agents must not see the original prompt or
+   each other's outputs — only the CSV to check.
+2. **Diversity**: use different models, or different decomposition strategies,
+   to maximize coverage of blind spots.
+3. **Per-row granularity**: each row carries its own source citations,
+   enabling targeted verification without full re-extraction.
+
+## Candidate protocols
+- **Cross-model check**: Model A extracts, Model B verifies each row against
+  cited sources. Swap roles and compare.
+- **Majority vote**: k independent extractions, accept rows appearing in
+  ≥ ceil(k/2) outputs. Already implemented for multi-run aggregation
+  (self-consistency sweep).
+- **Debate**: two models argue for/against inclusion of disputed rows, a
+  judge model decides. Higher cost, potentially higher precision.
+- **Source grounding**: a verifier agent fetches the cited source and checks
+  whether the claimed data actually appears there. Requires RAG corpus access.
+
+## Infrastructure
+- `query_verification.py` already supports 5 verification modes (unverified,
+  tool, self, cross, web). Extend with a "multi-agent" mode.
+- Per-row Source_1/Source_2 columns from ticket 0038's sourcing module feed
+  directly into the verification step.
+- The existing `extract_csv_rows()` utility handles CSV extraction from
+  responses.
+
+## Actions
+1. Design verification protocol (choose among candidates above)
+2. Implement multi-agent verification mode in query_verification.py
+3. Run verification on best ablation prompt outputs (ticket 0038 results)
+4. Evaluate: verified F1 vs unverified F1 vs cost delta
+5. Write results section in report
+
+## Test
+First test: run cross-model verification on one Opus extraction output
+with DeepSeek as verifier. Compare verified vs unverified F1.
+
+## Exit criteria
+- At least one multi-agent verification protocol implemented and evaluated
+- Comparison table: unverified F1 vs verified F1 vs cost
+- Finding stated: does independent verification improve extraction, and at
+  what cost?

--- a/tickets/0049-wire-prompt-modules.erg
+++ b/tickets/0049-wire-prompt-modules.erg
@@ -1,0 +1,41 @@
+%erg v1
+Title: Wire prompt_modules in query runner
+Status: open
+Created: 2026-04-10
+Author: claude
+Blocked-by: 0038
+
+--- log ---
+2026-04-10T20:00Z claude created — split from ticket 0038 action 7
+
+--- body ---
+## Context
+Ticket 0038 added `prompt_modules` as a sweep config key and
+`assemble_prompt()` in harness.py. But `query_frontier.py` only reads
+`--prompt` as a file path. The runner must bridge this gap before any
+ablation sweep can execute.
+
+## Actions
+1. Add `--prompt-modules` flag to `query_frontier.py` as alternative
+   to `--prompt`. When present, call `assemble_prompt()` with the
+   modules directory and the given module list.
+2. Update the manager/dispatcher to read `prompt_modules` from sweep
+   config and pass it to the query script (either via `--prompt-modules`
+   or by assembling the text and writing a temp file).
+3. Fallback: when `prompt_modules` is absent, use `--prompt` as before.
+   Existing sweeps unchanged.
+
+## Test
+```
+python -m aedist.query_frontier \
+  --prompt-modules persona overview \
+  --models models.yaml --model anthropic/claude-opus-4.6 \
+  --output /tmp/test --dry-run
+```
+Succeeds and shows the assembled prompt (persona prepended, overview appended).
+
+## Exit criteria
+- `query_frontier.py` accepts `--prompt-modules` and calls `assemble_prompt()`
+- Manager reads `prompt_modules` from experiments.toml sweep config
+- Existing sweeps with `prompt` key work unchanged
+- `ablation_select_base` sweep runs end-to-end in dry-run mode

--- a/tickets/0050-preregister-ablation-hypotheses.erg
+++ b/tickets/0050-preregister-ablation-hypotheses.erg
@@ -1,0 +1,36 @@
+%erg v1
+Title: Preregister directional hypotheses for ablation experiment
+Status: open
+Created: 2026-04-10
+Author: claude
+Blocked-by: 0038
+
+--- log ---
+2026-04-10T22:00Z claude created — from independent vision review
+
+--- body ---
+## Context
+The ablation experiment (ticket 0038) tests 6 prompt modules but states no
+directional hypotheses. Without pre-stated expectations, the analysis risks
+post-hoc rationalization of whatever the data shows. This ticket blocks the
+full (paper-grade, 5 reps) experiment — not the pilot (2 reps).
+
+## Actions
+1. For each of the 6 modules (persona, overview, narratives, bibliography,
+   statistics, sourcing), state:
+   - Expected direction: helps recall / hurts recall / neutral
+   - Proposed mechanism: e.g. "narratives tax output budget, leaving fewer
+     tokens for inventory rows"
+   - Literature support if available
+2. State expected base-vs-census comparison direction
+3. State expected composite-vs-frontier comparison direction
+4. Document in report section (plan_ablation.tex) or appendix
+
+## Test
+Deliverable is a document, not code. Review gate: author confirms
+hypotheses are specific enough to be falsifiable.
+
+## Exit criteria
+- One directional hypothesis per module with mechanism
+- Documented before Phase 2 (5-rep) runs begin
+- Pilot (2-rep) results may inform but not determine hypotheses

--- a/tickets/0051-base-vs-census-analysis.erg
+++ b/tickets/0051-base-vs-census-analysis.erg
@@ -1,0 +1,37 @@
+%erg v1
+Title: Analyze base prompt vs census prompt gap
+Status: open
+Created: 2026-04-10
+Author: claude
+Blocked-by: 0049
+
+--- log ---
+2026-04-10T22:00Z claude created — from independent vision review
+
+--- body ---
+## Context
+The ablation experiment compares module additions/removals relative to the
+base prompt. But the base prompt itself (300 words, structured columns,
+30 MWe threshold, captive/cogen scope) differs from the census prompt
+(40 words, minimal structure) by far more than any single module. The
+jump from census to base embeds many design choices whose individual
+contributions are not measured by the module ablation.
+
+This deserves a dedicated brief analysis: what explains the F1 difference
+between census and base? Is it the column structure? The exhaustiveness
+instruction? The status vocabulary? The 30 MWe threshold?
+
+## Actions
+1. After Phase 1 selection runs (ticket 0038), compare census vs base
+   F1 across all models
+2. Qualitative analysis: inspect a few responses to identify what the
+   base prompt captures that census misses (or vice versa)
+3. Brief paragraph in report discussing the gap
+
+## Test
+Census and base are both run in Phase 1 selection. No additional API
+calls needed — just analysis of existing results.
+
+## Exit criteria
+- Census vs base F1 comparison across models reported
+- Brief discussion paragraph in plan_ablation.tex or results section

--- a/tickets/0052-run-ablation-sweeps.erg
+++ b/tickets/0052-run-ablation-sweeps.erg
@@ -1,0 +1,41 @@
+%erg v1
+Title: Run ablation sweeps and analyze results
+Status: open
+Created: 2026-04-10
+Author: claude
+Blocked-by: 0049
+Blocked-by: 0044
+
+--- log ---
+2026-04-10T22:00Z claude created — split execution from 0038 design ticket
+2026-04-10T22:00Z claude note Phase 2 (paper-grade) also blocked by 0050 (preregistration)
+
+--- body ---
+## Context
+Ticket 0038 designed the experiment. Ticket 0049 wires the runtime. This
+ticket runs the sweeps and produces results.
+
+## Actions — Pilot (2 reps, for conference presentation)
+1. Run Phase 1 selection: ablation_p1_base + ablation_p1_composite
+2. HUMAN GATE: review Phase 1 results, select k models where
+   |ΔF1| > 0.05 (mean of 2 runs). Populate sets.ablation in
+   experiments.toml with selected model IDs.
+3. Run Phase 2: all 16 ablation sweeps on selected models (2 reps)
+4. Evaluate all outputs, produce comparison table
+5. Write brief results paragraph in report
+
+## Actions — Paper upgrade (5 reps, post-conference)
+6. Blocked by ticket 0050 (preregistration of hypotheses)
+7. Re-run Phase 2 with repeat=5, wider model panel
+8. Full statistical analysis: bootstrap CIs, interaction effects
+9. Write full results section in report
+
+## Test
+Phase 1 dry-run: `query_frontier --prompt-modules --dry-run` lists
+correct models and assembled prompt.
+
+## Exit criteria (pilot)
+- Phase 1 selection complete, k models identified
+- Phase 2 (2 reps) complete, results evaluated
+- Comparison table: ΔF1 per module (composition + ablation arms)
+- Brief finding paragraph in report

--- a/tickets/0053-multi-agent-verify-run.erg
+++ b/tickets/0053-multi-agent-verify-run.erg
@@ -1,0 +1,30 @@
+%erg v1
+Title: Implement and run multi-agent verification protocol
+Status: open
+Created: 2026-04-10
+Author: claude
+Blocked-by: 0048
+Blocked-by: 0052
+
+--- log ---
+2026-04-10T22:00Z claude created — Phase B execution, split from 0048 design
+
+--- body ---
+## Context
+Ticket 0048 chooses the verification protocol. This ticket implements
+it and runs it on ablation experiment outputs (ticket 0052).
+
+## Actions
+1. Implement chosen protocol in query_verification.py
+2. Run verification on best ablation prompt outputs
+3. Evaluate: verified F1 vs unverified F1 vs cost delta
+4. Write results section in report
+
+## Test
+Run chosen protocol on one extraction output. Compare verified vs
+unverified F1.
+
+## Exit criteria
+- Protocol implemented and evaluated on k models
+- Comparison table: unverified F1 vs verified F1 vs cost
+- Finding stated in report


### PR DESCRIPTION
## Summary
- Symmetric experiment design to isolate which prompt components help/hurt extraction: composition (add one module to base) and ablation (remove one module from composite), 16 prompts total
- HITL-designed base prompt with 6 modular components (persona, overview, narratives, bibliography, statistics, sourcing), assembled at runtime via `assemble_prompt()` — DRY, no repeated base text
- Experimental plan written in French for tech report (`plan_ablation.tex`), integrated into Chapter 2 as Expérience 3
- Ticket 0048 created for multi-agent verification (split from original Phase B — single-model self-repair deemed too weak)

## Changes
- `experiments/prompts/modules/` — 7 module files (base + 6 add-ons)
- `src/aedist/harness.py` — `assemble_prompt()` function with fixed module ordering
- `experiments/experiments.toml` — 18 ablation sweep configs using `prompt_modules` key, `ablation` model set
- `src/aedist/extract.py`, `evaluate.py` — `name_vi`/`name_en` column aliases
- `report/inputs/plan_ablation.tex` — full experimental plan section
- `report/report.tex` — includes plan, forward-reference from Discussion
- `tickets/0038-skill-reflexive-multiturn.erg` — rewritten for new design
- `tickets/0048-multi-agent-verification.erg` — new ticket (blocked by 0038)
- `tests/test_models.py` — updated sweep validation, assembler tests

## Blocking note
Runtime integration (action 7 in ticket): `query_frontier.py` needs to read `prompt_modules` from sweep config and call `assemble_prompt()`. Existing sweeps using `prompt` key are unaffected.

## Test plan
- [x] 858 tests pass (`make check-fast`)
- [x] Assembler test: base-only, persona prepend, overview append
- [x] Module file existence validated for all sweep configs
- [ ] Visual review of `plan_ablation.tex` in compiled PDF (no LaTeX on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)