### PR TITLE
Ticket hygiene: fix misplaced log entries and add structural validator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test:
 
 lint:
 	uv run ruff check src/ tests/ scripts/
+	uv run python scripts/check_ticket_structure.py
 
 check-fast: test lint
 

--- a/scripts/check_ticket_structure.py
+++ b/scripts/check_ticket_structure.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Validator: check that no .erg ticket has log entries in the body section.
+
+Log entries belong between --- log --- and --- body ---.
+Appending log entries at end-of-file places them in the body section — this
+is a spec violation that this script detects.
+
+Usage:
+    uv run python scripts/check_ticket_structure.py
+
+Exit code:
+    0  — all clear
+    1  — one or more violations found
+"""
+
+import re
+import sys
+from pathlib import Path
+
+LOG_ENTRY_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z \w+ (created|status|claimed|released|note|bump)"
+)
+
+
+def check_erg_file(path: Path) -> list[str]:
+    """
+    Return a list of violation messages for the given .erg file.
+    """
+    content = path.read_text(encoding="utf-8")
+
+    if "--- body ---" not in content:
+        return []  # No body section; skip (other validators handle missing separator)
+
+    # Everything after the first --- body --- is the body section
+    _pre, body = content.split("--- body ---", 1)
+
+    violations = []
+    for lineno, line in enumerate(body.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped and LOG_ENTRY_PATTERN.match(stripped):
+            violations.append(
+                f"{path}: log entry found in body section (body line {lineno}): {stripped}"
+            )
+    return violations
+
+
+def main() -> int:
+    repo_root = Path(__file__).parent.parent
+    tickets_dir = repo_root / "tickets"
+    archive_dir = tickets_dir / "archive"
+
+    dirs = [tickets_dir]
+    if archive_dir.exists() and archive_dir.is_dir():
+        dirs.append(archive_dir)
+
+    all_violations: list[str] = []
+    checked = 0
+    for d in dirs:
+        for fpath in sorted(d.glob("*.erg")):
+            violations = check_erg_file(fpath)
+            all_violations.extend(violations)
+            checked += 1
+
+    if all_violations:
+        print(f"TICKET STRUCTURE CHECK FAILED ({len(all_violations)} violation(s)):")
+        for v in all_violations:
+            print(f"  {v}")
+        print()
+        print(
+            "Fix: run 'uv run python scripts/fix_ticket_log_placement.py' to move"
+            " misplaced log entries to the log section."
+        )
+        return 1
+
+    print(f"Ticket structure OK ({checked} files checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fix_ticket_log_placement.py
+++ b/scripts/fix_ticket_log_placement.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Fix misplaced log entries in .erg ticket files.
+
+Agents have been appending log entries at end-of-file (in the body section)
+instead of into the log section (between --- log --- and --- body ---).
+
+This script:
+- Reads every .erg file in tickets/ and tickets/archive/
+- Splits on --- body ---
+- Extracts lines from the body section that match the log-entry pattern
+- Moves those lines into the log section (appended before --- body ---)
+- Writes the fixed file back
+
+Idempotent: a second run produces no changes.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+LOG_ENTRY_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z \w+ (created|status|claimed|released|note|bump)"
+)
+
+
+def fix_erg_file(path: Path) -> bool:
+    """
+    Fix a single .erg file. Returns True if the file was modified.
+    """
+    content = path.read_text(encoding="utf-8")
+
+    # Split into pre-body and body sections
+    split_marker = "--- body ---"
+    if split_marker not in content:
+        return False  # No body section; skip
+
+    pre_body, body = content.split(split_marker, 1)
+
+    # Find misplaced log entries in body
+    body_lines = body.split("\n")
+    misplaced = []
+    remaining_body_lines = []
+
+    for line in body_lines:
+        stripped = line.strip()
+        if stripped and LOG_ENTRY_PATTERN.match(stripped):
+            misplaced.append(stripped)
+        else:
+            remaining_body_lines.append(line)
+
+    if not misplaced:
+        return False  # Nothing to fix
+
+    # Remove trailing blank lines from pre_body, then add misplaced entries,
+    # then restore the blank line before --- body --- (standard format).
+    pre_body_stripped = pre_body.rstrip("\n")
+    # Append misplaced log entries to the log section
+    extra_log = "\n".join(misplaced)
+    new_pre_body = pre_body_stripped + "\n" + extra_log + "\n\n"
+
+    # Rebuild body — drop leading blank line that often follows the marker
+    new_body = "\n".join(remaining_body_lines)
+
+    new_content = new_pre_body + split_marker + new_body
+    path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    repo_root = Path(__file__).parent.parent
+    tickets_dir = repo_root / "tickets"
+    archive_dir = tickets_dir / "archive"
+
+    dirs = [tickets_dir]
+    if archive_dir.exists() and archive_dir.is_dir():
+        dirs.append(archive_dir)
+
+    fixed = []
+    for d in dirs:
+        for fpath in sorted(d.glob("*.erg")):
+            if fix_erg_file(fpath):
+                fixed.append(fpath.relative_to(repo_root))
+                print(f"  fixed: {fpath.relative_to(repo_root)}")
+
+    if fixed:
+        print(f"\nFixed {len(fixed)} file(s).")
+    else:
+        print("No misplaced log entries found. Nothing to do.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fix_ticket_log_placement.py
+++ b/scripts/fix_ticket_log_placement.py
@@ -30,19 +30,16 @@ def fix_erg_file(path: Path) -> bool:
     """
     content = path.read_text(encoding="utf-8")
 
-    # Split into pre-body and body sections
     split_marker = "--- body ---"
     if split_marker not in content:
         return False  # No body section; skip
 
     pre_body, body = content.split(split_marker, 1)
 
-    # Find misplaced log entries in body
-    body_lines = body.split("\n")
     misplaced = []
     remaining_body_lines = []
 
-    for line in body_lines:
+    for line in body.splitlines():
         stripped = line.strip()
         if stripped and LOG_ENTRY_PATTERN.match(stripped):
             misplaced.append(stripped)
@@ -52,14 +49,9 @@ def fix_erg_file(path: Path) -> bool:
     if not misplaced:
         return False  # Nothing to fix
 
-    # Remove trailing blank lines from pre_body, then add misplaced entries,
-    # then restore the blank line before --- body --- (standard format).
-    pre_body_stripped = pre_body.rstrip("\n")
-    # Append misplaced log entries to the log section
+    # rstrip then re-add ensures exactly one blank line before --- body ---
     extra_log = "\n".join(misplaced)
-    new_pre_body = pre_body_stripped + "\n" + extra_log + "\n\n"
-
-    # Rebuild body — drop leading blank line that often follows the marker
+    new_pre_body = pre_body.rstrip("\n") + "\n" + extra_log + "\n\n"
     new_body = "\n".join(remaining_body_lines)
 
     new_content = new_pre_body + split_marker + new_body

--- a/tickets/0075-autoresearch-universal-prompt.erg
+++ b/tickets/0075-autoresearch-universal-prompt.erg
@@ -16,6 +16,7 @@ Author: claude
 2026-04-13T11:00Z claude note separated result quality (evidence ladder, completeness, coherence) from system requirements (cheap, fast, cross-model, generic). They are orthogonal — a cheap system can produce garbage, a perfect single-model pipeline can produce impeccable data. Criteria section rewritten as two blocks.
 2026-04-13T11:30Z claude note operator confirmed: prompt is only for seed table, verification is on top. Evidence scores are not an optimization signal for the prompt — they're the verification pipeline's job. Objective simplified to min-of-5(recall × hallucination_gate). Three-way separation: (1) what optimizer controls (seed extraction), (2) result quality (evidence ladder, post-verification), (3) system requirements (cost, speed, universality, genericity).
 2026-04-21T00:00Z claude note produced docs/prompt-optimizer-survey.md — decision memo covering DSPy MIPROv2, TextGrad, OPRO, Promptbreeder, APE, AdalFlow, balukosuri autoresearch skill. Recommendation: adopt DSPy MIPROv2 (black-box metric API, LiteLLM multi-provider, seed+trace logging). Defer: OPRO, TextGrad, AdalFlow. Reject: Promptbreeder, APE, balukosuri as standalone optimizer. Prototype (Phase 1 actions 3–7) deferred to follow-up ticket.
+2026-04-21T07:50Z claude note survey complete — DSPy MIPROv2 adopt, TextGrad/AdalFlow defer, Promptbreeder/APE/balukosuri reject. Memo: docs/prompt-optimizer-survey.md (PR #276). Prototype phase (actions 3-7) deferred to follow-up ticket.
 
 --- body ---
 ## Context
@@ -417,4 +418,3 @@ A short script or notebook that:
 - Decision recorded: adopt (which tool, which stages), defer, or
   reject. If adopt, open a follow-up ticket for integration into
   the prompt_modules workflow and the measurement-hygiene wall.
-2026-04-21T07:50Z claude note survey complete — DSPy MIPROv2 adopt, TextGrad/AdalFlow defer, Promptbreeder/APE/balukosuri reject. Memo: docs/prompt-optimizer-survey.md (PR #276). Prototype phase (actions 3-7) deferred to follow-up ticket.

--- a/tickets/0076-langchain-deep-agents-pipeline.erg
+++ b/tickets/0076-langchain-deep-agents-pipeline.erg
@@ -9,6 +9,11 @@ Author: claude
 2026-04-21T07:48Z claude claimed
 2026-04-21T07:48Z claude status doing
 2026-04-21T07:57Z claude note wrote docs/langchain-deep-agents-eval.md — verdict: deepagents reject, LangGraph narrow defer
+2026-04-21T07:50Z claude status closed — verdict: deepagents reject (shape mismatch), LangGraph defer to ticket 0059. Memo: docs/langchain-deep-agents-eval.md (PR #275)
+2026-04-22T04:50Z user note scope correction — objectif était de trouver un usage deepagents dans un PROTOTYPE v1 (pas d'évaluer vs pipeline v0). L'agent a répondu à la mauvaise question. Relancer avec cadrage v1 : où deepagents peut-il prototyper une capacité stateful-agentique (découverte documentaire, boucle de vérification web, fusion multi-sources) ?
+2026-04-21T08:30Z claude status doing — v1 re-scope: building iterative web-verification prototype
+2026-04-21T09:00Z claude note built src/aedist/prototype_v1_verify_agent.py; ran on 3 plants (Pha Lai 1 search, Song Hau 1 3 searches, Bạc Liêu 1 7 searches); key finding: search depth adapts to name ambiguity — this is the v1 value-add
+2026-04-21T09:00Z claude status closed — v1 prototype complete; addendum added to docs/langchain-deep-agents-eval.md; recommendation: adopt deepagents planner loop for per-entity web-verification in v1 pipeline
 
 --- body ---
 ## Context
@@ -72,8 +77,3 @@ the same input, and a side-by-side report of cost/latency/LOC.
   a clear recommendation with a reproducibility verdict.
 - Decision recorded: adopt (which stages), defer, or reject.
 - If adopt: follow-up ticket(s) opened for the concrete migration.
-2026-04-21T07:50Z claude status closed — verdict: deepagents reject (shape mismatch), LangGraph defer to ticket 0059. Memo: docs/langchain-deep-agents-eval.md (PR #275)
-2026-04-22T04:50Z user note scope correction — objectif était de trouver un usage deepagents dans un PROTOTYPE v1 (pas d'évaluer vs pipeline v0). L'agent a répondu à la mauvaise question. Relancer avec cadrage v1 : où deepagents peut-il prototyper une capacité stateful-agentique (découverte documentaire, boucle de vérification web, fusion multi-sources) ?
-2026-04-21T08:30Z claude status doing — v1 re-scope: building iterative web-verification prototype
-2026-04-21T09:00Z claude note built src/aedist/prototype_v1_verify_agent.py; ran on 3 plants (Pha Lai 1 search, Song Hau 1 3 searches, Bạc Liêu 1 7 searches); key finding: search depth adapts to name ambiguity — this is the v1 value-add
-2026-04-21T09:00Z claude status closed — v1 prototype complete; addendum added to docs/langchain-deep-agents-eval.md; recommendation: adopt deepagents planner loop for per-entity web-verification in v1 pipeline

--- a/tickets/0077-lit-review-auto-statistics-pypsa.erg
+++ b/tickets/0077-lit-review-auto-statistics-pypsa.erg
@@ -17,6 +17,7 @@ Author: claude
 2026-04-20T20:22Z claude note P2 note written: 02_rag_knowledge_intensive.md — 4 citations proposed
 2026-04-20T20:22Z claude note P3 note written: 03_ai_economic_energy_data.md — 5 citations
 2026-04-21T20:22Z claude note P4 note written: 04_gap_and_positioning.md — 0 citations (total 14 across P1-P4; slot left empty, no direct precedent found; LM-KBC excluded as closed-domain)
+2026-04-21T07:43Z claude status closed — four notes + four §2 paragraphs + 15 citations written, reviewed and merged (PR #273)
 
 --- body ---
 ## Context
@@ -232,4 +233,3 @@ If paragraph 1 clears these, paragraphs 2, 3, 4 follow.
   discuss verification architectures (that's §6 Error Analysis /
   §7 Discussion territory).
 
-2026-04-21T07:43Z claude status closed — four notes + four §2 paragraphs + 15 citations written, reviewed and merged (PR #273)

--- a/tickets/0117-growth-curve-real-run.erg
+++ b/tickets/0117-growth-curve-real-run.erg
@@ -6,6 +6,7 @@ Author: claude
 
 --- log ---
 2026-04-22T14:00Z claude created — follow-up to ticket 0101 (PR #280): script exists, real 36-call run deferred
+2026-04-22T15:45Z claude status closed — 36-call run done; incremental F1@18=88.0%, global=46.2%; Freshness slide filled
 
 --- body ---
 ## Context
@@ -42,4 +43,3 @@ the execution and the two downstream artifacts.
 - `derived/fusion_proto/growth_curve.pdf` committed (two-line F1 curve).
 - Freshness slide shows real F1@18 numbers (not stub).
 - `make check` green.
-2026-04-22T15:45Z claude status closed — 36-call run done; incremental F1@18=88.0%, global=46.2%; Freshness slide filled

--- a/tickets/0120-namespace-schema-method-values.erg
+++ b/tickets/0120-namespace-schema-method-values.erg
@@ -15,6 +15,7 @@ Blocked-by: 0123
 2026-04-24T00:00Z claude note DSPy: prompt_version="dspy", compiled output stored as prompt_dspy.txt
 2026-04-24T10:58Z claude claimed
 2026-04-24T10:58Z claude status doing
+2026-04-24T11:35Z claude status closed — PR #286 merged; 324 records migrated, readers updated, frontier_scenarios edge case noted
 
 --- body ---
 ## Design
@@ -135,4 +136,3 @@ Contrast in analyses: `complete` (human-elaborated) vs `dspy` (machine-optimized
 - `frontier_skill` fully purged.
 - Unblocks 0121, 0124.
 
-2026-04-24T11:35Z claude status closed — PR #286 merged; 324 records migrated, readers updated, frontier_scenarios edge case noted

--- a/tickets/0121-namespace-config-sweep-names.erg
+++ b/tickets/0121-namespace-config-sweep-names.erg
@@ -8,6 +8,11 @@ Blocked-by: 0120
 --- log ---
 2026-04-24T00:00Z claude created — child of epic 0069; blocked by 0120 (vocabulary spine)
 2026-04-24T00:00Z claude note vocabulary finalised; sweep_ prefix (Hungarian), modelset_ prefix for sets
+2026-04-24T11:35Z claude claimed
+2026-04-24T11:35Z claude status doing
+2026-04-24T11:57Z claude note verify-gate REROLL: exit criterion 2 (harness translation) deferred to 0122 — prompt_version comes from output dir names, not sweep IDs; translation must wait for 0122 dir renames to avoid split prompt_version values across old/new runs
+2026-04-24T12:00Z claude bump verify-reroll — round 1: harness plus/minus sign-notation translation not implemented (exit criterion 2 MISSING)
+2026-04-24T12:09Z claude status closed — PR #288 merged; 53 sweeps + 14 modelsets renamed; ablation[sets] kept as modelset_ablation_phase2
 
 --- body ---
 ## Design
@@ -135,9 +140,4 @@ Ablation sweep IDs use `plus`/`minus` words; the harness translates to sign-nota
 - `make test` green.
 - Unblocks 0122.
 
-2026-04-24T11:35Z claude claimed
-2026-04-24T11:35Z claude status doing
-2026-04-24T11:57Z claude note verify-gate REROLL: exit criterion 2 (harness translation) deferred to 0122 — prompt_version comes from output dir names, not sweep IDs; translation must wait for 0122 dir renames to avoid split prompt_version values across old/new runs
-2026-04-24T12:00Z claude bump verify-reroll — round 1: harness plus/minus sign-notation translation not implemented (exit criterion 2 MISSING)
 
-2026-04-24T12:09Z claude status closed — PR #288 merged; 53 sweeps + 14 modelsets renamed; ablation[sets] kept as modelset_ablation_phase2

--- a/tickets/0122-namespace-filesystem-output-dirs.erg
+++ b/tickets/0122-namespace-filesystem-output-dirs.erg
@@ -9,6 +9,9 @@ Blocked-by: 0121
 2026-04-24T00:00Z claude created — child of epic 0069; blocked by 0121 (sweep names decided first)
 2026-04-24T00:00Z claude note no prefix on directory names — identified by parent path experiments/outputs/
 2026-04-24T11:57Z claude note ticket 0121 deferred harness plus/minus→sign-notation translation to this ticket (action 6); must be done after ablation subdir renames so prompt_version values are consistent
+2026-04-24T12:11Z claude claimed
+2026-04-24T12:11Z claude status doing
+2026-04-24T12:42Z claude status closed — PR #289 merged; 8 dirs renamed, 280 record.json + measurements.jsonl migrated, ablation subdir renames done
 
 --- body ---
 ## Design
@@ -71,7 +74,4 @@ No `frontier_scenarios/` or `verification/` top-level directory exists on disk y
 - Harness `plus`/`minus` → sign-notation translation in place (transferred from 0121).
 - `make test` green.
 
-2026-04-24T12:11Z claude claimed
-2026-04-24T12:11Z claude status doing
 
-2026-04-24T12:42Z claude status closed — PR #289 merged; 8 dirs renamed, 280 record.json + measurements.jsonl migrated, ablation subdir renames done

--- a/tickets/0123-namespace-prompts.erg
+++ b/tickets/0123-namespace-prompts.erg
@@ -11,6 +11,8 @@ Author: claude
 2026-04-24T00:00Z claude note DSPy: compiled output frozen as prompt_dspy.txt; program in scripts/dspy/
 2026-04-24T10:58Z claude claimed
 2026-04-24T10:58Z claude status doing
+2026-04-24T11:29Z claude bump circuit-breaker — agent timeout (wave 1: 0123+0120 completed ~31min, branch pushed, PR #286 open; exceeded 10min but delivered; no kill needed)
+2026-04-24T11:35Z claude status closed — PR #286 merged; all prompt files renamed, frontier_skill deleted
 
 --- body ---
 ## Context
@@ -69,6 +71,4 @@ This ticket renames existing files to match and defines the full vocabulary.
 - `make test` green.
 - Unblocks 0120.
 
-2026-04-24T11:29Z claude bump circuit-breaker — agent timeout (wave 1: 0123+0120 completed ~31min, branch pushed, PR #286 open; exceeded 10min but delivered; no kill needed)
 
-2026-04-24T11:35Z claude status closed — PR #286 merged; all prompt files renamed, frontier_skill deleted

--- a/tickets/0124-namespace-code-query-modules.erg
+++ b/tickets/0124-namespace-code-query-modules.erg
@@ -8,6 +8,9 @@ Blocked-by: 0120
 --- log ---
 2026-04-24T00:00Z claude created — child of epic 0069; blocked by 0120 (method name decided first)
 2026-04-24T00:00Z claude note naming axis: call pattern (not method value); query_sourced.py absent from disk
+2026-04-24T11:35Z claude claimed
+2026-04-24T11:35Z claude status doing
+2026-04-24T12:09Z claude status closed — PR #287 merged; query_frontier/decomposed/web renamed to call-pattern names
 
 --- body ---
 ## Design
@@ -51,7 +54,4 @@ with `prompt_cited.txt`. No rename needed.
 - Each `query_*.py` has a one-line docstring stating its call pattern.
 - Unblocks 0125.
 
-2026-04-24T11:35Z claude claimed
-2026-04-24T11:35Z claude status doing
 
-2026-04-24T12:09Z claude status closed — PR #287 merged; query_frontier/decomposed/web renamed to call-pattern names

--- a/tickets/0125-namespace-report-labels.erg
+++ b/tickets/0125-namespace-report-labels.erg
@@ -10,6 +10,9 @@ Blocked-by: 0124
 
 --- log ---
 2026-04-24T00:00Z claude created — child of epic 0069; blocked by 0120 0121 0123 0124
+2026-04-24T12:42Z claude claimed
+2026-04-24T12:42Z claude status doing
+2026-04-24T13:15Z claude status closed — PR #290 merged; labels/captions updated, tabulate scripts fixed, generated files regenerated
 
 --- body ---
 ## Note on dependencies
@@ -55,6 +58,3 @@ be updated to use consistent terms. Key locations:
 - Visual spot-check: changed sections read naturally in French.
 - Unblocks 0126.
 
-2026-04-24T12:42Z claude claimed
-2026-04-24T12:42Z claude status doing
-2026-04-24T13:15Z claude status closed — PR #290 merged; labels/captions updated, tabulate scripts fixed, generated files regenerated

--- a/tickets/0127-ticket-log-placement-validator.erg
+++ b/tickets/0127-ticket-log-placement-validator.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Ticket hygiene — fix misplaced log entries and add validator rule
-Status: doing
+Status: closed
 Created: 2026-04-24
 Author: claude
 
@@ -8,6 +8,7 @@ Author: claude
 2026-04-24T13:20Z claude created — celebrate sweep: 15+ tickets have log entries in body section
 2026-04-24T13:22Z claude claimed
 2026-04-24T13:22Z claude status doing
+2026-04-24T14:00Z claude status closed — batch fix (10 tickets) + scripts/check_ticket_structure.py + make lint wired
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- **Batch fix (10 tickets):** Log entries in 0075, 0076, 0077, 0117, 0120, 0121, 0122, 0123, 0124, 0125 were appended at EOF (landing in the body section). This PR moves them into the log section (between `--- log ---` and `--- body ---`) where the spec requires them.
- **New validator** `scripts/check_ticket_structure.py`: scans every `.erg` file, fails with exit code 1 if any body section contains a log-entry timestamp line. No external dependencies (stdlib only).
- **New helper** `scripts/fix_ticket_log_placement.py`: idempotent batch fixer for the same pattern; safe to re-run.
- **`make lint` wired**: the ticket structure check runs alongside `ruff check`.

## Test plan

- [x] `make lint` passes clean (ruff + ticket structure check)
- [x] `make test` passes: 1128 passed, 1 skipped, 1 xfailed
- [x] Fix script is idempotent (second run: "No misplaced log entries found")
- [x] Validator exits 0 after fix (117 files checked)
- [x] Ticket 0127 closed with log entry in correct section (before `--- body ---`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)