### PR TITLE
Ticket 0105: regression test for plot_census underscore sanitation

### DIFF
--- a/tests/test_plot_census.py
+++ b/tests/test_plot_census.py
@@ -35,6 +35,19 @@ def test_build_census_rows():
     assert rows[2]["local"] == 1
 
 
+def test_slug_underscores_replaced_with_dashes():
+    """Underscore in model slug is sanitised to dash (pgfplots safety)."""
+    metrics_with_underscore = [
+        {"label": "census/gpt-5.4_cross-run1", "f1": 0.80},
+        {"label": "census/gpt-5.4_cross-run2", "f1": 0.78},
+        {"label": "census/gpt-5.4_cross-run3", "f1": 0.82},
+    ]
+    rows = build_census_rows(metrics_with_underscore)
+    assert len(rows) == 1
+    assert "_" not in rows[0]["model"], "underscores must be replaced with dashes"
+    assert rows[0]["model"] == "gpt-5.4-cross"
+
+
 def test_output_is_sorted_descending():
     """First row has highest F1."""
     rows = build_census_rows(SAMPLE_METRICS)

--- a/tickets/0105-plot-census-underscore-test.erg
+++ b/tickets/0105-plot-census-underscore-test.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Regression test for plot_census slug underscore sanitation
-Status: open
+Status: closed
 Created: 2026-04-17
 Author: claude
 
 --- log ---
 2026-04-17T12:00Z claude created — surfaced by self-review of commit 55a8548. The slug replace("_", "-") fix in plot_census.py has no test covering its input. Add one so a future revert cannot silently reintroduce the pgfplots "Missing $ inserted" compile failure.
+2026-04-17T14:00Z claude status closed — test added, passes green, confirmed regression on revert
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- Adds `test_slug_underscores_replaced_with_dashes()` to `tests/test_plot_census.py`
- Guards the `.replace('_', '-')` fix in `plot_census.py` from silent revert (would break pgfplots LaTeX builds)

## Test plan
- [x] New test passes
- [x] Reverting the `.replace()` line in `plot_census.py` causes the test to fail (verified)
- [x] Restored fix, 4/4 green

Closes ticket 0105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)