### PR TITLE
Namespace: rename query_*.py to call-pattern axis (0124)

### DIFF
--- a/scripts/audit_source_urls.py
+++ b/scripts/audit_source_urls.py
@@ -186,7 +186,7 @@ def verify_content_tavily(
     Returns dict with query, n_results, entity_found, top_result_url,
     top_result_snippet.
     """
-    from aedist.query_web import tavily_search
+    from aedist.query_livesearch import tavily_search
 
     key_terms = _extract_citation_key(citation_text)
     query = f"{plant_name} {key_terms}"
@@ -253,7 +253,7 @@ def check_fabrication(
             "search_evidence": None,
         }
 
-    from aedist.query_web import tavily_search
+    from aedist.query_livesearch import tavily_search
 
     # Disambiguate short identifiers (e.g. PDP7 -> DEC minicomputer)
     search_term = identifier

--- a/src/aedist/README.md
+++ b/src/aedist/README.md
@@ -15,9 +15,9 @@ utilities and save JSON results to `experiments/outputs/`.
 | `query.py` | single | Direct structured query via OpenAI-compatible API |
 | `query_rag.py` | rag | RAG: corpus injected as system context |
 | `query_multiturn.py` | multiturn | Initial prompt + follow-up questions |
-| `query_web.py` | web | Web-search augmented (Tavily API) |
-| `query_decomposed.py` | decomposed | Split by fuel type, merge results |
-| `query_frontier.py` | frontier | Deep-research prompt for reasoning models |
+| `query_livesearch.py` | web | Web-search augmented (Tavily API) |
+| `query_per_fuel.py` | decomposed | Split by fuel type, merge results |
+| `query_direct.py` | frontier | Deep-research prompt for reasoning models |
 | `query_verification.py` | verification | 5 provenance-checking modes |
 
 ### Core pipeline

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -1,6 +1,6 @@
 """Shared utilities for the AEDIST query harness.
 
-All query scripts (query, query_frontier, query_multiturn, query_rag, query_web) import
+All query scripts (query, query_frontier, query_multiturn, query_rag, query_livesearch) import
 from here to avoid duplicating client setup, budget tracking, model loading,
 save/skip logic, and cost computation.
 """

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -1,6 +1,6 @@
 """Shared utilities for the AEDIST query harness.
 
-All query scripts (query, query_frontier, query_multiturn, query_rag, query_livesearch) import
+All query scripts (query, query_direct, query_multiturn, query_rag, query_livesearch) import
 from here to avoid duplicating client setup, budget tracking, model loading,
 save/skip logic, and cost computation.
 """

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -176,7 +176,7 @@ def main():
                 continue
 
             log.info(
-                "Querying %s run %d/%d (frontier, max_tokens=%d, temp=%.1f)...",
+                "Querying %s run %d/%d (direct, max_tokens=%d, temp=%.1f)...",
                 label,
                 run,
                 args.repeat,
@@ -239,7 +239,7 @@ def main():
             except openai.APIError as e:
                 log.error("Error querying %s run %d: %s", label, run, e)
 
-    log.info("Frontier benchmark complete. Total cost: $%.4f", budget.total_cost)
+    log.info("Direct benchmark complete. Total cost: $%.4f", budget.total_cost)
 
 
 if __name__ == "__main__":

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -1,18 +1,18 @@
-"""Frontier deep-research benchmark: comprehensive Vietnam thermal sector report.
+"""Single direct LLM call, no retrieval context: comprehensive Vietnam thermal sector report.
 
 Sends a maximally-optimized comprehensive prompt to frontier reasoning models
 and captures full responses for qualitative evaluation.  Uses high max_tokens
 and temperature=0 for deterministic, exhaustive output.
 
 Usage:
-    uv run python -m aedist.query_frontier \
+    uv run python -m aedist.query_direct \
         --prompt prompts/prompt_complete.txt \
         --models models_frontier.yaml \
         --output outputs/frontier/ \
         --budget-usd 20
 
     # Single model:
-    uv run python -m aedist.query_frontier \
+    uv run python -m aedist.query_direct \
         --prompt prompts/prompt_complete.txt \
         --models models_frontier.yaml \
         --output outputs/frontier/ \

--- a/src/aedist/query_livesearch.py
+++ b/src/aedist/query_livesearch.py
@@ -1,10 +1,10 @@
-"""Web-augmented queries against LLMs.
+"""Live Tavily web search injection as context: web-augmented queries against LLMs.
 
 Runs predefined web searches via Tavily API, injects results as context,
 then sends the prompt to LLMs. Requires TAVILY_API_KEY environment variable.
 
 Usage:
-    python -m aedist.query_web \
+    python -m aedist.query_livesearch \
         --prompt prompts/prompt_extract.txt \
         --models models.yaml \
         --output outputs/web/ \

--- a/src/aedist/query_per_fuel.py
+++ b/src/aedist/query_per_fuel.py
@@ -1,4 +1,4 @@
-"""Task decomposition queries: split by fuel type, merge results.
+"""3 sub-calls split by fuel type, results merged: task decomposition query pipeline.
 
 Instead of asking for all thermal power plants in one query (which causes
 truncation), split into 3 sub-queries by fuel type:
@@ -10,7 +10,7 @@ Each sub-query gets the same RAG corpus. The 3 CSV responses are extracted
 and merged into a single consolidated CSV.
 
 Usage:
-    python -m aedist.query_decomposed \
+    python -m aedist.query_per_fuel \
         --prompt prompts/prompt_extract.txt \
         --corpus data/rag_corpus/ \
         --models models_selected.yaml \

--- a/src/aedist/verify.py
+++ b/src/aedist/verify.py
@@ -542,7 +542,7 @@ def verify_web(
     Returns (annotated_rows, summary). Caches search results to avoid
     redundant API calls across runs.
     """
-    from .query_web import tavily_search
+    from .query_livesearch import tavily_search
 
     cache: dict[str, list[dict]] = {}
     if cache_path:

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -27,11 +27,11 @@ from .harness import (
     save_json,
     should_skip,
 )
-from .query_decomposed import query_decomposed
 from .query_fusion import run_fusion
+from .query_livesearch import run_web_searches
 from .query_multiturn import run_conversation
+from .query_per_fuel import query_decomposed
 from .query_rag import load_corpus
-from .query_web import run_web_searches
 from .schema import (
     JobSpec,
     LeaseInfo,

--- a/tests/test_audit_source_urls.py
+++ b/tests/test_audit_source_urls.py
@@ -304,7 +304,7 @@ class TestSearchQueryDisambiguation:
             },
         ]
 
-        with patch("aedist.query_web.tavily_search", return_value=dec_pdp7_results):
+        with patch("aedist.query_livesearch.tavily_search", return_value=dec_pdp7_results):
             result = check_fabrication("PDP7A capacity list", tavily_key="fake-key")
 
         assert result["is_primary_pattern"] is True

--- a/tests/test_query_direct.py
+++ b/tests/test_query_direct.py
@@ -1,4 +1,4 @@
-"""Tests for aedist.query_frontier — reasoning flag, sweep derivation, budget, dry-run."""
+"""Tests for aedist.query_direct — reasoning flag, sweep derivation, budget, dry-run."""
 
 import json
 import sys
@@ -72,7 +72,7 @@ def test_basic_produces_output(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -81,7 +81,7 @@ def test_basic_produces_output(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -118,7 +118,7 @@ def test_reasoning_model_omits_temperature(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -127,7 +127,7 @@ def test_reasoning_model_omits_temperature(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -152,7 +152,7 @@ def test_non_reasoning_sends_temperature(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -161,7 +161,7 @@ def test_non_reasoning_sends_temperature(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -187,7 +187,7 @@ def test_budget_guard_stops(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -200,7 +200,7 @@ def test_budget_guard_stops(mock_openai_cls, tmp_path):
                 "0.0008",
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -224,7 +224,7 @@ def test_dry_run_no_api_calls(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -234,7 +234,7 @@ def test_dry_run_no_api_calls(mock_openai_cls, tmp_path):
                 "--dry-run",
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -265,7 +265,7 @@ def test_prompt_modules_assembles_prompt(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt-modules",
                 "persona",
                 "overview",
@@ -277,7 +277,7 @@ def test_prompt_modules_assembles_prompt(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -312,7 +312,7 @@ def test_prompt_modules_empty_list_uses_base_only(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt-modules",
                 "--modules-dir",
                 str(modules_dir),
@@ -322,7 +322,7 @@ def test_prompt_modules_empty_list_uses_base_only(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -343,7 +343,7 @@ def test_prompt_and_prompt_modules_mutually_exclusive(mock_openai_cls, tmp_path)
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--prompt-modules",
@@ -357,7 +357,7 @@ def test_prompt_and_prompt_modules_mutually_exclusive(mock_openai_cls, tmp_path)
             import pytest
 
             with pytest.raises(SystemExit):
-                from aedist.query_frontier import main
+                from aedist.query_direct import main
 
                 main()
 
@@ -381,7 +381,7 @@ def test_prompt_modules_dry_run(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt-modules",
                 "persona",
                 "--modules-dir",
@@ -393,7 +393,7 @@ def test_prompt_modules_dry_run(mock_openai_cls, tmp_path):
                 "--dry-run",
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -420,7 +420,7 @@ def test_prompt_modules_sweep_name(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt-modules",
                 "persona",
                 "--modules-dir",
@@ -431,7 +431,7 @@ def test_prompt_modules_sweep_name(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -457,7 +457,7 @@ def test_sweep_derived_from_prompt_filename(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -466,7 +466,7 @@ def test_sweep_derived_from_prompt_filename(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -476,7 +476,7 @@ def test_sweep_derived_from_prompt_filename(mock_openai_cls, tmp_path):
     assert record["sweep"] == "scenarios"
 
 
-@patch("aedist.query_frontier.build_api_kwargs", _build_api_kwargs_web_enabled)
+@patch("aedist.query_direct.build_api_kwargs", _build_api_kwargs_web_enabled)
 @patch("aedist.harness.OpenAI")
 def test_web_search_model_gets_plugin(mock_openai_cls, tmp_path):
     """Models with web_search: true get OpenRouter web plugin in extra_body."""
@@ -493,7 +493,7 @@ def test_web_search_model_gets_plugin(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -502,7 +502,7 @@ def test_web_search_model_gets_plugin(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -511,7 +511,7 @@ def test_web_search_model_gets_plugin(mock_openai_cls, tmp_path):
     assert call_kwargs["temperature"] == 0.0
 
 
-@patch("aedist.query_frontier.build_api_kwargs", _build_api_kwargs_web_enabled)
+@patch("aedist.query_direct.build_api_kwargs", _build_api_kwargs_web_enabled)
 @patch("aedist.harness.OpenAI")
 def test_both_reasoning_and_web_search(mock_openai_cls, tmp_path):
     """Model with both reasoning and web_search gets correct params."""
@@ -528,7 +528,7 @@ def test_both_reasoning_and_web_search(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -537,7 +537,7 @@ def test_both_reasoning_and_web_search(mock_openai_cls, tmp_path):
                 str(output_dir),
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -562,7 +562,7 @@ def test_no_web_search_flag_disables_plugin(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -572,7 +572,7 @@ def test_no_web_search_flag_disables_plugin(mock_openai_cls, tmp_path):
                 "--no-web-search",
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 
@@ -599,7 +599,7 @@ def test_no_web_search_flag_noop_without_web_model(mock_openai_cls, tmp_path):
             sys,
             "argv",
             [
-                "query_frontier",
+                "query_direct",
                 "--prompt",
                 str(prompt_path),
                 "--models",
@@ -609,7 +609,7 @@ def test_no_web_search_flag_noop_without_web_model(mock_openai_cls, tmp_path):
                 "--no-web-search",
             ],
         ):
-            from aedist.query_frontier import main
+            from aedist.query_direct import main
 
             main()
 

--- a/tests/test_query_livesearch.py
+++ b/tests/test_query_livesearch.py
@@ -1,4 +1,4 @@
-"""Tests for aedist.query_web — web-augmented queries."""
+"""Tests for aedist.query_livesearch — web-augmented queries."""
 
 import json
 import sys
@@ -36,7 +36,7 @@ def _setup_files(tmp_path: Path) -> tuple[Path, Path, Path]:
     return prompt, models, output
 
 
-@patch("aedist.query_web.tavily_search")
+@patch("aedist.query_livesearch.tavily_search")
 @patch("aedist.harness.OpenAI")
 def test_web_query_with_tavily(mock_openai_cls, mock_tavily, tmp_path):
     """When Tavily is available, search results are injected as context."""
@@ -55,12 +55,12 @@ def test_web_query_with_tavily(mock_openai_cls, mock_tavily, tmp_path):
         "TAVILY_API_KEY": "fake-tavily",
     }):
         with patch.object(sys, "argv", [
-            "query_web",
+            "query_livesearch",
             "--prompt", str(prompt),
             "--models", str(models),
             "--output", str(output),
         ]):
-            from aedist.query_web import main
+            from aedist.query_livesearch import main
             main()
 
     json_files = list(output.rglob("*.json"))
@@ -82,19 +82,19 @@ def test_web_query_skips_without_tavily_key(mock_openai_cls, tmp_path):
     # Ensure TAVILY_API_KEY is NOT set
     with patch.dict("os.environ", env, clear=True):
         with patch.object(sys, "argv", [
-            "query_web",
+            "query_livesearch",
             "--prompt", str(prompt),
             "--models", str(models),
             "--output", str(output),
         ]):
-            from aedist.query_web import main
+            from aedist.query_livesearch import main
             main()
 
     # No API calls — models skipped due to missing Tavily
     mock_client.chat.completions.create.assert_not_called()
 
 
-@patch("aedist.query_web.tavily_search")
+@patch("aedist.query_livesearch.tavily_search")
 @patch("aedist.harness.OpenAI")
 def test_web_query_output_metadata(mock_openai_cls, mock_tavily, tmp_path):
     """Output includes web_searches with query and results."""
@@ -113,12 +113,12 @@ def test_web_query_output_metadata(mock_openai_cls, mock_tavily, tmp_path):
         "TAVILY_API_KEY": "fake-tavily",
     }):
         with patch.object(sys, "argv", [
-            "query_web",
+            "query_livesearch",
             "--prompt", str(prompt),
             "--models", str(models),
             "--output", str(output),
         ]):
-            from aedist.query_web import main
+            from aedist.query_livesearch import main
             main()
 
     json_files = list(output.rglob("*.json"))

--- a/tests/test_query_per_fuel.py
+++ b/tests/test_query_per_fuel.py
@@ -1,6 +1,6 @@
-"""Tests for aedist.query_decomposed — CSV merging and extraction."""
+"""Tests for aedist.query_per_fuel — CSV merging and extraction."""
 
-from aedist.query_decomposed import extract_csv_text, merge_csvs
+from aedist.query_per_fuel import extract_csv_text, merge_csvs
 
 # --- merge_csvs ---
 
@@ -108,7 +108,7 @@ class TestQueryDecomposed:
 
     def test_basic_merge(self, monkeypatch):
         """3 sub-queries produce a merged CSV with all plants."""
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
         from aedist.harness import BudgetTracker
 
         call_count = 0
@@ -151,7 +151,7 @@ class TestQueryDecomposed:
 
     def test_budget_exceeded_returns_none(self, monkeypatch):
         """Returns None when budget is already exceeded."""
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
         from aedist.harness import BudgetTracker
 
         budget = BudgetTracker(budget_usd=0.001)
@@ -171,7 +171,7 @@ class TestQueryDecomposed:
         """Returns None when an API error occurs on a sub-query."""
         import openai
 
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
         from aedist.harness import BudgetTracker
 
         def fake_query_error(client, model_id, messages, **kwargs):
@@ -196,7 +196,7 @@ class TestQueryDecomposed:
 
     def test_no_csv_in_response(self, monkeypatch):
         """Handles sub-queries that return no extractable CSV gracefully."""
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
         from aedist.harness import BudgetTracker
 
         def fake_query_no_csv(client, model_id, messages, **kwargs):
@@ -225,7 +225,7 @@ class TestQueryDecomposed:
 
     def test_dedup_across_subqueries(self, monkeypatch):
         """Plants appearing in multiple sub-queries are deduplicated."""
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
         from aedist.harness import BudgetTracker
 
         call_count = 0
@@ -279,7 +279,7 @@ class TestQueryDecomposedMain:
         """--dry-run shows what would run without querying."""
         import logging
 
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
 
         # Create minimal corpus dir
         corpus_dir = tmp_path / "corpus"
@@ -305,7 +305,7 @@ class TestQueryDecomposedMain:
         monkeypatch.setattr(
             "sys.argv",
             [
-                "query_decomposed",
+                "query_per_fuel",
                 "--prompt",
                 str(prompt_file),
                 "--corpus",
@@ -333,7 +333,7 @@ class TestQueryDecomposedMain:
         """--model filters to a single model."""
         import logging
 
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
 
         corpus_dir = tmp_path / "corpus"
         corpus_dir.mkdir()
@@ -361,7 +361,7 @@ class TestQueryDecomposedMain:
         monkeypatch.setattr(
             "sys.argv",
             [
-                "query_decomposed",
+                "query_per_fuel",
                 "--prompt",
                 str(prompt_file),
                 "--corpus",
@@ -385,7 +385,7 @@ class TestQueryDecomposedMain:
 
     def test_model_not_found_exits(self, monkeypatch, tmp_path):
         """--model with nonexistent model raises SystemExit."""
-        from aedist import query_decomposed as qd_mod
+        from aedist import query_per_fuel as qd_mod
 
         corpus_dir = tmp_path / "corpus"
         corpus_dir.mkdir()
@@ -402,7 +402,7 @@ class TestQueryDecomposedMain:
         monkeypatch.setattr(
             "sys.argv",
             [
-                "query_decomposed",
+                "query_per_fuel",
                 "--prompt",
                 str(prompt_file),
                 "--corpus",

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -455,7 +455,7 @@ def test_verify_web_with_cache(tmp_path):
 
     cache_path = tmp_path / "cache.json"
 
-    with patch("aedist.query_web.tavily_search", side_effect=mock_tavily):
+    with patch("aedist.query_livesearch.tavily_search", side_effect=mock_tavily):
         annotated, summary = verify_web(rows, "fake-key", cache_path)
 
     assert len(annotated) == 2
@@ -493,7 +493,7 @@ def test_verify_web_cache_reuse(tmp_path):
     }
     cache_path.write_text(json.dumps(cache_data))
 
-    with patch("aedist.query_web.tavily_search") as mock_search:
+    with patch("aedist.query_livesearch.tavily_search") as mock_search:
         annotated, summary = verify_web(rows, "fake-key", cache_path)
 
     # Should not call Tavily — result was cached


### PR DESCRIPTION
## Summary
- query_frontier.py → query_direct.py (single call, no retrieval context)
- query_decomposed.py → query_per_fuel.py (3 sub-calls split by fuel type)
- query_web.py → query_livesearch.py (live Tavily search injection)
- All import sites, patch paths, and test files updated

## Tickets
Closes 0124

## Test plan
- [x] make test green (1128 passed)
- [x] No file named query_frontier.py, query_decomposed.py, or query_web.py in src/aedist/
- [x] All imports resolve

🤖 Generated with Claude Code