### PR TITLE
fix: Ollama native API regression test (ticket 0155)

### DIFF
--- a/src/aedist/query_livesearch.py
+++ b/src/aedist/query_livesearch.py
@@ -192,6 +192,13 @@ def main():
                 )
             client = legacy_client
 
+        # Ollama: bypass /v1/ shim to honour num_ctx; resolved once per model
+        if router == "ollama":
+            ollama_cfg = routers_config.get("ollama", {}) if args.model_set else {}
+            ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+            ctx_window = model.get("context_window", 32768)
+            num_ctx = min(ctx_window, 81920)
+
         for run in range(1, args.repeat + 1):
             if not budget.check_or_warn():
                 return
@@ -219,12 +226,6 @@ def main():
                     temperature=args.temperature,
                 )
                 if router == "ollama":
-                    ollama_cfg = (
-                        experiments.get("routers", {}).get("ollama", {}) if args.model_set else {}
-                    )
-                    ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
-                    ctx_window = model.get("context_window", 32768)
-                    num_ctx = min(ctx_window, 81920)
                     result = query_ollama_native(
                         ollama_url,
                         api_model_id,

--- a/src/aedist/query_livesearch.py
+++ b/src/aedist/query_livesearch.py
@@ -30,6 +30,7 @@ from .harness import (
     make_client_for_router,
     model_metadata,
     output_path,
+    query_ollama_native,
     query_single_turn,
     save_json,
     select_models,
@@ -217,7 +218,21 @@ def main():
                     model,
                     temperature=args.temperature,
                 )
-                result = query_single_turn(client, api_model_id, messages, **api_kwargs)
+                if router == "ollama":
+                    ollama_cfg = (
+                        experiments.get("routers", {}).get("ollama", {}) if args.model_set else {}
+                    )
+                    ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+                    ctx_window = model.get("context_window", 32768)
+                    num_ctx = min(ctx_window, 81920)
+                    result = query_ollama_native(
+                        ollama_url,
+                        api_model_id,
+                        messages,
+                        num_ctx,
+                    )
+                else:
+                    result = query_single_turn(client, api_model_id, messages, **api_kwargs)
                 usage = result.get("usage") or {}
                 cost = compute_cost(usage, model)
                 budget.add(cost)

--- a/src/aedist/query_livesearch.py
+++ b/src/aedist/query_livesearch.py
@@ -255,7 +255,7 @@ def main():
                 }
                 save_json(filepath, record)
                 log.info("  Done. cost=%.6f total=%.6f USD", cost, budget.total_cost)
-            except openai.APIError as e:
+            except (openai.APIError, httpx.HTTPError) as e:
                 log.error("Error querying %s run %d: %s", label, run, e)
 
     log.info("Completed. Total cost: %.6f USD", budget.total_cost)

--- a/src/aedist/query_per_fuel.py
+++ b/src/aedist/query_per_fuel.py
@@ -293,6 +293,15 @@ def main():
             log.warning("Skip %s: corpus too large for context window", label)
             continue
 
+        # Ollama: bypass /v1/ shim to honour num_ctx; resolved once per model
+        if router == "ollama":
+            ollama_cfg = routers_config.get("ollama", {}) if args.model_set else {}
+            ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+            ollama_num_ctx = min(ctx_window or 32768, 81920)
+        else:
+            ollama_url = None
+            ollama_num_ctx = None
+
         for run in range(1, args.repeat + 1):
             if not budget.check_or_warn():
                 return
@@ -304,16 +313,6 @@ def main():
             log.info("Querying %s run %d/%d (decomposed RAG)...", label, run, args.repeat)
 
             api_model_id = model.get("router_model", model_id)
-            # Ollama: bypass /v1/ shim to honour num_ctx
-            ollama_url_val = None
-            num_ctx_val = None
-            if router == "ollama":
-                ollama_cfg = (
-                    experiments.get("routers", {}).get("ollama", {}) if args.model_set else {}
-                )
-                ollama_url_val = ollama_cfg.get("base_url", "http://localhost:11434/v1")
-                ctx_window = model.get("context_window", 32768)
-                num_ctx_val = min(ctx_window, 81920)
             dec_api_kwargs = build_api_kwargs(
                 model,
                 temperature=args.temperature,
@@ -324,8 +323,8 @@ def main():
                 corpus_text,
                 budget,
                 model,
-                ollama_url=ollama_url_val,
-                num_ctx=num_ctx_val,
+                ollama_url=ollama_url,
+                num_ctx=ollama_num_ctx,
                 **dec_api_kwargs,
             )
 

--- a/src/aedist/query_per_fuel.py
+++ b/src/aedist/query_per_fuel.py
@@ -25,6 +25,7 @@ import logging
 from datetime import date
 from pathlib import Path
 
+import httpx
 import openai
 
 from .extract import (
@@ -166,7 +167,7 @@ def query_decomposed(
                 result = query_ollama_native(ollama_url, model_id, messages, num_ctx)
             else:
                 result = query_single_turn(client, model_id, messages, **api_kwargs)
-        except openai.APIError as e:
+        except (openai.APIError, httpx.HTTPError) as e:
             log.error("  Error on %s sub-query: %s", fuel, e)
             return None
 

--- a/src/aedist/query_per_fuel.py
+++ b/src/aedist/query_per_fuel.py
@@ -43,6 +43,7 @@ from .harness import (
     make_client_for_router,
     model_metadata,
     output_path,
+    query_ollama_native,
     query_single_turn,
     save_json,
     select_models,
@@ -140,6 +141,9 @@ def query_decomposed(
     corpus_text: str,
     budget: BudgetTracker,
     model: dict,
+    *,
+    ollama_url: str | None = None,
+    num_ctx: int | None = None,
     **api_kwargs,
 ) -> dict | None:
     """Run 3 sub-queries and merge results. Returns record dict or None."""
@@ -158,7 +162,10 @@ def query_decomposed(
         ]
 
         try:
-            result = query_single_turn(client, model_id, messages, **api_kwargs)
+            if ollama_url and num_ctx:
+                result = query_ollama_native(ollama_url, model_id, messages, num_ctx)
+            else:
+                result = query_single_turn(client, model_id, messages, **api_kwargs)
         except openai.APIError as e:
             log.error("  Error on %s sub-query: %s", fuel, e)
             return None
@@ -296,6 +303,16 @@ def main():
             log.info("Querying %s run %d/%d (decomposed RAG)...", label, run, args.repeat)
 
             api_model_id = model.get("router_model", model_id)
+            # Ollama: bypass /v1/ shim to honour num_ctx
+            ollama_url_val = None
+            num_ctx_val = None
+            if router == "ollama":
+                ollama_cfg = (
+                    experiments.get("routers", {}).get("ollama", {}) if args.model_set else {}
+                )
+                ollama_url_val = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+                ctx_window = model.get("context_window", 32768)
+                num_ctx_val = min(ctx_window, 81920)
             dec_api_kwargs = build_api_kwargs(
                 model,
                 temperature=args.temperature,
@@ -306,6 +323,8 @@ def main():
                 corpus_text,
                 budget,
                 model,
+                ollama_url=ollama_url_val,
+                num_ctx=num_ctx_val,
                 **dec_api_kwargs,
             )
 

--- a/tests/test_ollama_native_api.py
+++ b/tests/test_ollama_native_api.py
@@ -16,12 +16,16 @@ import yaml
 # Registry: deliberate friction for new query modules
 # ---------------------------------------------------------------------------
 
-OLLAMA_DISPATCH = {"query_direct", "query_multiturn", "query_rag"}
+OLLAMA_DISPATCH = {
+    "query_direct",
+    "query_multiturn",
+    "query_rag",
+    "query_per_fuel",
+    "query_livesearch",
+}
 NO_OLLAMA_DISPATCH = {
     "query",
     "query_fusion",
-    "query_livesearch",
-    "query_per_fuel",
     "query_verification",
 }
 
@@ -267,6 +271,90 @@ def test_query_rag_ollama_uses_native_api(mock_httpx_post, tmp_path):
         ],
     ):
         from aedist.query_rag import main
+
+        main()
+
+    _assert_ollama_native_call(mock_httpx_post)
+
+
+# ---------------------------------------------------------------------------
+# Per-module dispatch: query_per_fuel
+# ---------------------------------------------------------------------------
+
+
+@patch("httpx.post")
+@patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"})
+def test_query_per_fuel_ollama_uses_native_api(mock_httpx_post, tmp_path):
+    mock_httpx_post.return_value = _ollama_response()
+    _write_models_yaml(tmp_path)
+    _write_prompt(tmp_path)
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "doc.md").write_text("# Test\nSome corpus content about power plants.")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "query_per_fuel",
+            "--prompt",
+            str(tmp_path / "prompt.txt"),
+            "--corpus",
+            str(corpus_dir),
+            "--models",
+            str(tmp_path / "models.yaml"),
+            "--output",
+            str(output_dir),
+        ],
+    ):
+        from aedist.query_per_fuel import main
+
+        main()
+
+    assert mock_httpx_post.call_count == 3, (
+        f"Expected 3 sub-query calls (one per fuel), got {mock_httpx_post.call_count}"
+    )
+    for call in mock_httpx_post.call_args_list:
+        url = call.args[0] if call.args else call.kwargs.get("url", "")
+        assert url.endswith("/api/chat"), f"Expected /api/chat, got: {url}"
+        payload = call.kwargs.get("json", {})
+        assert "num_ctx" in payload.get("options", {}), (
+            f"num_ctx missing from options: {payload.get('options')}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-module dispatch: query_livesearch
+# ---------------------------------------------------------------------------
+
+
+@patch("aedist.query_livesearch.run_web_searches")
+@patch("httpx.post")
+@patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key", "TAVILY_API_KEY": "fake-key"})
+def test_query_livesearch_ollama_uses_native_api(mock_httpx_post, mock_web_searches, tmp_path):
+    mock_httpx_post.return_value = _ollama_response()
+    mock_web_searches.return_value = ("Web search context about power plants.", [])
+    _write_models_yaml(tmp_path)
+    _write_prompt(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "query_livesearch",
+            "--prompt",
+            str(tmp_path / "prompt.txt"),
+            "--models",
+            str(tmp_path / "models.yaml"),
+            "--output",
+            str(output_dir),
+        ],
+    ):
+        from aedist.query_livesearch import main
 
         main()
 


### PR DESCRIPTION
## Summary

- **Fixed `query_per_fuel.py` and `query_livesearch.py`**: both were calling `query_single_turn()` unconditionally for Ollama models, silently dropping `num_ctx` (same bug class as commits d27c393 + 031cef2 that fixed `query_direct` and `query_multiturn`)
- **Added `tests/test_ollama_native_api.py`** (7 tests): discovery test for new modules, per-module Ollama routing assertions for all 5 query CLIs, and a negative case for non-Ollama models
- Test suite: 1142 passed (+7 new), 1 skipped, 2 xfailed — no regressions

## Test plan

- [x] All 7 new tests pass (`uv run pytest tests/test_ollama_native_api.py -v`)
- [x] Full test suite passes with no regressions
- [x] ERG ticket validation passes
- [ ] Verify `query_per_fuel.py` Ollama routing works with a real Ollama model (manual)
- [ ] Verify `query_livesearch.py` Ollama routing works with a real Ollama model (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)