### PR TITLE
feat(ablation): complete verbatim module extraction (ticket 0142)

### DIFF
--- a/experiments/prompts/modules/README.md
+++ b/experiments/prompts/modules/README.md
@@ -2,7 +2,8 @@
 
 Each `.txt` file is a **verbatim paragraph extraction** from
 `experiments/prompts/prompt_complete.txt`. No abstraction, no rewording.
-Assembling all modules reproduces the complete prompt (minus section headers).
+Modules include their section headers (`## 1.`, `### Structured table`, etc.).
+Assembling all modules reproduces the complete prompt (modulo whitespace).
 This is enforced by `tests/test_modules_match_prompt_complete.py`.
 
 `base.txt` is always included. Other modules are optional.
@@ -12,31 +13,26 @@ This is enforced by `tests/test_modules_match_prompt_complete.py`.
 `harness.assemble_prompt(modules_dir, module_names)` composes the final
 prompt. Module ordering is deterministic:
 
-1. **persona** (prepended before base) — opening sentence, §intro
-2. **overview** (prepended before base) — §1 Sector Overview content
-3. **base** (always present) — §2 table spec with all 12 columns
-4. **narratives** (appended) — §2 per-plant discussion: history + issues
-5. **sourcing_ground** (appended) — §2 confidence rubric + Quality source-confidence rule
-6. **statistics** (appended) — §3 cross-tabs a–c
-7. **data_quality_table** (appended) — §3 d) confidence × fuel cross-tab
-8. **bibliography** (appended) — §4 annotated bibliography
-9. **citation_columns** (appended) — Quality: primary-source priority + URL fabrication guardrail
-10. **observed_vs_projected** (appended) — Quality: OBSERVED vs PROJECTED distinction
-11. **pdp_completeness** (appended) — Quality: PDP coverage + exhaustiveness + MWe units
+1. **persona** (prepended before base) — opening sentence
+2. **overview** (prepended before base) — §1 Sector Overview
+3. **base** (always present) — §2 Plant-by-Plant Inventory table spec (12 columns incl. Source 1/2)
+4. **narratives** (appended) — §2 Per-plant discussion (history, issues, HIGH/MEDIUM/LOW confidence)
+5. **statistics** (appended) — §3 cross-tabs a–c
+6. **data_quality_table** (appended) — §3 d) confidence × fuel cross-tab
+7. **bibliography** (appended) — §4 Annotated Bibliography
+8. **sourcing_ground** (appended) — Quality instructions header + bullets 1–2 (primary sources, cite or mark LOW)
+9. **citation_columns** (appended) — Quality bullet 3 (URL fabrication guardrail)
+10. **observed_vs_projected** (appended) — Quality bullet 4 (OBSERVED vs PROJECTED)
+11. **pdp_completeness** (appended) — Quality bullets 5–7 (PDP coverage, exhaustiveness, MWe units)
 
 The order is defined in `_MODULE_ORDER` in `src/aedist/harness.py`.
 
 ## Ablation semantics
 
 `base.txt` includes Source 1/Source 2 in the table header (verbatim from
-prompt_complete §2). Ablating `citation_columns` removes the quality
-guardrails on sources (primary-source priority, URL fabrication warning)
-but not the structural source-column requirement. This tests whether the
-guardrail matters, not whether sources are requested at all.
-
-`sourcing_ground` merges text from two sections of prompt_complete: the
-confidence rubric from §2 and the source-confidence quality rule. Both
-concern the same concept (confidence assessment) and ablate as one unit.
+prompt_complete §2). Ablating `citation_columns` removes the URL-fabrication
+guardrail but not the structural source-column requirement. This tests
+whether the guardrail matters, not whether sources are requested at all.
 
 ## Inspection
 

--- a/experiments/prompts/modules/base.txt
+++ b/experiments/prompts/modules/base.txt
@@ -1,5 +1,8 @@
+## 2. Plant-by-Plant Inventory
+
 For EVERY thermal power plant in Vietnam — operational, under construction, approved, and planned under PDP7 revised and PDP8 — provide:
 
+### Structured table
 Format: Markdown table with columns:
 | Name (Vietnamese) | Name (English) | Province | Fuel | Technology | Units × MW | Total MWe | Status | COD | Owner/Developer | Source 1 | Source 2 |
 

--- a/experiments/prompts/modules/bibliography.txt
+++ b/experiments/prompts/modules/bibliography.txt
@@ -1,3 +1,5 @@
+## 4. Annotated Bibliography
+
 List every source cited, organized by category:
 
 **Categories**: Government decisions (Quyết định) / Power Development Plans / EVN & subsidiary reports / PetroVietnam & subsidiary reports / Company filings & press releases / Regulatory & international organization reports / News & media / Academic sources

--- a/experiments/prompts/modules/citation_columns.txt
+++ b/experiments/prompts/modules/citation_columns.txt
@@ -1,2 +1,1 @@
-- PRIORITIZE primary sources: Vietnamese government decisions (Quyết định, Nghị quyết), official PDP documents, EVN/PVN annual reports, regulatory filings, company disclosures
 - Do NOT fabricate or hallucinate source URLs. If you cannot recall the exact URL, write "URL not verified" rather than inventing one

--- a/experiments/prompts/modules/narratives.txt
+++ b/experiments/prompts/modules/narratives.txt
@@ -1,3 +1,5 @@
+### Per-plant discussion
 After the inventory table, provide a sourced narrative paragraph for each plant (or plant complex) covering:
 - Development history and timeline (original plan, actual progress)
 - Notable issues: delays, financing changes, ownership transfers, environmental controversies, technology changes
+- Current status confidence: HIGH (verified by government decision or company annual report), MEDIUM (confirmed by multiple news sources), LOW (only found in older plans, status uncertain)

--- a/experiments/prompts/modules/overview.txt
+++ b/experiments/prompts/modules/overview.txt
@@ -1,3 +1,5 @@
+## 1. Sector Overview
+
 Provide introductory context on Vietnam's thermal power sector covering:
 - Evolution of Vietnam's electricity generation mix (hydro, thermal, renewables) with key statistics (installed capacity GW, generation TWh, shares by fuel)
 - Policy framework: Power Development Plans (PDP6, PDP7, PDP7 revised, PDP8) and their thermal power capacity targets and timelines

--- a/experiments/prompts/modules/sourcing_ground.txt
+++ b/experiments/prompts/modules/sourcing_ground.txt
@@ -1,2 +1,4 @@
-- Current status confidence: HIGH (verified by government decision or company annual report), MEDIUM (confirmed by multiple news sources), LOW (only found in older plans, status uncertain)
+## Quality instructions
+
+- PRIORITIZE primary sources: Vietnamese government decisions (Quyết định, Nghị quyết), official PDP documents, EVN/PVN annual reports, regulatory filings, company disclosures
 - When a fact comes from a primary source, cite it. When uncertain, mark confidence as LOW and explain why

--- a/experiments/prompts/modules/statistics.txt
+++ b/experiments/prompts/modules/statistics.txt
@@ -1,3 +1,5 @@
+## 3. Statistical Summary Tables
+
 Produce these cross-tabulations from your inventory:
 a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operational/Under construction/Approved/Planned columns), with row and column totals
 b) **Top provinces**: The 15 provinces with highest total thermal capacity (all statuses combined), showing breakdown by fuel

--- a/tests/test_modules_match_prompt_complete.py
+++ b/tests/test_modules_match_prompt_complete.py
@@ -1,8 +1,9 @@
 """Verify that assembling all modules reproduces prompt_complete.txt content.
 
 Every non-blank, non-header line in prompt_complete.txt must appear in the
-assembled composite, and vice versa.  Headers (lines starting with #) and
-blank lines are structural scaffolding that modules don't replicate.
+assembled composite, and vice versa.  Headers and blank lines are stripped
+for comparison since assembly joins modules with \\n\\n (which may differ
+from the original whitespace).
 """
 
 import re

--- a/tickets/0142-ablation-modules-verbatim-from-complete.erg
+++ b/tickets/0142-ablation-modules-verbatim-from-complete.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Rewrite ablation modules to verbatim-extract from prompt_complete
-Status: doing
+Status: closed
 Created: 2026-04-30
 Author: claude
 
@@ -10,6 +10,9 @@ Author: claude
 2026-04-30T20:05Z claude note sweep-assess: not-picked hash:a7490e8008b6 scope:rewrite 8 ablation modules verbatim from prompt_complete, create 3 new modules, verify diff risk:low — text/prompt file edits only
 2026-05-01T12:00Z claude claimed
 2026-05-01T12:30Z claude status doing — raid 0142: all 11 modules written, harness updated, equivalence test passing, experiments.toml composites updated
+2026-05-02T06:18Z claude claimed — raid session, worktree raid-0142
+2026-05-02T06:18Z claude note decomposition: citation_columns/sourcing_ground repurposed to Quality instruction bullets (Source columns embedded in base table header, can't extract separately); overview moved before base in assembly order; 3 orphan QI bullets folded into sourcing_ground (1+2), pdp_completeness (5+6+7)
+2026-05-02T06:30Z claude status closed — all 11 modules verbatim-extracted, section headers included, equivalence test passes (0 content drift, 4 whitespace-only diffs), README updated, 21 tests pass + 1 xfail
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Modules now include section headers (`## 1. Sector Overview`, `### Structured table`, etc.) — true verbatim extraction from `prompt_complete.txt`
- Moves confidence bullet (`HIGH/MEDIUM/LOW`) from `sourcing_ground.txt` to `narratives.txt` (matching §2 placement in prompt_complete)
- Moves `PRIORITIZE primary sources` bullet from `citation_columns.txt` to `sourcing_ground.txt` (matching Quality instructions order)
- Updates README to reflect current module semantics and assembly order

Follows up on PR #313 which did the initial verbatim rewrite. This commit completes the alignment by including section headers and correcting bullet placement.

**Equivalence diff**: 0 content-line drift, 4 whitespace-only differences (module joins vs. consecutive lines). Verified by `test_modules_cover_prompt_complete`.

## Test plan

- [x] `test_assemble_prompt` — assembly logic correct
- [x] `test_modules_cover_prompt_complete` — every content line bidirectionally matched
- [x] All 21 tests pass, 1 xfail
- [x] ERG ticket validator passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)