### PR TITLE
Add temperature-limitation caveat to slides

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -775,6 +775,9 @@ An off-the-shelf pipeline with the right \textbf{method conditions} recovers 89.
         no confidence intervals
   \item \textbf{Method interactions} --- axes tested
         separately, never composed
+  \item \textbf{Temperature} --- 211/280 runs used provider
+        defaults ($t{\approx}1$); $t{=}0$ enforced only for
+        later sweeps (PR\,\#244)
 \end{itemize}
 \end{columns}
 

--- a/tickets/0093-slides-temperature-caveat.erg
+++ b/tickets/0093-slides-temperature-caveat.erg
@@ -1,12 +1,13 @@
 %erg v1
 Title: Add temperature-limitation caveat to slides
-Status: open
+Status: closed
 Created: 2026-04-16
 Author: claude
 
 --- log ---
 2026-04-16T14:35Z claude created — sweep from ticket 0089 celebrate
 2026-04-16T22:30Z claude note reimagined: one bullet in existing limitations frame, 4 lines of LaTeX
+2026-04-16T22:45Z claude status closed — bullet added to limitations frame, PR created
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- Adds a temperature bullet to the "What this pilot measured --- and what it didn't" frame in slides
- Notes that 211/280 runs used provider defaults (t~1), with t=0 enforced only for later sweeps (PR #244)
- Closes ticket 0093

## Test plan
- [ ] Verify the new bullet appears in the limitations frame
- [ ] Confirm no other frames are modified
- [ ] LaTeX compiles (pre-existing census_bars.csv issue is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)