### PR TITLE
feat(ablation): verbatim modules from prompt_complete (ticket 0142)

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -492,7 +492,7 @@ output = "qualitative/scenarios"
 # Temperature: provider-recommended for structured extraction (0.0–0.3).
 # DeepSeek note: API temp 1.0 maps internally to 0.3 (their recommended).
 #
-# All modules: persona, overview, citation_columns, sourcing_ground, narratives, bibliography, statistics
+# All modules: persona, overview, narratives, sourcing_ground, statistics, data_quality_table, bibliography, citation_columns, observed_vs_projected, pdp_completeness
 
 # Phase 1 — Selection: base vs composite across 3 regimes
 # Uses modelset_ablation_dev (cheap reasoning models) for pipeline validation.
@@ -524,7 +524,7 @@ output = "outputs/ablation/direct/p1_base"
 
 [sweeps.sweep_ablation_p1_direct_composite]
 mode = "single"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_dev"
 repeat = 2
@@ -545,7 +545,7 @@ output = "outputs/ablation/rag/p1_base"
 
 [sweeps.sweep_ablation_p1_rag_composite]
 mode = "rag"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_dev"
 repeat = 2
@@ -568,7 +568,7 @@ output = "outputs/ablation/livesearch/p1_base"
 [sweeps.sweep_ablation_p1_livesearch_composite]
 mode = "single"
 web_search = true
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_dev"
 repeat = 2
@@ -662,7 +662,7 @@ output = "outputs/ablation/sourcing_ground"
 
 [sweeps.sweep_ablation_composite]
 mode = "single"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -694,7 +694,7 @@ output = "outputs/ablation/census"
 
 [sweeps.sweep_ablation_minus_persona]
 mode = "single"
-prompt_modules = ["overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -704,7 +704,7 @@ output = "outputs/ablation/no_persona"
 
 [sweeps.sweep_ablation_minus_overview]
 mode = "single"
-prompt_modules = ["persona", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -714,7 +714,7 @@ output = "outputs/ablation/no_overview"
 
 [sweeps.sweep_ablation_minus_narratives]
 mode = "single"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -724,7 +724,7 @@ output = "outputs/ablation/no_narratives"
 
 [sweeps.sweep_ablation_minus_bibliography]
 mode = "single"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -734,7 +734,7 @@ output = "outputs/ablation/no_bibliography"
 
 [sweeps.sweep_ablation_minus_statistics]
 mode = "single"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -744,7 +744,7 @@ output = "outputs/ablation/no_statistics"
 
 [sweeps.sweep_ablation_minus_citation_columns]
 mode = "single"
-prompt_modules = ["persona", "overview", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -754,7 +754,7 @@ output = "outputs/ablation/no_citation_columns"
 
 [sweeps.sweep_ablation_minus_sourcing_ground]
 mode = "single"
-prompt_modules = ["persona", "overview", "citation_columns", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models.yaml"
 model_set = "modelset_ablation_phase2"
 repeat = 3
@@ -777,7 +777,7 @@ output = "outputs/ablation/rag/p2_base"
 
 [sweeps.sweep_ablation_p2_rag_composite]
 mode = "rag"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -867,7 +867,7 @@ output = "outputs/ablation/rag/p2_sourcing_ground"
 
 [sweeps.sweep_ablation_p2_rag_minus_persona]
 mode = "rag"
-prompt_modules = ["overview", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -876,7 +876,7 @@ output = "outputs/ablation/rag/p2_no_persona"
 
 [sweeps.sweep_ablation_p2_rag_minus_overview]
 mode = "rag"
-prompt_modules = ["persona", "citation_columns", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -885,7 +885,7 @@ output = "outputs/ablation/rag/p2_no_overview"
 
 [sweeps.sweep_ablation_p2_rag_minus_narratives]
 mode = "rag"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -894,7 +894,7 @@ output = "outputs/ablation/rag/p2_no_narratives"
 
 [sweeps.sweep_ablation_p2_rag_minus_bibliography]
 mode = "rag"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -903,7 +903,7 @@ output = "outputs/ablation/rag/p2_no_bibliography"
 
 [sweeps.sweep_ablation_p2_rag_minus_statistics]
 mode = "rag"
-prompt_modules = ["persona", "overview", "citation_columns", "sourcing_ground", "narratives", "bibliography"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -912,7 +912,7 @@ output = "outputs/ablation/rag/p2_no_statistics"
 
 [sweeps.sweep_ablation_p2_rag_minus_citation_columns]
 mode = "rag"
-prompt_modules = ["persona", "overview", "sourcing_ground", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "sourcing_ground", "statistics", "data_quality_table", "bibliography", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5
@@ -921,7 +921,7 @@ output = "outputs/ablation/rag/p2_no_citation_columns"
 
 [sweeps.sweep_ablation_p2_rag_minus_sourcing_ground]
 mode = "rag"
-prompt_modules = ["persona", "overview", "citation_columns", "narratives", "bibliography", "statistics"]
+prompt_modules = ["persona", "overview", "narratives", "statistics", "data_quality_table", "bibliography", "citation_columns", "observed_vs_projected", "pdp_completeness"]
 models = "models_ablation_p2_rag.yaml"
 repeat = 3
 budget_usd = 5

--- a/experiments/prompts/modules/README.md
+++ b/experiments/prompts/modules/README.md
@@ -1,6 +1,10 @@
-# Prompt modules
+# Prompt modules — verbatim extraction from prompt_complete.txt
 
-Each `.txt` file is a self-contained prompt component.
+Each `.txt` file is a **verbatim paragraph extraction** from
+`experiments/prompts/prompt_complete.txt`. No abstraction, no rewording.
+Assembling all modules reproduces the complete prompt (minus section headers).
+This is enforced by `tests/test_modules_match_prompt_complete.py`.
+
 `base.txt` is always included. Other modules are optional.
 
 ## Assembly
@@ -8,18 +12,31 @@ Each `.txt` file is a self-contained prompt component.
 `harness.assemble_prompt(modules_dir, module_names)` composes the final
 prompt. Module ordering is deterministic:
 
-1. **persona** (prepended before base)
-2. **base** (always present)
-3. **overview** (appended)
-4. **citation_columns** (appended)
-5. **sourcing_ground** (appended)
-6. **narratives** (appended)
-7. **bibliography** (appended)
-8. **statistics** (appended)
+1. **persona** (prepended before base) — opening sentence, §intro
+2. **overview** (prepended before base) — §1 Sector Overview content
+3. **base** (always present) — §2 table spec with all 12 columns
+4. **narratives** (appended) — §2 per-plant discussion: history + issues
+5. **sourcing_ground** (appended) — §2 confidence rubric + Quality source-confidence rule
+6. **statistics** (appended) — §3 cross-tabs a–c
+7. **data_quality_table** (appended) — §3 d) confidence × fuel cross-tab
+8. **bibliography** (appended) — §4 annotated bibliography
+9. **citation_columns** (appended) — Quality: primary-source priority + URL fabrication guardrail
+10. **observed_vs_projected** (appended) — Quality: OBSERVED vs PROJECTED distinction
+11. **pdp_completeness** (appended) — Quality: PDP coverage + exhaustiveness + MWe units
 
 The order is defined in `_MODULE_ORDER` in `src/aedist/harness.py`.
-To add a new module: create the `.txt` file here and add its name to
-`_MODULE_ORDER` at the appropriate position.
+
+## Ablation semantics
+
+`base.txt` includes Source 1/Source 2 in the table header (verbatim from
+prompt_complete §2). Ablating `citation_columns` removes the quality
+guardrails on sources (primary-source priority, URL fabrication warning)
+but not the structural source-column requirement. This tests whether the
+guardrail matters, not whether sources are requested at all.
+
+`sourcing_ground` merges text from two sections of prompt_complete: the
+confidence rubric from §2 and the source-confidence quality rule. Both
+concern the same concept (confidence assessment) and ablate as one unit.
 
 ## Inspection
 

--- a/experiments/prompts/modules/base.txt
+++ b/experiments/prompts/modules/base.txt
@@ -1,36 +1,11 @@
-Produce a comprehensive CSV table listing ALL thermal power plants in
-Vietnam with capacity of 30 MWe or above, at every stage from early
-proposal through decommissioning. Include grid-connected utility plants,
-captive (self-generation) plants, and industrial cogeneration facilities.
+For EVERY thermal power plant in Vietnam — operational, under construction, approved, and planned under PDP7 revised and PDP8 — provide:
 
-Columns:
-- Name_VI: plant name in Vietnamese
-- Name_EN: plant name in English
-- Fuel: the primary fuel — e.g. Coal, Domestic gas, Imported LNG, Oil.
-  Exclude biomass and waste-to-energy plants (tracked separately).
+Format: Markdown table with columns:
+| Name (Vietnamese) | Name (English) | Province | Fuel | Technology | Units × MW | Total MWe | Status | COD | Owner/Developer | Source 1 | Source 2 |
+
+Where:
+- Fuel: Coal / Domestic gas / Imported LNG
 - Technology: Subcritical / Supercritical / USC / CCGT / OCGT / CFB
-- Status: current stage of the project, e.g. Operational, Under construction,
-  Proposed, Permitted, Financed, Suspended, Cancelled, Decommissioned.
-  Use the most specific term that applies. Projects may have been proposed
-  by investors, provincial authorities, international partners, or national
-  planners — capture all regardless of which authority originated them.
-- COD: actual or expected commercial operation date
-- Province: location
-- Capacity_MWe: current or as-built net generation capacity in MWe.
-  If the plant was proposed at a different capacity, note the difference.
-- Owner: key investors or controlling entities — e.g. "EVN/GENCO 1",
-  "Marubeni + KEPCO (BOT)", "Formosa Plastics". Skip single-purpose
-  project vehicles.
-- Note: additional context — e.g. original proposed capacity if different
-  from as-built, unit breakdowns, phase information, ownership changes.
-
-Be exhaustive. Cover every thermal power plant you know of, whether it
-appeared in a national power development plan, regulatory filing,
-investment proposal, international agreement, news report, or any other
-source. Include cancelled projects, suspended proposals, and plants that
-were planned but never built. Missing plants reduces the value of this
-inventory.
-
-Format the response as CSV with a header row.
-
-Do not fabricate entries. Include only plants you have clear evidence for.
+- Status: Operational / Under construction / Approved / Planned / Suspended / Cancelled
+- COD: Actual commercial operation date or expected date
+- Sources: primary source references (numbered, detailed in bibliography)

--- a/experiments/prompts/modules/bibliography.txt
+++ b/experiments/prompts/modules/bibliography.txt
@@ -1,5 +1,9 @@
-After completing the inventory, list every source you relied on as an
-annotated bibliography organized by category (government decisions, power
-development plans, utility reports, company filings, news). For each source:
-full citation, URL if known ("URL not verified" if unsure), and one sentence
-on what information was drawn from it.
+List every source cited, organized by category:
+
+**Categories**: Government decisions (Quyết định) / Power Development Plans / EVN & subsidiary reports / PetroVietnam & subsidiary reports / Company filings & press releases / Regulatory & international organization reports / News & media / Academic sources
+
+For each source provide:
+- Full citation: author/agency, title, date, publisher
+- URL if available online (do NOT fabricate URLs — if you are unsure of the exact URL, say "URL not verified")
+- For Vietnamese-language sources: original title in Vietnamese, then English translation in brackets
+- 1-sentence annotation: what specific information was drawn from this source

--- a/experiments/prompts/modules/citation_columns.txt
+++ b/experiments/prompts/modules/citation_columns.txt
@@ -1,4 +1,2 @@
-For each row, include Source_1 and Source_2 columns citing the primary
-source for that plant's data. After the table, list all cited sources
-with full citations. Do not fabricate URLs — write "URL not verified"
-if unsure of the exact address.
+- PRIORITIZE primary sources: Vietnamese government decisions (Quyết định, Nghị quyết), official PDP documents, EVN/PVN annual reports, regulatory filings, company disclosures
+- Do NOT fabricate or hallucinate source URLs. If you cannot recall the exact URL, write "URL not verified" rather than inventing one

--- a/experiments/prompts/modules/data_quality_table.txt
+++ b/experiments/prompts/modules/data_quality_table.txt
@@ -1,0 +1,1 @@
+d) **Data quality summary**: Count of plants by confidence level (High/Medium/Low) and fuel type

--- a/experiments/prompts/modules/narratives.txt
+++ b/experiments/prompts/modules/narratives.txt
@@ -1,5 +1,3 @@
-After the CSV table, provide a sourced paragraph for each plant complex
-covering: development history and timeline, notable issues (delays,
-financing changes, ownership transfers, technology changes), and status
-confidence (HIGH = government decision or company report, MEDIUM = multiple
-news sources, LOW = older plans only, status uncertain).
+After the inventory table, provide a sourced narrative paragraph for each plant (or plant complex) covering:
+- Development history and timeline (original plan, actual progress)
+- Notable issues: delays, financing changes, ownership transfers, environmental controversies, technology changes

--- a/experiments/prompts/modules/observed_vs_projected.txt
+++ b/experiments/prompts/modules/observed_vs_projected.txt
@@ -1,0 +1,1 @@
+- Distinguish OBSERVED facts (plant is operating, verified COD) from PROJECTED facts (planned capacity, expected COD from PDP)

--- a/experiments/prompts/modules/overview.txt
+++ b/experiments/prompts/modules/overview.txt
@@ -1,5 +1,6 @@
-Before the CSV table, provide a sector overview covering: Vietnam's
-electricity generation mix (installed capacity, generation shares by fuel),
-key policy documents and their thermal targets, fuel supply landscape
-(domestic coal, domestic gas, LNG import projects), and key institutional
-actors (state utilities, gas companies, BOT investors, provincial authorities).
+Provide introductory context on Vietnam's thermal power sector covering:
+- Evolution of Vietnam's electricity generation mix (hydro, thermal, renewables) with key statistics (installed capacity GW, generation TWh, shares by fuel)
+- Policy framework: Power Development Plans (PDP6, PDP7, PDP7 revised, PDP8) and their thermal power capacity targets and timelines
+- Fuel supply landscape: domestic coal (Vinacomin/TKV), imported coal, domestic natural gas (PetroVietnam offshore basins — Block B, Cá Voi Xanh/Blue Whale, Nam Côn Sơn), LNG import terminal projects
+- Key institutional actors: EVN and its generation subsidiaries (EVNGENCO 1/2/3), PetroVietnam Gas (PV Gas), PV Power, BOT investors (JBIC, KEPCO, Marubeni, EDF, AES, Sembcorp), provincial authorities, MOIT
+- Current challenges: coal phase-down commitments (COP26 JETP), LNG-to-power transition economics, renewable integration vs. baseload needs

--- a/experiments/prompts/modules/pdp_completeness.txt
+++ b/experiments/prompts/modules/pdp_completeness.txt
@@ -1,0 +1,3 @@
+- Include every plant from PDP7 revised (Decision 428/QĐ-TTg, 2016) and PDP8 (Decision 500/QĐ-TTg, 2023), even if suspended or cancelled — note which plan authorized each
+- Be exhaustive: Vietnam has approximately 80–100 thermal units across 50+ plant complexes. Missing plants reduces the value of this inventory
+- Use consistent units: MWe for net capacity throughout

--- a/experiments/prompts/modules/persona.txt
+++ b/experiments/prompts/modules/persona.txt
@@ -1,1 +1,1 @@
-You are a senior energy analyst.
+You are a senior energy analyst preparing a comprehensive technical inventory of Vietnam's thermal power sector. Produce a complete, primary-sourced reference document structured as follows.

--- a/experiments/prompts/modules/sourcing_ground.txt
+++ b/experiments/prompts/modules/sourcing_ground.txt
@@ -1,3 +1,2 @@
-For each plant, state your confidence level (HIGH / MEDIUM / LOW) and the
-primary evidence you relied on (one sentence). Do not fabricate sources —
-write "evidence uncertain" if unsure.
+- Current status confidence: HIGH (verified by government decision or company annual report), MEDIUM (confirmed by multiple news sources), LOW (only found in older plans, status uncertain)
+- When a fact comes from a primary source, cite it. When uncertain, mark confidence as LOW and explain why

--- a/experiments/prompts/modules/statistics.txt
+++ b/experiments/prompts/modules/statistics.txt
@@ -1,4 +1,4 @@
-After the inventory, produce cross-tabulation summary tables:
-a) Capacity by fuel x status (total MWe per cell, with row and column totals)
-b) Top 15 provinces by total thermal capacity, broken down by fuel
-c) Timeline of capacity additions by period and fuel type
+Produce these cross-tabulations from your inventory:
+a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operational/Under construction/Approved/Planned columns), with row and column totals
+b) **Top provinces**: The 15 provinces with highest total thermal capacity (all statuses combined), showing breakdown by fuel
+c) **Timeline of additions**: Capacity entering service by period — pre-2005, 2005–2010, 2011–2015, 2016–2020, 2021–2025, 2026–2030, post-2030 — by fuel type

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -136,14 +136,18 @@ def load_experiments(path: str) -> dict:
 # Prompt assembly
 # ---------------------------------------------------------------------------
 
-# Module ordering: persona is prepended, all others appended in this order.
+# Persona and overview are prepended (before base); all others appended.
+_BEFORE_BASE = frozenset({"persona", "overview"})
 _MODULE_ORDER = [
     "overview",
-    "citation_columns",
-    "sourcing_ground",
     "narratives",
-    "bibliography",
+    "sourcing_ground",
     "statistics",
+    "data_quality_table",
+    "bibliography",
+    "citation_columns",
+    "observed_vs_projected",
+    "pdp_completeness",
 ]
 KNOWN_MODULES = frozenset(["persona"] + _MODULE_ORDER)
 
@@ -153,8 +157,8 @@ def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
 
     *modules_dir* contains ``base.txt`` and one file per module
     (e.g. ``persona.txt``, ``overview.txt``).  The *module_names* list
-    selects which modules to include.  ``persona`` is prepended before
-    the base; all others are appended in a fixed order.
+    selects which modules to include.  ``persona`` and ``overview`` are
+    prepended before the base; all others are appended in a fixed order.
 
     Raises ``ValueError`` if *module_names* contains unknown names.
     """
@@ -166,11 +170,10 @@ def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
     base = (modules_dir / "base.txt").read_text().strip()
     parts_before: list[str] = []
     parts_after: list[str] = []
-    # Sort requested modules into fixed order for reproducibility.
     ordered = [m for m in ["persona"] + _MODULE_ORDER if m in module_names]
     for name in ordered:
         text = (modules_dir / f"{name}.txt").read_text().strip()
-        if name == "persona":
+        if name in _BEFORE_BASE:
             parts_before.append(text)
         else:
             parts_after.append(text)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -267,15 +267,15 @@ def test_assemble_prompt():
     modules_dir = EXPERIMENTS_DIR / "prompts" / "modules"
     # Base only
     base = assemble_prompt(modules_dir, [])
-    assert "Produce a comprehensive CSV table" in base
+    assert "For EVERY thermal power plant" in base
     assert "senior energy analyst" not in base
-    # With persona (prepended)
+    # With persona (prepended before base)
     with_persona = assemble_prompt(modules_dir, ["persona"])
     assert with_persona.startswith("You are a senior energy analyst")
-    assert "Produce a comprehensive CSV table" in with_persona
-    # With overview (appended)
-    with_overview = assemble_prompt(modules_dir, ["overview"])
-    assert with_overview.index("sector overview") > with_overview.index("CSV table")
+    assert "For EVERY thermal power plant" in with_persona
+    # With overview (prepended before base, after persona)
+    with_both = assemble_prompt(modules_dir, ["persona", "overview"])
+    assert with_both.index("thermal power sector") < with_both.index("For EVERY")
 
 
 def test_assemble_prompt_unknown_module_raises():

--- a/tests/test_modules_match_prompt_complete.py
+++ b/tests/test_modules_match_prompt_complete.py
@@ -1,0 +1,50 @@
+"""Verify that assembling all modules reproduces prompt_complete.txt content.
+
+Every non-blank, non-header line in prompt_complete.txt must appear in the
+assembled composite, and vice versa.  Headers (lines starting with #) and
+blank lines are structural scaffolding that modules don't replicate.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+EXPERIMENTS_DIR = Path(__file__).resolve().parent.parent / "experiments"
+
+
+def _content_lines(text: str) -> set[str]:
+    """Extract non-blank, non-header content lines, normalized."""
+    lines: set[str] = set()
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if re.match(r"^#{1,4}\s", stripped):
+            continue
+        lines.add(stripped)
+    return lines
+
+
+@pytest.mark.adherence
+def test_modules_cover_prompt_complete():
+    """Assembled composite covers every content line of prompt_complete.txt."""
+    from aedist.harness import KNOWN_MODULES, assemble_prompt
+
+    modules_dir = EXPERIMENTS_DIR / "prompts" / "modules"
+    prompt_complete = (EXPERIMENTS_DIR / "prompts" / "prompt_complete.txt").read_text()
+
+    assembled = assemble_prompt(modules_dir, sorted(KNOWN_MODULES))
+
+    expected = _content_lines(prompt_complete)
+    actual = _content_lines(assembled)
+
+    missing = expected - actual
+    assert not missing, f"Lines in prompt_complete but not in assembled composite:\n" + "\n".join(
+        sorted(missing)
+    )
+
+    extra = actual - expected
+    assert not extra, f"Lines in assembled composite but not in prompt_complete:\n" + "\n".join(
+        sorted(extra)
+    )

--- a/tests/test_modules_match_prompt_complete.py
+++ b/tests/test_modules_match_prompt_complete.py
@@ -40,11 +40,11 @@ def test_modules_cover_prompt_complete():
     actual = _content_lines(assembled)
 
     missing = expected - actual
-    assert not missing, f"Lines in prompt_complete but not in assembled composite:\n" + "\n".join(
+    assert not missing, "Lines in prompt_complete but not in assembled composite:\n" + "\n".join(
         sorted(missing)
     )
 
     extra = actual - expected
-    assert not extra, f"Lines in assembled composite but not in prompt_complete:\n" + "\n".join(
+    assert not extra, "Lines in assembled composite but not in prompt_complete:\n" + "\n".join(
         sorted(extra)
     )

--- a/tests/test_query_direct.py
+++ b/tests/test_query_direct.py
@@ -248,12 +248,12 @@ def test_prompt_modules_assembles_prompt(mock_openai_cls, tmp_path):
     call_args = mock_client.chat.completions.create.call_args
     messages = call_args.kwargs.get("messages") or call_args[1].get("messages")
     user_content = messages[0]["content"]
-    # persona is prepended before base, overview appended after base
+    # persona and overview are prepended before base
     assert "You are an expert." in user_content
     assert "Base prompt text." in user_content
     assert "Provide an overview." in user_content
-    assert user_content.index("You are an expert.") < user_content.index("Base prompt text.")
-    assert user_content.index("Base prompt text.") < user_content.index("Provide an overview.")
+    assert user_content.index("You are an expert.") < user_content.index("Provide an overview.")
+    assert user_content.index("Provide an overview.") < user_content.index("Base prompt text.")
 
 
 @patch("aedist.harness.OpenAI")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -823,8 +823,8 @@ def test_prompt_modules_assembled_in_execute(tmp_path: Path) -> None:
     assert "You are an expert." in content
     assert "Base prompt text." in content
     assert "Provide an overview." in content
-    assert content.index("You are an expert.") < content.index("Base prompt text.")
-    assert content.index("Base prompt text.") < content.index("Provide an overview.")
+    assert content.index("You are an expert.") < content.index("Provide an overview.")
+    assert content.index("Provide an overview.") < content.index("Base prompt text.")
 
 
 def test_prompt_modules_empty_uses_base_only_in_worker(tmp_path: Path) -> None:

--- a/tickets/0102-verify-escalation-decay-system.erg
+++ b/tickets/0102-verify-escalation-decay-system.erg
@@ -16,8 +16,6 @@ Author: claude
 2026-04-30T20:05Z claude note sweep-skip: scope-too-large expires:2026-05-02T12:00Z hash:6891fafed785
 2026-04-30T21:38Z claude note sweep-skip: scope-too-large hash:8d194ae194e4 expires:2026-05-02T12:00Z
 --- body ---
-:38Z claude note sweep-skip: scope-too-large hash:8d194ae194e4 expires:2026-05-02T12:00Z
---- body ---
  1) instead
 of escalating (tier 2+3). This ticket measures whether the claim
 holds empirically.

--- a/tickets/0118-source-grounding-phase2-llm-adjudication.erg
+++ b/tickets/0118-source-grounding-phase2-llm-adjudication.erg
@@ -16,8 +16,6 @@ Author: claude
 2026-04-30T20:05Z claude note sweep-skip: status-post-conference hash:866d6f2c54aa
 2026-04-30T21:38Z claude note sweep-skip: status-post-conference hash:48d29b09d538
 --- body ---
-:38Z claude note sweep-skip: status-post-conference hash:48d29b09d538
---- body ---
 * at the URL actually support the extracted value?
 This requires LLM adjudication, not just URL resolution.
 

--- a/tickets/0134-regimes-scatter-model-refresh.erg
+++ b/tickets/0134-regimes-scatter-model-refresh.erg
@@ -14,8 +14,6 @@ Author: claude
 2026-04-30T20:05Z claude note sweep-skip: scope-too-large expires:2026-05-01T12:00Z hash:ba30430a6d6d
 2026-04-30T21:38Z claude note sweep-skip: scope-too-large hash:d9018c23f6a0 expires:2026-05-01T12:00Z
 --- body ---
-:38Z claude note sweep-skip: scope-too-large hash:d9018c23f6a0 expires:2026-05-01T12:00Z
---- body ---
 3, DeepSeek. Ce ticket ajoute un modèle cloud top-end gratuit.
 
 ## Modèle ajouté

--- a/tickets/0141-registry-providers-block-refactor.erg
+++ b/tickets/0141-registry-providers-block-refactor.erg
@@ -10,8 +10,6 @@ Author: claude
 2026-04-30T20:05Z claude note sweep-skip: scope-too-large expires:2026-05-02T12:00Z hash:f8a1c80f13c2
 2026-04-30T21:38Z claude note sweep-skip: scope-too-large hash:f223bc51fbc1 expires:2026-05-02T12:00Z
 --- body ---
-:38Z claude note sweep-skip: scope-too-large hash:f223bc51fbc1 expires:2026-05-02T12:00Z
---- body ---
 der":
 
 - `qwen/qwen3.5-35b-a3b` (cloud) + `qwen3.5:35b` (local)

--- a/tickets/0142-ablation-modules-verbatim-from-complete.erg
+++ b/tickets/0142-ablation-modules-verbatim-from-complete.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Rewrite ablation modules to verbatim-extract from prompt_complete
-Status: open
+Status: doing
 Created: 2026-04-30
 Author: claude
 
@@ -8,6 +8,8 @@ Author: claude
 2026-04-30T13:25Z claude created — option B from prompt-prompt-complete-ablation alignment discussion 2026-04-30
 
 2026-04-30T20:05Z claude note sweep-assess: not-picked hash:a7490e8008b6 scope:rewrite 8 ablation modules verbatim from prompt_complete, create 3 new modules, verify diff risk:low — text/prompt file edits only
+2026-05-01T12:00Z claude claimed
+2026-05-01T12:30Z claude status doing — raid 0142: all 11 modules written, harness updated, equivalence test passing, experiments.toml composites updated
 --- body ---
 ## Context
 

--- a/tickets/0146-capability-timeline-expand-and-figure.erg
+++ b/tickets/0146-capability-timeline-expand-and-figure.erg
@@ -10,8 +10,6 @@ Author: claude
 2026-04-30T20:05Z claude note sweep-skip: scope-too-large expires:2026-05-02T12:00Z hash:7ff1e2fdb2cd
 2026-04-30T21:38Z claude note sweep-skip: scope-too-large hash:593c5ec1a894 expires:2026-05-02T12:00Z
 --- body ---
-:38Z claude note sweep-skip: scope-too-large hash:593c5ec1a894 expires:2026-05-02T12:00Z
---- body ---
 al) with a 7-stage matrix and 27 primary
 sources. The argument's "order is observed, not forced" claim
 strengthens with broader coverage. A figure (stage × time, one


### PR DESCRIPTION
## Summary
- Rewrote all 8 ablation modules as verbatim paragraph extractions from `prompt_complete.txt` — no abstraction, no rewording
- Created 3 new modules for previously-unablatable Quality instructions: `observed_vs_projected`, `pdp_completeness`, `data_quality_table`
- Updated assembly order: overview now prepended before base (matching prompt_complete section flow)
- Updated all composite and minus-one sweep definitions in `experiments.toml` to include new modules
- Added regression test enforcing assembled composite ≡ prompt_complete content lines

## Ablation semantic change
`base.txt` now includes Source 1/Source 2 columns (verbatim from §2). Ablating `citation_columns` removes quality guardrails on sources, not the structural column requirement. Documented in `modules/README.md`.

## Test plan
- [x] New equivalence test: `test_modules_match_prompt_complete.py` — every content line bidirectionally matched
- [x] Full suite: 1143 passed, 1 skipped, 2 xfailed (was 1142 — +1 new test)
- [x] ERG ticket validator: PASS

Unblocks ticket 0143 (rerun ablation with verbatim modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)