### PR TITLE
AGENTS.md: declare IDH as user-level dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,14 @@
 
 > `CLAUDE.md` contains only `@AGENTS.md` — do not modify it (enforced by pre-commit hook).
 
+## Dependencies
+
+**[Imperial Dragon Harness](https://github.com/MinhHaDuong/ImperialDragonHarness)** — workflow skills (`/review-pr`, `/celebrate`, `/end-session`, `/memory`, etc.). Installed at user level. If unavailable, follow the phase descriptions below — the skills automate the workflow, they don't define it.
+
 ## Configuration
 
 | Location | Purpose |
 |----------|---------|
-| `~/.claude/rules/` | Generic rules (git, workflow, coding, state-roadmap) |
-| `~/.claude/skills/` | Generic skills (celebrate, review-pr, memory, etc.) |
-| `~/.claude/hooks/` | Generic hooks (on-start identity setup) |
 | `.claude/rules/` | Project-specific rules (incl. `tickets.md` spec) |
 | `.claude/skills/` | Project-specific skills (incl. `ticket-*` skills) |
 | `.claude/hooks/` | Project-specific hooks |
@@ -85,7 +86,7 @@ The agent must always know and declare its current phase.
 | `/ticket-close NNNN` | Completing work | Set `Status: closed`, release `.wip`, commit |
 | `/ticket-release NNNN` | Abandoning work | Restore `Status: open`, release `.wip`, commit |
 
-### GitHub and workflow
+### Imperial Dragon Harness (user-level — may not be available)
 
 | Skill | When | Purpose |
 |-------|------|---------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,6 @@
 
 > `CLAUDE.md` contains only `@AGENTS.md` — do not modify it (enforced by pre-commit hook).
 
-## Dependencies
-
-**[Imperial Dragon Harness](https://github.com/MinhHaDuong/ImperialDragonHarness)** — workflow skills (`/review-pr`, `/celebrate`, `/end-session`, `/memory`, etc.). Installed at user level. If unavailable, follow the phase descriptions below — the skills automate the workflow, they don't define it.
-
 ## Configuration
 
 | Location | Purpose |
@@ -86,7 +82,7 @@ The agent must always know and declare its current phase.
 | `/ticket-close NNNN` | Completing work | Set `Status: closed`, release `.wip`, commit |
 | `/ticket-release NNNN` | Abandoning work | Restore `Status: open`, release `.wip`, commit |
 
-### Imperial Dragon Harness (user-level — may not be available)
+### [Imperial Dragon Harness](https://github.com/MinhHaDuong/ImperialDragonHarness) (user-level — may not be available)
 
 | Skill | When | Purpose |
 |-------|------|---------|


### PR DESCRIPTION
## Summary

- Add IDH to Dependencies section — user-level, graceful degradation
- Remove `~/.claude/*` paths from Configuration table (they belong to IDH, not this project)
- Label workflow skills as "user-level — may not be available"

## Context

IDH is evolving upstream and may become stock Claude Code. It should not be vendored into projects. Agents in web environments can follow the phase descriptions without the skills installed.

## Test plan

- [ ] An agent without IDH knows to follow phase descriptions manually
- [ ] Configuration table no longer claims user-level paths as project config

🤖 Generated with [Claude Code](https://claude.com/claude-code)