### PR TITLE
fix: add no_think=true to sweep_direct_extract_local

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -223,6 +223,7 @@ model_set = "modelset_census_local"
 repeat = 3
 budget_usd = 0
 seed = 42
+no_think = true
 output = "outputs/direct_extract"
 ollama_url = "http://localhost:11434/v1"
 

--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -63,6 +63,7 @@ model_ids = [
     "gemma4:e2b",
     "cogito:8b",
     "granite3.3:8b",
+    "qwen3.6:35b",
 ]
 
 [sets.modelset_frontier]


### PR DESCRIPTION
## Summary
- Adds `no_think = true` to `sweep_direct_extract_local` so Qwen3 models suppress chain-of-thought during extraction
- Non-Qwen3 models (cogito:8b, gemma4:*, granite3.3:8b) ignore the Ollama `think: false` option — no effect on them
- Existing local runs pre-this-commit lack no_think control (ticket 0138 Class A redo)

## Why the previous approach was wrong
PR #304 committed to running qwen3.6:35b without `no_think` "for consistency with existing local model data." That reasoning was flawed: the other models in the set don't support `no_think`, so there is no consistency to preserve. qwen3.6:35b is Qwen3 and needs the flag.

## Test plan
- [ ] `python3 -c "import tomllib; cfg = tomllib.load(open('experiments/experiments.toml','rb')); print(cfg['sweeps']['sweep_direct_extract_local'].get('no_think'))"` → `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)