### PR TITLE
Fix grammar in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Constraint: Maintain the Makefile DAG, prerequisites and targets must match each
 
 Review each PR before merging:
 
-1. **Review**: Route between `/review-pr` or `/review-pr-prose`.
+1. **Review**: Route between `/review` (stock), `/review-pr` or `/review-pr-prose` (IDH).
 2. **Fix**: Fix all issues. Nits: fix them. Push back against "No need to fix now" mindset. Non-fixed open tickets for oversized deferred work.
 3. **Lint**: Consider `/simplify`, advanced linter and codesmells checks.
 4. **Iterate**: Up to three review/fix cycles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 
 Every task passes through five phases.
 Maintain awareness of the conversation's current phase to behave accordingly.
-Infer the initial phase and announces it (e.g., `[→ Imagine]`) at conversation start, then announce transitions inline: `[Phase → Phase] reason`.
+Infer the initial phase and announce it (e.g., `[→ Imagine]`) at conversation start, then announce transitions inline: `[Phase → Phase] reason`.
 
 ### Imagine
 Engage with the user to form a vision.
@@ -37,7 +37,7 @@ Scope: Focus on one issue. Scope-creep guard: Create new tickets if investigatio
 
 Deliverable: a ticket ready to execute. No production code commit, change only ticket(s). The ticket includes the first test in the ticket body, specifies the definition of done literally, provides guidance and hands-off helpful context.
 
-Explore alternatives design strategies and prototype approaches using throwaway code, worktree isolated.
+Explore alternatives, design strategies, and prototype approaches using throwaway code, worktree isolated.
 
 Consider interaction with other tickets and PR.
 
@@ -101,9 +101,9 @@ Team Verification: independently review the plans and annotate for prerequisites
 Team Execute delivers the PR.
 Team Verify fixes them.
 Team Audit assumes non-compliance and lint, reverify, inspect scope creep and fix again.
-The orchestrator receives the clean PRs, reviews each against its ticket, and performs the merge in order. It then loop to the first step.
+The orchestrator receives the clean PRs, reviews each against its ticket, and performs the merge in order. It then loops to the first step.
 
-In autonomous mode, orchestrator never defers for human input. In face of hard issues, it resorts first to a diverse team of agent experts. It then escalate to deep research. Thirdly, it works around the issue.
+In autonomous mode, orchestrator never defers for human input. In the face of hard issues, it resorts first to a diverse team of agent experts. It then escalates to deep research. Thirdly, it works around the issue.
 
 ## Two ticket systems
 


### PR DESCRIPTION
## Summary

Postmerge fixes for review remarks on #222.

- Subject/verb agreement: announces → announce, loop → loops, escalate → escalates
- Missing commas in Plan phase enumeration
- "In face of" → "In the face of"

🤖 Generated with [Claude Code](https://claude.com/claude-code)