### PR TITLE
feat(registry): Python migration to v2 field names (ticket 0161)

### DIFF
--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -29,23 +29,14 @@ def load_models(path: str) -> list[dict]:
     """Load model registry from YAML file."""
     with open(path) as f:
         models = yaml.safe_load(f) or []
-    # Backward-compat aliases: callers still using old field names continue to work
-    # while the Python migration (ticket 0161) is in progress.
-    for m in models:
-        if "name" in m and "id" not in m:
-            m["id"] = m["name"]
-        if "route" in m and "router" not in m:
-            m["router"] = m["route"]
-        if "model_id" in m and "router_model" not in m:
-            m["router_model"] = m["model_id"]
     return models
 
 
 def select_models(models: list[dict], ids: list[str]) -> list[dict]:
     """Filter models by ID list. Warns on IDs not found in registry."""
     id_set = set(ids)
-    result = [m for m in models if m["id"] in id_set]
-    missing = id_set - {m["id"] for m in result}
+    result = [m for m in models if m["name"] in id_set]
+    missing = id_set - {m["name"] for m in result}
     if missing:
         log.warning("Model IDs not found in registry: %s", sorted(missing))
     return result
@@ -217,15 +208,15 @@ def make_client(base_url: str | None = None) -> OpenAI:
     )
 
 
-def make_client_for_router(router: str, routers_config: dict) -> OpenAI:
-    """Create an OpenAI-compatible client from router config.
+def make_client_for_route(model: dict) -> OpenAI:
+    """Create an OpenAI-compatible client from model registry entry.
 
-    Resolves base_url and API key from the router definition in
-    experiments.toml's [routers] section.
+    Reads ``route`` and ``base_url`` directly from the model dict
+    (v2 registry schema).  For Ollama (no env_key), uses a long timeout
+    and a dummy API key.
     """
-    cfg = routers_config[router]
-    base_url = cfg["base_url"]
-    env_key = cfg.get("env_key")
+    base_url = model["base_url"]
+    env_key = model.get("env_key")
     if env_key:
         api_key = os.environ.get(env_key)
         if not api_key:

--- a/src/aedist/manager.py
+++ b/src/aedist/manager.py
@@ -82,9 +82,9 @@ def generate(
     skipped = 0
 
     for model in models:
-        model_id = model["id"]
+        model_name = model["name"]
         for run in range(1, parent_spec.repeat + 1):
-            job_id = _deterministic_job_id(sweep_key, model_id, run)
+            job_id = _deterministic_job_id(sweep_key, model_name, run)
 
             if job_id in existing:
                 skipped += 1
@@ -96,7 +96,7 @@ def generate(
                 mode=parent_spec.mode,
                 prompt=parent_spec.prompt,
                 models_file=parent_spec.models_file,
-                model_filter=model_id,
+                model_filter=model_name,
                 corpus=parent_spec.corpus,
                 followups=parent_spec.followups,
                 strategy=parent_spec.strategy,
@@ -129,7 +129,8 @@ def main() -> None:
     gen.add_argument("sweep_yaml", nargs="?", help="Path to sweep YAML config (legacy).")
     gen.add_argument("--sweep", help="Sweep name from experiments.toml.")
     gen.add_argument(
-        "--experiments", default="experiments.toml",
+        "--experiments",
+        default="experiments.toml",
         help="Path to experiments.toml (default: experiments.toml).",
     )
     gen.add_argument(

--- a/src/aedist/query.py
+++ b/src/aedist/query.py
@@ -34,7 +34,6 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
-    make_client_for_router,
     model_metadata,
     output_path,
     query_single_turn,
@@ -115,20 +114,19 @@ def main():
 
     # Filter to single model if requested
     if args.model:
-        models = [m for m in models if m["id"] == args.model]
+        models = [m for m in models if m["name"] == args.model]
         if not models:
             raise SystemExit(f"Model {args.model} not found in {args.models}")
 
     if args.dry_run:
         for model in models:
             for run in range(1, args.repeat + 1):
-                log.info("Would query %s run %d", model["id"], run)
+                log.info("Would query %s run %d", model["name"], run)
         return
 
-    # Build client(s): per-router when using experiments.toml, else single legacy client
+    # Build client(s): per-route when using experiments.toml, else single legacy client
     legacy_client = None
     if args.model_set:
-        routers_config = experiments.get("routers", {})
         clients: dict[str, object] = {}
     else:
         legacy_client = make_client(args.base_url)
@@ -146,26 +144,26 @@ def main():
     prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
     for model in models:
-        model_id = model["id"]
-        label = model.get("name", model_id)
+        model_id = model["name"]
+        label = model.get("display_name", model_id)
 
         # Resolve client
-        router = model.get("router")
-        if args.model_set and router:
-            if router not in clients:
-                clients[router] = make_client_for_router(router, routers_config)
-            client = clients[router]
+        route = model.get("route")
+        if args.model_set and route:
+            if route not in clients:
+                clients[route] = make_client_for_route(model)
+            client = clients[route]
         else:
             if legacy_client is None:
                 raise SystemExit(
-                    f"{model_id}: no router field and no legacy client (use --base-url or add router to registry)"
+                    f"{model_id}: no route field and no legacy client (use --base-url or add route to registry)"
                 )
             client = legacy_client
 
-        # Router key for health tracking. Falls back to the model id's
+        # Route key for health tracking. Falls back to the model id's
         # namespace (e.g. "deepseek") when a legacy single-client run
-        # has no router field.
-        router_key = router or (model_id.split("/", 1)[0] if "/" in model_id else "default")
+        # has no route field.
+        router_key = route or (model_id.split("/", 1)[0] if "/" in model_id else "default")
 
         for run in range(1, args.repeat + 1):
             if not budget.check_or_warn():
@@ -191,7 +189,7 @@ def main():
 
             log.info("Querying %s run %d/%d...", label, run, args.repeat)
             try:
-                api_model_id = model.get("router_model", model_id)
+                api_model_id = model.get("model_id", model_id)
                 api_kwargs = build_api_kwargs(
                     model,
                     temperature=args.temperature,

--- a/src/aedist/query.py
+++ b/src/aedist/query.py
@@ -34,6 +34,7 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
+    make_client_for_route,
     model_metadata,
     output_path,
     query_single_turn,

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -34,6 +34,7 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
+    make_client_for_route,
     model_metadata,
     output_path,
     query_ollama_native,

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -34,7 +34,6 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
-    make_client_for_router,
     model_metadata,
     output_path,
     query_ollama_native,
@@ -123,7 +122,7 @@ def main():
         models = select_models(models, set_ids)
 
     if args.model:
-        models = [m for m in models if m["id"] == args.model]
+        models = [m for m in models if m["name"] == args.model]
         if not models:
             raise SystemExit(f"Model {args.model} not found in {args.models}")
 
@@ -135,7 +134,7 @@ def main():
         est_total = (est_cost_in + est_cost_out) * args.repeat
         log.info(
             "  %s: ~%d prompt tokens, max %d output → est $%.4f/run, $%.4f total",
-            model.get("name", model["id"]),
+            model.get("display_name", model["name"]),
             prompt_tokens_est,
             args.max_tokens,
             est_cost_in + est_cost_out,
@@ -146,28 +145,27 @@ def main():
         log.info("Dry run — no API calls made.")
         return
 
-    # Build client(s): per-router when using experiments.toml, else single legacy client
+    # Build client(s): per-route when using experiments.toml, else single legacy client
     legacy_client = None
     if args.model_set:
-        routers_config = experiments.get("routers", {})
         clients: dict = {}
     else:
         legacy_client = make_client()
     budget = BudgetTracker(args.budget_usd)
 
     for model in models:
-        model_id = model["id"]
-        label = model.get("name", model_id)
+        model_id = model["name"]
+        label = model.get("display_name", model_id)
 
-        router = model.get("router")
-        if args.model_set and router:
-            if router not in clients:
-                clients[router] = make_client_for_router(router, routers_config)
-            client = clients[router]
+        route = model.get("route")
+        if args.model_set and route:
+            if route not in clients:
+                clients[route] = make_client_for_route(model)
+            client = clients[route]
         else:
             if legacy_client is None:
                 raise SystemExit(
-                    f"{model_id}: no router field and no legacy client (use --base-url or add router to registry)"
+                    f"{model_id}: no route field and no legacy client (use --base-url or add route to registry)"
                 )
             client = legacy_client
 
@@ -198,13 +196,10 @@ def main():
                     temperature=args.temperature,
                     no_think=args.no_think,
                 )
-                api_model_id = model.get("router_model", model_id)
+                api_model_id = model.get("model_id", model_id)
                 # Ollama: bypass /v1/ shim to honour num_ctx (output cap via num_predict)
-                if model.get("router") == "ollama":
-                    ollama_cfg = (
-                        experiments.get("routers", {}).get("ollama", {}) if args.model_set else {}
-                    )
-                    ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+                if model.get("route") == "ollama":
+                    ollama_url = model.get("base_url", "http://localhost:11434/v1")
                     ctx_window = model.get("context_window", 32768)
                     num_ctx = min(ctx_window, 81920)
                     result = query_ollama_native(

--- a/src/aedist/query_livesearch.py
+++ b/src/aedist/query_livesearch.py
@@ -27,6 +27,7 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
+    make_client_for_route,
     model_metadata,
     output_path,
     query_ollama_native,

--- a/src/aedist/query_livesearch.py
+++ b/src/aedist/query_livesearch.py
@@ -27,7 +27,6 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
-    make_client_for_router,
     model_metadata,
     output_path,
     query_ollama_native,
@@ -144,7 +143,7 @@ def main():
         models = select_models(models, set_ids)
 
     if args.model:
-        models = [m for m in models if m["id"] == args.model]
+        models = [m for m in models if m["name"] == args.model]
         if not models:
             raise SystemExit(f"Model {args.model} not found in {args.models}")
 
@@ -156,7 +155,7 @@ def main():
     if args.dry_run:
         for model in models:
             for run in range(1, args.repeat + 1):
-                log.info("Would query %s run %d (web-augmented)", model["id"], run)
+                log.info("Would query %s run %d (web-augmented)", model["name"], run)
         return
 
     # Run web searches once (same context for all models/runs)
@@ -170,32 +169,30 @@ def main():
 
     legacy_client = None
     if args.model_set:
-        routers_config = experiments.get("routers", {})
         clients: dict = {}
     else:
         legacy_client = make_client()
     budget = BudgetTracker(args.budget_usd)
 
     for model in models:
-        model_id = model["id"]
-        label = model.get("name", model_id)
+        model_id = model["name"]
+        label = model.get("display_name", model_id)
 
-        router = model.get("router")
-        if args.model_set and router:
-            if router not in clients:
-                clients[router] = make_client_for_router(router, routers_config)
-            client = clients[router]
+        route = model.get("route")
+        if args.model_set and route:
+            if route not in clients:
+                clients[route] = make_client_for_route(model)
+            client = clients[route]
         else:
             if legacy_client is None:
                 raise SystemExit(
-                    f"{model_id}: no router field and no legacy client (use --base-url or add router to registry)"
+                    f"{model_id}: no route field and no legacy client (use --base-url or add route to registry)"
                 )
             client = legacy_client
 
         # Ollama: bypass /v1/ shim to honour num_ctx; resolved once per model
-        if router == "ollama":
-            ollama_cfg = routers_config.get("ollama", {}) if args.model_set else {}
-            ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+        if route == "ollama":
+            ollama_url = model.get("base_url", "http://localhost:11434/v1")
             ctx_window = model.get("context_window", 32768)
             num_ctx = min(ctx_window, 81920)
 
@@ -220,12 +217,12 @@ def main():
                     },
                     {"role": "user", "content": prompt},
                 ]
-                api_model_id = model.get("router_model", model_id)
+                api_model_id = model.get("model_id", model_id)
                 api_kwargs = build_api_kwargs(
                     model,
                     temperature=args.temperature,
                 )
-                if router == "ollama":
+                if route == "ollama":
                     result = query_ollama_native(
                         ollama_url,
                         api_model_id,

--- a/src/aedist/query_multiturn.py
+++ b/src/aedist/query_multiturn.py
@@ -28,7 +28,6 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
-    make_client_for_router,
     model_metadata,
     output_path,
     query_ollama_native,
@@ -74,7 +73,7 @@ def run_conversation(
     **api_kwargs,
 ) -> dict | None:
     """Run a multi-turn conversation. Returns record dict or None if budget exceeded."""
-    is_ollama = model.get("router") == "ollama"
+    is_ollama = model.get("route") == "ollama"
     num_ctx = min(model.get("context_window", 32768), 81920) if is_ollama else None
     ollama_url = ollama_base_url or "http://localhost:11434/v1"
 
@@ -217,37 +216,38 @@ def main():
         models = select_models(models, set_ids)
 
     if args.model:
-        models = [m for m in models if m["id"] == args.model]
+        models = [m for m in models if m["name"] == args.model]
         if not models:
             raise SystemExit(f"Model {args.model} not found in {args.models}")
 
     if args.dry_run:
         for model in models:
             for run in range(1, args.repeat + 1):
-                log.info("Would query %s run %d (%d turns)", model["id"], run, 1 + len(followups))
+                log.info(
+                    "Would query %s run %d (%d turns)", model["name"], run, 1 + len(followups)
+                )
         return
 
     legacy_client = None
     if args.model_set:
-        routers_config = experiments.get("routers", {})
         clients: dict = {}
     else:
         legacy_client = make_client()
     budget = BudgetTracker(args.budget_usd)
 
     for model in models:
-        model_id = model["id"]
-        label = model.get("name", model_id)
+        model_id = model["name"]
+        label = model.get("display_name", model_id)
 
-        router = model.get("router")
-        if args.model_set and router:
-            if router not in clients:
-                clients[router] = make_client_for_router(router, routers_config)
-            client = clients[router]
+        route = model.get("route")
+        if args.model_set and route:
+            if route not in clients:
+                clients[route] = make_client_for_route(model)
+            client = clients[route]
         else:
             if legacy_client is None:
                 raise SystemExit(
-                    f"{model_id}: no router field and no legacy client (use --base-url or add router to registry)"
+                    f"{model_id}: no route field and no legacy client (use --base-url or add route to registry)"
                 )
             client = legacy_client
 
@@ -268,15 +268,13 @@ def main():
             )
 
             try:
-                api_model_id = model.get("router_model", model_id)
+                api_model_id = model.get("model_id", model_id)
                 mt_api_kwargs = build_api_kwargs(
                     model,
                     temperature=args.temperature,
                     no_think=args.no_think,
                 )
-                ollama_base_url = (
-                    routers_config.get("ollama", {}).get("base_url") if args.model_set else None
-                )
+                ollama_base_url = model.get("base_url") if model.get("route") == "ollama" else None
                 conv = run_conversation(
                     client,
                     api_model_id,

--- a/src/aedist/query_multiturn.py
+++ b/src/aedist/query_multiturn.py
@@ -28,6 +28,7 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
+    make_client_for_route,
     model_metadata,
     output_path,
     query_ollama_native,

--- a/src/aedist/query_per_fuel.py
+++ b/src/aedist/query_per_fuel.py
@@ -41,7 +41,6 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
-    make_client_for_router,
     model_metadata,
     output_path,
     query_ollama_native,
@@ -254,38 +253,37 @@ def main():
     log.info("Corpus: %d files, ~%d tokens", len(corpus_files), corpus_tokens)
 
     if args.model:
-        models = [m for m in models if m["id"] == args.model]
+        models = [m for m in models if m["name"] == args.model]
         if not models:
             raise SystemExit(f"Model {args.model} not found in {args.models}")
 
     if args.dry_run:
         for model in models:
             for run in range(1, args.repeat + 1):
-                log.info("Would query %s run %d (3 sub-queries)", model["id"], run)
+                log.info("Would query %s run %d (3 sub-queries)", model["name"], run)
         return
 
     legacy_client = None
     if args.model_set:
-        routers_config = experiments.get("routers", {})
         clients: dict = {}
     else:
         legacy_client = make_client()
     budget = BudgetTracker(args.budget_usd)
 
     for model in models:
-        model_id = model["id"]
-        label = model.get("name", model_id)
+        model_id = model["name"]
+        label = model.get("display_name", model_id)
         ctx_window = model.get("context_window", 0)
 
-        router = model.get("router")
-        if args.model_set and router:
-            if router not in clients:
-                clients[router] = make_client_for_router(router, routers_config)
-            client = clients[router]
+        route = model.get("route")
+        if args.model_set and route:
+            if route not in clients:
+                clients[route] = make_client_for_route(model)
+            client = clients[route]
         else:
             if legacy_client is None:
                 raise SystemExit(
-                    f"{model_id}: no router field and no legacy client (use --base-url or add router to registry)"
+                    f"{model_id}: no route field and no legacy client (use --base-url or add route to registry)"
                 )
             client = legacy_client
 
@@ -294,9 +292,8 @@ def main():
             continue
 
         # Ollama: bypass /v1/ shim to honour num_ctx; resolved once per model
-        if router == "ollama":
-            ollama_cfg = routers_config.get("ollama", {}) if args.model_set else {}
-            ollama_url = ollama_cfg.get("base_url", "http://localhost:11434/v1")
+        if route == "ollama":
+            ollama_url = model.get("base_url", "http://localhost:11434/v1")
             ollama_num_ctx = min(ctx_window or 32768, 81920)
         else:
             ollama_url = None
@@ -312,7 +309,7 @@ def main():
 
             log.info("Querying %s run %d/%d (decomposed RAG)...", label, run, args.repeat)
 
-            api_model_id = model.get("router_model", model_id)
+            api_model_id = model.get("model_id", model_id)
             dec_api_kwargs = build_api_kwargs(
                 model,
                 temperature=args.temperature,

--- a/src/aedist/query_per_fuel.py
+++ b/src/aedist/query_per_fuel.py
@@ -41,6 +41,7 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
+    make_client_for_route,
     model_metadata,
     output_path,
     query_ollama_native,

--- a/src/aedist/query_rag.py
+++ b/src/aedist/query_rag.py
@@ -31,7 +31,7 @@ from .harness import (
     load_experiments,
     load_models,
     make_client,
-    make_client_for_router,
+    make_client_for_route,
     model_metadata,
     output_path,
     query_ollama_native,
@@ -147,7 +147,7 @@ def main():
     log.info("Corpus: %d files, ~%d tokens", len(corpus_files), corpus_tokens)
 
     if args.model:
-        models = [m for m in models if m["id"] == args.model]
+        models = [m for m in models if m["name"] == args.model]
         if not models:
             raise SystemExit(f"Model {args.model} not found in {args.models}")
 
@@ -158,21 +158,18 @@ def main():
                 "OK" if corpus_tokens < ctx * CONTEXT_WINDOW_SAFETY_MARGIN else "SKIP (too large)"
             )
             for run in range(1, args.repeat + 1):
-                log.info("Would query %s run %d [%s]", model["id"], run, fits)
+                log.info("Would query %s run %d [%s]", model["name"], run, fits)
         return
 
     budget = BudgetTracker(args.budget_usd)
-    routers_config = experiments.get("routers", {}) if experiments else {}
     clients: dict[str, object] = {}
 
     for model in models:
-        model_id = model["id"]
-        label = model.get("name", model_id)
-        # Consolidated registry entries always have "router". Legacy per-experiment
-        # YAML files (without "router") fall through to the base_url path.
-        router = model.get("router")
-        base_url = model.get("base_url")  # legacy path only
-        is_ollama = router == "ollama" if router else bool(base_url)
+        model_id = model["name"]
+        label = model.get("display_name", model_id)
+        route = model.get("route")
+        base_url = model.get("base_url")
+        is_ollama = route == "ollama"
 
         ctx_window = model.get("context_window", 0)
 
@@ -194,11 +191,11 @@ def main():
                 log.info("Skip %s run %d (cached)", label, run)
                 continue
 
-            # Create/switch client per router
-            if router and routers_config:
-                if router not in clients:
-                    clients[router] = make_client_for_router(router, routers_config)
-                client = clients[router]
+            # Create/switch client per route
+            if route:
+                if route not in clients:
+                    clients[route] = make_client_for_route(model)
+                client = clients[route]
             elif base_url:
                 if base_url not in clients:
                     clients[base_url] = make_client(base_url)
@@ -217,13 +214,10 @@ def main():
                 ]
                 # Use native Ollama API to set num_ctx (OpenAI /v1/ ignores it)
                 # Size to actual need, not model max — saves KV cache VRAM
-                # router_model is the ID the router expects (future-proof for Phase B)
-                api_model_id = model.get("router_model", model_id)
+                # model_id is the ID the backend API expects
+                api_model_id = model.get("model_id", model_id)
                 if is_ollama:
-                    ollama_cfg = routers_config.get("ollama", {})
-                    ollama_url = (
-                        ollama_cfg.get("base_url") or base_url or "http://localhost:11434/v1"
-                    )
+                    ollama_url = base_url or "http://localhost:11434/v1"
                     num_ctx = min(ctx_window, 81920)
                     result = query_ollama_native(
                         ollama_url,

--- a/src/aedist/select_models.py
+++ b/src/aedist/select_models.py
@@ -75,11 +75,11 @@ def load_registry(models: list[dict], *, is_padme: bool = False) -> dict[str, di
     """
     result: dict[str, dict] = {}
     for model in models:
-        model_id = model["id"]
+        model_name = model["name"]
         if is_padme:
-            slug = "padme-" + model_id.replace(":", "-")
+            slug = "padme-" + model_name.replace(":", "-")
         else:
-            slug = model_id.split("/")[-1].replace(":", "-")
+            slug = model_name.split("/")[-1].replace(":", "-")
         result[slug] = {**model, "_slug": slug}
     return result
 
@@ -125,7 +125,7 @@ def select_models(
                 log.info(
                     "  %s: %s (median F1=%.1f%%)",
                     label,
-                    m.get("name", m["_slug"]),
+                    m.get("display_name", m["_slug"]),
                     m["_median_f1"] * 100,
                 )
             return picked
@@ -152,7 +152,7 @@ def select_models(
             scored.append(entry)
 
     # 1. Frontier tier: best F1 per required country (frontier only)
-    picked_ids: set[str] = set()
+    picked_names: set[str] = set()
     frontier_picks: list[dict] = []
     for country in require_countries:
         candidates = [
@@ -160,17 +160,17 @@ def select_models(
             for m in scored
             if m.get("country") == country
             and m.get("size_class") == "frontier"
-            and m["id"] not in picked_ids
+            and m["name"] not in picked_names
         ]
         candidates.sort(key=lambda m: m["_median_f1"], reverse=True)
         if candidates:
             pick = candidates[0]
             frontier_picks.append(pick)
-            picked_ids.add(pick["id"])
+            picked_names.add(pick["name"])
             log.info(
                 "  frontier %s: %s (F1=%.1f%%)",
                 country,
-                pick.get("name", pick["id"]),
+                pick.get("display_name", pick["name"]),
                 pick["_median_f1"] * 100,
             )
         else:
@@ -182,14 +182,14 @@ def select_models(
     log.info("  local floor: F1=%.1f%%", local_floor * 100)
 
     cheap_candidates = [
-        m for m in scored if m["id"] not in picked_ids and m["_median_f1"] > local_floor
+        m for m in scored if m["name"] not in picked_names and m["_median_f1"] > local_floor
     ]
     cheap_candidates.sort(key=lambda m: m.get("price_per_mtok_in", 999))
     cheap_picks = cheap_candidates[:n_cheap]
     for m in cheap_picks:
         log.info(
             "  cheap: %s ($%.2f/Mtok, F1=%.1f%%)",
-            m.get("name", m["id"]),
+            m.get("display_name", m["name"]),
             m.get("price_per_mtok_in", 0),
             m["_median_f1"] * 100,
         )
@@ -274,8 +274,8 @@ def main() -> None:
         cloud_models = all_models
     else:
         # New: single registry, split by router field
-        cloud_models = [m for m in all_models if m.get("router") != "ollama"]
-        padme_models = [m for m in all_models if m.get("router") == "ollama"]
+        cloud_models = [m for m in all_models if m.get("route") != "ollama"]
+        padme_models = [m for m in all_models if m.get("route") == "ollama"]
 
     cloud_reg = load_registry(cloud_models, is_padme=False)
     padme_reg = load_registry(padme_models, is_padme=True)

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -183,11 +183,11 @@ class Worker:
         output_dir = Path(job.output_dir)
 
         if job.model_filter:
-            models = [m for m in models if job.model_filter in m["id"]]
+            models = [m for m in models if job.model_filter in m["name"]]
         if not models:
             raise ValueError(f"No model matched filter {job.model_filter!r}")
         model_entry = models[0]
-        model_id = model_entry["id"]
+        model_id = model_entry["name"]
         run = job.run_number
         api_kwargs = build_api_kwargs(
             model_entry,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -12,9 +12,9 @@ from aedist.schema import JobSpec, Method
 def _write_sweep(tmp_path: Path, repeat: int = 2) -> Path:
     """Write a minimal sweep YAML and model registry, return sweep path."""
     models = [
-        {"id": "provider/model-a", "name": "Model A"},
-        {"id": "provider/model-b", "name": "Model B"},
-        {"id": "provider/model-c", "name": "Model C"},
+        {"name": "provider/model-a", "display_name": "Model A"},
+        {"name": "provider/model-b", "display_name": "Model B"},
+        {"name": "provider/model-c", "display_name": "Model C"},
     ]
     models_path = tmp_path / "models.yaml"
     models_path.write_text(yaml.dump(models))
@@ -102,7 +102,7 @@ def test_dirs_created(tmp_path: Path):
 
 def test_prompt_modules_propagated_to_jobs(tmp_path: Path):
     """Sweep with prompt_modules propagates to each generated job."""
-    models = [{"id": "provider/model-a", "name": "Model A"}]
+    models = [{"name": "provider/model-a", "display_name": "Model A"}]
     models_path = tmp_path / "models.yaml"
     models_path.write_text(yaml.dump(models))
 
@@ -129,7 +129,7 @@ def test_prompt_modules_propagated_to_jobs(tmp_path: Path):
 
 def test_prompt_modules_empty_list_propagated(tmp_path: Path):
     """Sweep with empty prompt_modules list propagates correctly."""
-    models = [{"id": "provider/model-a", "name": "Model A"}]
+    models = [{"name": "provider/model-a", "display_name": "Model A"}]
     models_path = tmp_path / "models.yaml"
     models_path.write_text(yaml.dump(models))
 

--- a/tests/test_ollama_native_api.py
+++ b/tests/test_ollama_native_api.py
@@ -63,10 +63,11 @@ def _ollama_response():
 
 def _ollama_model(context_window=32768):
     return {
-        "id": "test-ollama:9b",
-        "name": "Test Ollama 9B",
-        "router": "ollama",
-        "router_model": "test-ollama:9b",
+        "name": "test-ollama:9b",
+        "display_name": "Test Ollama 9B",
+        "route": "ollama",
+        "model_id": "test-ollama:9b",
+        "base_url": "http://localhost:11434/v1",
         "context_window": context_window,
         "price_per_mtok_in": 0,
         "price_per_mtok_out": 0,

--- a/tests/test_provider_health.py
+++ b/tests/test_provider_health.py
@@ -357,9 +357,9 @@ def test_sweep_parks_remaining_cells_after_hard_stop(tmp_path):
 
     health = ProviderHealth()
     models = [
-        {"id": "deepseek/deepseek-chat", "router": "openrouter"},
-        {"id": "deepseek/deepseek-chat", "router": "openrouter"},
-        {"id": "deepseek/deepseek-chat", "router": "openrouter"},
+        {"name": "deepseek/deepseek-chat", "route": "openrouter"},
+        {"name": "deepseek/deepseek-chat", "route": "openrouter"},
+        {"name": "deepseek/deepseek-chat", "route": "openrouter"},
     ]
     dispatches = 0
     parks: list[tuple[str, int]] = []
@@ -377,30 +377,30 @@ def test_sweep_parks_remaining_cells_after_hard_stop(tmp_path):
         raise PaymentRequiredError()
 
     for run, model in enumerate(models, start=1):
-        if health.is_blocked(model["router"], model["id"]):
+        if health.is_blocked(model["route"], model["name"]):
             park_cell(
                 tmp_path,
                 sweep_id="t",
-                model_id=model["id"],
+                model_id=model["name"],
                 run=run,
                 prompt_hash="h",
-                reason=health.block_reason(model["router"], model["id"]) or "blocked",
+                reason=health.block_reason(model["route"], model["name"]) or "blocked",
             )
-            parks.append((model["id"], run))
+            parks.append((model["name"], run))
             continue
         try:
             fake_dispatch(model, run)
         except Exception as exc:
-            health.record_failure(model["router"], model["id"], exc)
+            health.record_failure(model["route"], model["name"], exc)
             park_cell(
                 tmp_path,
                 sweep_id="t",
-                model_id=model["id"],
+                model_id=model["name"],
                 run=run,
                 prompt_hash="h",
-                reason=health.block_reason(model["router"], model["id"]) or "failed",
+                reason=health.block_reason(model["route"], model["name"]) or "failed",
             )
-            parks.append((model["id"], run))
+            parks.append((model["name"], run))
 
     assert dispatches == 1  # only the first one tried
     assert len(parks) == 3  # all three parked

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,8 +21,8 @@ def _minimal_models_yaml(tmp_path: Path) -> Path:
     """Write a minimal models.yaml with one cheap model."""
     p = tmp_path / "models.yaml"
     p.write_text(
-        "- id: test/tiny-model\n"
-        "  name: Tiny\n"
+        "- name: test/tiny-model\n"
+        "  display_name: Tiny\n"
         "  price_per_mtok_in: 1.0\n"
         "  price_per_mtok_out: 2.0\n"
         "  context_window: 8000\n"
@@ -51,13 +51,23 @@ def test_repeat_produces_n_files(mock_openai_cls, tmp_path):
     output_dir = tmp_path / "out"
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query", "--prompt", str(prompt_path),
-            "--models", str(models_path),
-            "--output", str(output_dir),
-            "--repeat", "3",
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_dir),
+                "--repeat",
+                "3",
+            ],
+        ):
             from aedist.query import main
+
             main()
 
     # Find JSON files in the date subdirectory
@@ -79,12 +89,21 @@ def test_output_json_has_operational_metrics(mock_openai_cls, tmp_path):
     output_dir = tmp_path / "out"
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query", "--prompt", str(prompt_path),
-            "--models", str(models_path),
-            "--output", str(output_dir),
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_dir),
+            ],
+        ):
             from aedist.query import main
+
             main()
 
     json_files = list(output_dir.rglob("*.json"))
@@ -115,14 +134,25 @@ def test_budget_guard_stops(mock_openai_cls, tmp_path):
 
     # Budget of 0.0008 should allow 1 call but stop before the 2nd
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query", "--prompt", str(prompt_path),
-            "--models", str(models_path),
-            "--output", str(output_dir),
-            "--repeat", "5",
-            "--budget-usd", "0.0008",
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_dir),
+                "--repeat",
+                "5",
+                "--budget-usd",
+                "0.0008",
+            ],
+        ):
             from aedist.query import main
+
             main()
 
     json_files = list(output_dir.rglob("*.json"))
@@ -141,13 +171,22 @@ def test_dry_run_no_api_calls(mock_openai_cls, tmp_path):
     output_dir = tmp_path / "out"
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query", "--prompt", str(prompt_path),
-            "--models", str(models_path),
-            "--output", str(output_dir),
-            "--dry-run",
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_dir),
+                "--dry-run",
+            ],
+        ):
             from aedist.query import main
+
             main()
 
     mock_client.chat.completions.create.assert_not_called()
@@ -169,12 +208,21 @@ def test_skip_existing_files(mock_openai_cls, tmp_path):
     # Run twice
     for _ in range(2):
         with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-            with patch.object(sys, "argv", [
-                "query", "--prompt", str(prompt_path),
-                "--models", str(models_path),
-                "--output", str(output_dir),
-            ]):
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "query",
+                    "--prompt",
+                    str(prompt_path),
+                    "--models",
+                    str(models_path),
+                    "--output",
+                    str(output_dir),
+                ],
+            ):
                 from aedist.query import main
+
                 main()
 
     # Only 1 API call (second run should skip)
@@ -193,13 +241,23 @@ def test_output_prefix_in_filenames(mock_openai_cls, tmp_path):
     output_dir = tmp_path / "out"
 
     with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(sys, "argv", [
-            "query", "--prompt", str(prompt_path),
-            "--models", str(models_path),
-            "--output", str(output_dir),
-            "--output-prefix", "padme",
-        ]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_dir),
+                "--output-prefix",
+                "padme",
+            ],
+        ):
             from aedist.query import main
+
             main()
 
     json_files = list(output_dir.rglob("*.json"))
@@ -218,13 +276,23 @@ def test_base_url_passed_to_client(mock_openai_cls, tmp_path):
     prompt_path = _prompt_file(tmp_path)
     output_dir = tmp_path / "out"
 
-    with patch.object(sys, "argv", [
-        "query", "--prompt", str(prompt_path),
-        "--models", str(models_path),
-        "--output", str(output_dir),
-        "--base-url", "http://localhost:11434/v1",
-    ]):
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "query",
+            "--prompt",
+            str(prompt_path),
+            "--models",
+            str(models_path),
+            "--output",
+            str(output_dir),
+            "--base-url",
+            "http://localhost:11434/v1",
+        ],
+    ):
         from aedist.query import main
+
         main()
 
     mock_openai_cls.assert_called_with(

--- a/tests/test_query_per_fuel.py
+++ b/tests/test_query_per_fuel.py
@@ -128,7 +128,7 @@ class TestQueryDecomposed:
         monkeypatch.setattr(qd_mod, "compute_cost", lambda usage, model: 0.001)
 
         budget = BudgetTracker(budget_usd=10.0)
-        model = {"id": "test-model", "price_per_mtok_in": 0, "price_per_mtok_out": 0}
+        model = {"name": "test-model", "price_per_mtok_in": 0, "price_per_mtok_out": 0}
         result = qd_mod.query_decomposed(
             client=None,
             model_id="test-model",
@@ -157,7 +157,7 @@ class TestQueryDecomposed:
         budget = BudgetTracker(budget_usd=0.001)
         budget.add(0.002)  # exceed the budget
 
-        model = {"id": "test-model"}
+        model = {"name": "test-model"}
         result = qd_mod.query_decomposed(
             client=None,
             model_id="test-model",
@@ -184,7 +184,7 @@ class TestQueryDecomposed:
         monkeypatch.setattr(qd_mod, "query_single_turn", fake_query_error)
 
         budget = BudgetTracker(budget_usd=10.0)
-        model = {"id": "test-model"}
+        model = {"name": "test-model"}
         result = qd_mod.query_decomposed(
             client=None,
             model_id="test-model",
@@ -211,7 +211,7 @@ class TestQueryDecomposed:
         monkeypatch.setattr(qd_mod, "compute_cost", lambda usage, model: 0.0001)
 
         budget = BudgetTracker(budget_usd=10.0)
-        model = {"id": "test-model"}
+        model = {"name": "test-model"}
         result = qd_mod.query_decomposed(
             client=None,
             model_id="test-model",
@@ -253,7 +253,7 @@ class TestQueryDecomposed:
         monkeypatch.setattr(qd_mod, "compute_cost", lambda usage, model: 0.001)
 
         budget = BudgetTracker(budget_usd=10.0)
-        model = {"id": "test-model"}
+        model = {"name": "test-model"}
         result = qd_mod.query_decomposed(
             client=None,
             model_id="test-model",
@@ -293,8 +293,8 @@ class TestQueryDecomposedMain:
         # Create minimal models.yaml
         models_file = tmp_path / "models.yaml"
         models_file.write_text(
-            "- id: test-model\n"
-            "  name: Test Model\n"
+            "- name: test-model\n"
+            "  display_name: Test Model\n"
             "  context_window: 100000\n"
             "  price_per_mtok_in: 1.0\n"
             "  price_per_mtok_out: 2.0\n"
@@ -344,13 +344,13 @@ class TestQueryDecomposedMain:
 
         models_file = tmp_path / "models.yaml"
         models_file.write_text(
-            "- id: model-a\n"
-            "  name: A\n"
+            "- name: model-a\n"
+            "  display_name: A\n"
             "  context_window: 100000\n"
             "  price_per_mtok_in: 1.0\n"
             "  price_per_mtok_out: 2.0\n"
-            "- id: model-b\n"
-            "  name: B\n"
+            "- name: model-b\n"
+            "  display_name: B\n"
             "  context_window: 100000\n"
             "  price_per_mtok_in: 1.0\n"
             "  price_per_mtok_out: 2.0\n"
@@ -395,7 +395,7 @@ class TestQueryDecomposedMain:
         prompt_file.write_text("prompt text")
 
         models_file = tmp_path / "models.yaml"
-        models_file.write_text("- id: model-a\n  name: A\n  context_window: 100000\n")
+        models_file.write_text("- name: model-a\n  display_name: A\n  context_window: 100000\n")
 
         output_dir = tmp_path / "output"
 

--- a/tests/test_select_models.py
+++ b/tests/test_select_models.py
@@ -31,40 +31,40 @@ SAMPLE_METRICS = [
 
 SAMPLE_CLOUD = [
     {
-        "id": "openai/gpt-5.4",
-        "name": "GPT-5.4",
+        "name": "openai/gpt-5.4",
+        "display_name": "GPT-5.4",
         "provider": "OpenAI",
         "country": "US",
         "size_class": "frontier",
         "price_per_mtok_in": 2.5,
     },
     {
-        "id": "deepseek/deepseek-v3.2",
-        "name": "DeepSeek V3.2",
+        "name": "deepseek/deepseek-v3.2",
+        "display_name": "DeepSeek V3.2",
         "provider": "DeepSeek",
         "country": "CN",
         "size_class": "frontier",
         "price_per_mtok_in": 0.26,
     },
     {
-        "id": "anthropic/claude-opus-4.6",
-        "name": "Claude Opus 4.6",
+        "name": "anthropic/claude-opus-4.6",
+        "display_name": "Claude Opus 4.6",
         "provider": "Anthropic",
         "country": "US",
         "size_class": "frontier",
         "price_per_mtok_in": 5.0,
     },
     {
-        "id": "google/gemini-2.5-flash-lite",
-        "name": "Gemini 2.5 Flash Lite",
+        "name": "google/gemini-2.5-flash-lite",
+        "display_name": "Gemini 2.5 Flash Lite",
         "provider": "Google",
         "country": "US",
         "size_class": "edge",
         "price_per_mtok_in": 0.1,
     },
     {
-        "id": "mistralai/mistral-large-2512",
-        "name": "Mistral Large 3",
+        "name": "mistralai/mistral-large-2512",
+        "display_name": "Mistral Large 3",
         "provider": "Mistral",
         "country": "FR",
         "size_class": "frontier",
@@ -74,20 +74,20 @@ SAMPLE_CLOUD = [
 
 SAMPLE_PADME = [
     {
-        "id": "qwen3.5:122b",
-        "name": "Qwen 3.5 122B (local)",
+        "name": "qwen3.5:122b",
+        "display_name": "Qwen 3.5 122B (local)",
         "provider": "Ollama/Padme",
         "country": "CN",
     },
     {
-        "id": "glm-4.7-flash",
-        "name": "GLM 4.7 Flash (local)",
+        "name": "glm-4.7-flash",
+        "display_name": "GLM 4.7 Flash (local)",
         "provider": "Ollama/Padme",
         "country": "CN",
     },
     {
-        "id": "nemotron-3-nano",
-        "name": "Nemotron 3 Nano (local)",
+        "name": "nemotron-3-nano",
+        "display_name": "Nemotron 3 Nano (local)",
         "provider": "Ollama/Padme",
         "country": "US",
     },
@@ -151,14 +151,14 @@ class TestSelectModels:
         selected = self._select(n=1)
         cloud = [s for s in selected if "Padme" not in s.get("provider", "")]
         assert len(cloud) == 1
-        assert cloud[0]["id"] == "openai/gpt-5.4"
+        assert cloud[0]["name"] == "openai/gpt-5.4"
 
     def test_n1_best_local_is_qwen(self):
         """Best local model is padme-qwen3.5-122b (F1=0.49)."""
         selected = self._select(n=1)
         local = [s for s in selected if "Padme" in s.get("provider", "")]
         assert len(local) == 1
-        assert local[0]["id"] == "qwen3.5:122b"
+        assert local[0]["name"] == "qwen3.5:122b"
 
     def test_n2_gives_four_models(self):
         """--n 2 → 2 cloud + 2 local = 4 total."""
@@ -215,21 +215,21 @@ class TestDiverseSelection:
     def test_us_frontier_is_best_f1(self):
         """GPT-5.4 (F1=0.65) beats Claude Opus (F1=0.60) for US frontier."""
         selected = self._select(["US"])
-        assert selected[0]["id"] == "openai/gpt-5.4"
+        assert selected[0]["name"] == "openai/gpt-5.4"
 
     def test_fr_frontier_is_mistral(self):
         selected = self._select(["FR"])
-        assert selected[0]["id"] == "mistralai/mistral-large-2512"
+        assert selected[0]["name"] == "mistralai/mistral-large-2512"
 
     def test_cn_frontier_is_deepseek(self):
         selected = self._select(["CN"])
-        assert selected[0]["id"] == "deepseek/deepseek-v3.2"
+        assert selected[0]["name"] == "deepseek/deepseek-v3.2"
 
     def test_cheap_tier_beats_local_floor(self):
         """Cheap models must have F1 > best local (0.49)."""
         selected = self._select(["US"], n_cheap=2)
         # Frontier pick is GPT-5.4; cheap picks from remaining
-        cheap = [m for m in selected if m["id"] != "openai/gpt-5.4"]
+        cheap = [m for m in selected if m["name"] != "openai/gpt-5.4"]
         for m in cheap:
             assert m["_median_f1"] > 0.49 if "_median_f1" in m else True
 
@@ -239,14 +239,14 @@ class TestDiverseSelection:
         # With no frontier requirement, all slots are cheap tier
         # Sorted by price: gemini-flash-lite ($0.1) is cheapest but F1=0.40
         # which is below local floor (0.49), so it should be excluded
-        ids = [m["id"] for m in selected]
-        assert "google/gemini-2.5-flash-lite" not in ids
+        names = [m["name"] for m in selected]
+        assert "google/gemini-2.5-flash-lite" not in names
 
     def test_cheap_excludes_frontier_picks(self):
         """A model picked for frontier is not duplicated in cheap tier."""
         selected = self._select(["US", "CN", "FR"], n_cheap=5)
-        ids = [m["id"] for m in selected]
-        assert len(ids) == len(set(ids))
+        names = [m["name"] for m in selected]
+        assert len(names) == len(set(names))
 
     def test_missing_country_warns(self, caplog):
         """Requesting a country with no frontier model logs a warning."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -338,7 +338,7 @@ def _harness_patches(tmp_path):
     """
     return {
         "make_client": MagicMock(return_value=MagicMock()),
-        "load_models": MagicMock(return_value=[{"id": "qwen3:8b"}]),
+        "load_models": MagicMock(return_value=[{"name": "qwen3:8b"}]),
         "query_single_turn": MagicMock(return_value=_canned_single_result()),
         "compute_cost": MagicMock(return_value=0.0),
         "model_metadata": MagicMock(return_value={}),


### PR DESCRIPTION
## Summary

- Remove backward-compat shim from `harness.load_models()` (3 alias blocks)
- Replace `make_client_for_router(router, routers_config)` with `make_client_for_route(model)` — dispatches on `model["route"]` directly
- Migrate all 10 source files: `m["id"]`→`m["name"]`, `model.get("router")`→`model.get("route")`, `model.get("router_model")`→`model.get("model_id")`
- Remove `routers_config` lookups (the `[routers]` TOML section is already gone)
- Update 7 test files to match new field names

## Test plan

- [x] `make test` — 1144 passed, 1 skipped, 2 xfailed
- [x] No old field names remain: `grep -rn 'routers_config\|make_client_for_router\|\.get("router"\|\.get("router_model"' src/aedist/` returns empty
- [x] Shim block removed from `load_models()`
- [ ] Dry-run sweep: `uv run python -m aedist.query --dry-run --model-set modelset_census_cloud`

Closes ticket 0161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)