### PR TITLE
feat(registry): models.yaml v2 schema — name/display_name/route/base_url/model_id (ticket 0156)

### DIFF
--- a/experiments/_list_models.py
+++ b/experiments/_list_models.py
@@ -23,7 +23,9 @@ def main():
     parser = argparse.ArgumentParser(description="List model names for Makefile targets")
     parser.add_argument("models", help="Path to models.yaml")
     parser.add_argument("--set", required=True, dest="model_set", help="Model set name")
-    parser.add_argument("--experiments", default="experiments.toml", help="Path to experiments.toml")
+    parser.add_argument(
+        "--experiments", default="experiments.toml", help="Path to experiments.toml"
+    )
     parser.add_argument(
         "--format",
         choices=["short", "full", "padme-short"],
@@ -52,18 +54,18 @@ def main():
         sys.exit(1)
 
     set_ids = set(model_set["model_ids"])
-    selected = [m for m in models if m["id"] in set_ids]
-    missing = set_ids - {m["id"] for m in selected}
+    selected = [m for m in models if m["name"] in set_ids]
+    missing = set_ids - {m["name"] for m in selected}
     if missing:
         print(f"Error: IDs not found in registry: {sorted(missing)}", file=sys.stderr)
         sys.exit(1)
 
     if args.format == "full":
-        names = [m["id"] for m in selected]
+        names = [m["name"] for m in selected]
     elif args.format == "padme-short":
-        names = [m["id"].replace(":", "-") for m in selected]
+        names = [m["name"].replace(":", "-") for m in selected]
     else:
-        names = [short_name(m["id"]) for m in selected]
+        names = [short_name(m["name"]) for m in selected]
 
     print(" ".join(names))
 

--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -1,17 +1,10 @@
 # AEDIST Benchmark — Experiment Configuration
-# Model sets and router definitions. Registry in models.yaml.
+# Model sets. Registry in models.yaml (includes per-model base_url).
 
 [paths]
 outputs = "experiments/outputs"
 measurements = "measurements.jsonl"
 reference = "data/reference/vietnam_thermal_v1.csv"
-
-[routers.openrouter]
-base_url = "https://openrouter.ai/api/v1"
-env_key = "OPENROUTER_API_KEY"
-
-[routers.ollama]
-base_url = "http://localhost:11434/v1"
 
 # ---------------------------------------------------------------------------
 # Model sets — explicit ID lists referencing models.yaml entries

--- a/experiments/models.yaml
+++ b/experiments/models.yaml
@@ -18,10 +18,11 @@
 
 # --- Frontier ---
 
-- id: "tencent/hy3-preview:free"
-  router: openrouter
-  router_model: "tencent/hy3-preview:free"
-  name: "Hy3 Preview"
+- name: "tencent/hy3-preview:free"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "tencent/hy3-preview:free"
+  display_name: "Hy3 Preview"
   provider: Tencent
   country: CN
   architecture: moe
@@ -33,10 +34,11 @@
   web_search: true
   # Free preview — expires 2026-05-08. Sweep before then or remove.
 
-- id: "qwen/qwen3-max-thinking"
-  router: openrouter
-  router_model: "qwen/qwen3-max-thinking"
-  name: "Qwen3 Max Thinking"
+- name: "qwen/qwen3-max-thinking"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3-max-thinking"
+  display_name: "Qwen3 Max Thinking"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -47,10 +49,11 @@
   license: commercial
   web_search: true
 
-- id: "anthropic/claude-opus-4.6"
-  router: openrouter
-  router_model: "anthropic/claude-opus-4.6"
-  name: "Claude Opus 4.6"
+- name: "anthropic/claude-opus-4.6"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "anthropic/claude-opus-4.6"
+  display_name: "Claude Opus 4.6"
   provider: Anthropic
   country: US
   architecture: dense
@@ -61,10 +64,11 @@
   license: commercial
   web_search: true
 
-- id: "anthropic/claude-sonnet-4.6"
-  router: openrouter
-  router_model: "anthropic/claude-sonnet-4.6"
-  name: "Claude Sonnet 4.6"
+- name: "anthropic/claude-sonnet-4.6"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "anthropic/claude-sonnet-4.6"
+  display_name: "Claude Sonnet 4.6"
   provider: Anthropic
   country: US
   architecture: dense
@@ -75,10 +79,11 @@
   license: commercial
   web_search: true
 
-- id: "deepseek/deepseek-v3.2"
-  router: openrouter
-  router_model: "deepseek/deepseek-v3.2"
-  name: "DeepSeek V3.2"
+- name: "deepseek/deepseek-v3.2"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "deepseek/deepseek-v3.2"
+  display_name: "DeepSeek V3.2"
   provider: DeepSeek
   country: CN
   architecture: moe
@@ -90,10 +95,11 @@
   license: open-MIT
   web_search: true
 
-- id: "google/gemini-3-flash-preview"
-  router: openrouter
-  router_model: "google/gemini-3-flash-preview"
-  name: "Gemini 3 Flash"
+- name: "google/gemini-3-flash-preview"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "google/gemini-3-flash-preview"
+  display_name: "Gemini 3 Flash"
   provider: Google
   country: US
   architecture: dense
@@ -104,10 +110,11 @@
   license: commercial
   web_search: true
 
-- id: "mistralai/mistral-large-2512"
-  router: openrouter
-  router_model: "mistralai/mistral-large-2512"
-  name: "Mistral Large 3"
+- name: "mistralai/mistral-large-2512"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "mistralai/mistral-large-2512"
+  display_name: "Mistral Large 3"
   provider: Mistral
   country: FR
   architecture: moe
@@ -119,10 +126,11 @@
   license: open-apache
   web_search: true
 
-- id: "moonshotai/kimi-k2-thinking"
-  router: openrouter
-  router_model: "moonshotai/kimi-k2-thinking"
-  name: "Kimi K2 Thinking"
+- name: "moonshotai/kimi-k2-thinking"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "moonshotai/kimi-k2-thinking"
+  display_name: "Kimi K2 Thinking"
   provider: "Moonshot AI"
   country: CN
   architecture: moe
@@ -133,10 +141,11 @@
   license: commercial
   web_search: true
 
-- id: "openai/gpt-5.4"
-  router: openrouter
-  router_model: "openai/gpt-5.4"
-  name: GPT-5.4
+- name: "openai/gpt-5.4"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "openai/gpt-5.4"
+  display_name: GPT-5.4
   provider: OpenAI
   country: US
   architecture: dense
@@ -147,10 +156,11 @@
   license: commercial
   web_search: true
 
-- id: "x-ai/grok-4.20"
-  router: openrouter
-  router_model: "x-ai/grok-4.20"
-  name: "Grok 4.20"
+- name: "x-ai/grok-4.20"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "x-ai/grok-4.20"
+  display_name: "Grok 4.20"
   provider: xAI
   country: US
   architecture: dense
@@ -161,10 +171,11 @@
   license: commercial
   web_search: true
 
-- id: "z-ai/glm-5-turbo"
-  router: openrouter
-  router_model: "z-ai/glm-5-turbo"
-  name: "GLM-5 Turbo"
+- name: "z-ai/glm-5-turbo"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "z-ai/glm-5-turbo"
+  display_name: "GLM-5 Turbo"
   provider: "Zhipu AI"
   country: CN
   architecture: moe
@@ -176,10 +187,11 @@
   license: open-other
   web_search: true
 
-- id: "z-ai/glm-5.1"
-  router: openrouter
-  router_model: "z-ai/glm-5.1"
-  name: "GLM-5.1"
+- name: "z-ai/glm-5.1"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "z-ai/glm-5.1"
+  display_name: "GLM-5.1"
   provider: "Zhipu AI"
   country: CN
   architecture: moe
@@ -193,10 +205,11 @@
 
 # --- Large ---
 
-- id: "qwen/qwen3.5-122b-a10b"
-  router: openrouter
-  router_model: "qwen/qwen3.5-122b-a10b"
-  name: "Qwen 3.5 122B"
+- name: "qwen/qwen3.5-122b-a10b"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.5-122b-a10b"
+  display_name: "Qwen 3.5 122B"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -208,10 +221,11 @@
   license: open-apache
   web_search: true
 
-- id: "qwen/qwen3.5-397b-a17b"
-  router: openrouter
-  router_model: "qwen/qwen3.5-397b-a17b"
-  name: "Qwen 3.5 397B"
+- name: "qwen/qwen3.5-397b-a17b"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.5-397b-a17b"
+  display_name: "Qwen 3.5 397B"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -223,10 +237,11 @@
   license: open-apache
   web_search: true
 
-- id: "qwen/qwen3.5-plus-02-15"
-  router: openrouter
-  router_model: "qwen/qwen3.5-plus-02-15"
-  name: "Qwen 3.5 Plus"
+- name: "qwen/qwen3.5-plus-02-15"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.5-plus-02-15"
+  display_name: "Qwen 3.5 Plus"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -237,10 +252,11 @@
   license: commercial
   web_search: true
 
-- id: "alibaba/tongyi-deepresearch-30b-a3b"
-  router: openrouter
-  router_model: "alibaba/tongyi-deepresearch-30b-a3b"
-  name: "Tongyi DeepResearch 30B"
+- name: "alibaba/tongyi-deepresearch-30b-a3b"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "alibaba/tongyi-deepresearch-30b-a3b"
+  display_name: "Tongyi DeepResearch 30B"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -252,10 +268,11 @@
   license: commercial
   web_search: true
 
-- id: "baidu/ernie-4.5-21b-a3b-thinking"
-  router: openrouter
-  router_model: "baidu/ernie-4.5-21b-a3b-thinking"
-  name: "ERNIE 4.5 Thinking"
+- name: "baidu/ernie-4.5-21b-a3b-thinking"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "baidu/ernie-4.5-21b-a3b-thinking"
+  display_name: "ERNIE 4.5 Thinking"
   provider: Baidu
   country: CN
   architecture: moe
@@ -267,10 +284,11 @@
   license: commercial
   web_search: true
 
-- id: "meta-llama/llama-4-maverick"
-  router: openrouter
-  router_model: "meta-llama/llama-4-maverick"
-  name: "Llama 4 Maverick"
+- name: "meta-llama/llama-4-maverick"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "meta-llama/llama-4-maverick"
+  display_name: "Llama 4 Maverick"
   provider: Meta
   country: US
   architecture: moe
@@ -282,10 +300,11 @@
   license: open-llama
   web_search: true
 
-- id: "minimax/minimax-m2.7"
-  router: openrouter
-  router_model: "minimax/minimax-m2.7"
-  name: "MiniMax M2.7"
+- name: "minimax/minimax-m2.7"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "minimax/minimax-m2.7"
+  display_name: "MiniMax M2.7"
   provider: MiniMax
   country: CN
   architecture: dense
@@ -296,10 +315,11 @@
   license: commercial
   web_search: true
 
-- id: "moonshotai/kimi-k2.5"
-  router: openrouter
-  router_model: "moonshotai/kimi-k2.5"
-  name: "Kimi K2.5"
+- name: "moonshotai/kimi-k2.5"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "moonshotai/kimi-k2.5"
+  display_name: "Kimi K2.5"
   provider: "Moonshot AI"
   country: CN
   architecture: moe
@@ -310,10 +330,11 @@
   license: commercial
   web_search: true
 
-- id: "qwen3.5:122b"
-  router: ollama
-  router_model: "qwen3.5:122b"
-  name: "Qwen 3.5 122B (local)"
+- name: "qwen3.5:122b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "qwen3.5:122b"
+  display_name: "Qwen 3.5 122B (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: moe
@@ -323,10 +344,11 @@
   size_class: large
   license: open-apache
 
-- id: "xiaomi/mimo-v2-pro"
-  router: openrouter
-  router_model: "xiaomi/mimo-v2-pro"
-  name: "MiMo V2 Pro"
+- name: "xiaomi/mimo-v2-pro"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "xiaomi/mimo-v2-pro"
+  display_name: "MiMo V2 Pro"
   provider: Xiaomi
   country: CN
   architecture: dense
@@ -340,10 +362,11 @@
 
 # --- Medium ---
 
-- id: "qwen/qwen3.5-35b-a3b"
-  router: openrouter
-  router_model: "qwen/qwen3.5-35b-a3b"
-  name: "Qwen 3.5 35B"
+- name: "qwen/qwen3.5-35b-a3b"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.5-35b-a3b"
+  display_name: "Qwen 3.5 35B"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -355,10 +378,11 @@
   license: open-apache
   web_search: true
 
-- id: "qwen/qwen3.6-35b-a3b"
-  router: openrouter
-  router_model: "qwen/qwen3.6-35b-a3b"
-  name: "Qwen 3.6 35B"
+- name: "qwen/qwen3.6-35b-a3b"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.6-35b-a3b"
+  display_name: "Qwen 3.6 35B"
   provider: Alibaba
   country: CN
   architecture: moe
@@ -370,10 +394,11 @@
   license: open-apache
   web_search: true
 
-- id: "bytedance-seed/seed-2.0-lite"
-  router: openrouter
-  router_model: "bytedance-seed/seed-2.0-lite"
-  name: "Seed 2.0 Lite"
+- name: "bytedance-seed/seed-2.0-lite"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "bytedance-seed/seed-2.0-lite"
+  display_name: "Seed 2.0 Lite"
   provider: ByteDance
   country: CN
   architecture: dense
@@ -384,10 +409,11 @@
   license: commercial
   web_search: true
 
-- id: "inception/mercury-2"
-  router: openrouter
-  router_model: "inception/mercury-2"
-  name: "Mercury 2"
+- name: "inception/mercury-2"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "inception/mercury-2"
+  display_name: "Mercury 2"
   provider: Inception
   country: Other
   architecture: dense
@@ -398,10 +424,11 @@
   license: commercial
   web_search: true
 
-- id: "nvidia/nemotron-3-nano-30b-a3b"
-  router: openrouter
-  router_model: "nvidia/nemotron-3-nano-30b-a3b"
-  name: "Nemotron 3 Nano 30B"
+- name: "nvidia/nemotron-3-nano-30b-a3b"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  display_name: "Nemotron 3 Nano 30B"
   provider: NVIDIA
   country: US
   architecture: moe
@@ -413,10 +440,11 @@
   license: open-other
   web_search: true
 
-- id: "gemma4:31b"
-  router: ollama
-  router_model: "gemma4:31b"
-  name: "Gemma 4 31B (local)"
+- name: "gemma4:31b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "gemma4:31b"
+  display_name: "Gemma 4 31B (local)"
   provider: "Ollama/Padme"
   country: US
   architecture: dense
@@ -426,10 +454,11 @@
   size_class: medium
   license: open-other
 
-- id: "google/gemma-4-26b-a4b-it"
-  router: openrouter
-  router_model: "google/gemma-4-26b-a4b-it"
-  name: "Gemma 4 26B A4B"
+- name: "google/gemma-4-26b-a4b-it"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "google/gemma-4-26b-a4b-it"
+  display_name: "Gemma 4 26B A4B"
   provider: Google
   country: US
   architecture: moe
@@ -440,10 +469,11 @@
   license: open-apache
   params: "25.2B MoE (3.8B active)"
 
-- id: "google/gemma-4-31b-it"
-  router: openrouter
-  router_model: "google/gemma-4-31b-it"
-  name: "Gemma 4 31B"
+- name: "google/gemma-4-31b-it"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "google/gemma-4-31b-it"
+  display_name: "Gemma 4 31B"
   provider: Google
   country: US
   architecture: dense
@@ -454,10 +484,11 @@
   license: open-apache
   params: "31B dense"
 
-- id: "glm-4.7-flash"
-  router: ollama
-  router_model: "glm-4.7-flash"
-  name: "GLM 4.7 Flash (local)"
+- name: "glm-4.7-flash"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "glm-4.7-flash"
+  display_name: "GLM 4.7 Flash (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: dense
@@ -467,10 +498,11 @@
   size_class: medium
   license: open-apache
 
-- id: "nemotron-3-nano"
-  router: ollama
-  router_model: "nemotron-3-nano"
-  name: "Nemotron 3 Nano (local)"
+- name: "nemotron-3-nano"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "nemotron-3-nano"
+  display_name: "Nemotron 3 Nano (local)"
   provider: "Ollama/Padme"
   country: US
   architecture: moe
@@ -480,10 +512,11 @@
   size_class: medium
   license: open-other
 
-- id: "qwen3.5:35b"
-  router: ollama
-  router_model: "qwen3.5:35b"
-  name: "Qwen 3.5 35B (local)"
+- name: "qwen3.5:35b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "qwen3.5:35b"
+  display_name: "Qwen 3.5 35B (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: moe
@@ -493,10 +526,11 @@
   size_class: medium
   license: open-apache
 
-- id: "qwen3.6:35b"
-  router: ollama
-  router_model: "qwen3.6:35b"
-  name: "Qwen 3.6 35B (local)"
+- name: "qwen3.6:35b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "qwen3.6:35b"
+  display_name: "Qwen 3.6 35B (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: moe
@@ -509,10 +543,11 @@
 
 # --- Small ---
 
-- id: "mistralai/mistral-small-2603"
-  router: openrouter
-  router_model: "mistralai/mistral-small-2603"
-  name: "Mistral Small 4"
+- name: "mistralai/mistral-small-2603"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "mistralai/mistral-small-2603"
+  display_name: "Mistral Small 4"
   provider: Mistral
   country: FR
   architecture: dense
@@ -524,10 +559,11 @@
   license: open-apache
   web_search: true
 
-- id: "cogito:8b"
-  router: ollama
-  router_model: "cogito:8b"
-  name: "Cogito 8B (local)"
+- name: "cogito:8b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "cogito:8b"
+  display_name: "Cogito 8B (local)"
   provider: "Ollama/Padme"
   country: US
   architecture: dense
@@ -537,10 +573,11 @@
   size_class: small
   license: open-apache
 
-- id: "devstral-small-2"
-  router: ollama
-  router_model: "devstral-small-2"
-  name: "Devstral Small 2 (local)"
+- name: "devstral-small-2"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "devstral-small-2"
+  display_name: "Devstral Small 2 (local)"
   provider: "Ollama/Padme"
   country: FR
   architecture: dense
@@ -550,10 +587,11 @@
   size_class: small
   license: open-apache
 
-- id: "granite3.3:8b"
-  router: ollama
-  router_model: "granite3.3:8b"
-  name: "Granite 3.3 8B (local)"
+- name: "granite3.3:8b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "granite3.3:8b"
+  display_name: "Granite 3.3 8B (local)"
   provider: "Ollama/Padme"
   country: US
   architecture: dense
@@ -563,10 +601,11 @@
   size_class: small
   license: open-apache
 
-- id: "mistral-small3.2"
-  router: ollama
-  router_model: "mistral-small3.2"
-  name: "Mistral Small 3.2 (local)"
+- name: "mistral-small3.2"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "mistral-small3.2"
+  display_name: "Mistral Small 3.2 (local)"
   provider: "Ollama/Padme"
   country: FR
   architecture: dense
@@ -576,10 +615,11 @@
   size_class: small
   license: open-apache
 
-- id: "qwen3.5:9b"
-  router: ollama
-  router_model: "qwen3.5:9b"
-  name: "Qwen 3.5 9B (local)"
+- name: "qwen3.5:9b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "qwen3.5:9b"
+  display_name: "Qwen 3.5 9B (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: dense
@@ -589,10 +629,11 @@
   size_class: small
   license: open-apache
 
-- id: "ministral-3:14b"
-  router: ollama
-  router_model: "ministral-3:14b"
-  name: "Ministral 3 14B (local)"
+- name: "ministral-3:14b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "ministral-3:14b"
+  display_name: "Ministral 3 14B (local)"
   provider: "Ollama/Padme"
   country: FR
   architecture: dense
@@ -602,10 +643,11 @@
   size_class: small
   license: commercial
 
-- id: "openai/gpt-5-mini"
-  router: openrouter
-  router_model: "openai/gpt-5-mini"
-  name: "GPT-5 Mini"
+- name: "openai/gpt-5-mini"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "openai/gpt-5-mini"
+  display_name: "GPT-5 Mini"
   provider: OpenAI
   country: US
   architecture: dense
@@ -616,10 +658,11 @@
   license: commercial
   web_search: true
 
-- id: "stepfun/step-3.5-flash"
-  router: openrouter
-  router_model: "stepfun/step-3.5-flash"
-  name: "Step 3.5 Flash"
+- name: "stepfun/step-3.5-flash"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "stepfun/step-3.5-flash"
+  display_name: "Step 3.5 Flash"
   provider: StepFun
   country: CN
   architecture: dense
@@ -630,10 +673,11 @@
   license: commercial
   web_search: true
 
-- id: "xiaomi/mimo-v2-flash"
-  router: openrouter
-  router_model: "xiaomi/mimo-v2-flash"
-  name: "MiMo V2 Flash"
+- name: "xiaomi/mimo-v2-flash"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "xiaomi/mimo-v2-flash"
+  display_name: "MiMo V2 Flash"
   provider: Xiaomi
   country: CN
   architecture: dense
@@ -647,10 +691,11 @@
 
 # --- Edge ---
 
-- id: "qwen/qwen3.6-plus-preview:free"
-  router: openrouter
-  router_model: "qwen/qwen3.6-plus-preview:free"
-  name: "Qwen 3.6 Plus Preview"
+- name: "qwen/qwen3.6-plus-preview:free"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.6-plus-preview:free"
+  display_name: "Qwen 3.6 Plus Preview"
   provider: Alibaba
   country: CN
   architecture: dense
@@ -661,10 +706,11 @@
   license: commercial
   web_search: true
 
-- id: "google/gemini-2.5-flash-lite"
-  router: openrouter
-  router_model: "google/gemini-2.5-flash-lite"
-  name: "Gemini 2.5 Flash Lite"
+- name: "google/gemini-2.5-flash-lite"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "google/gemini-2.5-flash-lite"
+  display_name: "Gemini 2.5 Flash Lite"
   provider: Google
   country: US
   architecture: dense
@@ -675,10 +721,11 @@
   license: commercial
   web_search: true
 
-- id: "gemma4:e2b"
-  router: ollama
-  router_model: "gemma4:e2b"
-  name: "Gemma 4 E2B (local)"
+- name: "gemma4:e2b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "gemma4:e2b"
+  display_name: "Gemma 4 E2B (local)"
   provider: "Ollama/Padme"
   country: US
   architecture: dense
@@ -688,10 +735,11 @@
   size_class: edge
   license: open-other
 
-- id: "gemma4:e4b"
-  router: ollama
-  router_model: "gemma4:e4b"
-  name: "Gemma 4 E4B (local)"
+- name: "gemma4:e4b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "gemma4:e4b"
+  display_name: "Gemma 4 E4B (local)"
   provider: "Ollama/Padme"
   country: US
   architecture: dense
@@ -701,10 +749,11 @@
   size_class: edge
   license: open-other
 
-- id: "qwen3.5:2b"
-  router: ollama
-  router_model: "qwen3.5:2b"
-  name: "Qwen 3.5 2B (local)"
+- name: "qwen3.5:2b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "qwen3.5:2b"
+  display_name: "Qwen 3.5 2B (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: dense
@@ -714,10 +763,11 @@
   size_class: edge
   license: open-apache
 
-- id: "qwen3.5:4b"
-  router: ollama
-  router_model: "qwen3.5:4b"
-  name: "Qwen 3.5 4B (local)"
+- name: "qwen3.5:4b"
+  route: ollama
+  base_url: "http://localhost:11434/v1"
+  model_id: "qwen3.5:4b"
+  display_name: "Qwen 3.5 4B (local)"
   provider: "Ollama/Padme"
   country: CN
   architecture: moe
@@ -727,10 +777,11 @@
   size_class: edge
   license: open-apache
 
-- id: "openai/gpt-5-nano"
-  router: openrouter
-  router_model: "openai/gpt-5-nano"
-  name: "GPT-5 Nano"
+- name: "openai/gpt-5-nano"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "openai/gpt-5-nano"
+  display_name: "GPT-5 Nano"
   provider: OpenAI
   country: US
   architecture: dense
@@ -744,10 +795,11 @@
 
 # --- Reasoning / Deep Research ---
 
-- id: "deepseek/deepseek-r1-0528"
-  router: openrouter
-  router_model: "deepseek/deepseek-r1-0528"
-  name: "DeepSeek R1 0528"
+- name: "deepseek/deepseek-r1-0528"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "deepseek/deepseek-r1-0528"
+  display_name: "DeepSeek R1 0528"
   provider: DeepSeek
   country: CN
   architecture: moe
@@ -769,10 +821,11 @@
 # (reasoning flag: API errors if temperature is sent — removed entire codepath
 #  rather than carry a single-model exception indefinitely)
 #
-# - id: "openai/o3"
-#   router: openrouter
-#   router_model: "openai/o3"
-#   name: o3
+# - name: "openai/o3"
+#   route: openrouter
+#   base_url: "https://openrouter.ai/api/v1"
+#   model_id: "openai/o3"
+#   display_name: o3
 #   provider: OpenAI
 #   country: US
 #   architecture: dense

--- a/experiments/models_ablation_p2_rag.yaml
+++ b/experiments/models_ablation_p2_rag.yaml
@@ -1,10 +1,11 @@
 # Phase 2 RAG ablation — 2 models with strongest opposite-direction signal
 # from Phase 1 (ticket 0066). DeepSeek V3.2 (-27.4pp) vs Kimi K2 (+25.8pp).
 
-- id: "deepseek/deepseek-v3.2"
-  router: openrouter
-  router_model: "deepseek/deepseek-v3.2"
-  name: "DeepSeek V3.2"
+- name: "deepseek/deepseek-v3.2"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "deepseek/deepseek-v3.2"
+  display_name: "DeepSeek V3.2"
   provider: DeepSeek
   country: CN
   architecture: moe
@@ -16,10 +17,11 @@
   license: open-MIT
   web_search: true
 
-- id: "moonshotai/kimi-k2-thinking"
-  router: openrouter
-  router_model: "moonshotai/kimi-k2-thinking"
-  name: "Kimi K2 Thinking"
+- name: "moonshotai/kimi-k2-thinking"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "moonshotai/kimi-k2-thinking"
+  display_name: "Kimi K2 Thinking"
   provider: "Moonshot AI"
   country: CN
   architecture: moe

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -28,7 +28,17 @@ log = logging.getLogger(__name__)
 def load_models(path: str) -> list[dict]:
     """Load model registry from YAML file."""
     with open(path) as f:
-        return yaml.safe_load(f)
+        models = yaml.safe_load(f) or []
+    # Backward-compat aliases: callers still using old field names continue to work
+    # while the Python migration (ticket 0161) is in progress.
+    for m in models:
+        if "name" in m and "id" not in m:
+            m["id"] = m["name"]
+        if "route" in m and "router" not in m:
+            m["router"] = m["route"]
+        if "model_id" in m and "router_model" not in m:
+            m["router_model"] = m["model_id"]
+    return models
 
 
 def select_models(models: list[dict], ids: list[str]) -> list[dict]:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,11 +10,12 @@ EXPERIMENTS_DIR = Path(__file__).parent.parent / "experiments"
 MODELS_PATH = EXPERIMENTS_DIR / "models.yaml"
 EXPERIMENTS_PATH = EXPERIMENTS_DIR / "experiments.toml"
 
-REQUIRED_FIELDS = {
-    "id",
-    "router",
-    "router_model",
+# Native fields in models.yaml (v2 schema — ticket 0156)
+REQUIRED_FIELDS_V2 = {
     "name",
+    "display_name",
+    "route",
+    "model_id",
     "provider",
     "country",
     "architecture",
@@ -24,48 +25,52 @@ REQUIRED_FIELDS = {
     "size_class",
     "license",
 }
+# SDK-based routes require base_url; CLI routes must not have it.
+ROUTES_REQUIRE_BASE_URL = {"openrouter", "ollama", "openllm"}
+ROUTES_NO_BASE_URL = {"claude-code-cli", "codex"}
 
 VALID_COUNTRIES = {"US", "CN", "FR", "Other"}
 VALID_ARCHITECTURES = {"dense", "moe"}
 VALID_SIZE_CLASSES = {"frontier", "large", "medium", "small", "edge"}
 VALID_LICENSES = {"commercial", "open-apache", "open-MIT", "open-llama", "open", "open-other"}
-VALID_ROUTERS = {"openrouter", "ollama"}
+VALID_ROUTES = ROUTES_REQUIRE_BASE_URL | ROUTES_NO_BASE_URL
 
 
 def test_schema_validation(models):
-    """Each model entry has all required fields with valid values."""
+    """Each model entry has all required fields with valid values (v2 schema)."""
     for model in models:
-        model_id = model.get("id", "<missing>")
+        model_name = model.get("name", "<missing>")
         present = set(model.keys())
-        missing = REQUIRED_FIELDS - present
-        assert not missing, f"{model_id} missing fields: {missing}"
+        missing = REQUIRED_FIELDS_V2 - present
+        assert not missing, f"{model_name} missing fields: {missing}"
 
         assert model["country"] in VALID_COUNTRIES, (
-            f"{model_id}: invalid country {model['country']}"
+            f"{model_name}: invalid country {model['country']}"
         )
         assert model["architecture"] in VALID_ARCHITECTURES, (
-            f"{model_id}: invalid architecture {model['architecture']}"
+            f"{model_name}: invalid architecture {model['architecture']}"
         )
         assert model["size_class"] in VALID_SIZE_CLASSES, (
-            f"{model_id}: invalid size_class {model['size_class']}"
+            f"{model_name}: invalid size_class {model['size_class']}"
         )
         assert model["license"] in VALID_LICENSES, (
-            f"{model_id}: invalid license {model['license']}"
+            f"{model_name}: invalid license {model['license']}"
         )
-        assert model["router"] in VALID_ROUTERS, f"{model_id}: invalid router {model['router']}"
-        assert isinstance(model["context_window"], int), f"{model_id}: context_window must be int"
+        assert model["route"] in VALID_ROUTES, f"{model_name}: invalid route {model['route']}"
+        route = model["route"]
+        if route in ROUTES_REQUIRE_BASE_URL:
+            assert "base_url" in model, f"{model_name}: route={route} requires base_url"
+        if route in ROUTES_NO_BASE_URL:
+            assert "base_url" not in model, f"{model_name}: route={route} must not have base_url"
+        assert isinstance(model["context_window"], int), (
+            f"{model_name}: context_window must be int"
+        )
         assert isinstance(model["price_per_mtok_in"], (int, float)), (
-            f"{model_id}: price_per_mtok_in must be numeric"
+            f"{model_name}: price_per_mtok_in must be numeric"
         )
         assert isinstance(model["price_per_mtok_out"], (int, float)), (
-            f"{model_id}: price_per_mtok_out must be numeric"
+            f"{model_name}: price_per_mtok_out must be numeric"
         )
-
-
-def test_router_model_matches_id(models):
-    """In Phase A, router_model == id for every entry (scaffolding for Phase B)."""
-    for model in models:
-        assert model["router_model"] == model["id"], f"{model['id']}: router_model mismatch"
 
 
 def test_coverage(models):
@@ -76,8 +81,8 @@ def test_coverage(models):
     assert len(models) >= 45, f"Expected >= 45 models, got {len(models)}"
     # Spot-check that every model has required pricing fields
     for m in models:
-        assert m.get("price_per_mtok_in") is not None, f"{m['id']}: missing price_per_mtok_in"
-        assert m.get("price_per_mtok_out") is not None, f"{m['id']}: missing price_per_mtok_out"
+        assert m.get("price_per_mtok_in") is not None, f"{m['name']}: missing price_per_mtok_in"
+        assert m.get("price_per_mtok_out") is not None, f"{m['name']}: missing price_per_mtok_out"
     assert "US" in countries
     assert "CN" in countries
     assert {"frontier", "large", "medium", "small", "edge"} <= size_classes, (
@@ -85,20 +90,20 @@ def test_coverage(models):
     )
 
 
-def test_unique_ids(models):
-    """All model IDs must be unique."""
-    ids = [m["id"] for m in models]
-    assert len(ids) == len(set(ids)), (
-        f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
+def test_unique_names(models):
+    """All model instance names must be unique."""
+    names = [m["name"] for m in models]
+    assert len(names) == len(set(names)), (
+        f"Duplicate names found: {[x for x in names if names.count(x) > 1]}"
     )
 
 
 def test_experiments_model_ids_exist(models, experiments):
     """Every model_id in experiments.toml exists in the registry."""
-    registry_ids = {m["id"] for m in models}
+    registry_names = {m["name"] for m in models}
     for set_name, spec in experiments["sets"].items():
         for mid in spec["model_ids"]:
-            assert mid in registry_ids, (
+            assert mid in registry_names, (
                 f"experiments.toml sets.{set_name}: '{mid}' not in registry"
             )
 
@@ -113,10 +118,11 @@ def test_experiments_sets_nonempty(experiments):
         assert len(spec["model_ids"]) > 0, f"sets.{set_name} is empty"
 
 
-def test_experiments_routers(experiments):
-    """Router definitions have required fields."""
-    for name, router in experiments["routers"].items():
-        assert "base_url" in router, f"routers.{name} missing base_url"
+def test_no_routers_section(experiments):
+    """experiments.toml no longer has a [routers] section — base_url is per-model (ticket 0156)."""
+    assert "routers" not in experiments, (
+        "experiments.toml [routers] section should have been removed"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -231,14 +237,16 @@ def test_sweep_model_sets_exist(experiments):
 
 def test_sweep_model_set_ids_in_registry(models, experiments):
     """model_ids in sets referenced by sweeps all exist in the registry."""
-    registry_ids = {m["id"] for m in models}
+    registry_names = {m["name"] for m in models}
     for name, sweep in experiments["sweeps"].items():
         set_name = sweep.get("model_set")
         if set_name is None:
             continue
         model_set = experiments["sets"][set_name]
         for mid in model_set["model_ids"]:
-            assert mid in registry_ids, f"sweeps.{name} → sets.{set_name}: '{mid}' not in registry"
+            assert mid in registry_names, (
+                f"sweeps.{name} → sets.{set_name}: '{mid}' not in registry"
+            )
 
 
 def test_sweep_prompts_exist(experiments):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,6 +36,9 @@ VALID_LICENSES = {"commercial", "open-apache", "open-MIT", "open-llama", "open",
 VALID_ROUTES = ROUTES_REQUIRE_BASE_URL | ROUTES_NO_BASE_URL
 
 
+BANNED_FIELDS_V1 = {"id", "router", "router_model"}
+
+
 def test_schema_validation(models):
     """Each model entry has all required fields with valid values (v2 schema)."""
     for model in models:
@@ -43,6 +46,8 @@ def test_schema_validation(models):
         present = set(model.keys())
         missing = REQUIRED_FIELDS_V2 - present
         assert not missing, f"{model_name} missing fields: {missing}"
+        leftover = BANNED_FIELDS_V1 & present
+        assert not leftover, f"{model_name} still has v1 fields: {leftover}"
 
         assert model["country"] in VALID_COUNTRIES, (
             f"{model_name}: invalid country {model['country']}"

--- a/tickets/0156-model-instance-registry.erg
+++ b/tickets/0156-model-instance-registry.erg
@@ -7,6 +7,7 @@ Author: claude
 --- log ---
 2026-05-01T10:00Z claude created — supersedes 0141 per design discussion
 2026-05-01T10:15Z claude note amended — added `route` enum field; Claude Code CLI route split to ticket 0160
+2026-05-03T10:00Z claude note split — raid hit budget mid-migration; YAML done, Python deferred to ticket 0161; this ticket now covers YAML + shim + tests only
 
 --- body ---
 ## Context

--- a/tickets/0161-model-instance-registry-python-migration.erg
+++ b/tickets/0161-model-instance-registry-python-migration.erg
@@ -1,0 +1,81 @@
+%erg v1
+Title: Model instance registry — Python migration (phase 2 of ticket 0156)
+Status: open
+Created: 2026-05-03
+Author: claude
+Blocked-by: 0156
+
+--- log ---
+2026-05-03T10:00Z claude created — phase 2 of 0156 after YAML + shim landed
+
+--- body ---
+## Context
+
+Ticket 0156 landed the YAML schema migration (`models.yaml` v2: `name`, `display_name`,
+`route`, `base_url`, `model_id`) plus a backward-compat shim in `load_models()` that adds
+`id`/`router`/`router_model` aliases so existing callers continue to work.
+
+This ticket removes the shim and migrates every call site to the new field names.
+
+## Actions
+
+1. In `src/aedist/harness.py`:
+   - Remove the backward-compat alias block from `load_models()`.
+   - Replace `make_client_for_router(router, routers_config)` with `make_client_for_route(model)`
+     (reads `model["route"]` and `model["base_url"]` directly). The partial implementation
+     from the failed raid (worktree `agent-ace1b9a565323f258`) can be used as a starting point.
+
+2. Update `src/aedist/query.py`:
+   - `m["id"]` → `m["name"]`; `m.get("router")` → `m.get("route")`; `m.get("router_model", ...)` → `m.get("model_id", ...)`
+   - Client dispatch: use `make_client_for_route(model)` instead of `make_client_for_router(router, routers_config)`
+   - Partial implementation from raid worktree is correct; apply it.
+
+3. Update `src/aedist/query_direct.py`, `query_rag.py`, `query_multiturn.py`,
+   `query_per_fuel.py`, `query_livesearch.py` — same field-name substitutions as step 2.
+   Pattern to replace in each file:
+   - `model.get("router")` → `model.get("route")`
+   - `model.get("router_model", model_id)` → `model.get("model_id", model_id)`
+   - Client dispatch: `make_client_for_router(router, routers_config)` →
+     `make_client_for_route(model)`; remove `routers_config` lookups.
+   - `model["id"]` → `model["name"]`
+
+4. Update `src/aedist/worker.py`:
+   - Line 186: `m["id"]` → `m["name"]`
+   - Line 190: `model_entry["id"]` → `model_entry["name"]`
+
+5. Update `src/aedist/manager.py`:
+   - Line 85: `model["id"]` → `model["name"]`
+
+6. Update `src/aedist/select_models.py`:
+   - Lines 78, 163: `m["id"]` → `m["name"]`
+   - Lines 277–278: `m.get("router") == "ollama"` → `m.get("route") == "ollama"`
+
+7. Update figure scripts to use `display_name` for axis/legend labels:
+   - `src/aedist/plot_regimes_scatter.py`
+   - `src/aedist/plot_scaling_curve.py`
+   Check each for `m.get("name", ...)` and replace with `m.get("display_name", m.get("name"))`.
+
+8. Remove the `[routers]` lookup from `experiments/experiments.toml` dependent code
+   paths (any remaining `routers_config = experiments.get("routers", {})` lines that
+   now go unused after step 3).
+
+9. After all call sites are migrated: remove the backward-compat shim block from
+   `harness.load_models()` (the three `if "name" in m and "id" not in m:` lines).
+
+10. Close ticket 0141 as `won't do` with a log note referencing 0156.
+
+## Test
+
+- `pytest tests/test_models.py` — all 19 tests green (no shim needed).
+- `pytest tests/test_select_models.py` — models selected by new `name` field.
+- Full suite: `pytest -q` — 1144+ passed, 0 regressions.
+- Dry-run sweep: `uv run python -m aedist.query --dry-run --model-set modelset_census_cloud`
+  dispatches without error; each model uses its `route` field.
+
+## Exit criteria
+
+- No `m["id"]`, `m.get("router")`, `m.get("router_model")`, or `routers_config` lookups
+  remain in any `src/aedist/` file.
+- `load_models()` shim block removed.
+- All figures use `display_name`.
+- Tests green; ticket 0141 closed.


### PR DESCRIPTION
## Summary

- Migrates all 52 entries in `models.yaml` to v2 schema: `id`→`name`, `name`→`display_name`, `router`→`route`, `router_model`→`model_id`; adds `base_url` per entry
- Removes `[routers]` section from `experiments.toml` (base_url now lives per-model)
- Adds backward-compat shim in `load_models()` so all existing Python callers stay green while ticket 0161 (Python migration) is in progress
- Updates `tests/test_models.py` to validate v2 schema; renames `test_unique_ids` → `test_unique_names`, replaces `test_experiments_routers` with `test_no_routers_section`
- Salvages YAML work from the failed raid worktree (`agent-ace1b9a565323f258`)
- Creates ticket 0161 for the Python call-site migration (phase 2)

## Test plan

- [x] `pytest tests/test_models.py` — 19 passed
- [x] Full suite `pytest -q` — 1144 passed, 1 skipped, 2 xfailed (same as baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)