### PR TITLE
test(0162): model-set dispatch smoke test

### DIFF
--- a/tests/test_model_set_dispatch.py
+++ b/tests/test_model_set_dispatch.py
@@ -12,6 +12,7 @@ import pytest
 
 from aedist import harness
 
+# query_fusion and query_verification don't use make_client_for_route
 QUERY_MODULES = [
     "aedist.query",
     "aedist.query_direct",

--- a/tests/test_model_set_dispatch.py
+++ b/tests/test_model_set_dispatch.py
@@ -1,0 +1,32 @@
+"""Regression: ruff stripped make_client_for_route imports in 5/6 query modules (PR #326).
+
+The import is used only inside ``if args.model_set:`` branches, so ruff sees
+it as unused and removes it.  Python's late name resolution means the
+NameError surfaces only at production runtime.  This test verifies each
+module still imports the canonical function from harness.
+"""
+
+import importlib
+
+import pytest
+
+from aedist import harness
+
+QUERY_MODULES = [
+    "aedist.query",
+    "aedist.query_direct",
+    "aedist.query_rag",
+    "aedist.query_multiturn",
+    "aedist.query_livesearch",
+    "aedist.query_per_fuel",
+]
+
+
+@pytest.mark.parametrize("mod_name", QUERY_MODULES)
+def test_make_client_for_route_imported(mod_name):
+    """Each query module must re-export make_client_for_route from harness."""
+    mod = importlib.import_module(mod_name)
+    assert hasattr(mod, "make_client_for_route"), (
+        f"{mod_name} is missing make_client_for_route — ruff may have stripped the import"
+    )
+    assert mod.make_client_for_route is harness.make_client_for_route


### PR DESCRIPTION
## Summary

- Adds `tests/test_model_set_dispatch.py` with a parametrized test across all 6 query modules
- Verifies each module imports `make_client_for_route` from `harness` (identity check)
- Regression guard: ruff strips the import when CI never exercises the `--model-set` branch (PR #326 bug class)

## Test plan

- [x] 6 parametrized tests pass (one per query module)
- [x] Full suite: 1155 passed, 1 skipped, 2 xfailed, 0 regressions

Closes #0162

🤖 Generated with [Claude Code](https://claude.com/claude-code)