### PR TITLE
Ticket 0097: deterministic source grounding verification

### DIFF
--- a/src/aedist/tabulate_source_grounding.py
+++ b/src/aedist/tabulate_source_grounding.py
@@ -1,0 +1,117 @@
+"""Generate LaTeX table for source grounding verification results.
+
+Reads the 3 sourced extraction runs and 3 non-sourced baseline runs,
+computes source grounding metrics, and writes a LaTeX table.
+
+Usage:
+    python -m aedist.tabulate_source_grounding
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+
+from .verify import extract_csv_rows
+from .verify_source_grounding import verify_source_grounding
+
+log = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+_CORPUS_DIR = _PROJECT_ROOT / "data" / "rag_corpus"
+_SOURCED_DIR = _PROJECT_ROOT / "experiments" / "outputs" / "sourced"
+_DECOMPOSED_DIR = _PROJECT_ROOT / "experiments" / "outputs" / "decomposed"
+_OUTPUT_PATH = _PROJECT_ROOT / "report" / "inputs" / "generated" / "tab_source_grounding.tex"
+
+
+def _load_sourced_csv(path: Path) -> list[dict]:
+    with open(path, encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _load_json_response_rows(path: Path) -> list[dict]:
+    record = json.loads(path.read_text())
+    response = record.get("response", "")
+    return extract_csv_rows(response)
+
+
+def _fmt_pct(value: float) -> str:
+    return f"{100 * value:.1f}\\%"
+
+
+def generate_table() -> str:
+    """Generate the LaTeX source for the source grounding table."""
+    lines = []
+    lines.append(r"\begin{table}[ht]")
+    lines.append(r"\centering")
+    lines.append(r"\caption{Source grounding verification: sourced extractions vs.\ baseline.}")
+    lines.append(r"\label{tab:source-grounding}")
+    lines.append(r"\begin{tabular}{l r r r r r r r r}")
+    lines.append(r"\toprule")
+    lines.append(
+        r"Method & Run & Plants & Source & Grounding & Traceability "
+        r"& \multicolumn{4}{c}{2$\times$2 counts} \\"
+    )
+    lines.append(
+        r" & & & rate & rate & rate "
+        r"& T/R & T/$\neg$R & $\neg$T/R & $\neg$T/$\neg$R \\"
+    )
+    lines.append(r"\midrule")
+
+    # Sourced runs
+    for run in [1, 2, 3]:
+        csv_path = _SOURCED_DIR / f"claude-opus-4.6-run{run}.csv"
+        rows = _load_sourced_csv(csv_path)
+        _, s = verify_source_grounding(rows, _CORPUS_DIR)
+        c = s["counts_2x2"]
+        label = "Sourced RAG" if run == 1 else ""
+        lines.append(
+            f"  {label} & {run} & {s['total_plants']} "
+            f"& {_fmt_pct(s['source_rate'])} & {_fmt_pct(s['grounding_rate'])} "
+            f"& {_fmt_pct(s['traceability_rate'])} "
+            f"& {c['tt']} & {c['tf']} & {c['ft']} & {c['ff']} \\\\"
+        )
+
+    lines.append(r"\midrule")
+
+    # Baseline: decomposed deepseek-v3.2
+    for run in [1, 2, 3]:
+        json_path = _DECOMPOSED_DIR / f"deepseek-v3.2-run{run}.json"
+        rows = _load_json_response_rows(json_path)
+        _, s = verify_source_grounding(rows, _CORPUS_DIR)
+        c = s["counts_2x2"]
+        label = "Decomposed RAG" if run == 1 else ""
+        lines.append(
+            f"  {label} & {run} & {s['total_plants']} "
+            f"& {_fmt_pct(s['source_rate'])} & {_fmt_pct(s['grounding_rate'])} "
+            f"& {_fmt_pct(s['traceability_rate'])} "
+            f"& {c['tt']} & {c['tf']} & {c['ft']} & {c['ff']} \\\\"
+        )
+
+    lines.append(r"\bottomrule")
+    lines.append(r"\end{tabular}")
+    lines.append(
+        r"\par\smallskip\footnotesize "
+        r"Source rate = fraction with any citation; "
+        r"Grounding rate = citation fuzzy-matches a corpus filename; "
+        r"Traceability = grounded \emph{and} plant name found in matched file. "
+        r"T = traceable, R = in reference corpus."
+    )
+    lines.append(r"\end{table}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    tex = generate_table()
+    _OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _OUTPUT_PATH.write_text(tex, encoding="utf-8")
+    log.info("Wrote %s", _OUTPUT_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/tabulate_source_grounding.py
+++ b/src/aedist/tabulate_source_grounding.py
@@ -48,7 +48,7 @@ def generate_table() -> str:
     lines.append(r"\centering")
     lines.append(r"\caption{Source grounding verification: sourced extractions vs.\ baseline.}")
     lines.append(r"\label{tab:source-grounding}")
-    lines.append(r"\begin{tabular}{l r r r r r r r r}")
+    lines.append(r"\begin{tabular}{l r r r r r r r r r}")
     lines.append(r"\toprule")
     lines.append(
         r"Method & Run & Plants & Source & Grounding & Traceability "
@@ -97,7 +97,7 @@ def generate_table() -> str:
         r"Source rate = fraction with any citation; "
         r"Grounding rate = citation fuzzy-matches a corpus filename; "
         r"Traceability = grounded \emph{and} plant name found in matched file. "
-        r"T = traceable, R = in reference corpus."
+        r"T = traceable, R = in reference dataset."
     )
     lines.append(r"\end{table}")
 

--- a/src/aedist/verify_source_grounding.py
+++ b/src/aedist/verify_source_grounding.py
@@ -1,0 +1,328 @@
+"""Verify source grounding: check whether LLM citations trace to the RAG corpus.
+
+For each extracted plant with source_1 / source_2 columns, we:
+  1. Fuzzy-match the citation text against the 18 corpus filenames.
+  2. If a file matches, search it for the plant name.
+  3. Report three rates:
+     - source_rate:        fraction of plants with any non-empty citation
+     - grounding_rate:     fraction of plants whose citation matches a corpus file
+     - traceability_rate:  fraction of plants whose citation matches AND the
+                           matched file mentions the plant name
+
+This replaces post-hoc LLM verification (ticket 0059 showed 0-10% inter-
+verifier agreement).  No API calls required -- everything is local.
+
+Usage:
+    python -m aedist.verify_source_grounding \
+        --input experiments/outputs/sourced \
+        --corpus data/rag_corpus \
+        --output derived/source_grounding_summary.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import re
+from pathlib import Path
+
+from rapidfuzz import fuzz
+
+log = logging.getLogger(__name__)
+
+# Minimum fuzzy-match score for citation -> corpus filename
+FILENAME_MATCH_THRESHOLD = 70
+
+# Minimum fuzzy-match score for plant name -> file content
+PLANT_NAME_MATCH_THRESHOLD = 60
+
+
+# ---------------------------------------------------------------------------
+# Corpus filename normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalise_filename(name: str) -> str:
+    """Strip extension and convert underscores/camelCase to lowercase tokens.
+
+    >>> _normalise_filename("EVN_Annual_Report_2010_2011_CapacitiesTable.md")
+    'evn annual report 2010 2011 capacitiestable'
+    """
+    stem = Path(name).stem
+    return stem.replace("_", " ").lower()
+
+
+def _normalise_citation(text: str) -> str:
+    """Normalise a free-text citation for fuzzy matching against filenames.
+
+    Drops page references (p13, pp34-35), parenthesised detail, and
+    punctuation noise while keeping the document identity tokens.
+    """
+    t = text.strip()
+    # Remove parenthesised details
+    t = re.sub(r"\([^)]*\)", "", t)
+    # Remove page references like p13, pp34-35, page 5
+    t = re.sub(r"\b(?:pp?\.?\s*\d[\d\-]*)", "", t, flags=re.IGNORECASE)
+    t = re.sub(r"\bpage\s+\d+", "", t, flags=re.IGNORECASE)
+    # Normalise whitespace
+    t = re.sub(r"\s+", " ", t).strip().lower()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Core verification
+# ---------------------------------------------------------------------------
+
+
+def match_citation_to_corpus(
+    citation: str,
+    corpus_filenames: list[str],
+    *,
+    threshold: int = FILENAME_MATCH_THRESHOLD,
+) -> str | None:
+    """Return the best-matching corpus filename, or None if below threshold."""
+    if not citation or not citation.strip():
+        return None
+
+    norm_cit = _normalise_citation(citation)
+    best_score = 0.0
+    best_file: str | None = None
+
+    for fname in corpus_filenames:
+        norm_fn = _normalise_filename(fname)
+        score = fuzz.token_sort_ratio(norm_cit, norm_fn)
+        if score > best_score:
+            best_score = score
+            best_file = fname
+
+    if best_score >= threshold:
+        return best_file
+    return None
+
+
+def plant_name_in_file(
+    plant_name: str,
+    file_content: str,
+    *,
+    threshold: int = PLANT_NAME_MATCH_THRESHOLD,
+) -> bool:
+    """Check whether the plant name appears (fuzzily) in the file content.
+
+    We search line-by-line for a partial-ratio match, which catches
+    Vietnamese diacritical variants (e.g. "Duyen Hai" vs "Duyên Hải").
+    """
+    name_lower = plant_name.strip().lower()
+    if not name_lower:
+        return False
+
+    # Quick exact substring check first (fast path)
+    content_lower = file_content.lower()
+    if name_lower in content_lower:
+        return True
+
+    # Fuzzy search line-by-line
+    for line in file_content.split("\n"):
+        if fuzz.partial_ratio(name_lower, line.lower()) >= threshold:
+            return True
+
+    return False
+
+
+def verify_source_grounding(
+    rows: list[dict],
+    corpus_dir: Path,
+) -> tuple[list[dict], dict]:
+    """Verify source grounding for extracted rows with source_1/source_2 columns.
+
+    Parameters
+    ----------
+    rows : list[dict]
+        CSV row dicts, each with at least 'name' and optionally
+        'source_1', 'source_2'.
+    corpus_dir : Path
+        Directory containing the .md corpus files.
+
+    Returns
+    -------
+    annotated : list[dict]
+        Input rows with added boolean columns:
+        source_file_found, source_content_found, source_verified
+    summary : dict
+        Aggregate metrics: source_rate, grounding_rate, traceability_rate,
+        and a 2x2 counts table.
+    """
+    # Load corpus
+    corpus_files = sorted(f.name for f in corpus_dir.glob("*.md"))
+    corpus_contents: dict[str, str] = {}
+    for fname in corpus_files:
+        corpus_contents[fname] = (corpus_dir / fname).read_text(encoding="utf-8")
+
+    annotated = []
+    n_has_source = 0
+    n_file_found = 0
+    n_content_found = 0
+    n_verified = 0
+
+    # 2x2 counters: (traceable, in_reference)
+    # "traceable" = source_verified; "in_reference" = plant exists in corpus
+    counts_2x2 = {"tt": 0, "tf": 0, "ft": 0, "ff": 0}
+
+    for row in rows:
+        entry = dict(row)
+        name = row.get("name", "").strip()
+        s1 = (row.get("source_1") or "").strip()
+        s2 = (row.get("source_2") or "").strip()
+
+        has_source = bool(s1 or s2)
+        file_found = False
+        content_found = False
+        matched_file: str | None = None
+
+        # Try source_1 first, then source_2
+        for citation in [s1, s2]:
+            if not citation:
+                continue
+            mf = match_citation_to_corpus(citation, corpus_files)
+            if mf:
+                matched_file = mf
+                file_found = True
+                # Check if plant name appears in the matched file
+                if plant_name_in_file(name, corpus_contents[mf]):
+                    content_found = True
+                break  # Use first matching citation
+
+        verified = file_found and content_found
+
+        entry["source_file_found"] = str(file_found)
+        entry["source_content_found"] = str(content_found)
+        entry["source_verified"] = str(verified)
+        entry["matched_corpus_file"] = matched_file or ""
+        annotated.append(entry)
+
+        if has_source:
+            n_has_source += 1
+        if file_found:
+            n_file_found += 1
+        if content_found:
+            n_content_found += 1
+        if verified:
+            n_verified += 1
+
+        # 2x2: traceable (verified) x in_reference (name found in ANY corpus file)
+        in_ref = (
+            any(plant_name_in_file(name, content) for content in corpus_contents.values())
+            if name
+            else False
+        )
+
+        if verified and in_ref:
+            counts_2x2["tt"] += 1
+        elif verified and not in_ref:
+            counts_2x2["tf"] += 1
+        elif not verified and in_ref:
+            counts_2x2["ft"] += 1
+        else:
+            counts_2x2["ff"] += 1
+
+    total = len(rows) or 1
+    summary = {
+        "total_plants": len(rows),
+        "n_has_source": n_has_source,
+        "n_file_found": n_file_found,
+        "n_content_found": n_content_found,
+        "n_verified": n_verified,
+        "source_rate": round(n_has_source / total, 4),
+        "grounding_rate": round(n_file_found / total, 4),
+        "traceability_rate": round(n_verified / total, 4),
+        "counts_2x2": counts_2x2,
+    }
+
+    return annotated, summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Verify source grounding against RAG corpus")
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Directory with sourced CSV files (or a single CSV path)",
+    )
+    parser.add_argument(
+        "--corpus",
+        required=True,
+        help="Path to RAG corpus directory",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write summary JSON",
+    )
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input)
+    corpus_dir = Path(args.corpus)
+    output_path = Path(args.output)
+
+    if not corpus_dir.is_dir():
+        raise SystemExit(f"Corpus directory not found: {corpus_dir}")
+
+    # Collect CSV files
+    if input_path.is_dir():
+        csv_files = sorted(
+            f
+            for f in input_path.glob("*.csv")
+            if _has_source_columns(f) and "reconciliation" not in f.name
+        )
+    elif input_path.is_file():
+        csv_files = [input_path]
+    else:
+        raise SystemExit(f"Input not found: {input_path}")
+
+    if not csv_files:
+        raise SystemExit(f"No CSV files with source columns found in: {input_path}")
+
+    all_summaries = {}
+    for csv_path in csv_files:
+        rows = _load_csv(csv_path)
+        if not rows:
+            continue
+        annotated, summary = verify_source_grounding(rows, corpus_dir)
+        all_summaries[csv_path.stem] = summary
+        log.info(
+            "%s: %d plants, source_rate=%.1f%%, grounding=%.1f%%, traceable=%.1f%%",
+            csv_path.stem,
+            summary["total_plants"],
+            100 * summary["source_rate"],
+            100 * summary["grounding_rate"],
+            100 * summary["traceability_rate"],
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(all_summaries, indent=2) + "\n", encoding="utf-8")
+    log.info("Wrote %s", output_path)
+
+
+def _has_source_columns(csv_path: Path) -> bool:
+    """Check if a CSV has source_1 in its header."""
+    with open(csv_path, encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        header = next(reader, [])
+    return "source_1" in header
+
+
+def _load_csv(csv_path: Path) -> list[dict]:
+    """Load a CSV into a list of dicts."""
+    with open(csv_path, encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/verify_source_grounding.py
+++ b/src/aedist/verify_source_grounding.py
@@ -130,9 +130,50 @@ def plant_name_in_file(
     return False
 
 
+def _load_reference_names(
+    reference_path: Path,
+    *,
+    name_column: str = "name",
+) -> list[str]:
+    """Load plant names from a reference CSV."""
+    names: list[str] = []
+    with open(reference_path, encoding="utf-8", newline="") as f:
+        for row in csv.DictReader(f):
+            n = (row.get(name_column) or "").strip()
+            if n:
+                names.append(n)
+    return names
+
+
+def _name_in_reference(
+    plant_name: str,
+    reference_names: list[str],
+    *,
+    threshold: int = FILENAME_MATCH_THRESHOLD,
+) -> bool:
+    """Check whether *plant_name* fuzzy-matches any name in the reference list."""
+    if not plant_name:
+        return False
+    name_lower = plant_name.strip().lower()
+    for ref in reference_names:
+        ref_lower = ref.strip().lower()
+        if name_lower == ref_lower:
+            return True
+        if fuzz.token_sort_ratio(name_lower, ref_lower) >= threshold:
+            return True
+    return False
+
+
+_DEFAULT_REFERENCE_PATH = (
+    Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
+)
+
+
 def verify_source_grounding(
     rows: list[dict],
     corpus_dir: Path,
+    *,
+    reference_path: Path | None = None,
 ) -> tuple[list[dict], dict]:
     """Verify source grounding for extracted rows with source_1/source_2 columns.
 
@@ -143,6 +184,9 @@ def verify_source_grounding(
         'source_1', 'source_2'.
     corpus_dir : Path
         Directory containing the .md corpus files.
+    reference_path : Path | None
+        Path to the reference CSV with a ``name`` column.  Defaults to
+        ``data/reference/vietnam_thermal_v1.csv`` relative to the project root.
 
     Returns
     -------
@@ -153,6 +197,18 @@ def verify_source_grounding(
         Aggregate metrics: source_rate, grounding_rate, traceability_rate,
         and a 2x2 counts table.
     """
+    if reference_path is None:
+        reference_path = _DEFAULT_REFERENCE_PATH
+
+    # Load reference names
+    if reference_path.is_file():
+        reference_names = _load_reference_names(reference_path)
+    else:
+        log.warning(
+            "Reference file not found: %s — in_reference will be False for all", reference_path
+        )
+        reference_names = []
+
     # Load corpus
     corpus_files = sorted(f.name for f in corpus_dir.glob("*.md"))
     corpus_contents: dict[str, str] = {}
@@ -166,7 +222,7 @@ def verify_source_grounding(
     n_verified = 0
 
     # 2x2 counters: (traceable, in_reference)
-    # "traceable" = source_verified; "in_reference" = plant exists in corpus
+    # "traceable" = source_verified; "in_reference" = plant exists in reference CSV
     counts_2x2 = {"tt": 0, "tf": 0, "ft": 0, "ff": 0}
 
     for row in rows:
@@ -191,7 +247,8 @@ def verify_source_grounding(
                 # Check if plant name appears in the matched file
                 if plant_name_in_file(name, corpus_contents[mf]):
                     content_found = True
-                break  # Use first matching citation
+                    break  # Fully verified — no need to try next citation
+                # File matched but plant not found — continue to next citation
 
         verified = file_found and content_found
 
@@ -210,12 +267,8 @@ def verify_source_grounding(
         if verified:
             n_verified += 1
 
-        # 2x2: traceable (verified) x in_reference (name found in ANY corpus file)
-        in_ref = (
-            any(plant_name_in_file(name, content) for content in corpus_contents.values())
-            if name
-            else False
-        )
+        # 2x2: traceable (verified) x in_reference (name found in reference CSV)
+        in_ref = _name_in_reference(name, reference_names) if name else False
 
         if verified and in_ref:
             counts_2x2["tt"] += 1

--- a/tests/test_verify_source_grounding.py
+++ b/tests/test_verify_source_grounding.py
@@ -1,0 +1,258 @@
+"""Tests for verify_source_grounding module."""
+
+import textwrap
+
+import pytest
+
+from aedist.verify_source_grounding import (
+    match_citation_to_corpus,
+    plant_name_in_file,
+    verify_source_grounding,
+)
+
+# ---------------------------------------------------------------------------
+# Corpus filenames used in tests (subset of the real 18)
+# ---------------------------------------------------------------------------
+
+CORPUS_FILENAMES = [
+    "EVN_Annual_Report_2010_2011_CapacitiesTable.md",
+    "EVN_Annual_Report_2017_CapacitiesTable.md",
+    "EVN_Annual_Report_2018_CapacitiesTable.md",
+    "PDP7A_annex1_table1.md",
+    "PDP7_annex1.md",
+    "PDP7_annex2.md",
+    "PDP8_annex2_table1.md",
+    "PDP8_annex2_table2.md",
+    "Report_32_annex1.md",
+    "Report_58_annex.md",
+    "Study_E542_table_9.1.md",
+    "Study_E542_table_9.2.md",
+]
+
+
+# ---------------------------------------------------------------------------
+# match_citation_to_corpus
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCitationToCorpus:
+    def test_source_file_found(self):
+        """Citation mentioning PDP8 annex2 table1 matches the corpus file."""
+        citation = "PDP8 Annex II Table 1 (NMNĐ Sơn Mỹ II 2250MW giai đoạn 2021-2030)"
+        result = match_citation_to_corpus(citation, CORPUS_FILENAMES)
+        assert result == "PDP8_annex2_table1.md"
+
+    def test_evn_report_matches(self):
+        """EVN Annual Report 2010-2011 p13 should match the EVN 2010_2011 file."""
+        citation = "EVN Annual Report 2010-2011 p13"
+        result = match_citation_to_corpus(citation, CORPUS_FILENAMES)
+        assert result is not None
+        assert "2010_2011" in result
+
+    def test_report_32(self):
+        """Report 32 Appendix 1 matches Report_32_annex1.md."""
+        citation = "Report 32 Appendix 1 (NĐ Thái Bình I 2x300MW)"
+        result = match_citation_to_corpus(citation, CORPUS_FILENAMES)
+        assert result == "Report_32_annex1.md"
+
+    def test_report_58(self):
+        """Report 58 Appendix matches Report_58_annex.md."""
+        citation = "Report 58 Appendix (NĐ Nghi Sơn 2 2x600MW chậm ~1 năm 2022)"
+        result = match_citation_to_corpus(citation, CORPUS_FILENAMES)
+        assert result == "Report_58_annex.md"
+
+    def test_source_file_missing(self):
+        """Citation mentioning a nonexistent document returns None."""
+        citation = "World Bank Report 2023 on Vietnamese energy transition"
+        result = match_citation_to_corpus(citation, CORPUS_FILENAMES)
+        assert result is None
+
+    def test_empty_citation(self):
+        """Empty citation returns None without error."""
+        assert match_citation_to_corpus("", CORPUS_FILENAMES) is None
+        assert match_citation_to_corpus("  ", CORPUS_FILENAMES) is None
+
+    def test_pdp7a_matches(self):
+        """PDP7A Table 1 matches PDP7A_annex1_table1.md."""
+        citation = "PDP7A Table 1 (NĐ Na Dương II 110MW listed 2019)"
+        result = match_citation_to_corpus(citation, CORPUS_FILENAMES)
+        assert result is not None
+        assert "PDP7A" in result
+
+
+# ---------------------------------------------------------------------------
+# plant_name_in_file
+# ---------------------------------------------------------------------------
+
+
+class TestPlantNameInFile:
+    def test_exact_match(self):
+        """Plant name appears exactly in file content."""
+        content = "| Duyên Hải 1 | 1245 MW | Trà Vinh |"
+        assert plant_name_in_file("Duyen Hai 1", content) is True
+
+    def test_no_match(self):
+        """Plant name not in file content."""
+        content = "| Phú Mỹ 1 | 1108 MW | Bà Rịa-Vũng Tàu |"
+        assert plant_name_in_file("Duyen Hai 1", content) is False
+
+    def test_diacritical_fuzzy(self):
+        """Vietnamese diacriticals match via fuzzy partial ratio."""
+        content = "NĐ Vĩnh Tân IV 2x600MW vận hành sớm 3 tháng 2017-2018"
+        assert plant_name_in_file("Vinh Tan 4", content) is True
+
+    def test_empty_name(self):
+        """Empty plant name returns False."""
+        assert plant_name_in_file("", "some content") is False
+
+    def test_source_content_found(self):
+        """File exists and contains plant name -> verified."""
+        content = textwrap.dedent("""\
+            ## Bảng 2: Danh mục các nhà máy nhiệt điện than
+            | NĐ Duyên Hải III | 2x622MW | vận hành sớm 6 tháng 2016 |
+            | NĐ Thái Bình I | 2x300MW | đã vận hành đúng tiến độ 2017 |
+        """)
+        assert plant_name_in_file("Duyen Hai 3", content) is True
+        assert plant_name_in_file("Thai Binh 1", content) is True
+
+
+# ---------------------------------------------------------------------------
+# verify_source_grounding (integration with temp corpus)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mini_corpus(tmp_path):
+    """Create a minimal corpus directory with 2 files."""
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    (corpus / "PDP8_annex2_table1.md").write_text(
+        "## Bảng 1: Danh mục các nhà máy nhiệt điện LNG\n"
+        "| LNG Quảng Ninh | 1500 MW | 2021-2030 |\n"
+        "| LNG Thái Bình | 1500 MW | 2021-2030 |\n"
+        "| NMNĐ Nhơn Trạch 3 | 750 MW | 2021-2030 |\n",
+        encoding="utf-8",
+    )
+
+    (corpus / "Report_32_annex1.md").write_text(
+        "## Phụ lục 1\n"
+        "| NĐ Thái Bình I | 2x300MW | đúng tiến độ 2017 |\n"
+        "| NĐ Duyên Hải III | 2x622MW | sớm 6 tháng 2016 |\n",
+        encoding="utf-8",
+    )
+
+    return corpus
+
+
+class TestVerifySourceGrounding:
+    def test_verified_plant(self, mini_corpus):
+        """Plant with correct citation and name in file -> all True."""
+        rows = [
+            {
+                "name": "Nhon Trach 3",
+                "source_1": "PDP8 Annex II Table 1 (NMNĐ Nhơn Trạch 3 750MW)",
+                "source_2": "",
+            }
+        ]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        assert annotated[0]["source_file_found"] == "True"
+        assert annotated[0]["source_content_found"] == "True"
+        assert annotated[0]["source_verified"] == "True"
+        assert summary["traceability_rate"] == 1.0
+
+    def test_file_found_but_plant_missing(self, mini_corpus):
+        """Citation matches a file but plant name is not in that file."""
+        rows = [
+            {
+                "name": "Vinh Tan 4",
+                "source_1": "PDP8 Annex II Table 1 (something)",
+                "source_2": "",
+            }
+        ]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        assert annotated[0]["source_file_found"] == "True"
+        assert annotated[0]["source_content_found"] == "False"
+        assert annotated[0]["source_verified"] == "False"
+
+    def test_empty_source(self, mini_corpus):
+        """Empty source_1 -> source_verified=False (not an error)."""
+        rows = [
+            {
+                "name": "Some Plant",
+                "source_1": "",
+                "source_2": "",
+            }
+        ]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        assert annotated[0]["source_file_found"] == "False"
+        assert annotated[0]["source_verified"] == "False"
+        assert summary["source_rate"] == 0.0
+
+    def test_no_source_columns(self, mini_corpus):
+        """Rows without source_1/source_2 keys -> graceful degradation."""
+        rows = [{"name": "Thai Binh 1"}]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        assert annotated[0]["source_verified"] == "False"
+        assert summary["source_rate"] == 0.0
+
+    def test_2x2_counts(self, mini_corpus):
+        """Verify the 2x2 table counts are correct."""
+        rows = [
+            # Traceable AND in reference
+            {
+                "name": "Nhon Trach 3",
+                "source_1": "PDP8 Annex II Table 1 (NMNĐ Nhơn Trạch 3 750MW)",
+                "source_2": "",
+            },
+            # NOT traceable but in reference (file citation wrong)
+            {
+                "name": "Thai Binh 1",
+                "source_1": "World Bank Report 2025",
+                "source_2": "",
+            },
+            # NOT traceable and NOT in reference
+            {
+                "name": "Fictional Plant X",
+                "source_1": "",
+                "source_2": "",
+            },
+        ]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        c = summary["counts_2x2"]
+        assert c["tt"] == 1  # Nhon Trach 3: traceable + in ref
+        assert c["ft"] == 1  # Thai Binh 1: not traceable + in ref
+        assert c["ff"] == 1  # Fictional: not traceable + not in ref
+
+    def test_source_2_fallback(self, mini_corpus):
+        """If source_1 doesn't match, try source_2."""
+        rows = [
+            {
+                "name": "Thai Binh 1",
+                "source_1": "Some unknown document",
+                "source_2": "Report 32 Appendix 1 (NĐ Thái Bình I 2x300MW)",
+            }
+        ]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        assert annotated[0]["source_file_found"] == "True"
+        assert annotated[0]["source_content_found"] == "True"
+        assert annotated[0]["source_verified"] == "True"
+
+    def test_summary_rates(self, mini_corpus):
+        """Check aggregate rate calculations."""
+        rows = [
+            {
+                "name": "Nhon Trach 3",
+                "source_1": "PDP8 Annex II Table 1",
+                "source_2": "",
+            },
+            {
+                "name": "Missing Plant",
+                "source_1": "",
+                "source_2": "",
+            },
+        ]
+        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        assert summary["total_plants"] == 2
+        assert summary["source_rate"] == 0.5  # 1/2 has source
+        assert summary["grounding_rate"] == 0.5  # 1/2 file found

--- a/tests/test_verify_source_grounding.py
+++ b/tests/test_verify_source_grounding.py
@@ -123,14 +123,14 @@ class TestPlantNameInFile:
 
 @pytest.fixture()
 def mini_corpus(tmp_path):
-    """Create a minimal corpus directory with 2 files."""
+    """Create a minimal corpus directory with 2 files and a reference CSV."""
     corpus = tmp_path / "corpus"
     corpus.mkdir()
 
     (corpus / "PDP8_annex2_table1.md").write_text(
         "## Bảng 1: Danh mục các nhà máy nhiệt điện LNG\n"
         "| LNG Quảng Ninh | 1500 MW | 2021-2030 |\n"
-        "| LNG Thái Bình | 1500 MW | 2021-2030 |\n"
+        "| LNG Cà Ná | 1500 MW | 2021-2030 |\n"
         "| NMNĐ Nhơn Trạch 3 | 750 MW | 2021-2030 |\n",
         encoding="utf-8",
     )
@@ -142,10 +142,24 @@ def mini_corpus(tmp_path):
         encoding="utf-8",
     )
 
+    # Reference CSV with known plant names
+    ref = tmp_path / "reference.csv"
+    ref.write_text(
+        "name,capacity_mwe,status\n"
+        "Nhon Trach 3,750,planned\n"
+        "Thai Binh 1,600,operational\n"
+        "Duyen Hai 3,1244,operational\n",
+        encoding="utf-8",
+    )
+
     return corpus
 
 
 class TestVerifySourceGrounding:
+    def _ref(self, mini_corpus):
+        """Return the reference CSV path from the fixture's tmp_path."""
+        return mini_corpus.parent / "reference.csv"
+
     def test_verified_plant(self, mini_corpus):
         """Plant with correct citation and name in file -> all True."""
         rows = [
@@ -155,7 +169,9 @@ class TestVerifySourceGrounding:
                 "source_2": "",
             }
         ]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         assert annotated[0]["source_file_found"] == "True"
         assert annotated[0]["source_content_found"] == "True"
         assert annotated[0]["source_verified"] == "True"
@@ -170,7 +186,9 @@ class TestVerifySourceGrounding:
                 "source_2": "",
             }
         ]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         assert annotated[0]["source_file_found"] == "True"
         assert annotated[0]["source_content_found"] == "False"
         assert annotated[0]["source_verified"] == "False"
@@ -184,7 +202,9 @@ class TestVerifySourceGrounding:
                 "source_2": "",
             }
         ]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         assert annotated[0]["source_file_found"] == "False"
         assert annotated[0]["source_verified"] == "False"
         assert summary["source_rate"] == 0.0
@@ -192,40 +212,44 @@ class TestVerifySourceGrounding:
     def test_no_source_columns(self, mini_corpus):
         """Rows without source_1/source_2 keys -> graceful degradation."""
         rows = [{"name": "Thai Binh 1"}]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         assert annotated[0]["source_verified"] == "False"
         assert summary["source_rate"] == 0.0
 
     def test_2x2_counts(self, mini_corpus):
-        """Verify the 2x2 table counts are correct."""
+        """Verify the 2x2 table counts are correct against reference CSV."""
         rows = [
-            # Traceable AND in reference
+            # Traceable AND in reference CSV
             {
                 "name": "Nhon Trach 3",
                 "source_1": "PDP8 Annex II Table 1 (NMNĐ Nhơn Trạch 3 750MW)",
                 "source_2": "",
             },
-            # NOT traceable but in reference (file citation wrong)
+            # NOT traceable but in reference CSV (file citation wrong)
             {
                 "name": "Thai Binh 1",
                 "source_1": "World Bank Report 2025",
                 "source_2": "",
             },
-            # NOT traceable and NOT in reference
+            # NOT traceable and NOT in reference CSV
             {
                 "name": "Fictional Plant X",
                 "source_1": "",
                 "source_2": "",
             },
         ]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         c = summary["counts_2x2"]
         assert c["tt"] == 1  # Nhon Trach 3: traceable + in ref
         assert c["ft"] == 1  # Thai Binh 1: not traceable + in ref
         assert c["ff"] == 1  # Fictional: not traceable + not in ref
 
-    def test_source_2_fallback(self, mini_corpus):
-        """If source_1 doesn't match, try source_2."""
+    def test_source_2_fallback_no_file_match(self, mini_corpus):
+        """If source_1 doesn't match any file, try source_2."""
         rows = [
             {
                 "name": "Thai Binh 1",
@@ -233,10 +257,32 @@ class TestVerifySourceGrounding:
                 "source_2": "Report 32 Appendix 1 (NĐ Thái Bình I 2x300MW)",
             }
         ]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         assert annotated[0]["source_file_found"] == "True"
         assert annotated[0]["source_content_found"] == "True"
         assert annotated[0]["source_verified"] == "True"
+
+    def test_source_2_fallback_plant_missing_in_source_1(self, mini_corpus):
+        """source_1 matches a file but plant not in it; source_2 matches and contains plant."""
+        rows = [
+            {
+                "name": "Thai Binh 1",
+                # source_1 matches PDP8_annex2_table1.md but "Thai Binh 1" is NOT in that file
+                "source_1": "PDP8 Annex II Table 1 (something)",
+                # source_2 matches Report_32_annex1.md which DOES contain "Thái Bình I"
+                "source_2": "Report 32 Appendix 1 (NĐ Thái Bình I 2x300MW)",
+            }
+        ]
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
+        # With the fix, source_2 should be tried after source_1 fails content check
+        assert annotated[0]["source_file_found"] == "True"
+        assert annotated[0]["source_content_found"] == "True"
+        assert annotated[0]["source_verified"] == "True"
+        assert annotated[0]["matched_corpus_file"] == "Report_32_annex1.md"
 
     def test_summary_rates(self, mini_corpus):
         """Check aggregate rate calculations."""
@@ -252,7 +298,9 @@ class TestVerifySourceGrounding:
                 "source_2": "",
             },
         ]
-        annotated, summary = verify_source_grounding(rows, mini_corpus)
+        annotated, summary = verify_source_grounding(
+            rows, mini_corpus, reference_path=self._ref(mini_corpus)
+        )
         assert summary["total_plants"] == 2
         assert summary["source_rate"] == 0.5  # 1/2 has source
         assert summary["grounding_rate"] == 0.5  # 1/2 file found


### PR DESCRIPTION
## Summary
- `verify_source_grounding()`: fuzzy-match citations against corpus filenames, check plant name in matched file
- `tabulate_source_grounding.py`: generates LaTeX 2x2 table (traceable x in-reference)
- 19 tests covering exact/fuzzy matching, empty sources, 2x2 counts
- Replaces post-hoc LLM verification (ticket 0059: 0-10% agreement)

## Test plan
- [x] `uv run pytest tests/test_verify_source_grounding.py -v` — 19 pass
- [ ] Run tabulation on existing sourced extraction data
- [ ] Visual review of generated LaTeX table

🤖 Generated with [Claude Code](https://claude.com/claude-code)