### PR TITLE
chore: add qwen3.6:35b to modelset_census_local

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -63,6 +63,7 @@ model_ids = [
     "gemma4:e2b",
     "cogito:8b",
     "granite3.3:8b",
+    "qwen3.6:35b",
 ]
 
 [sets.modelset_frontier]


### PR DESCRIPTION
## Summary
- Adds `qwen3.6:35b` to `modelset_census_local` so `sweep_direct_extract_local` picks it up
- Runs without `no_think` for consistency with existing local model data (same uncontrolled state as cogito:8b, qwen3.5:* runs)
- When ticket 0138 schedules Class A redo, all local extraction models will be redone together

## Test plan
- [ ] Verify `qwen3.6:35b` appears in the modelset via `python -c "import tomllib; cfg = tomllib.load(open('experiments/experiments.toml','rb')); print(cfg['sets']['modelset_census_local'])"`
- [ ] Run one test call before launching full sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)