### PR TITLE
Hygiene ratchet: no raise-NotImplementedError / pytest.skip / TODO

### DIFF
--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -208,7 +208,7 @@ class Worker:
                 api_kwargs=api_kwargs,
             )
         elif mode == Method.VERIFICATION:
-            raise NotImplementedError(
+            raise NotImplementedError(  # noqa: hygiene — documented design choice
                 "verification mode requires external orchestration "
                 "(use query_verification.py directly)"
             )

--- a/tests/test_hygiene_stubs.py
+++ b/tests/test_hygiene_stubs.py
@@ -1,0 +1,38 @@
+"""Ratchet: no half-finished work in committed code.
+
+Stubs (`raise NotImplementedError`), skip-marked tests (`pytest.skip`,
+`@pytest.mark.skip`), and TODO comments are signals of deferred work
+that someone "will come back to." In autonomous-TDD codebases, nobody
+does. Use a follow-up ticket instead.
+
+Escape hatch: `# noqa: hygiene` on the line if the marker is genuinely
+load-bearing or documents a known design choice with no immediate fix
+(e.g. a runtime guard pointing the caller at a different entry point).
+
+The `NotImplementedError` pattern matches `raise NotImplementedError`
+(verb form), not bare mentions inside docstrings.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "aedist"
+
+PATTERNS = [
+    (r"raise\s+NotImplementedError", "NotImplementedError"),
+    (r"@pytest\.mark\.skip\b|pytest\.skip\(", "pytest.skip"),
+    (r"#\s*TODO\b", "TODO"),
+]
+
+
+@pytest.mark.parametrize("pattern,name", PATTERNS, ids=[n for _, n in PATTERNS])
+def test_no_stubs_or_skips_or_todos_in_src(pattern, name):
+    rx = re.compile(pattern)
+    offenders: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if rx.search(line) and "noqa: hygiene" not in line:
+                offenders.append(f"{path.relative_to(SRC.parent.parent)}:{i}: {line.strip()}")
+    assert not offenders, f"{name} found:\n  " + "\n  ".join(offenders)


### PR DESCRIPTION
Adds parametrized adherence test scanning `src/aedist/` for half-finished-work markers. Tightened `NotImplementedError` regex to `raise\s+NotImplementedError` (verb form), so docstring mentions like "Raises NotImplementedError" are not flagged. Annotates one pre-existing documented `raise NotImplementedError` in `worker.py` (verification-mode dispatch guard) with `# noqa: hygiene`. Test passes.