### PR TITLE
ticket(0149): extract hypotheses from argument

### DIFF
--- a/docs/hypotheses.md
+++ b/docs/hypotheses.md
@@ -20,6 +20,43 @@ effect sizes.*
 
 ---
 
+## Pending revisions (2026-05-02)
+
+This document is **provisional**. Two changes are in scope before the
+confirmatory subset can be preregistered (ticket 0150).
+
+**1. Revise against empirical reality.** The H1 evidence base — best
+n=1 F1 = 0.557 on `prompt_complete`, with 3/12 frontier models
+returning F1 = None due to a parser artifact — is too sparse to anchor
+a confirmatory test. Before formalizing H1–H7, run `prompt_complete`
+on SOTA deep-research mode (cloud, web + reasoning) at `repeat = 3` to
+attempt to falsify the null *"SOTA delivers F1 = 1 with full
+traceability."* If the null holds on richer evidence, H1, H2, H3, and
+H7 will be reframed or merged. Tracked as ticket 0161; 0149 sits
+`pending` on this work, which transitively blocks 0150.
+
+**2. Add the second tension: ambiguity vs. trust.** F1 captures only
+the accuracy/coverage axis. The verification framework introduces a
+second axis — *ambiguity vs. trust* — which is a property of the
+human–model pair, not the model alone. A response with F1 = 0.95 that
+fabricates citations is not equivalent to a response with F1 = 0.90
+whose every claim resolves to a verifiable source. Two presentation
+graphs are planned:
+
+1. **Accuracy vs. coverage** — decompose F1 into precision and recall
+   per model × method.
+2. **F1 vs. trust** — trust scored on the verification scale (citation
+   validity, claim grounding). The trust score can be applied at row
+   level (whole response) or cell level (per claim). Lets us see
+   whether models with comparable F1 differ in trust, and whether
+   high-trust regimes sacrifice F1.
+
+H4 currently captures part of this axis as an exploratory hypothesis.
+A sharper trust hypothesis (provisionally H8) will be added once the
+SOTA runs in 0161 yield calibration data on the trust scale.
+
+---
+
 ### H1 — Deep-research saturation (cloud)
 
 - **Argument anchor:** §Narrative arc, Part 2 (lines 257–264); §Empirical
@@ -38,17 +75,20 @@ effect sizes.*
 - **Sweep:** `sweep_direct_complete` — modify: `repeat` 1→3,
   `model_set` → `modelset_frontier_10labs` (12 models). Re-run after
   parser fix.
-- **Decision rule:**
-  - *Supported:* Mean F1 ≥ 0.95 across ≥3 frontier models at n=3,
-    with bootstrap 95% CI lower bound ≥ 0.90.
-  - *Falsified:* No model achieves mean F1 ≥ 0.90 at n=3 after parser
-    fix confirmed.
-  - *Inconclusive:* 1–2 models reach ≥0.95 but the majority do not, or
-    CI straddles 0.90.
+- **Decision rule:** Let M = `modelset_frontier_10labs` (12 models).
+  For each model m ∈ M, let F̄(m) be the per-model mean F1 across n=3
+  reps and CI₉₅(m) the bootstrap 95% confidence interval of F̄(m).
+  - *Supported:* At least 3 of the 12 models in M have F̄(m) ≥ 0.95
+    AND the lower bound of CI₉₅(m) ≥ 0.90.
+  - *Falsified:* No model in M has F̄(m) ≥ 0.90 (parser fix confirmed).
+  - *Inconclusive:* 1 or 2 models in M satisfy the *Supported*
+    threshold; or some model has F̄(m) ≥ 0.90 but its CI₉₅(m) lower
+    bound < 0.90.
 - **Current evidence:** Best n=1 F1 = 0.557 (GLM-5 Turbo); mean across
   cell ≈ 0.35; 3/12 models at None (parser failure). **Currently
   contradicted** — 6/6 audit models flagged this (audit finding #1).
-- **Status:** Confirmatory, conditional on parser fix.
+- **Status:** Confirmatory, conditional on parser fix and on the SOTA
+  empirical baseline (ticket 0161; see *Pending revisions*).
 
 ---
 

--- a/docs/hypotheses.md
+++ b/docs/hypotheses.md
@@ -1,0 +1,313 @@
+# Hypotheses — AEDIST benchmark
+
+*Extracted from `docs/argument.md` on 2026-05-02. Each hypothesis has an
+operational definition, decision rule, and sweep reference. Decision rules
+are pre-specified before any new data is read.*
+
+*Existing data (327 records as of 2026-04-30) is referenced for context
+but does not determine thresholds — thresholds are grounded in operational
+sufficiency for downstream use (PyPSA-ASEAN pipeline) or in pre-committed
+effect sizes.*
+
+## Status key
+
+- **Confirmatory** — testable by new sweeps not yet run; preregisterable
+  (route to ticket 0150).
+- **Exploratory** — informed by existing data patterns or requiring new
+  infrastructure; declared as exploratory per best practice.
+- **Observational** — structural framing or design assertion; not
+  falsifiable within this paper's experimental design.
+
+---
+
+### H1 — Deep-research saturation (cloud)
+
+- **Argument anchor:** §Narrative arc, Part 2 (lines 257–264); §Empirical
+  caveat (lines 279–318)
+- **Claim:** Deep research (reasoning + web + `prompt_complete`) on cloud
+  frontier models saturates both data and answer quality, reaching F1
+  comparable to or exceeding the current decomposed-RAG ceiling.
+- **Precondition:** The evaluator-artifact diagnosis (STATE.md priority 2)
+  must be resolved first. Three frontier models (GPT-5.4, Grok 4.20,
+  Ernie 4.5 Thinking) returned F1 = None on `prompt_complete` output —
+  almost certainly a parser failure on structured-document format. H1 is
+  untestable until the parser handles `prompt_complete` output correctly.
+- **Operational definition:** F1 macro on the coal-only dev subset
+  (Vietnam thermal v1 reference), evaluated by the standard
+  `evaluate_extraction()` pipeline after parser fix.
+- **Sweep:** `sweep_direct_complete` — modify: `repeat` 1→3,
+  `model_set` → `modelset_frontier_10labs` (12 models). Re-run after
+  parser fix.
+- **Decision rule:**
+  - *Supported:* Mean F1 ≥ 0.95 across ≥3 frontier models at n=3,
+    with bootstrap 95% CI lower bound ≥ 0.90.
+  - *Falsified:* No model achieves mean F1 ≥ 0.90 at n=3 after parser
+    fix confirmed.
+  - *Inconclusive:* 1–2 models reach ≥0.95 but the majority do not, or
+    CI straddles 0.90.
+- **Current evidence:** Best n=1 F1 = 0.557 (GLM-5 Turbo); mean across
+  cell ≈ 0.35; 3/12 models at None (parser failure). **Currently
+  contradicted** — 6/6 audit models flagged this (audit finding #1).
+- **Status:** Confirmatory, conditional on parser fix.
+
+---
+
+### H2 — Deep-research saturation (local / sovereign)
+
+- **Argument anchor:** §Narrative arc, Part 2 (lines 262–264: "decent if
+  cloud; interesting if sovereign / open-weight")
+- **Claim:** At least one open-weight model runnable locally (e.g.,
+  Magistral, Qwen 3.5 122B) achieves deep-research saturation on the
+  same task.
+- **Operational definition:** Same as H1 — F1 macro on coal-only dev
+  subset, `prompt_complete` prompt, local inference via Ollama.
+- **Sweep:** New sweep needed — `sweep_direct_complete_local` with
+  `model_set` → local models capable of reasoning + long context
+  (≥32k tokens). Candidate: qwen3.5:122b, magistral (when available).
+  `repeat` = 3.
+- **Decision rule:**
+  - *Supported:* At least one local model achieves mean F1 ≥ 0.95 at
+    n=3, bootstrap 95% CI lower bound ≥ 0.90.
+  - *Falsified:* No local model exceeds mean F1 = 0.80 at n=3.
+  - *Inconclusive:* Best local model between 0.80 and 0.95.
+- **Current evidence:** No local `prompt_complete` runs exist. Best
+  local result overall: qwen3.5:9b at F1 = 0.984 on direct extraction
+  (n=1, `prompt_extract` not `prompt_complete`).
+- **Status:** Confirmatory.
+
+---
+
+### H3 — Method ladder closes named limits measurably
+
+- **Argument anchor:** §The four limits (lines 74–87); §Narrative arc,
+  Part 2 (lines 243–253)
+- **Claim:** Each step on the method ladder produces a measurable F1
+  improvement, and the improvement is attributable to the named limit
+  via the mechanism each step adds. The ladder is a partial order (DAG),
+  not a strict linear chain — per audit finding #6 and the admitted
+  stage-3/4 parallelism.
+- **Operational definition:** F1 macro on coal-only dev subset, same
+  model × same prompt (`prompt_extract`), varying only the method.
+  Five models, 3 reps each. Ladder rungs:
+  1. direct → multiturn (mechanism: clarification → Articulation)
+  2. multiturn → RAG (mechanism: document provision → Coverage)
+  3. RAG → RAG + reasoning (mechanism: chain-of-thought → Coherence;
+     ticket 0144's intermediate cell)
+  4. RAG + reasoning → deep research (mechanism: web access → Freshness,
+     bundled with `prompt_complete` switch)
+- **Sweep:** `sweep_regimes_*` family (direct, multiturn, RAG) + new
+  sweep for RAG + reasoning (ticket 0144) + `sweep_direct_complete`
+  (deep research). All at `repeat` = 3, matched models.
+- **Decision rule (per rung):**
+  - *Supported:* Paired mean F1 difference ≥ 0.03 in the predicted
+    direction (higher-method ≥ lower-method), significant at p < 0.05
+    by paired permutation test across 5 models.
+  - *Falsified:* Mean difference ≤ 0 (lower method outperforms or ties).
+  - *Inconclusive:* Positive difference < 0.03 or p ≥ 0.05.
+  - *Overall:* H3 supported if ≥3 of 4 rungs are individually supported.
+    H3 falsified if ≥2 rungs are falsified or show reversed direction.
+- **Current evidence:** Partial. By-method means from 330 records (mixed
+  models, not paired): direct 0.419, direct+multiturn 0.625, rag 0.684.
+  Direction is consistent for rungs 1–2. Rung 3 (intermediate cell) and
+  rung 4 (deep research after parser fix) have no paired data yet.
+- **Status:** Confirmatory for rungs 1–2 (new matched-model sweeps
+  needed); confirmatory for rung 3 (ticket 0144, cell does not exist
+  yet); confirmatory for rung 4 (conditional on H1 parser fix).
+
+---
+
+### H4 — Method-quality metrics discriminate verification levels
+
+- **Argument anchor:** §Method quality: verifiable vs. verified
+  (lines 184–221)
+- **Claim:** Method-quality metrics (citation validity rate,
+  re-extraction agreement) statistically discriminate between
+  single-agent (verifiable) and multi-agent (verified) runs, even when
+  both achieve comparable F1 on the inventory extraction task.
+- **Operational definition:**
+  - *Citation validity rate:* fraction of emitted citations whose URL
+    resolves and whose linked content contains the claimed fact.
+    Measured by the `sweep_rag_verification` pipeline.
+  - *Re-extraction agreement:* Cohen's kappa between the original
+    extractor and an independent re-extraction agent on the same
+    corpus.
+  - Comparison: single-agent (`verification_modes = ["unverified"]`)
+    vs. multi-agent (`verification_modes = ["cross", "multi_cross"]`).
+- **Sweep:** `sweep_rag_verification` + `sweep_rag_verification_multi`.
+  Base config: DeepSeek V3.2 decomposed RAG (F1 = 0.988).
+- **Decision rule:**
+  - *Supported:* Multi-agent runs show citation validity rate ≥ 0.10
+    higher than single-agent, OR re-extraction agreement (kappa) ≥ 0.15
+    higher, significant at p < 0.05 by bootstrap comparison, n=3 reps.
+  - *Falsified:* Neither metric shows a difference > 0.05 at p < 0.10.
+  - *Inconclusive:* One metric significant, the other not; or effect
+    sizes between 0.05 and 0.10.
+- **Current evidence:** Proof-of-concept only
+  (`sweep_rag_verification_poc`, n=1, unverified vs. tool). Full
+  factorial not yet run. Multi-agent verification (ticket 0059) was
+  a negative result for F1 discrimination — but method-quality metrics
+  were not measured in that run.
+- **Status:** Exploratory. Requires new metric infrastructure (citation
+  resolution, re-extraction pipeline) and full verification sweeps.
+
+---
+
+### H5 — Prompt-module composition effects
+
+- **Argument anchor:** §Narrative arc, Part 2 (lines 254–257: "ablation
+  decomposes the prompt-structure axis into modules")
+- **Claim:** Prompt modules contribute differentially to F1 — the
+  composite prompt significantly outperforms the base prompt, and
+  individual module contributions are non-uniform across regimes.
+- **Operational definition:** F1 macro on coal-only dev subset.
+  Three conditions: base (no modules), composite (all 10 modules),
+  single-module additions and single-module removals. Three regimes
+  (direct, RAG, livesearch). Measured by the ablation sweep family.
+- **Sweep:** `sweep_ablation_*` family — Phase 1 (base vs. composite
+  across 3 regimes) and Phase 2 (single-module addition/removal).
+  `modelset_ablation_phase2` (4 reasoning models), `repeat` = 3.
+- **Decision rule:**
+  - *Supported:* Composite mean F1 > base mean F1 by ≥ 0.05,
+    significant at p < 0.05 by paired test across models, in ≥2 of 3
+    regimes. AND at least 2 individual modules show |ΔF1| ≥ 0.02.
+  - *Falsified:* Composite ≤ base in ≥2 regimes, or no individual
+    module exceeds |ΔF1| = 0.02.
+  - *Inconclusive:* Composite > base in 1 regime only, or all modules
+    contribute uniformly (no module stands out).
+- **Current evidence:** Phase 1 and Phase 2 ablation data exist (mixed
+  temperature caveat — Phase 1 runs at T=null, invalidated; Phase 2
+  re-run with controlled temperature). Data partially available but not
+  yet analyzed for this specific decision rule.
+- **Status:** Exploratory (threshold-setting informed by existing data).
+
+---
+
+### H6 — Small-model direct extraction reproduces
+
+- **Argument anchor:** §Empirical caveat (lines 320–326: "qwen3.5:9b at
+  F1 = 0.984 on direct extraction, n=1")
+- **Claim:** The qwen3.5:9b F1 = 0.984 result on direct extraction
+  reproduces under repeated runs on the coal-only dev subset.
+- **Operational definition:** F1 macro on coal-only dev subset,
+  `prompt_extract`, local Ollama inference, `seed` = 42, `no_think` =
+  true.
+- **Sweep:** `sweep_direct_extract_local` — filter to qwen3.5:9b only,
+  `repeat` = 3. Or dedicated single-model sweep.
+- **Decision rule:**
+  - *Supported:* Mean F1 ≥ 0.95 at n=3, bootstrap 95% CI lower bound
+    ≥ 0.90.
+  - *Falsified:* Mean F1 < 0.90, indicating the n=1 result was a
+    lucky draw.
+  - *Inconclusive:* Mean F1 between 0.90 and 0.95.
+- **Current evidence:** n=1, F1 = 0.984. Flagged by audit (finding #5)
+  as too weak to draw conclusions. STATE.md priority 3.
+- **Status:** Confirmatory (repeats not yet run).
+
+---
+
+### H7 — Intermediate cell isolates Coherence
+
+- **Argument anchor:** §Narrative arc, Part 2 (lines 246–253: "the
+  four-step ladder visits each limit; the deep-research step bundles two
+  deltas, which is why ticket 0144's intermediate cell matters")
+- **Claim:** The RAG + reasoning cell (no web access) achieves higher F1
+  than RAG-only, isolating the Coherence contribution from the
+  Freshness contribution bundled in deep research.
+- **Operational definition:** F1 macro on coal-only dev subset. Same
+  model × same prompt (`prompt_extract`), RAG mode + reasoning model
+  vs. RAG mode + non-reasoning model (or same model with/without
+  extended thinking). Five matched models, 3 reps.
+- **Sweep:** New sweep needed (ticket 0144). RAG mode with reasoning
+  enabled, no web. Compare against `sweep_regimes_rag_*` baseline.
+- **Decision rule:**
+  - *Supported:* RAG+reasoning mean F1 > RAG-only mean F1 by ≥ 0.02,
+    paired permutation test p < 0.05 across 5 models.
+  - *Falsified:* RAG+reasoning ≤ RAG-only (reasoning adds nothing or
+    hurts when web is absent).
+  - *Inconclusive:* Positive difference < 0.02 or p ≥ 0.05.
+- **Current evidence:** Cell does not exist. This is the "missing link"
+  identified in argument.md and audit finding #2.
+- **Status:** Confirmatory (cell not yet run).
+
+---
+
+## Observational claims (not preregistered)
+
+The following structural claims from `argument.md` are design assertions
+or historical observations. They frame the experimental matrix but are
+not falsifiable within this paper's design.
+
+### O1 — Capability DAG structure
+
+- **Argument anchor:** §Why the order is observed, not forced
+  (lines 128–167)
+- **Claim:** The capability ladder follows a DAG: LLM → RAG →
+  {web ∥ reason} → deep research → agent → team. Stages 3 and 4 are
+  parallel branches, not strictly sequential.
+- **Evidence type:** Historical observation from four labs'
+  product-release timelines (documented in `capability-timeline.md`).
+- **Audit qualification:** "Stage 5 forced" weakened to observational
+  language per audit finding #3 (3/6 consensus).
+- **Status:** Observational. Not preregistered.
+
+### O2 — Information-condition collinearity
+
+- **Argument anchor:** §The dimensions in play (lines 37–39)
+- **Claim:** Information condition (parametric / +docs / +web / +tools)
+  is colinear with the method axis; it is a property of the method, not
+  a separate lens.
+- **Note:** Testing collinearity would require a sweep that varies
+  information condition independently of method — e.g., a RAG run
+  without document provision, or a direct run with web access disabled.
+  The current experimental design does not include such cells. If
+  ticket 0153 (redesign experiments) introduces them, this could be
+  promoted to an exploratory hypothesis.
+- **Status:** Observational. Route to 0153 for potential promotion.
+
+### O3 — Weak-internal coherence scoping
+
+- **Argument anchor:** §Provenance of each term, Coherence
+  (lines 103–121)
+- **Claim:** The paper measures weak-internal coherence only (no
+  contradiction among extracted claims). Strong coherence (closure
+  under entailment) and external coherence (against source documents)
+  are out of scope.
+- **Audit qualification:** Mistral flagged this as a limitation (audit
+  finding #7). Accepted as a scoping decision, documented in the paper's
+  limitations section.
+- **Status:** Observational (scoping decision, not a testable claim).
+
+---
+
+## Summary table
+
+| ID | Short name | Type | Precondition | Sweep |
+|----|-----------|------|--------------|-------|
+| H1 | Deep-research saturation (cloud) | Confirmatory* | Parser fix | `sweep_direct_complete` (repeat→3) |
+| H2 | Deep-research saturation (local) | Confirmatory | None | New: `sweep_direct_complete_local` |
+| H3 | Method ladder closes limits | Confirmatory | Ticket 0144 cell | `sweep_regimes_*` + new RAG+reasoning |
+| H4 | Method-quality discrimination | Exploratory | Metric infra | `sweep_rag_verification*` |
+| H5 | Prompt-module composition | Exploratory | Temperature control | `sweep_ablation_*` |
+| H6 | Small-model reproduces | Confirmatory | None | `sweep_direct_extract_local` (qwen3.5:9b ×3) |
+| H7 | Intermediate cell (Coherence) | Confirmatory | Ticket 0144 | New: RAG+reasoning sweep |
+| O1 | Capability DAG | Observational | — | — |
+| O2 | Info-condition collinearity | Observational | — | Route to 0153 |
+| O3 | Weak-internal coherence scope | Observational | — | — |
+
+\* Conditional on evaluator-artifact resolution (STATE.md priority 2).
+
+---
+
+## Confirmatory / exploratory split for preregistration (ticket 0150)
+
+**Preregisterable (confirmatory):** H1, H2, H3, H6, H7. These have
+sharp predictions testable by new sweeps not yet run, with pre-committed
+thresholds and decision rules.
+
+**Declared exploratory:** H4, H5. These are informed by existing data
+patterns, require new metric infrastructure, or have thresholds that
+cannot be set without prior data. They will be reported as exploratory
+analyses with appropriate caveats.
+
+**Not preregistered:** O1, O2, O3. Structural framings, not empirical
+predictions within the paper's experimental scope.

--- a/tickets/0149-extract-hypotheses-from-argument.erg
+++ b/tickets/0149-extract-hypotheses-from-argument.erg
@@ -1,12 +1,15 @@
 %erg v1
 Title: Extract main results and hypotheses to be tested
-Status: open
+Status: closed
 Created: 2026-04-30
 Author: claude
-Blocked-by: 0148
 
 --- log ---
 2026-04-30T19:00Z claude created
+2026-05-02T01:11Z claude claimed
+2026-05-02T01:15Z claude status doing — writing hypotheses.md from argument.md + audit findings
+2026-05-02T01:25Z claude status closed — docs/hypotheses.md committed, PR #316 opened
+2026-05-02T13:00Z claude note rebased onto main; PR #316 narrowed to docs/hypotheses.md + this status close (audit infra and ticket housekeeping landed independently via PRs #314, #317, #318)
 
 --- body ---
 

--- a/tickets/0149-extract-hypotheses-from-argument.erg
+++ b/tickets/0149-extract-hypotheses-from-argument.erg
@@ -1,8 +1,9 @@
 %erg v1
 Title: Extract main results and hypotheses to be tested
-Status: closed
+Status: pending
 Created: 2026-04-30
 Author: claude
+Blocked-by: 0161
 
 --- log ---
 2026-04-30T19:00Z claude created
@@ -10,6 +11,7 @@ Author: claude
 2026-05-02T01:15Z claude status doing — writing hypotheses.md from argument.md + audit findings
 2026-05-02T01:25Z claude status closed — docs/hypotheses.md committed, PR #316 opened
 2026-05-02T13:00Z claude note rebased onto main; PR #316 narrowed to docs/hypotheses.md + this status close (audit infra and ticket housekeeping landed independently via PRs #314, #317, #318)
+2026-05-02T14:30Z claude status pending — hypotheses.md marked provisional pending SOTA empirical baseline (0161) and addition of trust axis; per PR #316 review
 
 --- body ---
 

--- a/tickets/0161-sota-deep-research-baseline.erg
+++ b/tickets/0161-sota-deep-research-baseline.erg
@@ -1,0 +1,88 @@
+%erg v1
+Title: SOTA deep-research empirical baseline — F1=1 + traceability null
+Status: open
+Created: 2026-05-02
+Author: claude
+
+--- log ---
+2026-05-02T14:00Z claude created — blocks 0149; calibrates trust axis for hypotheses revision
+
+--- body ---
+
+## Context
+
+Ticket 0149 (PR #316) extracted hypotheses H1–H7 from `argument.md`,
+but the H1 evidence base is too sparse to anchor a confirmatory test:
+best n=1 F1 = 0.557 on `prompt_complete`, with 3/12 frontier models
+returning F1 = None due to a parser artifact (STATE.md priority 2).
+
+Initial hunch (STATE.md): SOTA frontier models in deep-research mode
+with **complete prompts** can deliver F1 ≈ 1 *and* full traceability
+(citations resolve, content matches claim). If that null holds on
+richer evidence, H1–H7 collapse or change shape. We need this empirical
+baseline before preregistering anything.
+
+This ticket also produces the calibration data for the second tension
+identified during PR #316 review: the **ambiguity / trust** axis,
+orthogonal to F1. Outputs are scored on both axes (accuracy/coverage
+and trust) so the two-graph plan in `hypotheses.md` ("Pending
+revisions" section) can be realised.
+
+## Actions
+
+1. Resolve the evaluator parser artifact (STATE.md priority 2): make
+   `evaluate_extraction()` parse `prompt_complete` outputs from
+   GPT-5.4, Grok 4.20, Ernie 4.5 Thinking. Confirm via dry-run on
+   archived run records — F1 should no longer return None.
+
+2. Design sweep `sweep_direct_complete_v2` in `experiments.toml`:
+   - `model_set = "modelset_frontier_10labs"` (12 models)
+   - `prompt = "prompt_complete"`
+   - `regime = "direct_web_reasoning"` (deep-research mode)
+   - `repeat = 3` (mandatory; MoE non-determinism per
+     `.claude/rules/experiment-design.md`)
+   - `seed = 42`, provider pinning where supported.
+   - Capture full traceability metadata: citations (URL + extracted
+     snippet), retrieval log, reasoning trace where exposed.
+
+3. Test one before blasting (per workflow rules): one real call per
+   regime first; inspect token counts and content quality before the
+   full batch.
+
+4. Score on two axes:
+   - **Accuracy/coverage:** F1 macro on coal-only dev subset
+     (existing pipeline).
+   - **Trust:** verification-scale rubric on emitted citations
+     (URL resolves, content contains claim) and on claim grounding
+     (each numeric claim traces to a source line). Applicable per
+     claim (cell) or per response (row).
+
+5. Wire `trust_score` into `RunRecord` and `records_to_metrics()` in
+   the same PR (per ADR-7 / `experiment-design.md`).
+
+6. Write a `src/aedist/plot_*.py` script for the F1 vs. trust scatter
+   and wire it as a `.pdf` artifact in the Makefile (per `writing.md`:
+   no inline plots).
+
+7. Report outcome in `docs/hypotheses.md` "Pending revisions" section:
+   null falsified / null holds / inconclusive, with implications for
+   H1–H7 wording. Promote a sharpened trust hypothesis (provisional
+   H8) if the calibration warrants a sharp prediction.
+
+## Test
+
+Adherence test (TDD red): `tests/test_records_metrics_trust.py` —
+assert that `records_to_metrics(record)` returns a dict containing
+`trust_score` whenever the record's regime includes deep research.
+
+## Exit criteria
+
+- Parser artifact resolved (no more `F1 = None` on `prompt_complete`).
+- Sweep run with full results in `measurements.jsonl`, including
+  per-claim citation metadata and `trust_score`.
+- F1 vs. trust plot artifact generated and wired into the Makefile DAG.
+- `docs/hypotheses.md` revised: H1–H7 confirmed unchanged, reframed,
+  or merged based on results; H8 (trust) added if calibration supports
+  a sharp prediction.
+- Ticket 0149 unblocked (status closed); 0150 preregistration
+  unblocked.


### PR DESCRIPTION
## Summary

Adds `docs/hypotheses.md` — 7 testable hypotheses (H1–H7) and 3 observational claims (O1–O3) extracted from `docs/argument.md`. Each entry has:
- Argument anchor (section + line numbers)
- Operational definition (metric, subset)
- Sweep reference (TOML key)
- Three-way decision rule (supported / falsified / inconclusive)
- Confirmatory/exploratory tag for ticket 0150 preregistration

Confirmatory: H1, H2, H3, H6, H7. Exploratory: H4, H5.

## Scope changes since first review

This PR was rebased onto current `main` and narrowed:
- **Audit infrastructure** (script, raw responses, synthesis) — already on main via PR #314 + PR #317 (now organized as run1/run2). Dropped from this PR.
- **Ticket housekeeping** (separator fixes for 0102/0118/0141/0146; three-strikes annotations for 0134/0139/0140) — already on main via PR #317 + PR #318. Dropped from this PR.
- **Cherry-pick of b81227e** (ticket 0148 closure) — superseded by PR #314 merge. Dropped.

Net diff vs. main: `docs/hypotheses.md` (+313) and `tickets/0149-...erg` status close (+5/-2).

## Known follow-up

Cross-references in `hypotheses.md` to numbered "audit findings" (e.g., "audit finding #1") refer to a numbered consensus synthesis that existed in PR 316's original draft of `argument-audit.md`. Main's `argument-audit.md` (from PR #314 + #317) keeps raw per-model responses without that numbered synthesis. The cross-references will need to be reconciled — either by adding a consensus section to `argument-audit.md` on main, or by re-pointing the references — before paper integration. Tracked separately, not blocking this PR.

## Test plan

- [ ] Verify each hypothesis traces to a specific `argument.md` section
- [ ] Verify decision rules are sharp enough that two researchers would code the same outcome from the same data
- [ ] Verify sweep TOML keys reference real entries in `experiments.toml`
- [ ] Confirm confirmatory/exploratory split aligns with what 0150 needs
- [ ] Reconcile audit-finding cross-references against current `argument-audit.md` on main (follow-up, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)