### PR TITLE
chore: update xfail reason — only ticket 0133 remains

### DIFF
--- a/tests/test_no_inline_plots.py
+++ b/tests/test_no_inline_plots.py
@@ -25,7 +25,7 @@ def _tracked_tex_files() -> list[Path]:
     return [REPO_ROOT / f for f in result.stdout.split("\0") if f.endswith(".tex")]
 
 
-@pytest.mark.xfail(reason="remediation pending: tickets 0131, 0133")
+@pytest.mark.xfail(reason="remediation pending: ticket 0133")
 def test_no_begin_axis():
     violations = []
     for tex_file in _tracked_tex_files():


### PR DESCRIPTION
0131 and 0132 both merged; xfail string was stale.