### PR TITLE
Namespace audit complete: tickets + memory + STATE.md + epic closure (0126)

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,10 +1,12 @@
-Last updated: 2026-04-24 (session: healthcheck nits)
+Last updated: 2026-04-24 (session: namespace audit coordination — 0126)
 
 ## Status
 
 Pipeline end-to-end. Benchmark: 57 models, headline F1 macro-wired (`\HeadlineMeanFOne`, deepseek-v3.2/decomposed, n=4 runs). CI: 1128 passing, 1 skipped, 1 xfailed.
 
-**This session (2026-04-24, healthcheck nits):** Orphaned worktree agent-afb64d7d removed (locked by dead PID 13232, missed in morning pass). Local branch ticket-0075-prompt-optimizer-survey deleted (remote was gone but local survived morning session).
+**This session (2026-04-24, namespace audit coordination — 0126):** No active tickets contained deprecated vocabulary (all grep hits were closed tickets or 0069's historical body). No memory files required updates. Epic 0069 closed: full namespace audit complete across 7 domain tickets (0120-0126).
+
+**Previous session (2026-04-24, healthcheck nits):** Orphaned worktree agent-afb64d7d removed (locked by dead PID 13232, missed in morning pass). Local branch ticket-0075-prompt-optimizer-survey deleted (remote was gone but local survived morning session).
 
 **Previous session (2026-04-24, morning housekeeping):** Orphaned worktree dir removed (agent-a2597ed5). Remote branches deleted (lit-review-0077-notes, ticket-0075-prompt-optimizer-survey). Stale .wip claim files cleared (0067, 0076, 0085 — all closed). Diverged main reconciled: STATE.md refresh rebased onto origin/main.
 
@@ -65,12 +67,12 @@ Abstract: `docs/HaDuong-2026-EconomIA-Abstract.md`. Homepage: https://economia.s
 - [x] Coherence verification script (ticket 0103, PR #282)
 - [x] Fusion worker integration: Method.FUSION, query_fusion CLI (ticket 0115, PR #283)
 - [x] v1 prototype: incremental fusion loop, 18 iterations master+doc_i (ticket 0076, PR #278)
+- [x] Full namespace audit: method values, sweep names, prompts, query modules, output dirs, report labels (tickets 0120-0126, epic 0069)
 - [ ] Source-grounding verification Phases 2+3 — full audit (ticket 0097, post-talk)
 - [ ] Escalation-rate decay verification (ticket 0102, post-talk)
 - [ ] DSPy/MIPROv2 prompt optimization prototype (ticket 0075, post-talk)
 
-## Non-closed tickets (3)
+## Non-closed tickets (2)
 
-- 0069 Project namespace audit (pending — awaiting external input)
 - 0075 DSPy/MIPROv2 prompt optimization — survey done (PR #276); prototype deferred to Phase 0 of ablation campaign
 - 0102 Verify escalation-rate decay × system (blocked by 0097 Phases 2+3, post-talk)

--- a/tickets/0069-namespace-audit.erg
+++ b/tickets/0069-namespace-audit.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Project namespace audit — every entity name must be self-explanatory to a fresh reader
-Status: doing
+Status: closed
 Created: 2026-04-11
 Author: claude
 
@@ -10,6 +10,7 @@ Author: claude
 2026-04-16T22:30Z claude status pending — deferred to pre-publication cleanup; too disruptive mid-development
 2026-04-24T00:00Z claude status doing — decomposed into 7 domain tickets: 0120 schema, 0121 config, 0122 filesystem, 0123 prompts, 0124 code, 0125 report, 0126 coordination
 2026-04-24T00:00Z claude note PRECONDITION: pause all running sweeps before 0120/0122 execution; do not launch new sweeps until 0125 lands. A sweep writing output mid-rename lands in a renamed dir with stale method values.
+2026-04-24T13:15Z claude status closed — full namespace audit complete; PRs #286-#290 merged; method vocabulary (direct/rag/rag_livesearch/+multiturn/+verification), prompt_version (extract/complete/cited/per_fuel/followups/dspy), sweep_ prefix, modelset_ prefix, query call-pattern names, output dir renames, report labels all applied; make test + lint green
 
 --- body ---
 ## Context

--- a/tickets/0126-namespace-coordination-tickets-memory.erg
+++ b/tickets/0126-namespace-coordination-tickets-memory.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Namespace audit — coordination: update ticket bodies and MEMORY.md
-Status: doing
+Status: closed
 Created: 2026-04-24
 Author: claude
 Blocked-by: 0125
@@ -36,3 +36,5 @@ names.
 
 2026-04-24T13:07Z claude claimed
 2026-04-24T13:07Z claude status doing
+2026-04-24T13:15Z claude note audit result: all active ticket grep hits were closed tickets; no live ticket bodies contain deprecated vocabulary; no memory files required updates
+2026-04-24T13:15Z claude status closed — epic 0069 closed; STATE.md updated; no deprecated vocabulary found in live tickets or memory

--- a/tickets/0126-namespace-coordination-tickets-memory.erg
+++ b/tickets/0126-namespace-coordination-tickets-memory.erg
@@ -7,6 +7,10 @@ Blocked-by: 0125
 
 --- log ---
 2026-04-24T00:00Z claude created — child of epic 0069; last step, blocked by 0125
+2026-04-24T13:07Z claude claimed
+2026-04-24T13:07Z claude status doing
+2026-04-24T13:15Z claude note audit result: all active ticket grep hits were closed tickets; no live ticket bodies contain deprecated vocabulary; no memory files required updates
+2026-04-24T13:15Z claude status closed — epic 0069 closed; STATE.md updated; no deprecated vocabulary found in live tickets or memory
 
 --- body ---
 ## Context
@@ -33,8 +37,3 @@ names.
 - No live ticket body contains deprecated method/sweep names.
 - No memory file contains deprecated names.
 - Epic 0069 closed.
-
-2026-04-24T13:07Z claude claimed
-2026-04-24T13:07Z claude status doing
-2026-04-24T13:15Z claude note audit result: all active ticket grep hits were closed tickets; no live ticket bodies contain deprecated vocabulary; no memory files required updates
-2026-04-24T13:15Z claude status closed — epic 0069 closed; STATE.md updated; no deprecated vocabulary found in live tickets or memory


### PR DESCRIPTION
## Summary
- Audited all active (non-closed) tickets for deprecated vocabulary — none found; all grep hits were closed tickets or 0069's historical body text
- Memory files scanned — no deprecated names present (no updates needed)
- STATE.md updated: 0069 removed from non-closed list, session summary added, namespace audit added to journal milestone checklist
- Epic 0069 closed with full audit summary log entry
- Ticket 0126 closed

## Tickets
Closes 0126, closes 0069

## Test plan
- [ ] make test green (1128 passed)
- [ ] make lint clean
- [ ] No live ticket body contains deprecated method/sweep names
- [ ] Epic 0069 Status: closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)