### PR TITLE
feat(0133): replace inline pgfplots Pareto scatter with Python PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,10 @@ $(SLIDE_GEN)/census_bars.csv: $(MEASUREMENTS)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_census --output $@
 
-$(SLIDE_GEN)/pareto.csv: $(MEASUREMENTS)
+$(SLIDE_GEN)/fig_pareto.pdf: $(MEASUREMENTS)
 	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_pareto --output $@
+	uv run python -m aedist.plot_pareto \
+	    --output $(SLIDE_GEN)/pareto.csv --figure $@
 
 $(SLIDE_GEN)/regimes.csv: $(GEN)/regimes.csv
 	@mkdir -p $(dir $@)
@@ -202,7 +203,7 @@ report/report.pdf: report/report.tex report/refs.bib \
 	$(MAKE) -C report
 
 slides/slides.pdf: slides/slides.tex \
-    $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/pareto.csv \
+    $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/fig_pareto.pdf \
     $(SLIDE_GEN)/regimes.csv $(SLIDE_GEN)/fig_census_direct.pdf \
     $(SLIDE_GEN)/macros_census.tex \
     $(SLIDE_GEN)/fig_method_convergence.pdf \
@@ -219,7 +220,7 @@ slides/slides.pdf: slides/slides.tex \
 report: report/report.pdf
 slides: slides/slides.pdf
 tables: $(GEN)/tab_census.tex $(GEN)/macros.tex $(GEN)/tab_relances.tex $(GEN)/tab_comparaison.tex $(GEN)/tab_converter_benchmark.tex $(GEN)/tab_variance.tex $(GEN)/tab_verification.tex $(GEN)/tab_base_vs_census.tex $(GEN)/tab_decomposition_fix.tex $(GEN)/tab_self_consistency.tex $(GEN)/tab_per_run.tex $(GEN)/tab_coherence.tex $(GEN)/tab_reconciliation.tex
-figures: $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/pareto.csv $(SLIDE_GEN)/fig_census_direct.pdf $(GEN)/fig_census_direct.pdf $(SLIDE_GEN)/fig_method_convergence.pdf $(SLIDE_GEN)/fig_regimes_scatter.pdf $(SLIDE_GEN)/fig_scaling_curve.pdf $(GEN)/fig_base_vs_census.pdf $(SLIDE_GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_heatmap.pdf
+figures: $(SLIDE_GEN)/census_bars.csv $(SLIDE_GEN)/fig_pareto.pdf $(SLIDE_GEN)/fig_census_direct.pdf $(GEN)/fig_census_direct.pdf $(SLIDE_GEN)/fig_method_convergence.pdf $(SLIDE_GEN)/fig_regimes_scatter.pdf $(SLIDE_GEN)/fig_scaling_curve.pdf $(GEN)/fig_base_vs_census.pdf $(SLIDE_GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_strip.pdf $(GEN)/fig_ablation_heatmap.pdf
 select: experiments/models_selected.yaml
 census:
 	$(MAKE) -C experiments census

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -362,30 +362,7 @@ C'est le résultat central qui justifie «~Beyond RAG~» comme titre.}
 % -------------------------------------------------------------------
 \begin{frame}{Pareto coût-qualité~: les méthodes, pas les modèles}
 \begin{center}
-\pgfplotstableread[col sep=comma]{inputs/generated/pareto.csv}\paretodata
-\begin{tikzpicture}
-\begin{axis}[
-    width=0.85\textwidth,
-    height=6cm,
-    xlabel={Coût par requête (USD)},
-    ylabel={Score F1},
-    xmin=-0.005, xmax=0.30,
-    ymin=0, ymax=1.0,
-    grid=major,
-    legend style={at={(0.98,0.02)}, anchor=south east, font=\scriptsize},
-]
-% Modèles cloud
-\addplot[only marks, mark=*, mark size=3pt, color=matched]
-    table [x=cost_usd, y=f1,
-           restrict expr to domain={\thisrow{local}}{0:0}] {\paretodata};
-\addlegendentry{Modèles cloud}
-% Modèles locaux --- coût nul
-\addplot[only marks, mark=triangle*, mark size=4pt, color=matched!50!black]
-    table [x=cost_usd, y=f1,
-           restrict expr to domain={\thisrow{local}}{1:1}] {\paretodata};
-\addlegendentry{Modèles locaux}
-\end{axis}
-\end{tikzpicture}
+\includegraphics[width=0.85\textwidth]{inputs/generated/fig_pareto.pdf}
 \end{center}
 
 \smallskip

--- a/src/aedist/plot_pareto.py
+++ b/src/aedist/plot_pareto.py
@@ -1,12 +1,12 @@
-"""Generate Pareto-front CSV from measurements.jsonl.
+"""Generate Pareto-front CSV and scatter PDF from measurements.jsonl.
 
 Writes a CSV with columns: model, f1, cost_usd, local
-sorted by f1 descending.
+sorted by f1 descending.  Optionally writes a PDF scatter plot.
 
 Usage:
     uv run python -m aedist.plot_pareto \\
-        --measurements measurements.jsonl \\
-        --output slides/inputs/generated/pareto.csv
+        --output slides/inputs/generated/pareto.csv \\
+        --figure slides/inputs/generated/fig_pareto.pdf
 """
 
 import argparse
@@ -15,8 +15,58 @@ import logging
 from pathlib import Path
 
 from .tabulate_macros import load_and_summarize
+from .util import COLOR_MATCHED
 
 log = logging.getLogger(__name__)
+
+# Darker blue for local models (matched colour mixed with black).
+_COLOR_LOCAL = "#1A5070"
+
+
+def write_pdf(rows: list[dict], output: Path) -> None:
+    """Write a Pareto scatter plot (F1 vs cost) to *output* as PDF."""
+    import matplotlib.pyplot as plt
+
+    # Keep local models (cost=0 is expected) but drop cloud models without cost data.
+    filtered = [r for r in rows if r["cost_usd"] > 0 or r["local"] == 1]
+
+    cloud = [r for r in filtered if r["local"] == 0]
+    local = [r for r in filtered if r["local"] == 1]
+
+    fig, ax = plt.subplots(figsize=(7, 4.5))
+
+    if cloud:
+        ax.scatter(
+            [r["cost_usd"] for r in cloud],
+            [r["f1"] for r in cloud],
+            color=COLOR_MATCHED,
+            marker="o",
+            s=40,
+            label="Modèles cloud",
+            zorder=3,
+        )
+    if local:
+        ax.scatter(
+            [r["cost_usd"] for r in local],
+            [r["f1"] for r in local],
+            color=_COLOR_LOCAL,
+            marker="^",
+            s=50,
+            label="Modèles locaux",
+            zorder=3,
+        )
+
+    ax.set_xlabel("Coût par requête (USD)")
+    ax.set_ylabel("Score F1")
+    ax.set_xlim(-0.005, 0.30)
+    ax.set_ylim(0, 1.0)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="lower right", fontsize="small")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches="tight", dpi=300)
+    plt.close(fig)
+    log.info("Wrote %s", output)
 
 
 def build_pareto_rows(metrics: list[dict]) -> list[dict]:
@@ -55,26 +105,31 @@ def build_pareto_rows(metrics: list[dict]) -> list[dict]:
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     parser = argparse.ArgumentParser(
-        description="Generate Pareto-front CSV from measurements.jsonl",
+        description="Generate Pareto-front CSV and/or scatter PDF",
     )
-    parser.add_argument("--output", required=True, help="Path to write pareto.csv")
+    parser.add_argument("--output", help="Path to write pareto.csv")
+    parser.add_argument("--figure", help="Path to write scatter PDF")
     args = parser.parse_args()
 
-    output_path = Path(args.output)
+    if not args.output and not args.figure:
+        parser.error("at least one of --output or --figure is required")
 
     from .measurements import load_metrics
 
     metrics = load_metrics()
-
     rows = build_pareto_rows(metrics)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["model", "f1", "cost_usd", "local"])
-        writer.writeheader()
-        writer.writerows(rows)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["model", "f1", "cost_usd", "local"])
+            writer.writeheader()
+            writer.writerows(rows)
+        log.info("Wrote %d rows to %s", len(rows), output_path)
 
-    log.info("Wrote %d rows to %s", len(rows), output_path)
+    if args.figure:
+        write_pdf(rows, Path(args.figure))
 
 
 if __name__ == "__main__":

--- a/tests/test_no_inline_plots.py
+++ b/tests/test_no_inline_plots.py
@@ -25,7 +25,6 @@ def _tracked_tex_files() -> list[Path]:
     return [REPO_ROOT / f for f in result.stdout.split("\0") if f.endswith(".tex")]
 
 
-@pytest.mark.xfail(reason="remediation pending: ticket 0133")
 def test_no_begin_axis():
     violations = []
     for tex_file in _tracked_tex_files():

--- a/tests/test_plot_pareto.py
+++ b/tests/test_plot_pareto.py
@@ -66,3 +66,26 @@ def test_main_writes_csv(tmp_path, monkeypatch):
     rows = list(reader)
     assert len(rows) == 2
     assert set(reader.fieldnames) == {"model", "f1", "cost_usd", "local"}
+
+
+def test_main_writes_figure(tmp_path, monkeypatch):
+    """CLI --figure writes a PDF."""
+    input_path = tmp_path / "measurements.jsonl"
+    write_measurements(input_path, SAMPLE_METRICS)
+    patch_measurements_loader(monkeypatch, input_path)
+    figure_path = tmp_path / "fig_pareto.pdf"
+
+    import sys
+
+    from aedist.plot_pareto import main
+
+    sys.argv = [
+        "plot_pareto",
+        "--output",
+        str(tmp_path / "pareto.csv"),
+        "--figure",
+        str(figure_path),
+    ]
+    main()
+    assert figure_path.exists()
+    assert figure_path.stat().st_size > 0

--- a/tickets/0133-pareto-scatter-python-pdf.erg
+++ b/tickets/0133-pareto-scatter-python-pdf.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-04-29T18:00Z claude created
 2026-04-29T20:00Z claude status pending — déféré manuellement, 0134 à prioriser cette nuit
+2026-05-07T12:00Z claude note executing: Python PDF + Makefile + slides + test
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Replace 24-line inline `\begin{axis}` pgfplots block in `slides/slides.tex` with `\includegraphics{fig_pareto.pdf}`
- Add `write_pdf()` to `src/aedist/plot_pareto.py` (matplotlib scatter: F1 vs cost, cloud circles + local triangles, French labels)
- Wire `fig_pareto.pdf` into Makefile DAG, remove `pareto.csv` from slides dependencies
- Remove `@pytest.mark.xfail` from `test_no_begin_axis` — no inline plots remain

Closes ticket 0133.

## Test plan

- [x] `pytest tests/test_plot_pareto.py tests/test_no_inline_plots.py` — 6/6 pass
- [x] `tectonic slides.tex` compiles without error
- [ ] Visual check of `fig_pareto.pdf` scatter matches original pgfplots appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)