### PR TITLE
Tickets 0091-0092: extract shared plot colors and normalize_model

### DIFF
--- a/src/aedist/palette.toml
+++ b/src/aedist/palette.toml
@@ -1,0 +1,23 @@
+# Plot color palette — single source of truth for all figures.
+#
+# Semantic names, not CSS names. Each color serves a role in the visual language.
+# Change a value here and all figures update on next `make figures`.
+
+[semantic]
+matched   = "#2E86AB"  # blue — correctly identified (TP)
+halluc    = "#F5A623"  # orange — hallucinated (FP)
+refusal   = "#BBBBBB"  # gray — model refusal markers
+alert     = "#E74C3C"  # red — warning / primary reference
+reference = "#2ca02c"  # green — inventory reference line (163 plants)
+
+[families.qwen]
+single = "#AAAAAA"
+rag    = "#2E86AB"
+
+[families.gemma]
+single = "#CCAA88"
+rag    = "#E07B39"
+
+[families.fallback]
+single = "#888888"
+rag    = "#444444"

--- a/src/aedist/plot_ablation.py
+++ b/src/aedist/plot_ablation.py
@@ -18,13 +18,9 @@ from collections import defaultdict
 from pathlib import Path
 
 from .measurements import load
+from .util import COLOR_HALLUC, COLOR_MATCHED, COLOR_REFERENCE, COLOR_REFUSAL, normalize_model
 
 log = logging.getLogger(__name__)
-
-# Colors matching slides.tex and plot_method_convergence.py
-_MATCHED = "#2E86AB"
-_HALLUC = "#F5A623"
-_REFUSAL = "#BBBBBB"
 
 # The 6 prompt modules in display order
 _MODULES = ["persona", "overview", "narratives", "bibliography", "statistics", "sourcing"]
@@ -93,7 +89,7 @@ def load_ablation_data() -> list[dict]:
         pv = record.method_params.prompt_version
         if not pv or not pv.startswith("p2_"):
             continue
-        model = (record.method_params.model or "").split("/")[-1]
+        model = normalize_model(record.method_params.model)
         s = record.result_summary
         is_refusal = s.status != "ok"
         rows.append(
@@ -162,7 +158,7 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
                     [0],
                     [y],
                     s=40,
-                    c=_REFUSAL,
+                    c=COLOR_REFUSAL,
                     marker="x",
                     linewidths=1.5,
                     zorder=3,
@@ -172,7 +168,7 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
                     y,
                     "refusal",
                     fontsize=5,
-                    color=_REFUSAL,
+                    color=COLOR_REFUSAL,
                     va="center",
                     ha="left",
                     style="italic",
@@ -191,7 +187,7 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
                     xs,
                     ys,
                     s=4,
-                    c=_MATCHED,
+                    c=COLOR_MATCHED,
                     marker="|",
                     linewidths=0.5,
                     zorder=3,
@@ -205,7 +201,7 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
                     xs,
                     ys,
                     s=4,
-                    c=_HALLUC,
+                    c=COLOR_HALLUC,
                     marker="|",
                     linewidths=0.5,
                     zorder=3,
@@ -216,7 +212,7 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
                         y,
                         f"({fp_raw})",
                         fontsize=5,
-                        color=_HALLUC,
+                        color=COLOR_HALLUC,
                         va="center",
                         ha="right",
                     )
@@ -227,8 +223,8 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
         y_offset += n_plotted * run_spacing + variant_gap
 
     # Reference line at 163
-    ax.axvline(x=163, color="#2ca02c", linewidth=1, linestyle="--", alpha=0.7, zorder=2)
-    ax.text(165, -0.5, "163\nplants", color="#2ca02c", fontsize=8, va="top", ha="left")
+    ax.axvline(x=163, color=COLOR_REFERENCE, linewidth=1, linestyle="--", alpha=0.7, zorder=2)
+    ax.text(165, -0.5, "163\nplants", color=COLOR_REFERENCE, fontsize=8, va="top", ha="left")
 
     # Zero line
     ax.axvline(x=0, color="black", linewidth=0.5, alpha=0.4, zorder=1)
@@ -247,12 +243,12 @@ def write_strip_pdf(rows: list[dict], output: Path, max_fp: int = 160) -> None:
 
     # Legend
     legend_handles = [
-        Line2D([0], [0], color=_MATCHED, linewidth=3, label="Correctly identified"),
-        Line2D([0], [0], color=_HALLUC, linewidth=3, label="Hallucinated"),
+        Line2D([0], [0], color=COLOR_MATCHED, linewidth=3, label="Correctly identified"),
+        Line2D([0], [0], color=COLOR_HALLUC, linewidth=3, label="Hallucinated"),
         Line2D(
             [0],
             [0],
-            color=_REFUSAL,
+            color=COLOR_REFUSAL,
             linewidth=0,
             marker="x",
             markersize=6,

--- a/src/aedist/plot_method_convergence.py
+++ b/src/aedist/plot_method_convergence.py
@@ -19,12 +19,9 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 from .measurements import SYNTHETIC_SUFFIXES, load
+from .util import COLOR_HALLUC, COLOR_MATCHED, COLOR_REFERENCE, normalize_model
 
 log = logging.getLogger(__name__)
-
-# Colors matching slides.tex definitions
-_MATCHED = "#2E86AB"
-_HALLUC = "#F5A623"
 
 # Methods to include and display order (bottom to top in plot)
 _METHOD_ORDER = ["single", "multiturn", "web", "rag", "decomposed"]
@@ -39,11 +36,6 @@ _METHOD_LABELS = {
 }
 
 
-def _normalize_model(raw: str) -> str:
-    """Normalize model name to slug (strip provider prefix)."""
-    return raw.split("/")[-1]
-
-
 def load_convergence_data() -> list[dict]:
     """Load and clean measurements for the convergence plot.
 
@@ -54,7 +46,7 @@ def load_convergence_data() -> list[dict]:
         method = record.method.value
         if method not in _METHOD_ORDER:
             continue
-        model = _normalize_model(record.method_params.model)
+        model = normalize_model(record.method_params.model)
         if any(model.endswith(s) for s in SYNTHETIC_SUFFIXES):
             continue
         s = record.result_summary
@@ -149,24 +141,31 @@ def write_pdf(
             if tp > 0:
                 xs = np.arange(1, tp + 1)
                 ys = np.full_like(xs, y, dtype=float)
-                ax.scatter(xs, ys, s=4, c=_MATCHED, marker="|", linewidths=0.5, zorder=3)
+                ax.scatter(xs, ys, s=4, c=COLOR_MATCHED, marker="|", linewidths=0.5, zorder=3)
 
             # FP dots (orange, left of 0) — 1 dot = 1 hallucinated plant
             if fp > 0:
                 xs = -np.arange(1, fp + 1)
                 ys = np.full_like(xs, y, dtype=float)
-                ax.scatter(xs, ys, s=4, c=_HALLUC, marker="|", linewidths=0.5, zorder=3)
+                ax.scatter(xs, ys, s=4, c=COLOR_HALLUC, marker="|", linewidths=0.5, zorder=3)
                 if fp_raw > max_fp:
-                    ax.text(-fp - 1, y, f"({fp_raw})", fontsize=5, color=_HALLUC,
-                            va="center", ha="right")
+                    ax.text(
+                        -fp - 1,
+                        y,
+                        f"({fp_raw})",
+                        fontsize=5,
+                        color=COLOR_HALLUC,
+                        va="center",
+                        ha="right",
+                    )
 
         band_center = band_start + (len(method_rows) - 1) * spacing / 2
         method_ticks.append((band_center, _METHOD_LABELS.get(method, method)))
         y_offset += len(method_rows) * spacing + gap
 
     # Reference line at 163
-    ax.axvline(x=163, color="#2ca02c", linewidth=1, linestyle="--", alpha=0.7, zorder=2)
-    ax.text(165, -0.5, "163\nplants", color="#2ca02c", fontsize=8, va="top", ha="left")
+    ax.axvline(x=163, color=COLOR_REFERENCE, linewidth=1, linestyle="--", alpha=0.7, zorder=2)
+    ax.text(165, -0.5, "163\nplants", color=COLOR_REFERENCE, fontsize=8, va="top", ha="left")
 
     # Zero line
     ax.axvline(x=0, color="black", linewidth=0.5, alpha=0.4, zorder=1)
@@ -187,8 +186,8 @@ def write_pdf(
     from matplotlib.lines import Line2D
 
     legend_handles = [
-        Line2D([0], [0], color=_MATCHED, linewidth=3, label="Correctly identified"),
-        Line2D([0], [0], color=_HALLUC, linewidth=3, label="Hallucinated"),
+        Line2D([0], [0], color=COLOR_MATCHED, linewidth=3, label="Correctly identified"),
+        Line2D([0], [0], color=COLOR_HALLUC, linewidth=3, label="Hallucinated"),
     ]
     ax.legend(handles=legend_handles, loc="center right", fontsize=9, framealpha=0.9)
 

--- a/src/aedist/plot_scaling_curve.py
+++ b/src/aedist/plot_scaling_curve.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from .measurements import SYNTHETIC_SUFFIXES, load
+from .util import COLOR_ALERT, COLOR_HALLUC, FAMILY_COLORS, normalize_model
 
 log = logging.getLogger(__name__)
 
@@ -70,7 +71,7 @@ def _compute_cloud_refs() -> dict[str, float]:
         pv = getattr(record.method_params, "prompt_version", None)
         if pv == "_extracted":
             continue
-        model = record.method_params.model.split("/")[-1]
+        model = normalize_model(record.method_params.model)
         if any(model.endswith(s) for s in SYNTHETIC_SUFFIXES):
             continue
         if model in _LOCAL_MODELS:
@@ -87,11 +88,6 @@ def _compute_cloud_refs() -> dict[str, float]:
         return dict(_CLOUD_REFS_FALLBACK)
 
     return {f"{slug} (best run)": f1 for slug, f1 in sorted(cloud_best.items())}
-
-
-def _normalize_model(raw: str) -> str:
-    """Normalize model name: strip provider prefix."""
-    return raw.split("/")[-1]
 
 
 # Per-family, per-method data: family -> method -> active_params -> [f1]
@@ -111,7 +107,7 @@ def collect_data() -> FamilyData:
         pv = getattr(record.method_params, "prompt_version", None)
         if pv == "_extracted":
             continue
-        model = _normalize_model(record.method_params.model)
+        model = normalize_model(record.method_params.model)
         if any(model.endswith(s) for s in SYNTHETIC_SUFFIXES):
             continue
         if model not in _MODEL_LOOKUP:
@@ -132,16 +128,13 @@ def write_pdf(data: FamilyData, output: Path) -> None:
 
     fig, ax = plt.subplots(figsize=(8, 5))
 
-    # Color scheme: family -> (single_color, rag_color)
-    family_colors = {
-        "Qwen 3.5": {"single": "#AAAAAA", "rag": "#2E86AB"},
-        "Gemma 4": {"single": "#CCAA88", "rag": "#E07B39"},
-    }
+    fc = FAMILY_COLORS
+    family_colors = {"Qwen 3.5": fc["qwen"], "Gemma 4": fc["gemma"]}
     markers = {"single": "s", "rag": "o"}
     all_sizes: set[float] = set()
 
     for family, fam_data in data.items():
-        colors = family_colors.get(family, {"single": "#888888", "rag": "#444444"})
+        colors = family_colors.get(family, fc["fallback"])
 
         for method in ("single", "rag"):
             method_data = fam_data[method]
@@ -183,7 +176,7 @@ def write_pdf(data: FamilyData, output: Path) -> None:
 
     # Cloud reference lines
     cloud_refs = _compute_cloud_refs()
-    ref_colors = ["#E74C3C", "#F5A623"]
+    ref_colors = [COLOR_ALERT, COLOR_HALLUC]
     ref_styles = ["--", "-."]
     max_size = max(all_sizes) if all_sizes else 35
     for i, (name, f1) in enumerate(cloud_refs.items()):

--- a/src/aedist/util.py
+++ b/src/aedist/util.py
@@ -1,6 +1,25 @@
 """Shared utilities for the aedist package."""
 
+import tomllib
 import unicodedata
+from pathlib import Path
+
+# ── Plot palette (loaded from palette.toml) ──────────────────────────────────
+
+with open(Path(__file__).parent / "palette.toml", "rb") as _f:
+    _palette = tomllib.load(_f)
+
+COLOR_MATCHED = _palette["semantic"]["matched"]
+COLOR_HALLUC = _palette["semantic"]["halluc"]
+COLOR_REFUSAL = _palette["semantic"]["refusal"]
+COLOR_ALERT = _palette["semantic"]["alert"]
+COLOR_REFERENCE = _palette["semantic"]["reference"]
+FAMILY_COLORS = _palette["families"]
+
+
+def normalize_model(raw: str) -> str:
+    """Strip provider prefix from a model slug: 'openrouter/deepseek-v3' → 'deepseek-v3'."""
+    return (raw or "").split("/")[-1]
 
 
 def strip_diacritics(s: str) -> str:

--- a/tickets/0091-shared-plot-colors.erg
+++ b/tickets/0091-shared-plot-colors.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Extract shared plot color constants to util module
-Status: open
+Status: closed
 Created: 2026-04-16
 Author: claude
 
 --- log ---
 2026-04-16T14:00Z claude created — found during PR 247 /simplify review
+2026-04-16T14:30Z claude status closed — colors moved to util.py, 3 plot modules updated
 
 --- body ---
 ## Context

--- a/tickets/0092-shared-normalize-model.erg
+++ b/tickets/0092-shared-normalize-model.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Extract shared normalize_model helper to util module
-Status: open
+Status: closed
 Created: 2026-04-16
 Author: claude
 
 --- log ---
 2026-04-16T14:00Z claude created — found during PR 247 /simplify review
+2026-04-16T14:30Z claude status closed — normalize_model moved to util.py, 3 plot modules updated
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- `COLOR_MATCHED`, `COLOR_HALLUC`, `COLOR_REFUSAL` moved from 2 plot modules to `util.py`
- `normalize_model()` moved from 3 plot modules (2 definitions + 1 inline) to `util.py`
- Tickets renumbered 0089→0091, 0090→0092 to avoid ID conflict with existing 0089

## Test plan
- [x] `ruff check` passes
- [x] Tests pass (1 pre-existing failure unrelated)
- [ ] `make figures` produces identical PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)