### PR TITLE
Ticket 0067: ablation visualization — strip plot + heatmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,18 @@ $(SLIDE_GEN)/fig_scaling_curve.pdf: $(MEASUREMENTS)
 	uv run python -m aedist.plot_scaling_curve \
 	    --output $@
 
+$(SLIDE_GEN)/fig_ablation_strip.pdf: $(MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_ablation --strip $@
+
+$(GEN)/fig_ablation_strip.pdf: $(MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_ablation --strip $@
+
+$(GEN)/fig_ablation_heatmap.pdf: $(MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_ablation --heatmap $@
+
 $(SLIDE_GEN)/macros.tex: $(SLIDE_GEN)/census_bars.csv $(MEASUREMENTS)
 	uv run python -m aedist.tabulate_macros --census-csv $< --output $@
 
@@ -161,13 +173,15 @@ report/report.pdf: report/report.tex report/refs.bib \
     $(GEN)/tab_base_vs_census.tex $(GEN)/fig_base_vs_census.pdf \
     $(GEN)/tab_decomposition_fix.tex \
     $(GEN)/tab_self_consistency.tex $(GEN)/tab_per_run.tex \
-    $(GEN)/tab_coherence.tex
+    $(GEN)/tab_coherence.tex \
+    $(GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_heatmap.pdf
 	$(MAKE) -C report
 
 slides/slides.pdf: slides/slides.tex \
     $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/pareto.csv \
     $(SLIDE_GEN)/regimes.csv $(SLIDE_GEN)/fig_method_convergence.pdf \
     $(SLIDE_GEN)/fig_scaling_curve.pdf \
+    $(SLIDE_GEN)/fig_ablation_strip.pdf \
     $(SLIDE_GEN)/macros.tex
 	$(MAKE) -C slides
 
@@ -178,7 +192,7 @@ slides/slides.pdf: slides/slides.tex \
 report: report/report.pdf
 slides: slides/slides.pdf
 tables: $(GEN)/tab_census.tex $(GEN)/macros.tex $(GEN)/tab_relances.tex $(GEN)/tab_comparaison.tex $(GEN)/tab_converter_benchmark.tex $(GEN)/tab_variance.tex $(GEN)/tab_verification.tex $(GEN)/tab_base_vs_census.tex $(GEN)/tab_decomposition_fix.tex $(GEN)/tab_self_consistency.tex $(GEN)/tab_per_run.tex $(GEN)/tab_coherence.tex
-figures: $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/pareto.csv $(SLIDE_GEN)/fig_method_convergence.pdf $(SLIDE_GEN)/fig_scaling_curve.pdf $(GEN)/fig_base_vs_census.pdf
+figures: $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/pareto.csv $(SLIDE_GEN)/fig_method_convergence.pdf $(SLIDE_GEN)/fig_scaling_curve.pdf $(GEN)/fig_base_vs_census.pdf $(SLIDE_GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_heatmap.pdf
 select: experiments/models_selected.yaml
 census:
 	$(MAKE) -C experiments census

--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ $(SLIDE_GEN)/fig_scaling_curve.pdf: $(MEASUREMENTS)
 	uv run python -m aedist.plot_scaling_curve \
 	    --output $@
 
-$(SLIDE_GEN)/fig_ablation_strip.pdf: $(MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_ablation --strip $@
-
 $(GEN)/fig_ablation_strip.pdf: $(MEASUREMENTS)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_ablation --strip $@
+
+$(SLIDE_GEN)/fig_ablation_strip.pdf: $(GEN)/fig_ablation_strip.pdf
+	@mkdir -p $(dir $@)
+	cp $< $@
 
 $(GEN)/fig_ablation_heatmap.pdf: $(MEASUREMENTS)
 	@mkdir -p $(dir $@)

--- a/report/inputs/plan_ablation.tex
+++ b/report/inputs/plan_ablation.tex
@@ -485,3 +485,47 @@ même modèle. Le module sourçage (colonnes Source\_1, Source\_2) est conçu po
 alimenter cette phase~: chaque ligne du CSV porte ses propres références,
 permettant à un agent vérificateur de contrôler la provenance sans accéder au
 prompt original.
+
+\subsection{Résultats de l'ablation --- régime RAG}\label{sec:results-ablation}
+
+La Phase~2 teste 16~variantes de prompt sur le régime RAG avec deux modèles
+frontière (DeepSeek~V3.2 et Kimi~K2~Thinking), choisis pour leurs effets
+opposés en Phase~1 ($-27{,}4$\,pp et $+25{,}8$\,pp respectivement avec le
+prompt composite). Chaque variante est répétée deux fois (64~appels au total,
+coût~: 3{,}77\,\$).
+
+La figure~\ref{fig:ablation-strip} montre les résultats par variante sous forme
+de strip~plot~: chaque point bleu est une centrale correctement identifiée,
+chaque point orange une hallucination. DeepSeek~V3.2 refuse (tool\_calls) sur
+16/32~variantes, rendant l'analyse $\Delta$F1 incomplète pour ce modèle.
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=0.85\linewidth]{inputs/generated/fig_ablation_strip.pdf}
+\caption{Strip plot de l'ablation Phase~2 en régime RAG. Bleu~: centrales
+correctement identifiées (TP). Orange~: hallucinations (FP). Croix grises~:
+refus du modèle. Ligne verte~: inventaire complet (163~centrales).}
+\label{fig:ablation-strip}
+\end{figure}
+
+La figure~\ref{fig:ablation-heatmap} résume les effets par module sous forme de
+matrice. Pour chaque module, deux $\Delta$F1 sont calculés~: l'effet de
+composition (base + module vs base seul) et l'effet d'ablation (composite $-$
+module vs composite complet).
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=0.7\linewidth]{inputs/generated/fig_ablation_heatmap.pdf}
+\caption{Effet de chaque module sur le F1 en régime RAG. Rouge~: le module
+dégrade les performances. Bleu~: le module les améliore. Tirets~: données
+insuffisantes (refus du modèle).}
+\label{fig:ablation-heatmap}
+\end{figure}
+
+Pour Kimi~K2~Thinking, le module \emph{sourçage} est le seul à améliorer
+le F1 en composition ($+3{,}6$\,pp) et son retrait dégrade le composite
+($-7{,}1$\,pp). Le module \emph{statistiques} a l'effet inverse~:
+$-30{,}4$\,pp en composition, $+11{,}5$\,pp en ablation. L'interprétation
+est que le module statistiques (format tabulaire imposé) interfère avec le
+contexte RAG déjà structuré, tandis que le sourçage (demande de références)
+aide le modèle à ancrer ses réponses dans les documents fournis.

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -494,6 +494,19 @@ With documents, a cheap model beats an expensive one. The \textbf{method} (RAG) 
 Local 35B with RAG approaches cloud API performance at \$0 marginal cost.}
 \end{frame}
 
+% -------------------------------------------------------------------
+\begin{frame}{Prompt ablation: which modules help RAG extraction?}
+\textbf{2 models} $\times$ \textbf{16 prompt variants} $\times$ 2 runs (RAG regime only)
+
+\begin{center}
+\includegraphics[width=\textwidth]{inputs/generated/fig_ablation_strip.pdf}
+\end{center}
+
+\vspace{-0.8em}
+{\footnotesize DeepSeek V3.2 refused (tool\_calls) on 16/32 variants.
+Kimi K2: sourcing module helps (+3.6\,pp); statistics module hurts ($-$30.4\,pp).}
+\end{frame}
+
 % ===================================================================
 \section{Conversation and aggregation}
 

--- a/src/aedist/plot_ablation.py
+++ b/src/aedist/plot_ablation.py
@@ -90,7 +90,7 @@ def load_ablation_data() -> list[dict]:
             continue
         model = (record.method_params.model or "").split("/")[-1]
         s = record.result_summary
-        is_refusal = s.tp is None or (s.tp == 0 and s.fp == 0 and s.fn == 0)
+        is_refusal = s.tp is None and s.fp is None and s.fn is None
         rows.append(
             {
                 "variant": pv,
@@ -224,7 +224,7 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
 
     # Y axis
     ax.set_yticks([t[0] for t in variant_ticks])
-    ax.set_yticklabels([t[1] for t in variant_ticks], fontsize=9)
+    ax.set_yticklabels([t[1] for t in variant_ticks], fontsize=11)
     ax.set_xlabel("Number of power plants", fontsize=11)
     ax.set_xlim(-max_fp - 15, 185)
     ax.invert_yaxis()
@@ -265,12 +265,17 @@ def write_heatmap_pdf(rows: list[dict], output: Path) -> None:
     import matplotlib.pyplot as plt
     import numpy as np
 
+    # Guard: empty data produces no figure
+    non_refusal = [r for r in rows if not r["is_refusal"]]
+    if not non_refusal:
+        log.warning("No non-refusal ablation data; skipping heatmap")
+        return
+
     # Compute mean F1 per (variant, model) excluding refusals
     mean_f1: dict[tuple[str, str], float] = {}
     groups: dict[tuple[str, str], list[float]] = defaultdict(list)
-    for r in rows:
-        if not r["is_refusal"]:
-            groups[(r["variant"], r["model"])].append(r["f1"])
+    for r in non_refusal:
+        groups[(r["variant"], r["model"])].append(r["f1"])
     for key, values in groups.items():
         mean_f1[key] = sum(values) / len(values)
 

--- a/src/aedist/plot_ablation.py
+++ b/src/aedist/plot_ablation.py
@@ -29,13 +29,15 @@ _REFUSAL = "#BBBBBB"
 # The 6 prompt modules in display order
 _MODULES = ["persona", "overview", "narratives", "bibliography", "statistics", "sourcing"]
 
-# Display order for the strip plot: anchors, then single-module, then minus-one
+# Display order for the strip plot: anchors, then single-module, then minus-one.
+# "" entries mark section breaks (visual gaps in the strip plot).
 _VARIANT_ORDER = [
     # Anchors
     "p2_census",
     "p2_base",
     "p2_composite",
     "p2_frontier",
+    "",  # ── section break ──
     # Single-module (base + one module)
     "p2_persona",
     "p2_overview",
@@ -43,6 +45,7 @@ _VARIANT_ORDER = [
     "p2_bibliography",
     "p2_statistics",
     "p2_sourcing",
+    "",  # ── section break ──
     # Minus-one (composite - one module)
     "p2_no_persona",
     "p2_no_overview",
@@ -52,8 +55,10 @@ _VARIANT_ORDER = [
     "p2_no_sourcing",
 ]
 
-# Section boundaries for visual grouping (indices where gaps go)
-_SECTION_BREAKS = {4, 10}  # after anchors, after single-module
+_MODEL_SHORT_NAMES = {
+    "deepseek-v3.2": "DS V3.2",
+    "kimi-k2-thinking": "Kimi K2",
+}
 
 _VARIANT_LABELS = {
     "p2_census": "Census (anchor)",
@@ -90,7 +95,7 @@ def load_ablation_data() -> list[dict]:
             continue
         model = (record.method_params.model or "").split("/")[-1]
         s = record.result_summary
-        is_refusal = s.tp is None and s.fp is None and s.fn is None
+        is_refusal = s.status != "ok"
         rows.append(
             {
                 "variant": pv,
@@ -115,6 +120,11 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
     import numpy as np
     from matplotlib.lines import Line2D
 
+    # Guard: empty data produces no figure
+    if not rows:
+        log.warning("No ablation data; skipping strip plot")
+        return
+
     fig, ax = plt.subplots(figsize=(10, 7.5))
 
     y_offset = 0.0
@@ -124,9 +134,10 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
     section_gap = 1.2
     variant_gap = 0.8
 
-    for idx, variant in enumerate(_VARIANT_ORDER):
-        if idx in _SECTION_BREAKS:
+    for variant in _VARIANT_ORDER:
+        if variant == "":
             y_offset += section_gap
+            continue
 
         variant_rows = [r for r in rows if r["variant"] == variant]
         if not variant_rows:
@@ -287,7 +298,7 @@ def write_heatmap_pdf(rows: list[dict], output: Path) -> None:
     matrix = np.full((n_modules, n_cols), np.nan)
     col_labels = []
     for mi, model in enumerate(models):
-        short = model.replace("deepseek-", "DS ").replace("kimi-k2-thinking", "Kimi K2")
+        short = _MODEL_SHORT_NAMES.get(model, model.split("-", 1)[-1][:10])
         col_labels.extend([f"{short}\n+module", f"{short}\n−module"])
         base_f1 = mean_f1.get(("p2_base", model))
         comp_f1 = mean_f1.get(("p2_composite", model))

--- a/src/aedist/plot_ablation.py
+++ b/src/aedist/plot_ablation.py
@@ -1,0 +1,374 @@
+"""Generate ablation result figures from measurements.jsonl.
+
+Two figures:
+1. Strip plot — prompt variants on Y, plant count on X, TP/FP dots
+   (same visual language as fig_method_convergence.pdf)
+2. Heatmap — 6 modules × 2 effects (composition ΔF1, ablation ΔF1)
+
+Usage:
+    uv run python -m aedist.plot_ablation \
+        --strip slides/inputs/generated/fig_ablation_strip.pdf
+    uv run python -m aedist.plot_ablation \
+        --heatmap report/inputs/generated/fig_ablation_heatmap.pdf
+"""
+
+import argparse
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+from .measurements import load
+
+log = logging.getLogger(__name__)
+
+# Colors matching slides.tex and plot_method_convergence.py
+_MATCHED = "#2E86AB"
+_HALLUC = "#F5A623"
+_REFUSAL = "#BBBBBB"
+
+# The 6 prompt modules in display order
+_MODULES = ["persona", "overview", "narratives", "bibliography", "statistics", "sourcing"]
+
+# Display order for the strip plot: anchors, then single-module, then minus-one
+_VARIANT_ORDER = [
+    # Anchors
+    "p2_census",
+    "p2_base",
+    "p2_composite",
+    "p2_frontier",
+    # Single-module (base + one module)
+    "p2_persona",
+    "p2_overview",
+    "p2_narratives",
+    "p2_bibliography",
+    "p2_statistics",
+    "p2_sourcing",
+    # Minus-one (composite - one module)
+    "p2_no_persona",
+    "p2_no_overview",
+    "p2_no_narratives",
+    "p2_no_bibliography",
+    "p2_no_statistics",
+    "p2_no_sourcing",
+]
+
+# Section boundaries for visual grouping (indices where gaps go)
+_SECTION_BREAKS = {4, 10}  # after anchors, after single-module
+
+_VARIANT_LABELS = {
+    "p2_census": "Census (anchor)",
+    "p2_base": "Base (no modules)",
+    "p2_composite": "Composite (all 6)",
+    "p2_frontier": "Frontier (anchor)",
+    "p2_persona": "+ Persona",
+    "p2_overview": "+ Overview",
+    "p2_narratives": "+ Narratives",
+    "p2_bibliography": "+ Bibliography",
+    "p2_statistics": "+ Statistics",
+    "p2_sourcing": "+ Sourcing",
+    "p2_no_persona": "All − Persona",
+    "p2_no_overview": "All − Overview",
+    "p2_no_narratives": "All − Narratives",
+    "p2_no_bibliography": "All − Bibliography",
+    "p2_no_statistics": "All − Statistics",
+    "p2_no_sourcing": "All − Sourcing",
+}
+
+
+def load_ablation_data() -> list[dict]:
+    """Load Phase 2 RAG ablation data from measurements.
+
+    Returns list of dicts: {variant, model, tp, fp, fn, f1, is_refusal}.
+    """
+    rows = []
+    for record in load():
+        rf = record.result_file or ""
+        if "ablation/rag/p2_" not in rf:
+            continue
+        pv = record.method_params.prompt_version
+        if not pv or not pv.startswith("p2_"):
+            continue
+        model = (record.method_params.model or "").split("/")[-1]
+        s = record.result_summary
+        is_refusal = s.tp is None or (s.tp == 0 and s.fp == 0 and s.fn == 0)
+        rows.append(
+            {
+                "variant": pv,
+                "model": model,
+                "tp": s.tp or 0,
+                "fp": s.fp or 0,
+                "fn": s.fn or 0,
+                "f1": s.f1 or 0.0,
+                "is_refusal": is_refusal,
+            }
+        )
+    return rows
+
+
+def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
+    """Generate ablation strip plot as PDF.
+
+    Y-axis: prompt variants grouped by section.
+    X-axis: plant count. Blue = TP, orange = FP, gray X = refusal.
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.lines import Line2D
+
+    fig, ax = plt.subplots(figsize=(10, 7.5))
+
+    y_offset = 0.0
+    variant_ticks = []
+    run_spacing = 0.35
+    model_gap = 0.1
+    section_gap = 1.2
+    variant_gap = 0.8
+
+    for idx, variant in enumerate(_VARIANT_ORDER):
+        if idx in _SECTION_BREAKS:
+            y_offset += section_gap
+
+        variant_rows = [r for r in rows if r["variant"] == variant]
+        if not variant_rows:
+            continue
+
+        # Sort by model, then TP descending
+        variant_rows.sort(key=lambda r: (r["model"], -r["tp"]))
+
+        band_start = y_offset
+        prev_model = None
+        n_plotted = 0
+        for run in variant_rows:
+            if prev_model is not None and run["model"] != prev_model:
+                y_offset += model_gap
+            y = y_offset + n_plotted * run_spacing
+            prev_model = run["model"]
+            n_plotted += 1
+
+            if run["is_refusal"]:
+                # Mark refusal with gray X at x=0
+                ax.scatter(
+                    [0],
+                    [y],
+                    s=40,
+                    c=_REFUSAL,
+                    marker="x",
+                    linewidths=1.5,
+                    zorder=3,
+                )
+                ax.text(
+                    3,
+                    y,
+                    "refusal",
+                    fontsize=5,
+                    color=_REFUSAL,
+                    va="center",
+                    ha="left",
+                    style="italic",
+                )
+                continue
+
+            tp = run["tp"]
+            fp_raw = run["fp"]
+            fp = min(fp_raw, max_fp)
+
+            # TP dots (blue, right of 0)
+            if tp > 0:
+                xs = np.arange(1, tp + 1)
+                ys = np.full_like(xs, y, dtype=float)
+                ax.scatter(
+                    xs,
+                    ys,
+                    s=4,
+                    c=_MATCHED,
+                    marker="|",
+                    linewidths=0.5,
+                    zorder=3,
+                )
+
+            # FP dots (orange, left of 0)
+            if fp > 0:
+                xs = -np.arange(1, fp + 1)
+                ys = np.full_like(xs, y, dtype=float)
+                ax.scatter(
+                    xs,
+                    ys,
+                    s=4,
+                    c=_HALLUC,
+                    marker="|",
+                    linewidths=0.5,
+                    zorder=3,
+                )
+                if fp_raw > max_fp:
+                    ax.text(
+                        -fp - 1,
+                        y,
+                        f"({fp_raw})",
+                        fontsize=5,
+                        color=_HALLUC,
+                        va="center",
+                        ha="right",
+                    )
+
+        band_center = band_start + (n_plotted - 1) * run_spacing / 2
+        label = _VARIANT_LABELS.get(variant, variant)
+        variant_ticks.append((band_center, label))
+        y_offset += n_plotted * run_spacing + variant_gap
+
+    # Reference line at 163
+    ax.axvline(x=163, color="#2ca02c", linewidth=1, linestyle="--", alpha=0.7, zorder=2)
+    ax.text(165, -0.5, "163\nplants", color="#2ca02c", fontsize=8, va="top", ha="left")
+
+    # Zero line
+    ax.axvline(x=0, color="black", linewidth=0.5, alpha=0.4, zorder=1)
+
+    # Y axis
+    ax.set_yticks([t[0] for t in variant_ticks])
+    ax.set_yticklabels([t[1] for t in variant_ticks], fontsize=9)
+    ax.set_xlabel("Number of power plants", fontsize=11)
+    ax.set_xlim(-max_fp - 15, 185)
+    ax.invert_yaxis()
+    ax.grid(axis="x", linewidth=0.2, alpha=0.3)
+    ax.set_axisbelow(True)
+    ax.tick_params(axis="x", labelsize=9)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # Legend
+    legend_handles = [
+        Line2D([0], [0], color=_MATCHED, linewidth=3, label="Correctly identified"),
+        Line2D([0], [0], color=_HALLUC, linewidth=3, label="Hallucinated"),
+        Line2D(
+            [0],
+            [0],
+            color=_REFUSAL,
+            linewidth=0,
+            marker="x",
+            markersize=6,
+            label="Refusal (tool_calls)",
+        ),
+    ]
+    ax.legend(handles=legend_handles, loc="lower right", fontsize=8, framealpha=0.9)
+
+    fig.tight_layout()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches="tight", dpi=300)
+    plt.close(fig)
+    log.info("Wrote strip plot: %s", output)
+
+
+def write_heatmap_pdf(rows: list[dict], output: Path) -> None:
+    """Generate module effect heatmap as PDF.
+
+    Rows: 6 modules. Columns: composition ΔF1, ablation ΔF1, per model.
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    # Compute mean F1 per (variant, model) excluding refusals
+    mean_f1: dict[tuple[str, str], float] = {}
+    groups: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for r in rows:
+        if not r["is_refusal"]:
+            groups[(r["variant"], r["model"])].append(r["f1"])
+    for key, values in groups.items():
+        mean_f1[key] = sum(values) / len(values)
+
+    models = sorted({r["model"] for r in rows})
+
+    # Build delta matrix: rows=modules, cols=models×2 (composition, ablation)
+    n_modules = len(_MODULES)
+    n_cols = len(models) * 2
+    matrix = np.full((n_modules, n_cols), np.nan)
+    col_labels = []
+    for mi, model in enumerate(models):
+        short = model.replace("deepseek-", "DS ").replace("kimi-k2-thinking", "Kimi K2")
+        col_labels.extend([f"{short}\n+module", f"{short}\n−module"])
+        base_f1 = mean_f1.get(("p2_base", model))
+        comp_f1 = mean_f1.get(("p2_composite", model))
+        for ri, mod in enumerate(_MODULES):
+            # Composition delta: base+module vs base
+            plus_f1 = mean_f1.get((f"p2_{mod}", model))
+            if plus_f1 is not None and base_f1 is not None:
+                matrix[ri, mi * 2] = (plus_f1 - base_f1) * 100
+
+            # Ablation delta: composite-module vs composite
+            minus_f1 = mean_f1.get((f"p2_no_{mod}", model))
+            if minus_f1 is not None and comp_f1 is not None:
+                matrix[ri, mi * 2 + 1] = (minus_f1 - comp_f1) * 100
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+
+    # Use diverging colormap, centered at 0
+    vmax = max(30, np.nanmax(np.abs(matrix)))
+    im = ax.imshow(
+        matrix,
+        cmap="RdBu",
+        vmin=-vmax,
+        vmax=vmax,
+        aspect="auto",
+        interpolation="nearest",
+    )
+
+    # Annotate cells
+    for i in range(n_modules):
+        for j in range(n_cols):
+            val = matrix[i, j]
+            if np.isnan(val):
+                ax.text(j, i, "—", ha="center", va="center", fontsize=8, color="gray")
+            else:
+                color = "white" if abs(val) > vmax * 0.6 else "black"
+                ax.text(
+                    j,
+                    i,
+                    f"{val:+.1f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    fontweight="bold",
+                    color=color,
+                )
+
+    # Axes
+    ax.set_xticks(range(n_cols))
+    ax.set_xticklabels(col_labels, fontsize=8)
+    ax.set_yticks(range(n_modules))
+    ax.set_yticklabels([m.capitalize() for m in _MODULES], fontsize=9)
+
+    # Vertical separator between models
+    for mi in range(1, len(models)):
+        ax.axvline(x=mi * 2 - 0.5, color="white", linewidth=2)
+
+    cbar = fig.colorbar(im, ax=ax, shrink=0.8, pad=0.02)
+    cbar.set_label("ΔF1 (percentage points)", fontsize=9)
+
+    ax.set_title("Prompt module effects on F1 — RAG regime", fontsize=11, pad=10)
+
+    fig.tight_layout()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches="tight", dpi=300)
+    plt.close(fig)
+    log.info("Wrote heatmap: %s", output)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Generate ablation figures")
+    parser.add_argument("--strip", default=None, help="Path to write strip plot PDF")
+    parser.add_argument("--heatmap", default=None, help="Path to write heatmap PDF")
+    args = parser.parse_args()
+
+    if not args.strip and not args.heatmap:
+        parser.error("At least one of --strip or --heatmap is required")
+
+    rows = load_ablation_data()
+    log.info("Loaded %d ablation records", len(rows))
+
+    if args.strip:
+        write_strip_pdf(rows, Path(args.strip))
+    if args.heatmap:
+        write_heatmap_pdf(rows, Path(args.heatmap))
+
+
+if __name__ == "__main__":
+    main()

--- a/tickets/0067-ablation-results-visualization.erg
+++ b/tickets/0067-ablation-results-visualization.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Visualize ablation results reusing method convergence strip plot style
-Status: open
+Status: doing
 Created: 2026-04-10
 Author: haduong
 Blocked-by: 0066
 
 --- log ---
 2026-04-10T23:50Z haduong created
+2026-04-13T23:42Z claude claimed
 
 --- body ---
 ## Context

--- a/tickets/0067-ablation-results-visualization.erg
+++ b/tickets/0067-ablation-results-visualization.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Visualize ablation results reusing method convergence strip plot style
-Status: doing
+Status: closed
 Created: 2026-04-10
 Author: haduong
 Blocked-by: 0066
@@ -8,6 +8,7 @@ Blocked-by: 0066
 --- log ---
 2026-04-10T23:50Z haduong created
 2026-04-13T23:42Z claude claimed
+2026-04-16T12:00Z claude status closed — strip plot + heatmap merged, integrated in slides and report
 
 --- body ---
 ## Context

--- a/tickets/0089-shared-plot-colors.erg
+++ b/tickets/0089-shared-plot-colors.erg
@@ -1,0 +1,26 @@
+%erg v1
+Title: Extract shared plot color constants to util module
+Status: open
+Created: 2026-04-16
+Author: claude
+
+--- log ---
+2026-04-16T14:00Z claude created — found during PR 247 /simplify review
+
+--- body ---
+## Context
+
+`_MATCHED = "#2E86AB"` and `_HALLUC = "#F5A623"` are defined independently in
+three plot modules: `plot_ablation.py`, `plot_method_convergence.py`, and
+`plot_scaling_curve.py`. A fourth color `_REFUSAL = "#BBBBBB"` exists only in
+`plot_ablation.py`.
+
+## Actions
+
+1. Add `COLOR_MATCHED`, `COLOR_HALLUC`, `COLOR_REFUSAL` to `src/aedist/util.py`
+2. Replace local definitions in all three plot modules with imports
+
+## Exit criteria
+- No color hex literals in plot modules
+- `ruff check` passes
+- `make figures` produces identical PDFs

--- a/tickets/0090-shared-normalize-model.erg
+++ b/tickets/0090-shared-normalize-model.erg
@@ -1,0 +1,26 @@
+%erg v1
+Title: Extract shared normalize_model helper to util module
+Status: open
+Created: 2026-04-16
+Author: claude
+
+--- log ---
+2026-04-16T14:00Z claude created — found during PR 247 /simplify review
+
+--- body ---
+## Context
+
+`raw.split("/")[-1]` to strip provider prefix from model slugs is defined as
+`_normalize_model` in `plot_method_convergence.py` and `plot_scaling_curve.py`,
+and inlined in `plot_ablation.py`. Three copies of the same one-liner.
+
+## Actions
+
+1. Add `normalize_model(raw: str) -> str` to `src/aedist/util.py`
+2. Replace all three call sites with imports
+3. Handle the `or ""` guard from `plot_ablation.py` (model field is Optional)
+
+## Exit criteria
+- No duplicate `split("/")[-1]` model normalization in plot modules
+- `ruff check` passes
+- `make figures` produces identical PDFs


### PR DESCRIPTION
## Summary
- New `plot_ablation.py` module generates two figures from Phase 2 RAG ablation data (64 records)
- **Strip plot**: prompt variants on Y-axis, TP/FP dots per plant, refusals marked — same visual language as `fig_method_convergence.pdf`
- **Heatmap**: ΔF1 per module × model, composition and ablation effects side by side
- Integrated into slides (new frame after scaling curve) and report (results section after experimental plan)
- Makefile targets wired for both slides and report dependency chains

## Test plan
- [x] `make figures` generates all 3 new PDFs (slides strip, report strip, report heatmap)
- [x] `make slides` compiles with new ablation frame
- [x] `make report` compiles with both figures and interpretation prose
- [x] `ruff check` passes
- [x] Existing tests pass (3 pre-existing failures unrelated)
- [x] Review findings addressed: refusal detection tightened, empty-data guard added, font size matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)