### PR TITLE
Ticket 0115: wire fusion into worker/sweep arch

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -828,7 +828,8 @@ output = "outputs/ablation/rag/p2_no_sourcing"
 # Alibaba supports seed on deepseek-v3.2; DeepSeek native does not.
 
 [sweeps.fusion]
-mode = "compare"
+# fusion_mode: pipeline scope — incremental | global | compare (all cells)
+fusion_mode = "compare"
 format = "both"
 model = "deepseek/deepseek-v3.2"
 corpus = "data/rag_corpus"
@@ -838,7 +839,7 @@ seed = 42
 provider = "Alibaba"
 
 [sweeps.fusion_dev]
-mode = "compare"
+fusion_mode = "compare"
 format = "md"
 model = "openai/gpt-4o-mini"
 corpus = "data/rag_corpus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = ["pytest>=8.0", "ruff>=0.4", "pylint", "mypy", "types-PyYAML"]
 
 [project.scripts]
 aedist = "aedist.evaluate:main"
+query-fusion = "aedist.query_fusion:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/aedist/prototype_v1_fusion.py
+++ b/src/aedist/prototype_v1_fusion.py
@@ -637,7 +637,17 @@ def _save_global_csv(plants_raw: list[dict], path: Path) -> None:
 
 
 _SWEEP_TOML_KEYS = frozenset(
-    {"model", "seed", "provider", "corpus", "reference", "output", "mode", "format", "fragments"}
+    {
+        "model",
+        "seed",
+        "provider",
+        "corpus",
+        "reference",
+        "output",
+        "fusion_mode",
+        "format",
+        "fragments",
+    }
 )
 
 
@@ -657,7 +667,13 @@ def main(argv: list[str] | None = None) -> None:
         metavar="NAME",
         help="Load parameters from [sweeps.NAME] in experiments.toml. CLI flags override.",
     )
-    p.add_argument("--mode", choices=["incremental", "global", "compare"], default="compare")
+    p.add_argument(
+        "--fusion-mode",
+        dest="fusion_mode",
+        choices=["incremental", "global", "compare"],
+        default="compare",
+        help="Pipeline scope: run incremental only, global only, or compare all cells",
+    )
     p.add_argument(
         "--format",
         choices=["json", "md", "both"],
@@ -747,7 +763,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     fmt = args.format
-    if fmt == "both" and args.mode != "compare":
+    if fmt == "both" and args.fusion_mode != "compare":
         p.error("--format both is only valid with --mode compare")
 
     sequence = _build_sequence(args)
@@ -769,7 +785,7 @@ def main(argv: list[str] | None = None) -> None:
     fuse_prompt = _load_prompt(args.fuse_prompt, _FUSE_PROMPT)
 
     print(
-        f"\nFusion prototype — mode={args.mode}, format={fmt}, "
+        f"\nFusion prototype — mode={args.fusion_mode}, format={fmt}, "
         f"fragments={len(sequence)}, model={args.model}"
         + (f", seed={args.seed}" if args.seed is not None else "")
         + (f", provider={args.provider}" if args.provider else "")
@@ -781,10 +797,10 @@ def main(argv: list[str] | None = None) -> None:
     # -----------------------------------------------------------------------
     cells: dict[str, dict] = {}  # key = "global×md" etc.
 
-    run_global_md_cell = fmt in ("md", "both") and args.mode in ("global", "compare")
-    run_global_json_cell = fmt in ("json", "both") and args.mode in ("global", "compare")
-    run_inc_md_cell = fmt in ("md", "both") and args.mode in ("incremental", "compare")
-    run_inc_json_cell = fmt in ("json", "both") and args.mode in ("incremental", "compare")
+    run_global_md_cell = fmt in ("md", "both") and args.fusion_mode in ("global", "compare")
+    run_global_json_cell = fmt in ("json", "both") and args.fusion_mode in ("global", "compare")
+    run_inc_md_cell = fmt in ("md", "both") and args.fusion_mode in ("incremental", "compare")
+    run_inc_json_cell = fmt in ("json", "both") and args.fusion_mode in ("incremental", "compare")
 
     ref_plants = load_plants_csv(args.reference) if args.reference else []
 
@@ -800,7 +816,7 @@ def main(argv: list[str] | None = None) -> None:
             f"  plants={scores['system_count']}  coverage={scores['coverage']:.1%}  "
             f"precision={scores['precision']:.1%}  F1={scores['f1']:.1%}"
         )
-        if args.mode == "global":
+        if args.fusion_mode == "global":
             out = args.output / "global_md"
             out.mkdir(parents=True, exist_ok=True)
             _save_plants_csv(plants, out / "master.csv")
@@ -818,7 +834,7 @@ def main(argv: list[str] | None = None) -> None:
             f"  plants={scores['system_count']}  coverage={scores['coverage']:.1%}  "
             f"precision={scores['precision']:.1%}  F1={scores['f1']:.1%}"
         )
-        if args.mode == "global":
+        if args.fusion_mode == "global":
             _save_global_csv(plants_raw, args.output / "global_json" / "master.csv")
 
     if run_inc_md_cell:
@@ -833,7 +849,7 @@ def main(argv: list[str] | None = None) -> None:
             f"  plants={scores['system_count']}  coverage={scores['coverage']:.1%}  "
             f"precision={scores['precision']:.1%}  F1={scores['f1']:.1%}"
         )
-        if args.mode == "incremental":
+        if args.fusion_mode == "incremental":
             out = args.output / "incremental_md"
             out.mkdir(parents=True, exist_ok=True)
             _save_plants_csv(plants, out / "master.csv")
@@ -851,12 +867,12 @@ def main(argv: list[str] | None = None) -> None:
             f"  plants={scores['system_count']}  coverage={scores['coverage']:.1%}  "
             f"precision={scores['precision']:.1%}  F1={scores['f1']:.1%}"
         )
-        if args.mode == "incremental":
+        if args.fusion_mode == "incremental":
             out = args.output / "incremental_json"
             save_master_csv(master, out / "master.csv")
             save_provenance(master, out / "master_provenance.json")
 
-    if args.mode == "compare" and len(cells) >= 2:
+    if args.fusion_mode == "compare" and len(cells) >= 2:
         print("\n" + "=" * 70)
         print("COMPARISON")
         print("=" * 70)

--- a/src/aedist/query_fusion.py
+++ b/src/aedist/query_fusion.py
@@ -1,0 +1,312 @@
+"""Fusion pipeline entry point — wraps prototype_v1_fusion for the worker/sweep arch.
+
+Fusion is different from the model-loop methods (RAG, decomposed, etc.):
+- It takes a *single* model as a string (not a models.yaml file).
+- It does not iterate over a model registry; each sweep run is one cell comparison.
+- Outputs go to ``derived/fusion_proto/`` (not ``outputs/``).
+- Results are not in measurements.jsonl format; they are saved as JSON in the
+  output directory by the prototype's own serialisation helpers.
+
+Accordingly, ``run_fusion`` skips the ``load_models`` + per-model loop and calls
+the prototype pipeline functions directly.
+
+CLI usage (standalone sweep run)::
+
+    uv run query-fusion --sweep fusion_dev
+
+Worker dispatch: ``worker.py`` calls ``_execute_fusion(job)`` which delegates here.
+"""
+
+import argparse
+import json
+import logging
+import time
+from pathlib import Path
+
+from .evaluate import load_plants_csv
+from .harness import load_experiments, make_client
+from .prototype_v1_fusion import (
+    _EXTRACT_PROMPT,
+    _FUSE_PROMPT,
+    _GLOBAL_MD_PROMPT,
+    _GLOBAL_PROMPT,
+    DEFAULT_SEQUENCE,
+    _save_plants_csv,
+    dicts_to_plants,
+    master_to_plants,
+    run_global,
+    run_global_md,
+    run_incremental,
+    run_incremental_direct,
+    save_master_csv,
+    save_provenance,
+    score_against_reference,
+)
+
+log = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+_DEFAULT_REF = _PROJECT_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"
+_DEFAULT_CORPUS = _PROJECT_ROOT / "data" / "rag_corpus"
+
+# Keys in experiments.toml [sweeps.fusion*] that query_fusion.py reads.
+_FUSION_SWEEP_KEYS = frozenset(
+    {
+        "model",
+        "seed",
+        "provider",
+        "corpus",
+        "reference",
+        "output",
+        "fusion_mode",
+        "format",
+        "fragments",
+    }
+)
+
+
+def run_fusion(
+    model: str,
+    corpus_dir: Path,
+    output_dir: Path,
+    fusion_mode: str = "compare",
+    fmt: str = "md",
+    fragments: int | None = None,
+    seed: int | None = None,
+    provider: str | None = None,
+    reference: Path | None = None,
+) -> dict:
+    """Run fusion pipeline for one model and return a summary dict.
+
+    Parameters
+    ----------
+    model:
+        OpenRouter model ID, e.g. ``openai/gpt-4o-mini``.
+    corpus_dir:
+        Path to the rag_corpus directory (must contain .md fragment files).
+    output_dir:
+        Directory where per-cell CSV outputs are written.
+    fusion_mode:
+        ``"incremental"``, ``"global"``, or ``"compare"`` (all cells).
+    fmt:
+        Intermediate representation: ``"md"``, ``"json"``, or ``"both"``
+        (``"both"`` requires ``fusion_mode == "compare"``).
+    fragments:
+        Limit to first N fragments from the default sequence.
+    seed:
+        RNG seed forwarded to every LLM call (best-effort).
+    provider:
+        Pin OpenRouter provider, e.g. ``"Alibaba"`` for DeepSeek.
+    reference:
+        Path to reference CSV for F1 scoring (defaults to vietnam_thermal_v1.csv).
+
+    Returns
+    -------
+    dict
+        Summary with keys: ``cells``, ``model``, ``fusion_mode``, ``format``,
+        ``n_fragments``, ``wall_seconds``.
+    """
+    if reference is None:
+        reference = _DEFAULT_REF
+
+    sequence = DEFAULT_SEQUENCE
+    if fragments is not None:
+        sequence = sequence[:fragments]
+
+    client = make_client()
+
+    api_kw: dict = {}
+    if seed is not None:
+        api_kw["seed"] = seed
+    if provider:
+        api_kw["extra_body"] = {"provider": {"order": [provider], "allow_fallbacks": False}}
+
+    ref_plants = load_plants_csv(reference) if reference.exists() else []
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cells: dict[str, dict] = {}
+    t0 = time.monotonic()
+
+    run_global_md_cell = fmt in ("md", "both") and fusion_mode in ("global", "compare")
+    run_global_json_cell = fmt in ("json", "both") and fusion_mode in ("global", "compare")
+    run_inc_md_cell = fmt in ("md", "both") and fusion_mode in ("incremental", "compare")
+    run_inc_json_cell = fmt in ("json", "both") and fusion_mode in ("incremental", "compare")
+
+    if run_global_md_cell:
+        log.info("[global×md]")
+        plants = run_global_md(corpus_dir, sequence, client, model, _GLOBAL_MD_PROMPT, **api_kw)
+        scores = score_against_reference(plants, ref_plants)
+        cells["global×md"] = scores
+        log.info("  plants=%d  F1=%.1f%%", scores["system_count"], scores["f1"] * 100)
+        if fusion_mode == "global":
+            out = output_dir / "global_md"
+            out.mkdir(parents=True, exist_ok=True)
+            _save_plants_csv(plants, out / "master.csv")
+
+    if run_global_json_cell:
+        log.info("[global×json]")
+        plants_raw = run_global(corpus_dir, sequence, client, model, _GLOBAL_PROMPT, **api_kw)
+        plants = dicts_to_plants(plants_raw)
+        scores = score_against_reference(plants, ref_plants)
+        cells["global×json"] = scores
+        log.info("  plants=%d  F1=%.1f%%", scores["system_count"], scores["f1"] * 100)
+        if fusion_mode == "global":
+            from .prototype_v1_fusion import _save_global_csv
+
+            _save_global_csv(plants_raw, output_dir / "global_json" / "master.csv")
+
+    if run_inc_md_cell:
+        log.info("[incremental×md]")
+        plants, diffs = run_incremental_direct(
+            corpus_dir, sequence, client, model, _FUSE_PROMPT, **api_kw
+        )
+        scores = score_against_reference(plants, ref_plants)
+        cells["incremental×md"] = scores
+        log.info("  plants=%d  F1=%.1f%%", scores["system_count"], scores["f1"] * 100)
+        if fusion_mode == "incremental":
+            out = output_dir / "incremental_md"
+            out.mkdir(parents=True, exist_ok=True)
+            _save_plants_csv(plants, out / "master.csv")
+
+    if run_inc_json_cell:
+        log.info("[incremental×json]")
+        master, diffs = run_incremental(
+            corpus_dir, sequence, client, model, _EXTRACT_PROMPT, **api_kw
+        )
+        plants = master_to_plants(master)
+        scores = score_against_reference(plants, ref_plants)
+        cells["incremental×json"] = scores
+        log.info("  plants=%d  F1=%.1f%%", scores["system_count"], scores["f1"] * 100)
+        if fusion_mode == "incremental":
+            out = output_dir / "incremental_json"
+            save_master_csv(master, out / "master.csv")
+            save_provenance(master, out / "master_provenance.json")
+
+    wall_seconds = time.monotonic() - t0
+
+    # Save summary JSON
+    summary = {
+        "model": model,
+        "fusion_mode": fusion_mode,
+        "format": fmt,
+        "n_fragments": len(sequence),
+        "cells": cells,
+        "wall_seconds": round(wall_seconds, 2),
+    }
+    summary_path = output_dir / "fusion_summary.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+    log.info("Saved fusion summary: %s", summary_path)
+
+    return summary
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point for standalone fusion sweep runs."""
+    p = argparse.ArgumentParser(
+        description="Run fusion pipeline for one sweep configuration.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--sweep",
+        required=True,
+        metavar="NAME",
+        help="Load parameters from [sweeps.NAME] in experiments.toml",
+    )
+    p.add_argument(
+        "--experiments",
+        default="experiments/experiments.toml",
+        metavar="FILE",
+        help="Path to experiments.toml",
+    )
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Override model from sweep config",
+    )
+    p.add_argument(
+        "--fusion-mode",
+        dest="fusion_mode",
+        choices=["incremental", "global", "compare"],
+        default=None,
+        help="Override fusion_mode from sweep config",
+    )
+    p.add_argument(
+        "--format",
+        choices=["json", "md", "both"],
+        default=None,
+        help="Override format from sweep config",
+    )
+    p.add_argument("--fragments", type=int, default=None, help="Limit to first N fragments")
+    p.add_argument("--output", default=None, help="Override output directory")
+    p.add_argument("--verbose", action="store_true")
+
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    exps = load_experiments(args.experiments)
+    sweep_cfg = exps.get("sweeps", {}).get(args.sweep)
+    if sweep_cfg is None:
+        p.error(f"Sweep '{args.sweep}' not found in {args.experiments}")
+
+    model = args.model or sweep_cfg.get("model", "openai/gpt-4o-mini")
+    fusion_mode = args.fusion_mode or sweep_cfg.get("fusion_mode", "compare")
+    fmt = args.format or sweep_cfg.get("format", "md")
+    fragments = args.fragments or sweep_cfg.get("fragments")
+    output_dir = Path(args.output or sweep_cfg.get("output", "derived/fusion_proto"))
+    corpus_dir = Path(sweep_cfg.get("corpus", str(_DEFAULT_CORPUS)))
+    reference = Path(sweep_cfg.get("reference", str(_DEFAULT_REF)))
+    seed = sweep_cfg.get("seed")
+    provider = sweep_cfg.get("provider")
+
+    if fmt == "both" and fusion_mode != "compare":
+        p.error("--format both is only valid with --fusion-mode compare")
+
+    log.info(
+        "Fusion sweep=%s model=%s fusion_mode=%s format=%s fragments=%s",
+        args.sweep,
+        model,
+        fusion_mode,
+        fmt,
+        fragments,
+    )
+
+    summary = run_fusion(
+        model=model,
+        corpus_dir=corpus_dir,
+        output_dir=output_dir,
+        fusion_mode=fusion_mode,
+        fmt=fmt,
+        fragments=fragments,
+        seed=seed,
+        provider=provider,
+        reference=reference,
+    )
+
+    if len(summary["cells"]) >= 2:
+        print("\nCOMPARISON")
+        print("=" * 60)
+        hdr = f"  {'Cell':<22} {'n':>5} {'coverage':>9} {'precision':>10} {'F1':>7}"
+        print(hdr)
+        for cell_name, sc in summary["cells"].items():
+            print(
+                f"  {cell_name:<22} {sc['system_count']:>5} "
+                f"{sc['coverage']:>9.1%} {sc['precision']:>10.1%} {sc['f1']:>7.1%}"
+            )
+    else:
+        for cell_name, sc in summary["cells"].items():
+            print(
+                f"{cell_name}: plants={sc['system_count']}  "
+                f"F1={sc['f1']:.1%}  coverage={sc['coverage']:.1%}"
+            )
+
+    log.info("Done. Wall time: %.1fs", summary["wall_seconds"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -125,6 +125,7 @@ class Method(StrEnum):
     SOURCED = "sourced"
     FRONTIER = "frontier"
     VERIFICATION = "verification"
+    FUSION = "fusion"
 
 
 class MethodParams(BaseModel):
@@ -289,7 +290,13 @@ class JobSpec(BaseModel):
 
     @model_validator(mode="after")
     def _require_prompt_or_modules(self) -> JobSpec:
-        """Ensure at least one of prompt (non-empty) or prompt_modules is set."""
+        """Ensure at least one of prompt (non-empty) or prompt_modules is set.
+
+        Fusion mode is exempt: it reads prompts directly from
+        experiments/prompts/fusion_*.txt and never needs a top-level prompt.
+        """
+        if self.mode == Method.FUSION:
+            return self
         if not self.prompt and self.prompt_modules is None:
             raise ValueError("Either 'prompt' or 'prompt_modules' must be provided.")
         return self

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -28,6 +28,7 @@ from .harness import (
     should_skip,
 )
 from .query_decomposed import query_decomposed
+from .query_fusion import run_fusion
 from .query_multiturn import run_conversation
 from .query_rag import load_corpus
 from .query_web import run_web_searches
@@ -207,6 +208,8 @@ class Worker:
                 job,
                 api_kwargs=api_kwargs,
             )
+        elif mode == Method.FUSION:
+            return self._execute_fusion(job)
         elif mode == Method.VERIFICATION:
             raise NotImplementedError(
                 "verification mode requires external orchestration "
@@ -493,6 +496,53 @@ class Worker:
             "tokens_in": decomposed.get("total_usage", {}).get("prompt_tokens", 0),
             "tokens_out": decomposed.get("total_usage", {}).get("completion_tokens", 0),
             "result_file": str(filepath),
+        }
+
+    @staticmethod
+    def _execute_fusion(job: JobSpec) -> dict:
+        """Execute the fusion pipeline for one sweep configuration.
+
+        Fusion is dispatch-different from other modes: it takes a single model
+        string (not a models.yaml file) and does not iterate over a model
+        registry.  Results are written to derived/fusion_proto/ by
+        run_fusion(), not to the standard outputs/ tree.
+        """
+        corpus_dir = Path(job.corpus) if job.corpus else None
+        if not corpus_dir or not corpus_dir.exists():
+            raise ValueError(f"Fusion mode requires a valid corpus directory, got {job.corpus!r}")
+
+        model = job.model_filter or "openai/gpt-4o-mini"
+        output_dir = Path(job.output_dir)
+
+        # Fusion-specific params live in job.extra (populated from sweep config
+        # fields that JobSpec doesn't have dedicated slots for).
+        extra = job.method_params.extra or {} if hasattr(job, "method_params") else {}
+        fusion_mode = extra.get("fusion_mode", "compare")
+        fmt = extra.get("format", "md")
+        fragments = extra.get("fragments")
+        seed = extra.get("seed")
+        provider = extra.get("provider")
+
+        log.info(
+            "Executing fusion sweep model=%s fusion_mode=%s format=%s", model, fusion_mode, fmt
+        )
+        summary = run_fusion(
+            model=model,
+            corpus_dir=corpus_dir,
+            output_dir=output_dir,
+            fusion_mode=fusion_mode,
+            fmt=fmt,
+            fragments=fragments,
+            seed=seed,
+            provider=provider,
+        )
+
+        return {
+            "wall_seconds": summary.get("wall_seconds", 0),
+            "cost_usd": 0,  # fusion uses make_client() directly; cost not tracked here
+            "tokens_in": 0,
+            "tokens_out": 0,
+            "result_file": str(output_dir / "fusion_summary.json"),
         }
 
     # -- completion ------------------------------------------------------------

--- a/tests/test_fusion_prototype.py
+++ b/tests/test_fusion_prototype.py
@@ -386,8 +386,8 @@ def test_score_against_reference_empty_system(tmp_path):
 
 
 def test_main_format_both_requires_compare(tmp_path):
-    """--format both is only valid with --mode compare."""
+    """--format both is only valid with --fusion-mode compare."""
     from aedist.prototype_v1_fusion import main
 
     with pytest.raises(SystemExit):
-        main(["--mode", "incremental", "--format", "both"])
+        main(["--fusion-mode", "incremental", "--format", "both"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -186,6 +186,27 @@ def test_standard_sweep_fields(experiments):
         )
 
 
+def test_fusion_sweep_fields(experiments):
+    """Fusion sweeps have their own required schema (different from standard sweeps)."""
+    fusion_required = {"fusion_mode", "format", "model", "corpus", "reference", "output"}
+    valid_fusion_modes = {"incremental", "global", "compare"}
+    valid_formats = {"json", "md", "both"}
+    for name, sweep in experiments["sweeps"].items():
+        if not name.startswith("fusion"):
+            continue
+        missing = fusion_required - set(sweep.keys())
+        assert not missing, f"sweeps.{name} missing fusion fields: {missing}"
+        assert sweep["fusion_mode"] in valid_fusion_modes, (
+            f"sweeps.{name}: invalid fusion_mode '{sweep['fusion_mode']}'"
+        )
+        assert sweep["format"] in valid_formats, (
+            f"sweeps.{name}: invalid format '{sweep['format']}'"
+        )
+        assert isinstance(sweep["model"], str) and sweep["model"], (
+            f"sweeps.{name}: model must be a non-empty string"
+        )
+
+
 def test_verification_structure(experiments):
     """verification has its special structure (base_configs, modes)."""
     s4 = experiments["sweeps"]["verification"]

--- a/tickets/0115-fusion-integrate-worker-arch.erg
+++ b/tickets/0115-fusion-integrate-worker-arch.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Integrate fusion prototype into experiments framework and worker arch
-Status: doing
+Status: closed
 Created: 2026-04-22
 Author: claude
 Blocked-by: gh#278
 
 --- log ---
+2026-04-22T15:10Z claude status closed — all exit criteria met; 1120 tests pass
 2026-04-22T14:55Z claude claimed
 2026-04-22T14:55Z claude status doing
 2026-04-22T13:00Z claude note renumbered 0113→0115 to resolve ID collision

--- a/tickets/0115-fusion-integrate-worker-arch.erg
+++ b/tickets/0115-fusion-integrate-worker-arch.erg
@@ -1,11 +1,13 @@
 %erg v1
 Title: Integrate fusion prototype into experiments framework and worker arch
-Status: open
+Status: doing
 Created: 2026-04-22
 Author: claude
 Blocked-by: gh#278
 
 --- log ---
+2026-04-22T14:55Z claude claimed
+2026-04-22T14:55Z claude status doing
 2026-04-22T13:00Z claude note renumbered 0113→0115 to resolve ID collision
 2026-04-22T00:00Z claude created — gap identified during PR #278 review
 


### PR DESCRIPTION
## Summary

- Add `Method.FUSION` to the `Method` enum in `schema.py`; exempt the `JobSpec` prompt validator for fusion (fusion reads its own prompts from `experiments/prompts/fusion_*.txt`)
- Create `src/aedist/query_fusion.py` — standalone CLI (`query-fusion --sweep fusion_dev`) and `run_fusion()` callable from worker dispatch; wraps prototype pipeline functions, saves summary JSON to output dir
- Wire `Method.FUSION` into `worker.py` dispatch via `_execute_fusion(job)` static method
- Rename `mode` → `fusion_mode` in `[sweeps.fusion*]` entries of `experiments.toml` and in `prototype_v1_fusion.py` argparse to avoid collision with `JobSpec.mode` (the dispatch enum)
- Register `query-fusion` in `pyproject.toml` `[project.scripts]`
- Update `tests/test_fusion_prototype.py`: fix `--mode` → `--fusion-mode` CLI reference
- Add `test_fusion_sweep_fields()` to `tests/test_models.py`; existing `fusion_sweeps` exemption in `test_standard_sweep_fields` is kept and intentional

## Design notes

Fusion output stays in `derived/fusion_proto/` (not `measurements.jsonl`): fusion is a multi-cell comparison, not a per-model row. Cost tracking is not wired in the worker dispatch because `run_fusion()` calls `make_client()` directly.

## Test plan

- [x] `uv run make check-fast` — 1120 passed, 2 skipped, 1 xfailed
- [x] `test_sweep_count` passes (fusion/fusion_dev still in core set)
- [x] `test_standard_sweep_fields` passes (fusion sweeps still exempted)
- [x] `test_fusion_sweep_fields` new test validates fusion-specific schema
- [ ] `uv run query-fusion --sweep fusion_dev` (requires live API — deferred to post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)