### PR TITLE
chore(tickets): close 0175 + 0176 — Wave 1 merge bookkeeping

### DIFF
--- a/tickets/0177-run-experiment-1-sweep.erg
+++ b/tickets/0177-run-experiment-1-sweep.erg
@@ -2,11 +2,11 @@
 Title: Run Experiment 1 production sweep (45 runs)
 Created: 2026-05-15
 Author: claude
-Blocked-by: 0175
 
 --- log ---
 2026-05-15T14:05Z claude created
 
+2026-05-20T18:57Z HDMX-coding-agent note blocker 0175 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0175-lock-experiment-1-design.erg
+++ b/tickets/closed/0175-lock-experiment-1-design.erg
@@ -2,6 +2,7 @@
 Title: Lock Experiment 1 design decisions before re-sweep
 Created: 2026-05-15
 Author: claude
+Closed: autoclosed — PR #334 (raid Wave 1)
 
 --- log ---
 2026-05-15T14:05Z claude created
@@ -14,6 +15,7 @@ Author: claude
 2026-05-20T09:30Z user note baseline must send a system instruction "No websearch" to the API; runner currently sends only a user message (query_direct.py:212/221) — system-message plumbing must be added in this ticket
 2026-05-20T10:30Z claude note implemented harness rewrite (assemble_prompt + build_messages + reasoning_effort), JobSpec.system_instruction, worker/query_direct threading, 11-entry models.yaml addition, 16-model journal v2 set, all p1 sweeps updated to new module names, p1_base/ git mv to p1_base.pilot/, Annex A rewrite. make check-fast passes (1186 tests).
 
+2026-05-20T18:57Z HDMX-coding-agent closed — autoclosed — PR #334 (raid Wave 1)
 --- body ---
 ## Context
 

--- a/tickets/closed/0176-write-experiment-1-reference-provenance.erg
+++ b/tickets/closed/0176-write-experiment-1-reference-provenance.erg
@@ -2,10 +2,12 @@
 Title: Document reference dataset provenance for Experiment 1
 Created: 2026-05-15
 Author: claude
+Closed: autoclosed — PR #333 (raid Wave 1)
 
 --- log ---
 2026-05-15T14:05Z claude created
 
+2026-05-20T18:57Z HDMX-coding-agent closed — autoclosed — PR #333 (raid Wave 1)
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Lands the close+archive that the `erg-pr-merge` wrapper would have made for PRs #334 (ticket 0175) and #333 (ticket 0176), had the validator not been pre-migration in those branches.

- `tickets/0175-lock-experiment-1-design.erg` → `tickets/closed/` with `Closed: autoclosed — PR #334 (raid Wave 1)`
- `tickets/0176-write-experiment-1-reference-provenance.erg` → `tickets/closed/` with `Closed: autoclosed — PR #333 (raid Wave 1)`
- `tickets/0177-run-experiment-1-sweep.erg`: `Blocked-by: 0175` line removed (0175 is closed)

This unblocks ticket 0177 for raid Wave 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)