### PR TITLE
Fix AttributeError on __spec__.name in pdf2md modules

### DIFF
--- a/src/aedist/pdf2md_grobid.py
+++ b/src/aedist/pdf2md_grobid.py
@@ -207,7 +207,8 @@ def main(argv=None):
     result = pdf_to_markdown(args.pdf, grobid_url=args.grobid_url)
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result + metadata_comment(args.pdf, backend="GROBID", model="n/a", argv=actual_argv),
         encoding="utf-8",

--- a/src/aedist/pdf2md_marker.py
+++ b/src/aedist/pdf2md_marker.py
@@ -97,7 +97,8 @@ def main(argv=None):
     result = pdf_to_markdown(args.pdf, marker_url=args.marker_url)
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result + metadata_comment(args.pdf, backend="Marker", model="n/a", argv=actual_argv),
         encoding="utf-8",

--- a/src/aedist/pdf2md_mineru.py
+++ b/src/aedist/pdf2md_mineru.py
@@ -112,7 +112,8 @@ def main(argv=None):
     result = pdf_to_markdown(args.pdf, mineru_url=args.mineru_url)
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result + metadata_comment(args.pdf, backend="MinerU", model="n/a", argv=actual_argv),
         encoding="utf-8",

--- a/src/aedist/pdf2md_mistral_ocr.py
+++ b/src/aedist/pdf2md_mistral_ocr.py
@@ -162,7 +162,8 @@ def main(argv=None):
     )
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result
         + metadata_comment(

--- a/src/aedist/pdf2md_ollama.py
+++ b/src/aedist/pdf2md_ollama.py
@@ -142,7 +142,8 @@ def main(argv=None):
     result = pdf_to_markdown(args.pdf, model=args.model, dpi=args.dpi, ollama_url=args.ollama_url)
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result + metadata_comment(args.pdf, backend="Ollama", model=args.model, argv=actual_argv),
         encoding="utf-8",

--- a/src/aedist/pdf2md_openrouter.py
+++ b/src/aedist/pdf2md_openrouter.py
@@ -134,7 +134,8 @@ def main(argv=None):
     result = pdf_to_markdown(args.pdf, model=args.model, dpi=args.dpi, max_tokens=args.max_tokens)
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result
         + metadata_comment(args.pdf, backend="OpenRouter", model=args.model, argv=actual_argv),

--- a/src/aedist/pdf2md_openrouter_doc.py
+++ b/src/aedist/pdf2md_openrouter_doc.py
@@ -157,7 +157,8 @@ def main(argv=None):
     )
 
     output = get_output_path(args.pdf, args.output)
-    actual_argv = sys.argv if argv is None else ["python", "-m", __spec__.name] + argv
+    mod = __spec__.name if __spec__ else __name__
+    actual_argv = sys.argv if argv is None else ["python", "-m", mod] + argv
     output.write_text(
         result
         + metadata_comment(


### PR DESCRIPTION
## Summary

- Fix `AttributeError` in all 7 `pdf2md_*.py` converters when `main(argv=[...])` is called in script mode (where `__spec__` is `None`)
- Falls back to `__name__` when `__spec__` is unavailable — safe in both `-m` and direct-script invocation
- 253 existing tests pass; no regressions

## Test plan

- [x] All 7 files parse without syntax errors
- [x] Existing test suite passes (253 pass, 1 pre-existing failure unrelated to this change)
- [x] Verified fix produces correct module name under both `__spec__=None` and `__spec__` set

https://claude.ai/code/session_01RWQiZoiqApFmNW2vRgRxPT