### PR TITLE
Register pytest 'adherence' marker; mark hygiene-stubs test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,5 @@ pythonpath = [".", "scripts"]
 markers = [
     "integration: spawns subprocesses or uses sleep-based timing",
     "slow: requires network access or real data",
+    "adherence: project rule enforcement (hygiene/discipline/contracts)",
 ]

--- a/tests/test_hygiene_stubs.py
+++ b/tests/test_hygiene_stubs.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.adherence
+
 SRC = Path(__file__).resolve().parents[1] / "src" / "aedist"
 
 PATTERNS = [


### PR DESCRIPTION
Adds the `adherence` marker to pyproject.toml (next to `integration` and `slow`) and applies `pytestmark = pytest.mark.adherence` to `tests/test_hygiene_stubs.py`. Contract item for `/verify-adherence` Phase 1.