### PR TITLE
Wire prompt_modules in query runner (ticket 0055)

### DIFF
--- a/src/aedist/manager.py
+++ b/src/aedist/manager.py
@@ -100,6 +100,8 @@ def generate(
                 corpus=parent_spec.corpus,
                 followups=parent_spec.followups,
                 strategy=parent_spec.strategy,
+                prompt_modules=parent_spec.prompt_modules,
+                modules_dir=parent_spec.modules_dir,
                 repeat=1,
                 run_number=run,
                 budget_usd=parent_spec.budget_usd,

--- a/src/aedist/query.py
+++ b/src/aedist/query.py
@@ -27,6 +27,7 @@ import openai
 
 from .harness import (
     BudgetTracker,
+    assemble_prompt,
     compute_cost,
     load_experiments,
     load_models,
@@ -45,7 +46,19 @@ log = logging.getLogger(__name__)
 
 def main():
     parser = argparse.ArgumentParser(description="Query LLMs via OpenRouter or compatible endpoint")
-    parser.add_argument("--prompt", required=True, help="Path to prompt text file")
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt", help="Path to prompt text file")
+    prompt_group.add_argument(
+        "--prompt-modules",
+        nargs="*",
+        default=None,
+        help="Module names for assemble_prompt() (e.g. persona overview)",
+    )
+    parser.add_argument(
+        "--modules-dir",
+        default="experiments/prompts/modules",
+        help="Directory containing prompt module text files",
+    )
     parser.add_argument("--models", required=True, help="Path to models.yaml")
     parser.add_argument("--output", required=True, help="Output directory for results")
     parser.add_argument("--model", help="Query only this model (full ID from YAML)")
@@ -60,7 +73,10 @@ def main():
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    prompt = Path(args.prompt).read_text().strip()
+    if args.prompt_modules is not None:
+        prompt = assemble_prompt(Path(args.modules_dir), args.prompt_modules)
+    else:
+        prompt = Path(args.prompt).read_text().strip()
     models = load_models(args.models)
     output_dir = Path(args.output)
 

--- a/src/aedist/query_frontier.py
+++ b/src/aedist/query_frontier.py
@@ -28,6 +28,7 @@ import openai
 
 from .harness import (
     BudgetTracker,
+    assemble_prompt,
     compute_cost,
     load_experiments,
     load_models,
@@ -52,7 +53,19 @@ def main():
     parser = argparse.ArgumentParser(
         description="Frontier deep-research benchmark for comprehensive extraction"
     )
-    parser.add_argument("--prompt", required=True, help="Path to prompt text file")
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt", help="Path to prompt text file")
+    prompt_group.add_argument(
+        "--prompt-modules",
+        nargs="*",
+        default=None,
+        help="Module names for assemble_prompt() (e.g. persona overview)",
+    )
+    parser.add_argument(
+        "--modules-dir",
+        default="experiments/prompts/modules",
+        help="Directory containing prompt module text files",
+    )
     parser.add_argument("--models", required=True, help="Path to models YAML")
     parser.add_argument("--output", required=True, help="Output directory")
     parser.add_argument("--model", help="Query only this model (full ID)")
@@ -77,10 +90,18 @@ def main():
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    prompt = Path(args.prompt).read_text().strip()
-    sweep = Path(args.prompt).stem
-    if sweep.startswith("prompt_"):
-        sweep = sweep[len("prompt_"):]
+    if args.prompt_modules is not None:
+        modules_dir = Path(args.modules_dir)
+        prompt = assemble_prompt(modules_dir, args.prompt_modules)
+        if args.prompt_modules:
+            sweep = "modules_" + "_".join(args.prompt_modules)
+        else:
+            sweep = "modules_base"
+    else:
+        prompt = Path(args.prompt).read_text().strip()
+        sweep = Path(args.prompt).stem
+        if sweep.startswith("prompt_"):
+            sweep = sweep[len("prompt_"):]
     models = load_models(args.models)
     output_dir = Path(args.output)
 

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -17,7 +17,7 @@ from typing import Any
 from uuid import uuid4
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class FuelType(StrEnum):
@@ -265,6 +265,13 @@ class JobSpec(BaseModel):
         default=None, ge=0, description="Estimated wall-clock seconds."
     )
     worker_pool: WorkerPool = WorkerPool.OPENROUTER
+
+    @model_validator(mode="after")
+    def _require_prompt_or_modules(self) -> JobSpec:
+        """Ensure at least one of prompt (non-empty) or prompt_modules is set."""
+        if not self.prompt and self.prompt_modules is None:
+            raise ValueError("Either 'prompt' or 'prompt_modules' must be provided.")
+        return self
 
     # -- YAML serialization ---------------------------------------------------
 

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -234,7 +234,7 @@ class JobSpec(BaseModel):
     job_id: str = Field(default_factory=lambda: uuid4().hex[:12])
     priority: int = Field(default=0, description="Higher value = higher priority.")
     mode: Method
-    prompt: str = Field(..., description="Path to prompt file.")
+    prompt: str = Field(default="", description="Path to prompt file (unused when prompt_modules is set).")
     models_file: str = Field(..., description="Path to models YAML file.")
     model_filter: str | None = Field(
         default=None, description="Glob or regex to select a subset of models."
@@ -247,6 +247,14 @@ class JobSpec(BaseModel):
     )
     strategy: str | None = Field(
         default=None, description="RAG retrieval strategy (e.g. wholesale)."
+    )
+    prompt_modules: list[str] | None = Field(
+        default=None,
+        description="Module names for assemble_prompt(). Mutually exclusive with prompt file.",
+    )
+    modules_dir: str | None = Field(
+        default=None,
+        description="Directory containing prompt module text files (default: experiments/prompts/modules/).",
     )
     repeat: int = Field(default=3, ge=1)
     run_number: int = Field(default=1, ge=1, description="Which run this job represents (1-indexed).")

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from .harness import (
     BudgetTracker,
+    assemble_prompt,
     compute_cost,
     load_models,
     make_client,
@@ -112,7 +113,11 @@ class Worker:
         for modes that require external orchestration (verification).
         """
         client = self.make_client()
-        prompt = Path(job.prompt).read_text().strip()
+        if job.prompt_modules is not None:
+            modules_dir = Path(job.modules_dir) if job.modules_dir else Path("experiments/prompts/modules")
+            prompt = assemble_prompt(modules_dir, job.prompt_modules)
+        else:
+            prompt = Path(job.prompt).read_text().strip()
         models = load_models(job.models_file)
         output_dir = Path(job.output_dir)
 

--- a/tests/test_jobspec.py
+++ b/tests/test_jobspec.py
@@ -141,6 +141,54 @@ class TestFromSweepYaml:
         assert j.followups == "prompts/followups.txt"
 
 
+class TestJobSpecPromptModules:
+    def test_prompt_modules_field(self):
+        j = _make_jobspec(prompt_modules=["persona", "overview"])
+        assert j.prompt_modules == ["persona", "overview"]
+
+    def test_prompt_modules_default_none(self):
+        j = _make_jobspec()
+        assert j.prompt_modules is None
+
+    def test_prompt_modules_empty_list(self):
+        j = _make_jobspec(prompt_modules=[])
+        assert j.prompt_modules == []
+
+    def test_prompt_modules_roundtrip_yaml(self):
+        original = _make_jobspec(prompt_modules=["persona", "overview", "sourcing"])
+        restored = JobSpec.from_yaml(original.to_yaml())
+        assert restored.prompt_modules == ["persona", "overview", "sourcing"]
+
+    def test_prompt_modules_none_excluded_from_yaml(self):
+        j = _make_jobspec()
+        yaml_str = j.to_yaml()
+        assert "prompt_modules" not in yaml_str
+
+    def test_prompt_modules_from_toml_section(self):
+        section = {
+            "mode": "single",
+            "prompt_modules": ["persona", "overview"],
+            "models": "models.yaml",
+            "repeat": 2,
+            "budget_usd": 5,
+            "output": "outputs/ablation/test",
+        }
+        j = JobSpec.from_toml_section(section)
+        assert j.prompt_modules == ["persona", "overview"]
+
+    def test_prompt_modules_empty_from_toml_section(self):
+        section = {
+            "mode": "single",
+            "prompt_modules": [],
+            "models": "models.yaml",
+            "repeat": 2,
+            "budget_usd": 5,
+            "output": "outputs/ablation/test",
+        }
+        j = JobSpec.from_toml_section(section)
+        assert j.prompt_modules == []
+
+
 class TestLeaseInfo:
     def test_construction(self):
         now = datetime.now(UTC)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -100,6 +100,60 @@ def test_dirs_created(tmp_path: Path):
         assert (jobs_root / subdir).is_dir()
 
 
+def test_prompt_modules_propagated_to_jobs(tmp_path: Path):
+    """Sweep with prompt_modules propagates to each generated job."""
+    models = [{"id": "provider/model-a", "name": "Model A"}]
+    models_path = tmp_path / "models.yaml"
+    models_path.write_text(yaml.dump(models))
+
+    sweep_config = {
+        "mode": "single",
+        "prompt_modules": ["persona", "overview"],
+        "models": str(models_path),
+        "repeat": 1,
+        "budget_usd": 5,
+        "output": "outputs/ablation/test",
+    }
+    jobs_root = tmp_path / "jobs"
+    generated, _ = generate(
+        jobs_root=jobs_root,
+        sweep_config=sweep_config,
+        sweep_name="ablation_test",
+    )
+    assert generated == 1
+
+    job_file = next((jobs_root / "pending").iterdir())
+    spec = JobSpec.from_yaml(job_file.read_text())
+    assert spec.prompt_modules == ["persona", "overview"]
+
+
+def test_prompt_modules_empty_list_propagated(tmp_path: Path):
+    """Sweep with empty prompt_modules list propagates correctly."""
+    models = [{"id": "provider/model-a", "name": "Model A"}]
+    models_path = tmp_path / "models.yaml"
+    models_path.write_text(yaml.dump(models))
+
+    sweep_config = {
+        "mode": "single",
+        "prompt_modules": [],
+        "models": str(models_path),
+        "repeat": 1,
+        "budget_usd": 5,
+        "output": "outputs/ablation/test",
+    }
+    jobs_root = tmp_path / "jobs"
+    generated, _ = generate(
+        jobs_root=jobs_root,
+        sweep_config=sweep_config,
+        sweep_name="ablation_base",
+    )
+    assert generated == 1
+
+    job_file = next((jobs_root / "pending").iterdir())
+    spec = JobSpec.from_yaml(job_file.read_text())
+    assert spec.prompt_modules == []
+
+
 def test_idempotency_across_dirs(tmp_path: Path):
     """Jobs already in running/done/failed are skipped."""
     sweep_path = _write_sweep(tmp_path, repeat=1)

--- a/tests/test_query_frontier.py
+++ b/tests/test_query_frontier.py
@@ -174,6 +174,158 @@ def test_dry_run_no_api_calls(mock_openai_cls, tmp_path):
 
 
 @patch("aedist.harness.OpenAI")
+def test_prompt_modules_assembles_prompt(mock_openai_cls, tmp_path):
+    """--prompt-modules assembles prompt from module files via assemble_prompt()."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_mock_response()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path)
+    output_dir = tmp_path / "out"
+
+    # Create modules directory with base + persona + overview
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "base.txt").write_text("Base prompt text.")
+    (modules_dir / "persona.txt").write_text("You are an expert.")
+    (modules_dir / "overview.txt").write_text("Provide an overview.")
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier",
+            "--prompt-modules", "persona", "overview",
+            "--modules-dir", str(modules_dir),
+            "--models", str(models_path),
+            "--output", str(output_dir),
+        ]):
+            from aedist.query_frontier import main
+            main()
+
+    # Verify the assembled prompt was sent to the API
+    call_args = mock_client.chat.completions.create.call_args
+    messages = call_args.kwargs.get("messages") or call_args[1].get("messages")
+    user_content = messages[0]["content"]
+    # persona is prepended before base, overview appended after base
+    assert "You are an expert." in user_content
+    assert "Base prompt text." in user_content
+    assert "Provide an overview." in user_content
+    assert user_content.index("You are an expert.") < user_content.index("Base prompt text.")
+    assert user_content.index("Base prompt text.") < user_content.index("Provide an overview.")
+
+
+@patch("aedist.harness.OpenAI")
+def test_prompt_modules_empty_list_uses_base_only(mock_openai_cls, tmp_path):
+    """--prompt-modules with no modules uses base.txt only."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_mock_response()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path)
+    output_dir = tmp_path / "out"
+
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "base.txt").write_text("Base prompt only.")
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier",
+            "--prompt-modules",
+            "--modules-dir", str(modules_dir),
+            "--models", str(models_path),
+            "--output", str(output_dir),
+        ]):
+            from aedist.query_frontier import main
+            main()
+
+    call_args = mock_client.chat.completions.create.call_args
+    messages = call_args.kwargs.get("messages") or call_args[1].get("messages")
+    assert messages[0]["content"] == "Base prompt only."
+
+
+@patch("aedist.harness.OpenAI")
+def test_prompt_and_prompt_modules_mutually_exclusive(mock_openai_cls, tmp_path):
+    """--prompt and --prompt-modules cannot be used together."""
+    models_path = _minimal_models_yaml(tmp_path)
+    prompt_path = _prompt_file(tmp_path)
+    output_dir = tmp_path / "out"
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier",
+            "--prompt", str(prompt_path),
+            "--prompt-modules", "persona",
+            "--models", str(models_path),
+            "--output", str(output_dir),
+        ]):
+            import pytest
+            with pytest.raises(SystemExit):
+                from aedist.query_frontier import main
+                main()
+
+
+@patch("aedist.harness.OpenAI")
+def test_prompt_modules_dry_run(mock_openai_cls, tmp_path):
+    """--prompt-modules with --dry-run assembles prompt but makes no API calls."""
+    mock_client = MagicMock()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path)
+    output_dir = tmp_path / "out"
+
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "base.txt").write_text("Base prompt text.")
+    (modules_dir / "persona.txt").write_text("You are an expert.")
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier",
+            "--prompt-modules", "persona",
+            "--modules-dir", str(modules_dir),
+            "--models", str(models_path),
+            "--output", str(output_dir),
+            "--dry-run",
+        ]):
+            from aedist.query_frontier import main
+            main()
+
+    mock_client.chat.completions.create.assert_not_called()
+
+
+@patch("aedist.harness.OpenAI")
+def test_prompt_modules_sweep_name(mock_openai_cls, tmp_path):
+    """When using --prompt-modules, sweep is derived from module list."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_mock_response()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path)
+    output_dir = tmp_path / "out"
+
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "base.txt").write_text("Base prompt text.")
+    (modules_dir / "persona.txt").write_text("You are an expert.")
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier",
+            "--prompt-modules", "persona",
+            "--modules-dir", str(modules_dir),
+            "--models", str(models_path),
+            "--output", str(output_dir),
+        ]):
+            from aedist.query_frontier import main
+            main()
+
+    json_files = list(output_dir.rglob("*.json"))
+    assert len(json_files) == 1
+    record = json.loads(json_files[0].read_text())
+    assert record["sweep"] == "modules_persona"
+
+
+@patch("aedist.harness.OpenAI")
 def test_sweep_derived_from_prompt_filename(mock_openai_cls, tmp_path):
     """Sweep field is derived from prompt filename, not hardcoded."""
     mock_client = MagicMock()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -758,6 +758,74 @@ def test_web_mode_raises_without_tavily_key(tmp_path: Path, monkeypatch) -> None
 # ---------------------------------------------------------------------------
 
 
+def test_prompt_modules_assembled_in_execute(tmp_path: Path) -> None:
+    """Worker.execute() uses assemble_prompt when job has prompt_modules."""
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "base.txt").write_text("Base prompt text.")
+    (modules_dir / "persona.txt").write_text("You are an expert.")
+    (modules_dir / "overview.txt").write_text("Provide an overview.")
+
+    job = JobSpec(
+        job_id="pm-test",
+        priority=50,
+        mode=Method.SINGLE,
+        prompt="unused",  # should be ignored when prompt_modules is set
+        prompt_modules=["persona", "overview"],
+        modules_dir=str(modules_dir),
+        models_file="models.yaml",
+        model_filter="qwen3:8b",
+        output_dir=str(tmp_path / "out"),
+        repeat=1,
+        budget_usd=1.0,
+    )
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
+
+    # Verify the assembled prompt was used (persona before base, overview after)
+    call_args = patches["query_single_turn"].call_args[0]
+    messages = call_args[2]
+    content = messages[0]["content"]
+    assert "You are an expert." in content
+    assert "Base prompt text." in content
+    assert "Provide an overview." in content
+    assert content.index("You are an expert.") < content.index("Base prompt text.")
+    assert content.index("Base prompt text.") < content.index("Provide an overview.")
+
+
+def test_prompt_modules_empty_uses_base_only_in_worker(tmp_path: Path) -> None:
+    """Worker.execute() with empty prompt_modules uses base.txt only."""
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    (modules_dir / "base.txt").write_text("Base prompt only.")
+
+    job = JobSpec(
+        job_id="pm-empty",
+        priority=50,
+        mode=Method.SINGLE,
+        prompt="unused",
+        prompt_modules=[],
+        modules_dir=str(modules_dir),
+        models_file="models.yaml",
+        model_filter="qwen3:8b",
+        output_dir=str(tmp_path / "out"),
+        repeat=1,
+        budget_usd=1.0,
+    )
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
+
+    call_args = patches["query_single_turn"].call_args[0]
+    messages = call_args[2]
+    assert messages[0]["content"] == "Base prompt only."
+
+
 def test_rag_empty_corpus_raises_runtime_error(tmp_path: Path) -> None:
     """RAG mode converts SystemExit from load_corpus into RuntimeError."""
     prompt_file = tmp_path / "prompt.txt"

--- a/tickets/0045-empty-csv-crash.erg
+++ b/tickets/0045-empty-csv-crash.erg
@@ -1,10 +1,11 @@
 %erg v1
 Title: Handle empty CSVs gracefully in evaluate pipeline
-Status: open
+Status: closed
 Created: 2026-04-08
 Author: claude
 
 --- log ---
+2026-04-10T22:30Z claude status closed PR #206 merged (missed closure)
 2026-04-08T22:00Z claude created
 2026-04-08T22:00Z claude note found during ticket 0036 rebuild
 2026-04-09T12:00Z claude status reimagined by IDD phase 1

--- a/tickets/0055-wire-prompt-modules.erg
+++ b/tickets/0055-wire-prompt-modules.erg
@@ -1,12 +1,14 @@
 %erg v1
 Title: Wire prompt_modules in query runner
-Status: open
+Status: doing
 Created: 2026-04-10
 Author: claude
 Blocked-by: 0038
 
 --- log ---
 2026-04-10T20:00Z claude created — split from ticket 0038 action 7
+2026-04-10T21:00Z claude claimed
+2026-04-10T21:00Z claude status doing — implementing --prompt-modules flag
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- `--prompt-modules` flag added to `query_frontier.py` and `query.py` (mutually exclusive with `--prompt`)
- `manager.py` propagates `prompt_modules` and `modules_dir` through fan-out
- `worker.py` calls `assemble_prompt()` when prompt_modules set
- `JobSpec` schema gains `prompt_modules` and `modules_dir` fields with model validator
- 16 new tests covering all paths
- Unblocks ablation sweep execution (tickets 0057, 0058)

## Test plan
- [x] `ruff check` passes
- [x] 16 new tests pass (construction, YAML roundtrip, TOML parsing, manager propagation, worker assembly, query integration)
- [x] Backwards compat: existing sweeps with `prompt` key unchanged
- [x] Model validator catches neither-prompt-nor-modules case

🤖 Generated with [Claude Code](https://claude.com/claude-code)