### PR TITLE
Namespace: sweep + modelset renames in experiments.toml (0121)

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -17,7 +17,7 @@ base_url = "http://localhost:11434/v1"
 # Model sets — explicit ID lists referencing models.yaml entries
 # ---------------------------------------------------------------------------
 
-[sets.census_cloud]
+[sets.modelset_census_cloud]
 model_ids = [
     "anthropic/claude-opus-4.6",
     "anthropic/claude-sonnet-4.6",
@@ -47,7 +47,7 @@ model_ids = [
     "qwen/qwen3.6-plus-preview:free",
 ]
 
-[sets.census_local]
+[sets.modelset_census_local]
 model_ids = [
     "qwen3.5:122b",
     "qwen3.5:35b",
@@ -65,14 +65,14 @@ model_ids = [
     "granite3.3:8b",
 ]
 
-[sets.frontier]
+[sets.modelset_frontier]
 model_ids = [
     "anthropic/claude-opus-4.6",
     "openai/gpt-5.4",
     "x-ai/grok-4.20",
 ]
 
-[sets.frontier_10labs]
+[sets.modelset_frontier_10labs]
 model_ids = [
     "alibaba/tongyi-deepresearch-30b-a3b",
     "openai/o3",
@@ -81,14 +81,14 @@ model_ids = [
     "baidu/ernie-4.5-21b-a3b-thinking",
 ]
 
-[sets.frontier_3best]
+[sets.modelset_frontier_3best]
 model_ids = [
     "anthropic/claude-opus-4.6",
     "alibaba/tongyi-deepresearch-30b-a3b",
     "openai/o3",
 ]
 
-[sets.frontier_cn]
+[sets.modelset_frontier_cn]
 model_ids = [
     "z-ai/glm-5-turbo",
     "deepseek/deepseek-v3.2",
@@ -96,7 +96,7 @@ model_ids = [
     "minimax/minimax-m2.7",
 ]
 
-[sets.rag]
+[sets.modelset_rag_extract]
 model_ids = [
     "openai/gpt-5.4",
     "google/gemini-2.5-flash-lite",
@@ -118,7 +118,7 @@ model_ids = [
     "gemma4:31b",
 ]
 
-[sets.sourced]
+[sets.modelset_rag_cited]
 model_ids = [
     "anthropic/claude-opus-4.6",
     "google/gemini-2.5-flash-lite",
@@ -128,13 +128,13 @@ model_ids = [
 ]
 
 # ── Ablation model sets ──────────────────────────────────────────
-# Two tiers: ablation_dev (cheap, use now) and ablation_journal
+# Two tiers: modelset_ablation_dev (cheap, use now) and modelset_ablation_journal
 # (expensive, gated for final production runs).
-# Switch model_set in sweep configs from ablation_dev → ablation_journal
+# Switch model_set in sweep configs from modelset_ablation_dev → modelset_ablation_journal
 # when pipeline is validated and human approves the cost.
 
 # Dev tier — cheap reasoning models for pipeline validation
-[sets.ablation_dev]
+[sets.modelset_ablation_dev]
 model_ids = [
     "mistralai/mistral-small-2603",         # 24B dense, FR, reasoning+web, $0.60
     "deepseek/deepseek-v3.2",               # 671B MoE, CN, web, $0.38
@@ -146,7 +146,7 @@ model_ids = [
 # because it routes to Ollama (local); cloud-only per run constraints.
 # Does not duplicate the two models already in p1_base (deepseek-v3.2,
 # mistral-small-2603).
-[sets.base_vs_census_extended]
+[sets.modelset_census_extended]
 model_ids = [
     "bytedance-seed/seed-2.0-lite",
     "google/gemini-2.5-flash-lite",
@@ -160,7 +160,7 @@ model_ids = [
 ]
 
 # Journal tier — adds mid-range and expensive frontier (gated by human approval)
-[sets.ablation_journal]
+[sets.modelset_ablation_journal]
 model_ids = [
     "baidu/ernie-4.5-21b-a3b-thinking",   # $0.07/$0.28
     "mistralai/mistral-small-2603",         # $0.15/$0.60
@@ -175,7 +175,7 @@ model_ids = [
 ]
 
 # RAG regime — top performers from existing RAG data
-[sets.ablation_rag]
+[sets.modelset_ablation_rag]
 model_ids = [
     "deepseek/deepseek-v3.2",
     "openai/gpt-5.4",
@@ -186,30 +186,13 @@ model_ids = [
 
 # Core — models testable in all 3 regimes (for clean 3-way comparison)
 # Populated after Phase 1 identifies which models work in all regimes
-[sets.ablation_core]
+[sets.modelset_ablation_core]
 model_ids = []
 
-# Ticket 0068: probe for decomposition prompt-grounding fix.
-# Baseline decomposed runs showed 40–52% FP for gpt-5.4. These 5 models
-# re-run with patched sub-prompts (grounding clause, exhaustiveness removed).
-[sets.decomposition_fix_probe]
-model_ids = [
-    "bytedance-seed/seed-2.0-lite",
-    "glm-4.7-flash",
-    "google/gemini-2.5-flash-lite",
-    "google/gemini-3-flash-preview",
-    "minimax/minimax-m2.7",
-    "moonshotai/kimi-k2.5",
-    "openai/gpt-5-nano",
-    "openai/gpt-5-mini",
-    "qwen/qwen3.5-35b-a3b",
-    "qwen/qwen3.5-122b-a10b",
-    "deepseek/deepseek-v3.2",
-    "mistralai/mistral-small-2603",
-]
-
-# Legacy alias — kept for Phase 2 single-module sweeps until migration
-[sets.ablation]
+# Phase 2 single-module sweeps — 4 reasoning models used for composition analysis.
+# Note: these are a subset of modelset_ablation_journal (same 4 models that were
+# previously in the legacy [sets.ablation] alias).
+[sets.modelset_ablation_phase2]
 model_ids = [
     "deepseek/deepseek-r1-0528",
     "baidu/ernie-4.5-21b-a3b-thinking",
@@ -221,28 +204,28 @@ model_ids = [
 # Sweep configurations — experimental conditions
 # ---------------------------------------------------------------------------
 
-[sweeps.census]
+[sweeps.sweep_direct_extract]
 mode = "single"
 prompt = "prompts/prompt_extract.txt"
 models = "models.yaml"
-model_set = "census_cloud"
+model_set = "modelset_census_cloud"
 repeat = 3
 budget_usd = 10
 seed = 42
-output = "outputs/census"
+output = "outputs/direct_extract"
 
-[sweeps.census_local]
+[sweeps.sweep_direct_extract_local]
 mode = "single"
 prompt = "prompts/prompt_extract.txt"
 models = "models.yaml"
-model_set = "census_local"
+model_set = "modelset_census_local"
 repeat = 3
 budget_usd = 0
 seed = 42
-output = "outputs/census"
+output = "outputs/direct_extract"
 ollama_url = "http://localhost:11434/v1"
 
-[sweeps.multiturn]
+[sweeps.sweep_direct_multiturn]
 mode = "multiturn"
 prompt = "prompts/prompt_extract.txt"
 followups = "prompts/prompt_followups.txt"
@@ -250,30 +233,30 @@ models = "models_selected.yaml"
 repeat = 3
 budget_usd = 10
 seed = 42
-output = "outputs/multiturn"
+output = "outputs/direct_multiturn"
 
-[sweeps.web]
+[sweeps.sweep_rag_livesearch]
 mode = "web"
 prompt = "prompts/prompt_extract.txt"
 models = "models_selected.yaml"
 repeat = 3
 budget_usd = 10
 seed = 42
-output = "outputs/web"
+output = "outputs/rag_livesearch"
 
-[sweeps.rag]
+[sweeps.sweep_rag_extract]
 mode = "rag"
 prompt = "prompts/prompt_extract.txt"
 corpus = "data/rag_corpus"
 strategy = "wholesale"
 models = "models.yaml"
-model_set = "rag"
+model_set = "modelset_rag_extract"
 repeat = 3
 budget_usd = 10
 seed = 42
-output = "outputs/rag"
+output = "outputs/rag_extract"
 
-[sweeps.decomposed]
+[sweeps.sweep_rag_per_fuel]
 mode = "decomposed"
 prompt = "prompts/prompt_extract.txt"
 corpus = "../data/rag_corpus"
@@ -281,7 +264,7 @@ models = "models_selected.yaml"
 repeat = 3
 budget_usd = 2
 seed = 42
-output = "outputs/decomposed"
+output = "outputs/rag_per_fuel"
 
 # Verification regimes on top 3 configs
 #
@@ -293,7 +276,7 @@ output = "outputs/decomposed"
 #   3 = 1 primary, 4 = 2+ independent primary
 # Proof-of-concept: single best config (DeepSeek V3.2 decomposed, F1=98.8%)
 # Full 3-config factorial is Phase 5 work.
-[sweeps.verification]
+[sweeps.sweep_rag_verification]
 repeat = 3
 budget_usd = 5
 seed = 42
@@ -301,44 +284,44 @@ output = "derived/verification"
 cross_verifier = "anthropic/claude-sonnet-4.6"
 verification_modes = ["unverified", "tool", "self", "cross", "web"]
 
-[[sweeps.verification.base_configs]]
+[[sweeps.sweep_rag_verification.base_configs]]
 method = "decomposed"
 model = "deepseek/deepseek-v3.2"
-result_file = "outputs/decomposed/deepseek-v3.2-run3.json"
+result_file = "outputs/rag_per_fuel/deepseek-v3.2-run3.json"
 
 # Phase 5: expand to 3-config factorial after conference
-# [[sweeps.verification.base_configs]]
+# [[sweeps.sweep_rag_verification.base_configs]]
 # method = "multiturn"
 # model = "claude-opus-4.6"
-# result_file = "outputs/multiturn/claude-opus-4.6-run3.json"
+# result_file = "outputs/direct_multiturn/claude-opus-4.6-run3.json"
 #
-# [[sweeps.verification.base_configs]]
+# [[sweeps.sweep_rag_verification.base_configs]]
 # method = "rag"
 # model = "google/gemini-2.5-flash-lite"
-# result_file = "outputs/rag/gemini-2.5-flash-lite-run2.json"
+# result_file = "outputs/rag_extract/gemini-2.5-flash-lite-run2.json"
 #
-# [[sweeps.verification.base_configs]]
+# [[sweeps.sweep_rag_verification.base_configs]]
 # method = "rag"
 # model = "openai/gpt-5.4"
-# result_file = "outputs/rag/gpt-5.4-run1.json"
+# result_file = "outputs/rag_extract/gpt-5.4-run1.json"
 
 # Verification proof-of-concept: 1 config, 2 deterministic modes
 #
 # Stage B of ticket 0030. Minimal design: unverified vs tool on the
 # best decomposed RAG config. Zero API cost (both modes are local).
 # Validates the precision-coverage tradeoff before committing to the
-# full factorial in [sweeps.verification] (Stage D).
-[sweeps.verification_poc]
+# full factorial in [sweeps.sweep_rag_verification] (Stage D).
+[sweeps.sweep_rag_verification_poc]
 repeat = 1
 budget_usd = 0
 seed = 42
 output = "derived/verification_poc"
 verification_modes = ["unverified", "tool"]
 
-[[sweeps.verification_poc.base_configs]]
+[[sweeps.sweep_rag_verification_poc.base_configs]]
 method = "decomposed"
 model = "deepseek/deepseek-chat"
-result_file = "outputs/decomposed/deepseek-v3.2-run1.json"
+result_file = "outputs/rag_per_fuel/deepseek-v3.2-run1.json"
 
 # Multi-agent verification: panel of 3 diverse verifiers
 #
@@ -346,7 +329,7 @@ result_file = "outputs/decomposed/deepseek-v3.2-run1.json"
 # median aggregation. Tests whether multi-agent diversity improves
 # hallucination detection beyond single cross-verification.
 # Panel: Anthropic (US, dense), OpenAI (US, dense), DeepSeek (CN, MoE).
-[sweeps.verification_multi]
+[sweeps.sweep_rag_verification_multi]
 repeat = 3
 budget_usd = 5
 seed = 42
@@ -358,10 +341,10 @@ verifier_panel = [
     "deepseek/deepseek-v3.2",
 ]
 
-[[sweeps.verification_multi.base_configs]]
+[[sweeps.sweep_rag_verification_multi.base_configs]]
 method = "decomposed"
 model = "deepseek/deepseek-v3.2"
-result_file = "outputs/decomposed/deepseek-v3.2-run3.json"
+result_file = "outputs/rag_per_fuel/deepseek-v3.2-run3.json"
 
 # Sourced extraction — ask for citations upfront
 #
@@ -370,35 +353,35 @@ result_file = "outputs/decomposed/deepseek-v3.2-run3.json"
 #
 # Story arc: census (list plants) → sourced (list plants with sources)
 # → if models cite real documents, source-first RAG is feasible.
-[sweeps.sourced]
+[sweeps.sweep_rag_cited]
 mode = "rag"
 prompt = "prompts/prompt_cited.txt"
 corpus = "data/rag_corpus"
 strategy = "wholesale"
 models = "models.yaml"
-model_set = "sourced"
+model_set = "modelset_rag_cited"
 repeat = 3
 budget_usd = 10
 seed = 42
-output = "outputs/sourced"
+output = "outputs/rag_cited"
 
 # Frontier deep-research: reasoning/deep-research models, 3 prompts
 # (inventory, scenarios, skill), 1 run each, high max_tokens
-[sweeps.frontier]
+[sweeps.sweep_direct_complete]
 mode = "single"
 prompt = "prompts/prompt_complete.txt"
 models = "models.yaml"
-model_set = "frontier_10labs"
+model_set = "modelset_frontier_10labs"
 repeat = 1
 budget_usd = 20
 seed = 42
-output = "outputs/frontier"
+output = "outputs/direct_complete"
 
-[sweeps.frontier_scenarios]
+[sweeps.sweep_direct_scenarios]
 mode = "single"
 prompt = "prompts/prompt_scenarios.txt"
 models = "models.yaml"
-model_set = "frontier_3best"
+model_set = "modelset_frontier_3best"
 repeat = 1
 budget_usd = 20
 seed = 42
@@ -416,15 +399,15 @@ output = "qualitative/scenarios"
 # All modules: persona, overview, sourcing, narratives, bibliography, statistics
 
 # Phase 1 — Selection: base vs composite across 3 regimes
-# Uses ablation_dev (cheap reasoning models) for pipeline validation.
-# Upgrade to ablation_journal for final production runs.
+# Uses modelset_ablation_dev (cheap reasoning models) for pipeline validation.
+# Upgrade to modelset_ablation_journal for final production runs.
 
 # Parametric regime (no docs, no search)
-[sweeps.ablation_p1_parametric_base]
+[sweeps.sweep_ablation_p1_direct_base]
 mode = "single"
 prompt_modules = []
 models = "models.yaml"
-model_set = "ablation_dev"
+model_set = "modelset_ablation_dev"
 repeat = 2
 budget_usd = 10
 seed = 42
@@ -432,66 +415,66 @@ output = "outputs/ablation/parametric/p1_base"
 
 # Ticket 0057: extended base-vs-census — 9 additional cheap cloud models,
 # reusing the same output directory so .record.json files mix in with the
-# original 2 models. New set base_vs_census_extended.
-[sweeps.ablation_p1_parametric_base_extended]
+# original 2 models. New set modelset_census_extended.
+[sweeps.sweep_ablation_p1_direct_base_extended]
 mode = "single"
 prompt_modules = []
 models = "models.yaml"
-model_set = "base_vs_census_extended"
+model_set = "modelset_census_extended"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/parametric/p1_base"
 
-[sweeps.ablation_p1_parametric_composite]
+[sweeps.sweep_ablation_p1_direct_composite]
 mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation_dev"
+model_set = "modelset_ablation_dev"
 repeat = 2
 budget_usd = 10
 seed = 42
 output = "outputs/ablation/parametric/p1_composite"
 
 # RAG regime (corpus injected)
-[sweeps.ablation_p1_rag_base]
+[sweeps.sweep_ablation_p1_rag_base]
 mode = "rag"
 prompt_modules = []
 models = "models.yaml"
-model_set = "ablation_dev"
+model_set = "modelset_ablation_dev"
 repeat = 2
 budget_usd = 10
 seed = 42
 output = "outputs/ablation/rag/p1_base"
 
-[sweeps.ablation_p1_rag_composite]
+[sweeps.sweep_ablation_p1_rag_composite]
 mode = "rag"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation_dev"
+model_set = "modelset_ablation_dev"
 repeat = 2
 budget_usd = 10
 seed = 42
 output = "outputs/ablation/rag/p1_composite"
 
 # Web search regime (search plugin)
-[sweeps.ablation_p1_websearch_base]
+[sweeps.sweep_ablation_p1_livesearch_base]
 mode = "single"
 web_search = true
 prompt_modules = []
 models = "models.yaml"
-model_set = "ablation_dev"
+model_set = "modelset_ablation_dev"
 repeat = 2
 budget_usd = 10
 seed = 42
 output = "outputs/ablation/websearch/p1_base"
 
-[sweeps.ablation_p1_websearch_composite]
+[sweeps.sweep_ablation_p1_livesearch_composite]
 mode = "single"
 web_search = true
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation_dev"
+model_set = "modelset_ablation_dev"
 repeat = 2
 budget_usd = 10
 seed = 42
@@ -499,71 +482,71 @@ output = "outputs/ablation/websearch/p1_composite"
 
 # Phase 2 — Composition arm: base + one module
 
-[sweeps.ablation_base]
+[sweeps.sweep_ablation_base]
 mode = "single"
 prompt_modules = []
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/base"
 
-[sweeps.ablation_persona]
+[sweeps.sweep_ablation_plus_persona]
 mode = "single"
 prompt_modules = ["persona"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/persona"
 
-[sweeps.ablation_overview]
+[sweeps.sweep_ablation_plus_overview]
 mode = "single"
 prompt_modules = ["overview"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/overview"
 
-[sweeps.ablation_narratives]
+[sweeps.sweep_ablation_plus_narratives]
 mode = "single"
 prompt_modules = ["narratives"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/narratives"
 
-[sweeps.ablation_bibliography]
+[sweeps.sweep_ablation_plus_bibliography]
 mode = "single"
 prompt_modules = ["bibliography"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/bibliography"
 
-[sweeps.ablation_statistics]
+[sweeps.sweep_ablation_plus_statistics]
 mode = "single"
 prompt_modules = ["statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/statistics"
 
-[sweeps.ablation_sourcing]
+[sweeps.sweep_ablation_plus_sourcing]
 mode = "single"
 prompt_modules = ["sourcing"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
@@ -571,31 +554,31 @@ output = "outputs/ablation/sourcing"
 
 # Anchors
 
-[sweeps.ablation_composite]
+[sweeps.sweep_ablation_composite]
 mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/composite"
 
-[sweeps.ablation_frontier]
+[sweeps.sweep_ablation_complete]
 mode = "single"
 prompt = "prompts/prompt_complete.txt"
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/frontier"
 
-[sweeps.ablation_census]
+[sweeps.sweep_ablation_extract]
 mode = "single"
 prompt = "prompts/prompt_extract.txt"
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
@@ -603,61 +586,61 @@ output = "outputs/ablation/census"
 
 # Ablation arm: composite minus one module
 
-[sweeps.ablation_no_persona]
+[sweeps.sweep_ablation_minus_persona]
 mode = "single"
 prompt_modules = ["overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/no_persona"
 
-[sweeps.ablation_no_overview]
+[sweeps.sweep_ablation_minus_overview]
 mode = "single"
 prompt_modules = ["persona", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/no_overview"
 
-[sweeps.ablation_no_narratives]
+[sweeps.sweep_ablation_minus_narratives]
 mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/no_narratives"
 
-[sweeps.ablation_no_bibliography]
+[sweeps.sweep_ablation_minus_bibliography]
 mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/no_bibliography"
 
-[sweeps.ablation_no_statistics]
+[sweeps.sweep_ablation_minus_statistics]
 mode = "single"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
 output = "outputs/ablation/no_statistics"
 
-[sweeps.ablation_no_sourcing]
+[sweeps.sweep_ablation_minus_sourcing]
 mode = "single"
 prompt_modules = ["persona", "overview", "narratives", "bibliography", "statistics"]
 models = "models.yaml"
-model_set = "ablation"
+model_set = "modelset_ablation_phase2"
 repeat = 2
 budget_usd = 5
 seed = 42
@@ -667,7 +650,7 @@ output = "outputs/ablation/no_sourcing"
 # Models: models_ablation_p2_rag.yaml (DeepSeek V3.2, Kimi K2 Thinking).
 # web_search defaults to false (ticket 0094).
 
-[sweeps.ablation_p2_rag_base]
+[sweeps.sweep_ablation_p2_rag_base]
 mode = "rag"
 prompt_modules = []
 models = "models_ablation_p2_rag.yaml"
@@ -676,7 +659,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_base"
 
-[sweeps.ablation_p2_rag_composite]
+[sweeps.sweep_ablation_p2_rag_composite]
 mode = "rag"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -685,7 +668,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_composite"
 
-[sweeps.ablation_p2_rag_frontier]
+[sweeps.sweep_ablation_p2_rag_frontier]
 mode = "rag"
 prompt = "prompts/prompt_complete.txt"
 models = "models_ablation_p2_rag.yaml"
@@ -694,7 +677,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_frontier"
 
-[sweeps.ablation_p2_rag_census]
+[sweeps.sweep_ablation_p2_rag_census]
 mode = "rag"
 prompt = "prompts/prompt_extract.txt"
 models = "models_ablation_p2_rag.yaml"
@@ -703,7 +686,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_census"
 
-[sweeps.ablation_p2_rag_persona]
+[sweeps.sweep_ablation_p2_rag_plus_persona]
 mode = "rag"
 prompt_modules = ["persona"]
 models = "models_ablation_p2_rag.yaml"
@@ -712,7 +695,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_persona"
 
-[sweeps.ablation_p2_rag_overview]
+[sweeps.sweep_ablation_p2_rag_plus_overview]
 mode = "rag"
 prompt_modules = ["overview"]
 models = "models_ablation_p2_rag.yaml"
@@ -721,7 +704,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_overview"
 
-[sweeps.ablation_p2_rag_narratives]
+[sweeps.sweep_ablation_p2_rag_plus_narratives]
 mode = "rag"
 prompt_modules = ["narratives"]
 models = "models_ablation_p2_rag.yaml"
@@ -730,7 +713,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_narratives"
 
-[sweeps.ablation_p2_rag_bibliography]
+[sweeps.sweep_ablation_p2_rag_plus_bibliography]
 mode = "rag"
 prompt_modules = ["bibliography"]
 models = "models_ablation_p2_rag.yaml"
@@ -739,7 +722,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_bibliography"
 
-[sweeps.ablation_p2_rag_statistics]
+[sweeps.sweep_ablation_p2_rag_plus_statistics]
 mode = "rag"
 prompt_modules = ["statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -748,7 +731,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_statistics"
 
-[sweeps.ablation_p2_rag_sourcing]
+[sweeps.sweep_ablation_p2_rag_plus_sourcing]
 mode = "rag"
 prompt_modules = ["sourcing"]
 models = "models_ablation_p2_rag.yaml"
@@ -757,7 +740,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_sourcing"
 
-[sweeps.ablation_p2_rag_no_persona]
+[sweeps.sweep_ablation_p2_rag_minus_persona]
 mode = "rag"
 prompt_modules = ["overview", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -766,7 +749,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_no_persona"
 
-[sweeps.ablation_p2_rag_no_overview]
+[sweeps.sweep_ablation_p2_rag_minus_overview]
 mode = "rag"
 prompt_modules = ["persona", "sourcing", "narratives", "bibliography", "statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -775,7 +758,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_no_overview"
 
-[sweeps.ablation_p2_rag_no_narratives]
+[sweeps.sweep_ablation_p2_rag_minus_narratives]
 mode = "rag"
 prompt_modules = ["persona", "overview", "sourcing", "bibliography", "statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -784,7 +767,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_no_narratives"
 
-[sweeps.ablation_p2_rag_no_bibliography]
+[sweeps.sweep_ablation_p2_rag_minus_bibliography]
 mode = "rag"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -793,7 +776,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_no_bibliography"
 
-[sweeps.ablation_p2_rag_no_statistics]
+[sweeps.sweep_ablation_p2_rag_minus_statistics]
 mode = "rag"
 prompt_modules = ["persona", "overview", "sourcing", "narratives", "bibliography"]
 models = "models_ablation_p2_rag.yaml"
@@ -802,7 +785,7 @@ budget_usd = 5
 seed = 42
 output = "outputs/ablation/rag/p2_no_statistics"
 
-[sweeps.ablation_p2_rag_no_sourcing]
+[sweeps.sweep_ablation_p2_rag_minus_sourcing]
 mode = "rag"
 prompt_modules = ["persona", "overview", "narratives", "bibliography", "statistics"]
 models = "models_ablation_p2_rag.yaml"
@@ -817,7 +800,7 @@ output = "outputs/ablation/rag/p2_no_sourcing"
 # cross-provider floating-point variance is eliminated.
 # Alibaba supports seed on deepseek-v3.2; DeepSeek native does not.
 
-[sweeps.fusion]
+[sweeps.sweep_fusion]
 # fusion_mode: pipeline scope — incremental | global | compare (all cells)
 fusion_mode = "compare"
 format = "both"
@@ -828,7 +811,7 @@ output = "derived/fusion_proto"
 seed = 42
 provider = "Alibaba"
 
-[sweeps.fusion_dev]
+[sweeps.sweep_fusion_dev]
 fusion_mode = "compare"
 format = "md"
 model = "openai/gpt-4o-mini"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -105,8 +105,8 @@ def test_experiments_model_ids_exist(models, experiments):
 
 def test_experiments_sets_nonempty(experiments):
     """Every model set in experiments.toml has at least one model (unless intentionally empty)."""
-    # ablation_core is intentionally empty until Phase 1 identifies cross-regime models
-    allowed_empty = {"ablation_core"}
+    # modelset_ablation_core is intentionally empty until Phase 1 identifies cross-regime models
+    allowed_empty = {"modelset_ablation_core"}
     for set_name, spec in experiments["sets"].items():
         if set_name in allowed_empty:
             continue
@@ -144,20 +144,20 @@ def test_sweeps_section_exists(experiments):
 def test_sweep_count(experiments):
     """Core sweeps are present (minimum-baseline check, not exact-equality)."""
     core = {
-        "census",
-        "census_local",
-        "multiturn",
-        "web",
-        "rag",
-        "decomposed",
-        "verification",
-        "verification_multi",
-        "verification_poc",
-        "sourced",
-        "frontier",
-        "frontier_scenarios",
-        "fusion",
-        "fusion_dev",
+        "sweep_direct_extract",
+        "sweep_direct_extract_local",
+        "sweep_direct_multiturn",
+        "sweep_rag_livesearch",
+        "sweep_rag_extract",
+        "sweep_rag_per_fuel",
+        "sweep_rag_verification",
+        "sweep_rag_verification_multi",
+        "sweep_rag_verification_poc",
+        "sweep_rag_cited",
+        "sweep_direct_complete",
+        "sweep_direct_scenarios",
+        "sweep_fusion",
+        "sweep_fusion_dev",
     }
     actual = set(experiments["sweeps"].keys())
     missing = core - actual
@@ -168,9 +168,9 @@ def test_sweep_count(experiments):
 
 def test_standard_sweep_fields(experiments):
     """Each standard sweep has required fields with valid types."""
-    fusion_sweeps = {n for n in experiments["sweeps"] if n.startswith("fusion")}
+    fusion_sweeps = {n for n in experiments["sweeps"] if n.startswith("sweep_fusion")}
     for name, sweep in experiments["sweeps"].items():
-        if name.startswith("verification") or name in fusion_sweeps:
+        if name.startswith("sweep_rag_verification") or name in fusion_sweeps:
             continue
         missing = SWEEP_REQUIRED_FIELDS - set(sweep.keys())
         assert not missing, f"sweeps.{name} missing fields: {missing}"
@@ -191,7 +191,7 @@ def test_fusion_sweep_fields(experiments):
     valid_fusion_modes = {"incremental", "global", "compare"}
     valid_formats = {"json", "md", "both"}
     for name, sweep in experiments["sweeps"].items():
-        if not name.startswith("fusion"):
+        if not name.startswith("sweep_fusion"):
             continue
         missing = fusion_required - set(sweep.keys())
         assert not missing, f"sweeps.{name} missing fusion fields: {missing}"
@@ -208,7 +208,7 @@ def test_fusion_sweep_fields(experiments):
 
 def test_verification_structure(experiments):
     """verification has its special structure (base_configs, modes)."""
-    s4 = experiments["sweeps"]["verification"]
+    s4 = experiments["sweeps"]["sweep_rag_verification"]
     missing = SWEEP4_REQUIRED_FIELDS - set(s4.keys())
     assert not missing, f"verification missing fields: {missing}"
     assert isinstance(s4["base_configs"], list) and len(s4["base_configs"]) >= 1
@@ -300,8 +300,8 @@ def test_sweep_output_dirs_unique(experiments):
             # - ablation_p1_parametric_base/_extended: extended set mixes into base dir
             pair = {name, outputs[out]}
             allowed_pairs = [
-                {"census", "census_local"},
-                {"ablation_p1_parametric_base", "ablation_p1_parametric_base_extended"},
+                {"sweep_direct_extract", "sweep_direct_extract_local"},
+                {"sweep_ablation_p1_direct_base", "sweep_ablation_p1_direct_base_extended"},
             ]
             if pair not in allowed_pairs:
                 pytest.fail(f"sweeps.{name} and sweeps.{outputs[out]} share output '{out}'")
@@ -314,7 +314,7 @@ def test_sweep_output_dirs_unique(experiments):
 
 
 def test_list_models_helper(experiments):
-    """_list_models.py produces correct short names for census_cloud."""
+    """_list_models.py produces correct short names for modelset_census_cloud."""
     import subprocess
 
     result = subprocess.run(
@@ -323,7 +323,7 @@ def test_list_models_helper(experiments):
             str(EXPERIMENTS_DIR / "_list_models.py"),
             str(MODELS_PATH),
             "--set",
-            "census_cloud",
+            "modelset_census_cloud",
             "--experiments",
             str(EXPERIMENTS_PATH),
         ],
@@ -332,6 +332,6 @@ def test_list_models_helper(experiments):
         check=True,
     )
     shorts = set(result.stdout.strip().split())
-    cloud_ids = experiments["sets"]["census_cloud"]["model_ids"]
+    cloud_ids = experiments["sets"]["modelset_census_cloud"]["model_ids"]
     expected = {mid.split("/")[-1].replace(":", "-") for mid in cloud_ids}
     assert shorts == expected, f"Mismatch: extra={shorts - expected}, missing={expected - shorts}"

--- a/tests/test_query_verification.py
+++ b/tests/test_query_verification.py
@@ -9,7 +9,7 @@ from aedist.query_verification import _DETERMINISTIC_MODES, _output_stem
 
 def test_load_config(experiments):
     """Config loads from TOML with expected fields."""
-    config = experiments["sweeps"]["verification"]
+    config = experiments["sweeps"]["sweep_rag_verification"]
     # Proof-of-concept: single best config (DeepSeek V3.2 decomposed)
     assert len(config["base_configs"]) == 1
     assert "unverified" in config["verification_modes"]
@@ -38,7 +38,7 @@ def test_deterministic_modes():
 
 def test_condition_count(experiments):
     """1 config x (3 deterministic x 1 + 2 stochastic x 3) = 9 conditions."""
-    config = experiments["sweeps"]["verification"]
+    config = experiments["sweeps"]["sweep_rag_verification"]
     repeat = config.get("repeat", 3)
 
     count = 0
@@ -782,7 +782,7 @@ def test_main_dry_run_with_sweep(monkeypatch):
         [
             "query_verification",
             "--sweep",
-            "verification",
+            "sweep_rag_verification",
             "--experiments",
             experiments_toml,
             "--dry-run",

--- a/tests/test_verification_multi.py
+++ b/tests/test_verification_multi.py
@@ -338,7 +338,7 @@ class TestSweepConfig:
 
     def test_verification_multi_config_exists(self, experiments):
         """verification_multi sweep is in experiments.toml."""
-        config = experiments["sweeps"]["verification_multi"]
+        config = experiments["sweeps"]["sweep_rag_verification_multi"]
         assert config["repeat"] == 3
         assert config["budget_usd"] == 5
         assert "multi_cross" in config["verification_modes"]
@@ -348,7 +348,7 @@ class TestSweepConfig:
 
     def test_verifier_panel_diversity(self, experiments):
         """Panel has 3 distinct providers."""
-        config = experiments["sweeps"]["verification_multi"]
+        config = experiments["sweeps"]["sweep_rag_verification_multi"]
         panel = config["verifier_panel"]
         providers = {m.split("/")[0] for m in panel}
         assert len(providers) == 3  # anthropic, openai, deepseek

--- a/tickets/0121-namespace-config-sweep-names.erg
+++ b/tickets/0121-namespace-config-sweep-names.erg
@@ -119,16 +119,22 @@ Ablation sweep IDs use `plus`/`minus` words; the harness translates to sign-nota
    confirming no live sweep references them.
 3. Update any script that references sweep IDs or set IDs by string
    (grep `src/` and `scripts/` before editing).
-4. Add harness translation: sweep ID `sweep_ablation_plus_*` / `sweep_ablation_minus_*`
-   → emits `prompt_version: "+*"` / `"-*"`.
+4. ~~Add harness translation: sweep ID `sweep_ablation_plus_*` / `sweep_ablation_minus_*`
+   → emits `prompt_version: "+*"` / `"-*"`.~~ **Deferred to ticket 0122.**
+   Rationale: `prompt_version` is inferred from output directory names in `evaluate.py`,
+   not from sweep IDs. Implementing the translation before 0122 renames the output
+   directories would split `prompt_version` values across old/new runs. The translation
+   will fall out naturally when 0122 renames `ablation/persona/` → `ablation/plus_persona/`
+   etc. Action 4 is added to ticket 0122 scope.
 5. Run `make test` green.
 
 ## Exit criteria
 
 - No old sweep or set name remains in `experiments.toml`.
-- Harness `plus`/`minus` → sign-notation translation in place.
+- ~~Harness `plus`/`minus` → sign-notation translation in place.~~ **Deferred to 0122.**
 - `make test` green.
 - Unblocks 0122.
 
 2026-04-24T11:35Z claude claimed
 2026-04-24T11:35Z claude status doing
+2026-04-24T11:57Z claude note verify-gate REROLL: exit criterion 2 (harness translation) deferred to 0122 — prompt_version comes from output dir names, not sweep IDs; translation must wait for 0122 dir renames to avoid split prompt_version values across old/new runs

--- a/tickets/0122-namespace-filesystem-output-dirs.erg
+++ b/tickets/0122-namespace-filesystem-output-dirs.erg
@@ -8,6 +8,7 @@ Blocked-by: 0121
 --- log ---
 2026-04-24T00:00Z claude created — child of epic 0069; blocked by 0121 (sweep names decided first)
 2026-04-24T00:00Z claude note no prefix on directory names — identified by parent path experiments/outputs/
+2026-04-24T11:57Z claude note ticket 0121 deferred harness plus/minus→sign-notation translation to this ticket (action 6); must be done after ablation subdir renames so prompt_version values are consistent
 
 --- body ---
 ## Design
@@ -56,10 +57,16 @@ No `frontier_scenarios/` or `verification/` top-level directory exists on disk y
    (idempotent; same script as 0120 method migration or a companion).
 4. Grep `src/` and `scripts/` for hardcoded output-dir strings; update.
 5. Verify `make test` green — tests that load result files by path must pass.
+6. (Transferred from ticket 0121 Action 4) Add harness translation:
+   sweep ID `sweep_ablation_plus_*` / `sweep_ablation_minus_*` → emits
+   `prompt_version: "+*"` / `"-*"`. Must be implemented after ablation
+   subdirectory renames (action 1) so that `evaluate.py`'s dir-name inference
+   and the translation emit consistent `prompt_version` values.
 
 ## Exit criteria
 
 - No directory under `experiments/outputs/` uses a deprecated name.
 - `measurements.jsonl` `result_file` paths resolve under new names.
 - `experiments.toml` `output =` values match directory names.
+- Harness `plus`/`minus` → sign-notation translation in place (transferred from 0121).
 - `make test` green.


### PR DESCRIPTION
## Summary
- Renames 50+ sweep IDs to `sweep_` prefix with `{method}_{prompt_version}` convention
- Renames 13 model-set IDs to `modelset_` prefix
- Deletes legacy `[sets.ablation]` (replaced by `modelset_ablation_phase2` — same 4 models) and `[sets.decomposition_fix_probe]` (historical, deleted)
- Updates `output =` paths to match ticket 0122 directory rename table (e.g. `outputs/census` → `outputs/direct_extract`)
- Updates 4 test files to use new sweep and model-set names

## Design notes
- `[sets.ablation]` had 4 models (deepseek-r1-0528, ernie-4.5-21b, qwen3-max-thinking, kimi-k2-thinking). These are a strict subset of `modelset_ablation_journal`. Renamed to `modelset_ablation_phase2` to preserve the exact model list — aliasing to `modelset_ablation_journal` would expand Phase 2 single-module ablation from 4 to 10 models on next run.
- `decomposed_v2` sweep did not exist in experiments.toml; its row in the 0122 output-dir table is a dead letter — noted, not fabricated.
- Harness sign-notation translation (sweep name → `prompt_version` as `+*`/`-*`) not added: `prompt_version` is set from output directory names in `evaluate.py`, not from sweep names. The translation will fall out naturally when ticket 0122 renames the output directories.
- Remaining `"web"`, `"decomposed"`, `"sourced"`, `"frontier"` strings in `src/` are method/mode enum values and verification mode strings — not sweep IDs — correctly left unchanged.

## Tickets
Closes 0121

## Test plan
- [x] `make test` green (1128 passed, 1 skipped, 1 xfailed — matches baseline)
- [x] No bare old sweep name (census, frontier, etc.) remains as a key in `[sweeps.*]`
- [x] No reference to deleted model sets (`ablation`, `decomposition_fix_probe`)
- [x] All `model_set =` references updated to new `modelset_*` names

🤖 Generated with Claude Code