### PR TITLE
schema: extend RunRecord for SOTA agent-mode runs (0172)

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -99,6 +99,7 @@ Raw JSON          →  RunRecord / measurements.jsonl  →  metrics dict  →  f
 | Diagnostic | `tokens_in`, `tokens_out`, `finish_reason` |
 | Results | `f1`, `coverage`, `precision`, `n_matched`, `n_missed`, `n_hallucinated`, `fuel_accuracy`, `status_accuracy`, `province_accuracy` |
 | Resources | `cost_usd`, `wall_seconds` |
+| Agent runs (0172) | `agent_family`, `agent_mode`, `synopsis_sha`, `designed_prompt_sha`, `n_web_search_calls`, `n_citations`, `parsed_table_path`, `retry_count`, `error`, `reasoning_summary`, `thinking_tokens`, `cost_breakdown`, `tool_calls_cost_usd` |
 
 **What does not belong:** bookkeeping fields (`run_id`, `timestamp`,
 `result_file`, `validation`). These are in `RunRecord` for system purposes;
@@ -124,3 +125,11 @@ display. Making the source richer does not change them.
   surfaced in the metrics dict on the same schedule.
 - `records_to_metrics()` docstring is updated to state this contract
   explicitly.
+- Ticket 0172 (SOTA frontier-API experiment, umbrella 0166): agent-mode
+  fields are surfaced as a single row in the table above. Schema additions
+  are strictly optional — the 330 pre-existing `measurements.jsonl` records
+  parse unchanged. `web_search_calls` and `citations` are projected as
+  counts (`n_web_search_calls`, `n_citations`); the raw lists remain in
+  the `RunRecord` for forensic re-reading. `tool_calls_cost_usd` is kept
+  distinct from `cost_usd` so connector / web-search fees do not blend
+  with token economics.

--- a/src/aedist/measurements.py
+++ b/src/aedist/measurements.py
@@ -88,6 +88,13 @@ def records_to_metrics(records: list[RunRecord]) -> list[dict]:
     web_search effective, finish_reason) are included when present in the
     record; absent otherwise.  Bookkeeping fields (run_id, timestamp,
     result_file, validation) are excluded.
+
+    Agent-mode fields (ticket 0172, umbrella 0166): agent_family,
+    agent_mode, synopsis_sha, designed_prompt_sha, n_web_search_calls,
+    n_citations, parsed_table_path, finish_reason, retry_count, error,
+    reasoning_summary, thinking_tokens, cost_breakdown, tool_calls_cost_usd
+    are surfaced when the underlying RunRecord field is non-None. Lists
+    are projected as counts; the raw lists stay in the RunRecord.
     """
     result = []
     for r in records:
@@ -152,6 +159,41 @@ def records_to_metrics(records: list[RunRecord]) -> list[dict]:
         ):
             if key in extra:
                 d[key] = extra[key]
+
+        # --- agent-mode fields (ticket 0172) -----------------------------
+        # Scalars: omit-when-None to match the existing pattern above.
+        # Lists: surface as counts so reporting can pivot without re-loading
+        # the raw record; the raw lists stay in the RunRecord itself.
+        if r.agent_family is not None:
+            d["agent_family"] = r.agent_family
+        if r.agent_mode is not None:
+            d["agent_mode"] = r.agent_mode
+        if r.synopsis_sha is not None:
+            d["synopsis_sha"] = r.synopsis_sha
+        if r.designed_prompt_sha is not None:
+            d["designed_prompt_sha"] = r.designed_prompt_sha
+        if r.web_search_calls is not None:
+            d["n_web_search_calls"] = len(r.web_search_calls)
+        if r.citations is not None:
+            d["n_citations"] = len(r.citations)
+        if r.parsed_table_path is not None:
+            d["parsed_table_path"] = r.parsed_table_path
+        # finish_reason is also written from extra above (0139 path); the
+        # first-class field takes precedence when present.
+        if r.finish_reason is not None:
+            d["finish_reason"] = r.finish_reason
+        if r.retry_count is not None:
+            d["retry_count"] = r.retry_count
+        if r.error is not None:
+            d["error"] = r.error
+        if r.reasoning_summary is not None:
+            d["reasoning_summary"] = r.reasoning_summary
+        if r.tool_calls_cost_usd is not None:
+            d["tool_calls_cost_usd"] = r.tool_calls_cost_usd
+        if r.resource_use.thinking_tokens is not None:
+            d["thinking_tokens"] = r.resource_use.thinking_tokens
+        if r.resource_use.cost_breakdown is not None:
+            d["cost_breakdown"] = r.resource_use.cost_breakdown
 
         result.append(d)
     return result

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -159,6 +159,19 @@ class ResourceUse(BaseModel):
     cost_usd: float | None = Field(default=None, ge=0, description="API cost in USD.")
     tokens_in: int | None = Field(default=None, ge=0)
     tokens_out: int | None = Field(default=None, ge=0)
+    # --- agent-mode additions (ticket 0172) ---
+    cost_breakdown: dict | None = Field(
+        default=None,
+        description=(
+            "Per-bucket dollar costs for agent-mode runs. Conventional keys: "
+            "'input', 'output', 'cache', 'reasoning'. Omit absent buckets."
+        ),
+    )
+    thinking_tokens: int | None = Field(
+        default=None,
+        ge=0,
+        description="Reasoning/thinking tokens billed separately by the provider.",
+    )
 
 
 class ResultSummary(BaseModel):
@@ -206,6 +219,84 @@ class RunRecord(BaseModel):
             "Run validation result (ticket 0072). Shape: "
             "{ok: bool, category: str, flags: list[str]}. Populated at "
             "assemble-time from validate_run() on the companion raw JSON."
+        ),
+    )
+
+    # -- agent-mode additions (ticket 0172, umbrella 0166) -------------------
+    # All optional with None defaults so the 330 pre-existing measurements.jsonl
+    # records parse unchanged. Field-level contracts (literal values for
+    # agent_family/agent_mode, entry shapes for the list fields) are documented
+    # in tickets/0166-raid-plans.md §0172 rather than enforced by a StrEnum,
+    # so adapters 0167/0168/0169/0173 can land independently.
+    agent_family: str | None = Field(
+        default=None,
+        description=(
+            "Agent stack identity. One of: 'anthropic-direct', 'openai-direct', "
+            "'mistral-direct', 'qwen-direct'. None for legacy non-agent runs."
+        ),
+    )
+    agent_mode: str | None = Field(
+        default=None,
+        description=(
+            "Agent run phase. One of: 'phase_a_design', 'phase_b_run', "
+            "'phase_c_score', 'smoke', 'probe'."
+        ),
+    )
+    synopsis_sha: str | None = Field(
+        default=None,
+        description="git SHA of docs/synopsis.md at launch time (spec freeze).",
+    )
+    designed_prompt_sha: str | None = Field(
+        default=None,
+        description=(
+            "SHA of the Phase-A-designed prompt being executed. Set on "
+            "phase_b_run records, None otherwise."
+        ),
+    )
+    web_search_calls: list[dict] | None = Field(
+        default=None,
+        description=(
+            "Tool-call trace. Each entry: "
+            "{'query': str, 'urls_returned': list[str]}."
+        ),
+    )
+    citations: list[dict] | None = Field(
+        default=None,
+        description=(
+            "Citation trace. Each entry: "
+            "{'url': str, 'snippet': str|None, 'supports_claim': bool|None}."
+        ),
+    )
+    parsed_table_path: str | None = Field(
+        default=None,
+        description=(
+            "Repo-relative path to the CSV extracted from the agent's narrative."
+        ),
+    )
+    finish_reason: str | None = Field(
+        default=None,
+        description="Provider-reported terminating condition (stop, length, ...).",
+    )
+    retry_count: int | None = Field(
+        default=None,
+        ge=0,
+        description="Number of retries before this run succeeded or terminally failed.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error string when status != ok; None on success.",
+    )
+    reasoning_summary: str | None = Field(
+        default=None,
+        description="Provider-supplied summary of the model's reasoning trace.",
+    )
+    tool_calls_cost_usd: float | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Connector / web-search fees billed separately from token cost. "
+            "Kept distinct from resource_use.cost_usd so token economics "
+            "are not blended with per-call connector pricing."
         ),
     )
 

--- a/tests/test_measurements_agent_fields.py
+++ b/tests/test_measurements_agent_fields.py
@@ -1,0 +1,282 @@
+"""Tests for the agent-mode RunRecord schema extension (ticket 0172).
+
+The SOTA frontier-API experiment (umbrella 0166) adds new first-class
+fields to RunRecord: agent identity (family/mode), spec freeze hashes,
+tool-call traces (web searches + citations), reasoning trace, and an
+extracted-table pointer. All additions are optional and default to
+None so that the 330 pre-existing measurements.jsonl records parse
+unchanged.
+
+The metrics dict (ADR-7) projects list fields as counts so that
+reporting can pivot on them without re-loading the raw record. Scalar
+fields are omitted when None, matching the existing pattern in
+``records_to_metrics``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aedist.measurements import records_to_metrics
+from aedist.schema import (
+    Method,
+    MethodParams,
+    ResourceUse,
+    ResultSummary,
+    RunRecord,
+)
+
+# ---------------------------------------------------------------------------
+# Backward-compat fixture: real production record (measurements.jsonl line 32)
+# Inlined verbatim to keep the test hermetic — no live-file dependency.
+# ---------------------------------------------------------------------------
+
+FIXTURE_LINE_32 = (
+    '{"run_id": "61326a1572ec", "timestamp": "2026-04-10T17:59:04.846510Z", '
+    '"method": "direct", "method_params": {"model": "deepseek/deepseek-v3.2", '
+    '"temperature": null, "max_tokens": null, "prompt_version": "p1_base", '
+    '"extra": {"size_class": "frontier", "country": "CN", "architecture": '
+    '"moe", "provider": "DeepSeek", "context_window": 163840}}, '
+    '"resource_use": {"wall_s": 79.067, "cost_usd": 0.0017366, '
+    '"tokens_in": 418, "tokens_out": 4284}, "result_file": '
+    '"experiments/outputs/ablation/direct/p1_base/deepseek-v3.2-run1.csv", '
+    '"result_summary": {"status": "ok", "n_plants": 73, "tp": 73, "fp": 0, '
+    '"fn": 90, "f1": 0.6186, "fuel_accuracy": 0.5616, "status_accuracy": '
+    '0.4521, "province_accuracy": 0.6986}, "justification": null, '
+    '"validation": {"ok": true, "category": "ok", "flags": []}}'
+)
+
+
+# ---------------------------------------------------------------------------
+# First failing test (per plan: non-tautological, asymmetric lengths)
+# ---------------------------------------------------------------------------
+
+
+def test_records_to_metrics_projects_web_search_count_from_list_length():
+    """Counts must come from ``len()`` of each list independently.
+
+    Asymmetric lengths catch two classes of bug:
+      * copy-pasted ``len(citations)`` written into both counters, and
+      * a forgotten ``len(...)`` that would store the list itself.
+    """
+    record = RunRecord(
+        method=Method.DIRECT,
+        method_params=MethodParams(model="claude-opus-4-7"),
+        web_search_calls=[
+            {"query": "vietnam coal plants", "urls_returned": ["https://a"]},
+            {"query": "vietnam gas plants", "urls_returned": ["https://b"]},
+            {"query": "vietnam LNG plants", "urls_returned": ["https://c"]},
+        ],
+        citations=[
+            {"url": "https://a", "snippet": None, "supports_claim": None},
+            {"url": "https://b", "snippet": None, "supports_claim": None},
+        ],
+    )
+
+    [m] = records_to_metrics([record])
+
+    assert m["n_web_search_calls"] == 3
+    assert m["n_citations"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: a real pre-extension record still parses cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_pre_extension_record_parses_with_new_fields_none():
+    """Production record from before the schema extension must round-trip.
+
+    The 330 measurements.jsonl records have no agent_* fields; loading
+    them under the new schema must yield ``None`` for every new field
+    and must preserve ``extra`` and ``validation`` payloads untouched.
+    """
+    record = RunRecord.from_jsonl_line(FIXTURE_LINE_32)
+
+    # New top-level fields default to None.
+    assert record.agent_family is None
+    assert record.agent_mode is None
+    assert record.synopsis_sha is None
+    assert record.designed_prompt_sha is None
+    assert record.web_search_calls is None
+    assert record.citations is None
+    assert record.parsed_table_path is None
+    assert record.finish_reason is None
+    assert record.retry_count is None
+    assert record.error is None
+    assert record.reasoning_summary is None
+    assert record.tool_calls_cost_usd is None
+
+    # New nested fields on ResourceUse default to None.
+    assert record.resource_use.cost_breakdown is None
+    assert record.resource_use.thinking_tokens is None
+
+    # Existing payload preserved.
+    assert record.method_params.extra is not None
+    assert record.method_params.extra["architecture"] == "moe"
+    assert record.method_params.extra["provider"] == "DeepSeek"
+    assert record.validation == {"ok": True, "category": "ok", "flags": []}
+    assert record.resource_use.cost_usd == 0.0017366
+    assert record.resource_use.tokens_out == 4284
+
+
+def test_pre_extension_record_metrics_omits_absent_agent_fields():
+    """metrics dict must not surface keys for fields the record did not carry."""
+    record = RunRecord.from_jsonl_line(FIXTURE_LINE_32)
+    [m] = records_to_metrics([record])
+
+    # All agent-mode keys absent from a non-agent record.
+    for key in (
+        "agent_family",
+        "agent_mode",
+        "synopsis_sha",
+        "designed_prompt_sha",
+        "n_web_search_calls",
+        "n_citations",
+        "parsed_table_path",
+        "finish_reason",
+        "retry_count",
+        "error",
+        "reasoning_summary",
+        "thinking_tokens",
+        "cost_breakdown",
+        "tool_calls_cost_usd",
+    ):
+        assert key not in m, f"{key!r} leaked into metrics for a non-agent record"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: a new agent-mode record serialises and deserialises losslessly
+# ---------------------------------------------------------------------------
+
+
+def test_agent_mode_record_round_trips_through_jsonl():
+    """Every new field must survive ``to_jsonl_line`` → ``from_jsonl_line``."""
+    original = RunRecord(
+        method=Method.DIRECT,
+        method_params=MethodParams(model="claude-opus-4-7"),
+        resource_use=ResourceUse(
+            wall_s=12.3,
+            cost_usd=0.19,
+            tokens_in=200,
+            tokens_out=600,
+            cost_breakdown={"input": 0.003, "output": 0.045, "reasoning": 0.142},
+            thinking_tokens=1500,
+        ),
+        result_summary=ResultSummary(status="ok"),
+        agent_family="anthropic-direct",
+        agent_mode="phase_b_run",
+        synopsis_sha="a" * 40,
+        designed_prompt_sha="b" * 64,
+        web_search_calls=[
+            {"query": "phu my 2.2", "urls_returned": ["https://example/1"]},
+            {"query": "vinh tan", "urls_returned": ["https://example/2"]},
+        ],
+        citations=[
+            {"url": "https://example/1", "snippet": "...", "supports_claim": True},
+            {"url": "https://example/2", "snippet": None, "supports_claim": None},
+            {"url": "https://example/3", "snippet": "third", "supports_claim": False},
+        ],
+        parsed_table_path="experiments/outputs/sota_smoke/anthropic_run1.csv",
+        finish_reason="stop",
+        retry_count=0,
+        error=None,
+        reasoning_summary="Considered Vietnamese coal fleet from EVN annual report.",
+        tool_calls_cost_usd=0.020,
+    )
+
+    restored = RunRecord.from_jsonl_line(original.to_jsonl_line())
+
+    assert restored.agent_family == "anthropic-direct"
+    assert restored.agent_mode == "phase_b_run"
+    assert restored.synopsis_sha == "a" * 40
+    assert restored.designed_prompt_sha == "b" * 64
+    assert restored.web_search_calls == original.web_search_calls
+    assert restored.citations == original.citations
+    assert restored.parsed_table_path == original.parsed_table_path
+    assert restored.finish_reason == "stop"
+    assert restored.retry_count == 0
+    assert restored.error is None
+    assert restored.reasoning_summary == original.reasoning_summary
+    assert restored.tool_calls_cost_usd == 0.020
+    assert restored.resource_use.cost_breakdown == {
+        "input": 0.003,
+        "output": 0.045,
+        "reasoning": 0.142,
+    }
+    assert restored.resource_use.thinking_tokens == 1500
+
+
+# ---------------------------------------------------------------------------
+# records_to_metrics surfaces every new column when present
+# ---------------------------------------------------------------------------
+
+
+def test_records_to_metrics_surfaces_all_new_fields_when_present():
+    """Per ADR-7: every new field flows through the metrics dict."""
+    record = RunRecord(
+        method=Method.DIRECT,
+        method_params=MethodParams(model="gpt-5.5"),
+        resource_use=ResourceUse(
+            cost_breakdown={"input": 0.001, "output": 0.05, "reasoning": 0.12},
+            thinking_tokens=2048,
+        ),
+        agent_family="openai-direct",
+        agent_mode="phase_b_run",
+        synopsis_sha="deadbeef" * 5,
+        designed_prompt_sha="cafebabe" * 8,
+        web_search_calls=[{"query": "q1", "urls_returned": []}],
+        citations=[
+            {"url": "u1", "snippet": None, "supports_claim": None},
+            {"url": "u2", "snippet": None, "supports_claim": None},
+        ],
+        parsed_table_path="experiments/outputs/sota_smoke/openai.csv",
+        finish_reason="stop",
+        retry_count=1,
+        error=None,
+        reasoning_summary="Brief plan.",
+        tool_calls_cost_usd=0.030,
+    )
+
+    [m] = records_to_metrics([record])
+
+    assert m["agent_family"] == "openai-direct"
+    assert m["agent_mode"] == "phase_b_run"
+    assert m["synopsis_sha"] == "deadbeef" * 5
+    assert m["designed_prompt_sha"] == "cafebabe" * 8
+    assert m["n_web_search_calls"] == 1
+    assert m["n_citations"] == 2
+    assert m["parsed_table_path"] == "experiments/outputs/sota_smoke/openai.csv"
+    assert m["finish_reason"] == "stop"
+    assert m["retry_count"] == 1
+    assert m["reasoning_summary"] == "Brief plan."
+    assert m["thinking_tokens"] == 2048
+    assert m["cost_breakdown"] == {"input": 0.001, "output": 0.05, "reasoning": 0.12}
+    assert m["tool_calls_cost_usd"] == 0.030
+    # error is None — keep omit-when-None contract.
+    assert "error" not in m
+
+
+def test_records_to_metrics_includes_error_when_set():
+    """``error`` participates in the omit-when-None contract symmetrically."""
+    record = RunRecord(
+        method=Method.DIRECT,
+        method_params=MethodParams(model="gpt-5.5"),
+        agent_family="openai-direct",
+        agent_mode="phase_b_run",
+        error="rate_limit_exceeded",
+        retry_count=3,
+    )
+    [m] = records_to_metrics([record])
+    assert m["error"] == "rate_limit_exceeded"
+    assert m["retry_count"] == 3
+
+
+def test_fixture_line_32_is_byte_identical_to_source():
+    """Sanity: the inlined fixture is valid JSON and has the expected run_id.
+
+    Catches accidental edits to FIXTURE_LINE_32 during refactors.
+    """
+    payload = json.loads(FIXTURE_LINE_32)
+    assert payload["run_id"] == "61326a1572ec"
+    assert payload["method_params"]["extra"]["architecture"] == "moe"

--- a/tickets/0166-sota-frontier-experiment.erg
+++ b/tickets/0166-sota-frontier-experiment.erg
@@ -7,7 +7,6 @@ Blocked-by: 0168
 Blocked-by: 0169
 Blocked-by: 0170
 Blocked-by: 0171
-Blocked-by: 0172
 Blocked-by: 0173
 
 --- log ---
@@ -15,6 +14,7 @@ Blocked-by: 0173
 2026-05-14T13:00Z claude note Raid Imagine pass: all six PROCEED. Two real concerns to track: (a) 0169 ESCALATE — Mistral web_search connector pricing unpublished; gate live smoke on a $0.50 probe of billed-units, fork to Kimi as 0173 if opaque. (b) 0167 Action 1 wording loosened — Opus 4.7 needs thinking={type:adaptive}, not enabled+budget_tokens. Wave order set via Blocked-by: 0172 (Wave 1) -> 0167/0168/0169 (Wave 2) -> 0170/0171 (Wave 3).
 2026-05-14T14:30Z claude note Expanded from 3 to 4 SOTA agents on user decision after 2026-05-14 field survey. Added Qwen3-Max via DashScope (CN, ticket 0173) as 4th slot for corpus diversity (Chinese-language sources under-indexed by Western search; hypothesis-relevant for Vietnamese power sector). Kimi K2.6 disqualified (thinking+web_search mutually exclusive). Wave 2 now: 0167/0168/0169/0173 parallel. Budget cap raised from ~$100 to ~$140. Cross-eval matrix 4x3 (was 3x3).
 
+2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0167-adapter-anthropic-web-thinking.erg
+++ b/tickets/0167-adapter-anthropic-web-thinking.erg
@@ -2,12 +2,12 @@
 Title: Adapter — Anthropic Claude with web_search tool + extended thinking
 Created: 2026-05-14
 Author: claude
-Blocked-by: 0172
 
 --- log ---
 2026-05-14T12:00Z claude created
 2026-05-14T13:00Z claude note Imagine: PROCEED. Loosen Action 1 thinking-config wording — Opus 4.7 rejects manual enabled+budget_tokens; use thinking={type:adaptive,display:summarized}. Pin default model claude-opus-4-7. Tool form: tools=[{type:web_search_20250305,name:web_search,max_uses:N}]. tool_choice must be auto or none. Capability verified on docs 2026-05-14.
 
+2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0168-adapter-openai-responses-websearch.erg
+++ b/tickets/0168-adapter-openai-responses-websearch.erg
@@ -2,12 +2,12 @@
 Title: Adapter — OpenAI Responses API with web_search + reasoning
 Created: 2026-05-14
 Author: claude
-Blocked-by: 0172
 
 --- log ---
 2026-05-14T12:00Z claude created
 2026-05-14T13:00Z claude note Imagine: PROCEED. Tool name is web_search (not web_search_preview — that is a legacy alias). Pre-call cap = max_output_tokens guard, not a fabricated dollar pre-estimate; verify cost post-call from usage. Default model gpt-5.5 (search + reasoning explicitly co-supported). Capability verified on docs 2026-05-14.
 
+2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0169-adapter-mistral-agents-websearch.erg
+++ b/tickets/0169-adapter-mistral-agents-websearch.erg
@@ -2,13 +2,13 @@
 Title: Adapter — Mistral Agents API with web_search connector
 Created: 2026-05-14
 Author: claude
-Blocked-by: 0172
 
 --- log ---
 2026-05-14T12:00Z claude created
 2026-05-14T13:00Z claude note Imagine: ESCALATE on pricing. Mistral web_search connector price not published on docs or pricing page (2026-05-14). Beta-API status acceptable. Gate before live smoke: one probe call (~$0.50) inspecting billed-units; if billing opaque, halt and fork to Kimi K2.5 as ticket 0173. Surface tool_calls_cost_usd as a discrete RunRecord field so connector fees do not blend into token cost. Use mistralai SDK beta.agents + beta.conversations.
 2026-05-14T14:30Z claude note Kimi swap path obsolete: K2.6 docs confirm thinking and $web_search are mutually exclusive, fatal for synopsis §4. If Mistral probe shows opaque billing, halt 0169 at probe and STOP; do NOT fork to Kimi. Corpus diversity now comes from 0173 Qwen3-Max (CN), opened as a parallel Wave-2 slot independent of this ticket's outcome.
 
+2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0173-adapter-qwen-dashscope-websearch.erg
+++ b/tickets/0173-adapter-qwen-dashscope-websearch.erg
@@ -2,12 +2,12 @@
 Title: Adapter — Qwen3-Max via DashScope with web_search + thinking mode
 Created: 2026-05-14
 Author: claude
-Blocked-by: 0172
 
 --- log ---
 2026-05-14T14:30Z claude created
 2026-05-14T14:30Z claude note Opens fourth SOTA-experiment slot for geographic + corpus diversity (CN frontier alongside US Anthropic/OpenAI and FR Mistral). Per 2026-05-14 SOTA field survey: Qwen3-Max supports the web_search tool inside thinking mode via DashScope Responses API; transparent pricing $10/1K searches international (or $0.57/1K mainland-region). User decision: run experiment with 4 agents rather than 3.
 
+2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0172-agent-run-record-schema.erg
+++ b/tickets/closed/0172-agent-run-record-schema.erg
@@ -2,11 +2,13 @@
 Title: RunRecord / output schema for SOTA agent-mode runs
 Created: 2026-05-14
 Author: claude
+Closed: autoclosed — PR #331
 
 --- log ---
 2026-05-14T12:00Z claude created
 2026-05-14T13:00Z claude note Imagine: PROCEED. RunRecord is Pydantic at src/aedist/schema.py:180-239 (NOT dataclass/TypedDict). Extend additively, all new fields Optional with defaults. Nest correctly: wall_clock_s/cost_usd already on ResourceUse (reuse wall_s,cost_usd; add cost_breakdown,thinking_tokens there); agent_family/agent_mode/synopsis_sha/designed_prompt_sha/web_search_calls/citations/parsed_table_path go top-level on RunRecord. Also first-class for agent runs: finish_reason, retry_count, error, reasoning_summary. records_to_metrics() at measurements.py:74 projects each new field; web_search_calls/citations exposed as counts in metrics dict, lists kept in record. Update ADR-7 in ADR.md (no new measurements_schema.md). 330 existing measurements.jsonl records all parse cleanly because new fields default None. Wave order: this ticket first, then 0167/0168/0169 in parallel, then 0170 + 0171.
 
+2026-05-14T19:11Z HDMX-coding-agent closed — autoclosed — PR #331
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0172-agent-run-record-schema.erg

Implements ticket **0172** under umbrella **0166** (SOTA frontier-API
experiment). Implementation plan: `tickets/0166-raid-plans.md` §0172.

## Summary
- `ResourceUse` gains `cost_breakdown: dict | None` and `thinking_tokens: int | None`.
- `RunRecord` gains 12 optional first-class fields: `agent_family`, `agent_mode`, `synopsis_sha`, `designed_prompt_sha`, `web_search_calls`, `citations`, `parsed_table_path`, `finish_reason`, `retry_count`, `error`, `reasoning_summary`, `tool_calls_cost_usd`.
- `records_to_metrics()` projects each new field per ADR-7. Lists become `n_web_search_calls` / `n_citations` counts; raw lists stay in `RunRecord`. Scalars follow the existing omit-when-None pattern.
- `ADR.md` ADR-7 table gains an `Agent runs (0172)` row plus an operational-consequences paragraph. No new `measurements_schema.md` (per ticket directive).
- `tool_calls_cost_usd` is kept distinct from `resource_use.cost_usd` so connector / web-search fees do not blend with token economics (needed by 0169 Mistral connector fees and 0173 Qwen per-search billing).

## Backward compatibility
- All new fields are `Optional` with `None` defaults.
- One-shot verification: `RunRecord.load_jsonl("measurements.jsonl")` returns **330 records** (unchanged).
- Hermetic test inlines the line-32 production record (`run_id=61326a1572ec`, DeepSeek V3.2 MoE) and asserts every new field is `None`, that `method_params.extra` (provider/architecture/etc.) survives untouched, and that the `validation` payload round-trips.

## Design deviation from the plan
- The plan suggested `agent_family` / `agent_mode` literals; I used `str | None` (no `StrEnum`). The ticket text mandates "additive only, Optional with defaults", and adapters 0167 / 0168 / 0169 / 0173 are still being designed. Pinning a `StrEnum` now would force cross-ticket coordination on every adapter add. The literal contract is documented in `tickets/0166-raid-plans.md` §0172 ("Contract surface for adapters"), which is the right home for it.

## Tests
- New file: `tests/test_measurements_agent_fields.py` — 7 tests covering:
  - First failing test: asymmetric-length counts (`n_web_search_calls == 3`, `n_citations == 2`) catching both copy-paste-len and forgot-len bugs.
  - Backward-compat parse of the line-32 fixture (every new field `None`, `extra` + `validation` preserved).
  - Metrics dict omits all agent-mode keys for a non-agent record.
  - JSONL round-trip of a fully populated agent-mode record.
  - Every new field surfaces in the metrics dict when set.
  - `error` participates in the omit-when-None contract symmetrically.
  - Fixture-integrity guard (the inlined line-32 stays valid JSON).
- Full suite: **1180 passed, 1 skipped, 1 xfailed** (no regressions).
- `ruff check src/ tests/ scripts/` and `scripts/check_ticket_structure.py` clean.

## Test plan
- [x] `uv run pytest tests/test_measurements_agent_fields.py -v`
- [x] `uv run pytest` (full suite)
- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run python -c "from aedist.schema import RunRecord; print(len(RunRecord.load_jsonl('measurements.jsonl')))"` → 330

Refs: ticket 0166 (umbrella), ticket 0172 (this), plans doc `tickets/0166-raid-plans.md` §0172.