### PR TITLE
Add web_search and reasoning activation to harness (ticket 0063)

### DIFF
--- a/experiments/models.yaml
+++ b/experiments/models.yaml
@@ -1,7 +1,8 @@
 # AEDIST Benchmark — Model Registry
-# 46 model instances, updated 2026-04-08
+# 46 model instances, updated 2026-04-10
 # Single source of truth. Experiment config in experiments.toml.
 # Sorted by size class, then provider.
+# Capability flags: reasoning (skip temperature), web_search (OpenRouter plugin).
 #
 # Removed 2026-04-08:
 #   openai/o3-deep-research    — broken: $1.96 empty response, finish_reason=length
@@ -26,6 +27,7 @@
   size_class: frontier
   license: commercial
   reasoning: true
+  web_search: true
 
 - id: "anthropic/claude-opus-4.6"
   router: openrouter
@@ -39,6 +41,7 @@
   price_per_mtok_out: 25.0
   size_class: frontier
   license: commercial
+  web_search: true
 
 - id: "anthropic/claude-sonnet-4.6"
   router: openrouter
@@ -52,6 +55,7 @@
   price_per_mtok_out: 15.0
   size_class: frontier
   license: commercial
+  web_search: true
 
 - id: "deepseek/deepseek-v3.2"
   router: openrouter
@@ -66,6 +70,7 @@
   params: "671B MoE"
   size_class: frontier
   license: open-MIT
+  web_search: true
 
 - id: "google/gemini-3-flash-preview"
   router: openrouter
@@ -79,6 +84,7 @@
   price_per_mtok_out: 3.0
   size_class: frontier
   license: commercial
+  web_search: true
 
 - id: "mistralai/mistral-large-2512"
   router: openrouter
@@ -93,6 +99,7 @@
   params: "675B MoE (41B active)"
   size_class: frontier
   license: open-apache
+  web_search: true
 
 - id: "moonshotai/kimi-k2-thinking"
   router: openrouter
@@ -107,6 +114,7 @@
   size_class: frontier
   license: commercial
   reasoning: true
+  web_search: true
 
 - id: "openai/gpt-5.4"
   router: openrouter
@@ -120,6 +128,7 @@
   price_per_mtok_out: 15.0
   size_class: frontier
   license: commercial
+  web_search: true
 
 - id: "x-ai/grok-4.20"
   router: openrouter
@@ -133,6 +142,7 @@
   price_per_mtok_out: 6.0
   size_class: frontier
   license: commercial
+  web_search: true
 
 - id: "z-ai/glm-5-turbo"
   router: openrouter
@@ -147,6 +157,7 @@
   params: "745B MoE (44B active)"
   size_class: frontier
   license: open-other
+  web_search: true
 
 
 # --- Large ---
@@ -164,6 +175,7 @@
   params: "122B MoE (10B active)"
   size_class: large
   license: open-apache
+  web_search: true
 
 - id: "qwen/qwen3.5-397b-a17b"
   router: openrouter
@@ -178,6 +190,7 @@
   params: "397B MoE (17B active)"
   size_class: large
   license: open-apache
+  web_search: true
 
 - id: "qwen/qwen3.5-plus-02-15"
   router: openrouter
@@ -191,6 +204,7 @@
   price_per_mtok_out: 1.56
   size_class: large
   license: commercial
+  web_search: true
 
 - id: "alibaba/tongyi-deepresearch-30b-a3b"
   router: openrouter
@@ -205,6 +219,7 @@
   params: "30B MoE (3B active)"
   size_class: large
   license: commercial
+  web_search: true
 
 - id: "baidu/ernie-4.5-21b-a3b-thinking"
   router: openrouter
@@ -220,6 +235,7 @@
   size_class: large
   license: commercial
   reasoning: true
+  web_search: true
 
 - id: "meta-llama/llama-4-maverick"
   router: openrouter
@@ -234,6 +250,7 @@
   params: "400B MoE"
   size_class: large
   license: open-llama
+  web_search: true
 
 - id: "minimax/minimax-m2.7"
   router: openrouter
@@ -247,6 +264,7 @@
   price_per_mtok_out: 1.2
   size_class: large
   license: commercial
+  web_search: true
 
 - id: "moonshotai/kimi-k2.5"
   router: openrouter
@@ -260,6 +278,7 @@
   price_per_mtok_out: 1.99
   size_class: large
   license: commercial
+  web_search: true
 
 - id: "qwen3.5:122b"
   router: ollama
@@ -286,6 +305,7 @@
   price_per_mtok_out: 3.0
   size_class: large
   license: open-apache
+  web_search: true
 
 
 # --- Medium ---
@@ -303,6 +323,7 @@
   params: "35B MoE (3B active)"
   size_class: medium
   license: open-apache
+  web_search: true
 
 - id: "bytedance-seed/seed-2.0-lite"
   router: openrouter
@@ -316,6 +337,7 @@
   price_per_mtok_out: 2.0
   size_class: medium
   license: commercial
+  web_search: true
 
 - id: "inception/mercury-2"
   router: openrouter
@@ -329,6 +351,7 @@
   price_per_mtok_out: 0.75
   size_class: medium
   license: commercial
+  web_search: true
 
 - id: "nvidia/nemotron-3-nano-30b-a3b"
   router: openrouter
@@ -343,6 +366,7 @@
   params: "30B MoE (3B active)"
   size_class: medium
   license: open-other
+  web_search: true
 
 - id: "gemma4:31b"
   router: ollama
@@ -412,6 +436,7 @@
   params: 24B
   size_class: small
   license: open-apache
+  web_search: true
 
 - id: "cogito:8b"
   router: ollama
@@ -490,6 +515,7 @@
   price_per_mtok_out: 2.0
   size_class: small
   license: commercial
+  web_search: true
 
 - id: "stepfun/step-3.5-flash"
   router: openrouter
@@ -503,6 +529,7 @@
   price_per_mtok_out: 0.3
   size_class: small
   license: commercial
+  web_search: true
 
 - id: "xiaomi/mimo-v2-flash"
   router: openrouter
@@ -516,6 +543,7 @@
   price_per_mtok_out: 0.29
   size_class: small
   license: open-apache
+  web_search: true
 
 
 # --- Edge ---
@@ -532,6 +560,7 @@
   price_per_mtok_out: 0.0
   size_class: edge
   license: commercial
+  web_search: true
 
 - id: "google/gemini-2.5-flash-lite"
   router: openrouter
@@ -545,6 +574,7 @@
   price_per_mtok_out: 0.4
   size_class: edge
   license: commercial
+  web_search: true
 
 - id: "gemma4:e2b"
   router: ollama
@@ -610,6 +640,7 @@
   price_per_mtok_out: 0.4
   size_class: edge
   license: commercial
+  web_search: true
 
 
 # --- Reasoning / Deep Research ---
@@ -628,6 +659,7 @@
   size_class: frontier
   license: open-MIT
   reasoning: true
+  web_search: true
 
 - id: "openai/o3"
   router: openrouter
@@ -642,5 +674,6 @@
   size_class: frontier
   license: commercial
   reasoning: true
+  web_search: true
 
 

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -300,6 +300,40 @@ def query_ollama_native(
 
 
 # ---------------------------------------------------------------------------
+# Capability-driven API kwargs
+# ---------------------------------------------------------------------------
+
+
+def build_api_kwargs(
+    model: dict,
+    *,
+    max_tokens: int,
+    temperature: float,
+) -> dict:
+    """Build API kwargs from model capability flags.
+
+    Reads ``reasoning`` and ``web_search`` flags from the model dict and
+    constructs the appropriate kwargs for ``chat.completions.create()``:
+
+    - ``reasoning: true`` → omit ``temperature`` (required by o3, R1, etc.)
+    - ``web_search: true`` → add ``extra_body: {plugins: [{id: "web"}]}``
+      (OpenRouter web search plugin)
+    """
+    kwargs: dict = {"max_tokens": max_tokens}
+
+    if not model.get("reasoning", False):
+        kwargs["temperature"] = temperature
+
+    extra_body: dict = {}
+    if model.get("web_search", False):
+        extra_body["plugins"] = [{"id": "web"}]
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
 # Single-turn query helper
 # ---------------------------------------------------------------------------
 

--- a/src/aedist/query_frontier.py
+++ b/src/aedist/query_frontier.py
@@ -29,6 +29,7 @@ import openai
 from .harness import (
     BudgetTracker,
     assemble_prompt,
+    build_api_kwargs,
     compute_cost,
     load_experiments,
     load_models,
@@ -175,9 +176,11 @@ def main():
             )
 
             try:
-                api_kwargs = {"max_tokens": args.max_tokens}
-                if not model.get("reasoning", False):
-                    api_kwargs["temperature"] = args.temperature
+                api_kwargs = build_api_kwargs(
+                    model,
+                    max_tokens=args.max_tokens,
+                    temperature=args.temperature,
+                )
                 api_model_id = model.get("router_model", model_id)
                 result = query_single_turn(
                     client,

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -2,6 +2,7 @@
 
 from aedist.harness import (
     BudgetTracker,
+    build_api_kwargs,
     compute_cost,
     model_metadata,
     output_filename,
@@ -156,3 +157,55 @@ def test_iter_model_replies_filters_derived_files(tmp_path):
         "deepseek-v3.2-run2.json",
         "padme-qwen3.5-122b-run1.json",
     ]
+
+
+# ---------------------------------------------------------------------------
+# build_api_kwargs — capability-driven API parameter construction
+# ---------------------------------------------------------------------------
+
+
+def test_no_capabilities_unchanged():
+    """Models without flags get standard params (backward compat)."""
+    model = {"id": "test/plain", "name": "Plain"}
+    kwargs = build_api_kwargs(model, max_tokens=4096, temperature=0.7)
+    assert kwargs == {"max_tokens": 4096, "temperature": 0.7}
+    assert "extra_body" not in kwargs
+
+
+def test_reasoning_model_skips_temperature():
+    """Models with reasoning=true don't get temperature param."""
+    model = {"id": "openai/o3", "reasoning": True}
+    kwargs = build_api_kwargs(model, max_tokens=4096, temperature=0.7)
+    assert "temperature" not in kwargs
+    assert kwargs["max_tokens"] == 4096
+
+
+def test_web_search_model_gets_plugin():
+    """Models with web_search=true get plugins in extra_body."""
+    model = {"id": "test/web", "web_search": True}
+    kwargs = build_api_kwargs(model, max_tokens=4096, temperature=0.7)
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["extra_body"] == {"plugins": [{"id": "web"}]}
+
+
+def test_both_capabilities():
+    """Model with both reasoning and web_search gets correct params."""
+    model = {"id": "test/both", "reasoning": True, "web_search": True}
+    kwargs = build_api_kwargs(model, max_tokens=4096, temperature=0.0)
+    assert "temperature" not in kwargs
+    assert kwargs["max_tokens"] == 4096
+    assert kwargs["extra_body"] == {"plugins": [{"id": "web"}]}
+
+
+def test_web_search_false_no_plugin():
+    """Explicit web_search=false produces no extra_body."""
+    model = {"id": "test/no-web", "web_search": False}
+    kwargs = build_api_kwargs(model, max_tokens=4096, temperature=0.5)
+    assert "extra_body" not in kwargs
+
+
+def test_reasoning_false_keeps_temperature():
+    """Explicit reasoning=false keeps temperature."""
+    model = {"id": "test/no-reason", "reasoning": False}
+    kwargs = build_api_kwargs(model, max_tokens=4096, temperature=0.3)
+    assert kwargs["temperature"] == 0.3

--- a/tests/test_query_frontier.py
+++ b/tests/test_query_frontier.py
@@ -17,7 +17,12 @@ def _make_mock_response(prompt_tokens=100, completion_tokens=200):
     return resp
 
 
-def _minimal_models_yaml(tmp_path: Path, *, reasoning: bool = False) -> Path:
+def _minimal_models_yaml(
+    tmp_path: Path,
+    *,
+    reasoning: bool = False,
+    web_search: bool = False,
+) -> Path:
     p = tmp_path / "models.yaml"
     lines = (
         "- id: test/tiny-model\n"
@@ -31,6 +36,8 @@ def _minimal_models_yaml(tmp_path: Path, *, reasoning: bool = False) -> Path:
     )
     if reasoning:
         lines += "  reasoning: true\n"
+    if web_search:
+        lines += "  web_search: true\n"
     p.write_text(lines)
     return p
 
@@ -349,3 +356,53 @@ def test_sweep_derived_from_prompt_filename(mock_openai_cls, tmp_path):
     assert len(json_files) == 1
     record = json.loads(json_files[0].read_text())
     assert record["sweep"] == "frontier_scenarios"
+
+
+@patch("aedist.harness.OpenAI")
+def test_web_search_model_gets_plugin(mock_openai_cls, tmp_path):
+    """Models with web_search: true get OpenRouter web plugin in extra_body."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_mock_response()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path, web_search=True)
+    prompt_path = _prompt_file(tmp_path)
+    output_dir = tmp_path / "out"
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier", "--prompt", str(prompt_path),
+            "--models", str(models_path),
+            "--output", str(output_dir),
+        ]):
+            from aedist.query_frontier import main
+            main()
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["extra_body"] == {"plugins": [{"id": "web"}]}
+    assert call_kwargs["temperature"] == 0.0
+
+
+@patch("aedist.harness.OpenAI")
+def test_both_reasoning_and_web_search(mock_openai_cls, tmp_path):
+    """Model with both reasoning and web_search gets correct params."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_mock_response()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path, reasoning=True, web_search=True)
+    prompt_path = _prompt_file(tmp_path)
+    output_dir = tmp_path / "out"
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(sys, "argv", [
+            "query_frontier", "--prompt", str(prompt_path),
+            "--models", str(models_path),
+            "--output", str(output_dir),
+        ]):
+            from aedist.query_frontier import main
+            main()
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert "temperature" not in call_kwargs
+    assert call_kwargs["extra_body"] == {"plugins": [{"id": "web"}]}

--- a/tickets/0063-capability-flags-harness.erg
+++ b/tickets/0063-capability-flags-harness.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Add web_search and reasoning activation to harness
-Status: open
+Status: doing
 Created: 2026-04-10
 Author: claude
 Blocked-by: 0061
 
 --- log ---
 2026-04-10T23:45Z claude created — split from 0061 action 1
+2026-04-10T12:00Z claude status doing — starting TDD implementation
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- `build_api_kwargs()` in harness.py reads model flags, constructs provider-specific params
- `web_search: true` → OpenRouter `plugins: [{id: "web"}]`
- `reasoning: true` → skips temperature
- Added `web_search: true` to all 28 OpenRouter models in models.yaml
- 8 new tests (6 unit + 2 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)