### PR TITLE
ticket(0180): SOTA adapter base scaffold + sota_smoke dir + 0167/0168 spec fixes

### DIFF
--- a/experiments/outputs/sota_smoke/README.md
+++ b/experiments/outputs/sota_smoke/README.md
@@ -1,0 +1,24 @@
+# SOTA-agent smoke + probe artifacts
+
+This directory holds single-call smoke tests and pricing probes from
+the four SOTA-agent adapters under umbrella ticket 0166:
+
+- `anthropic_*.json` — adapter 0167 (Claude Opus 4.7, web_search + adaptive thinking)
+- `openai_*.json`    — adapter 0168 (GPT-5.x via Responses API, web_search + reasoning)
+- `mistral_*.json`   — adapter 0169 (Mistral Large 2512, Agents API + web_search connector)
+- `qwen_*.json`      — adapter 0173 (Qwen3-Max via DashScope, web_search in thinking mode)
+
+## Scope
+
+Smoke calls and pricing probes only — **not batch experiment runs**.
+Batch runs land in sibling directories such as `../direct_complete/`,
+`../rag_cited/`, and the Phase B output dirs added by 0170/0171.
+
+## Filename convention
+
+`<agent>_<YYYYMMDDTHHMMZ>.json`
+
+Example: `anthropic_20260520T2030Z.json`. UTC timestamps, minute precision.
+
+Each JSON file is a `RunRecord` (see `src/aedist/schema.py`) with
+`agent_mode` set to `"smoke"` or `"probe"`.

--- a/src/aedist/adapter_base.py
+++ b/src/aedist/adapter_base.py
@@ -1,0 +1,87 @@
+"""Shared scaffold for SOTA agent adapters.
+
+This module defines the common Protocol, cost-cap utilities, and
+dry-run formatter used by the four SOTA agent adapters under umbrella
+0166:
+
+- 0167 Anthropic Claude (web_search + adaptive thinking)
+- 0168 OpenAI Responses (web_search + reasoning)
+- 0169 Mistral Agents (web_search connector)
+- 0173 Qwen DashScope (web_search in thinking mode)
+
+Each adapter ships transport code only. Prompt content lives in
+Phase A (ticket 0170). The Protocol is intentionally minimal —
+retry/backoff/rate-limit primitives are deferred until the first
+concrete adapter surfaces a real need.
+"""
+
+import json
+from typing import Any, Protocol, runtime_checkable
+
+from aedist.schema import RunRecord
+
+
+class CostCapExceeded(Exception):  # noqa: N818 — name fixed by ticket 0180 spec
+    """Raised when a pre-call cost estimate exceeds the configured cap."""
+
+    pass
+
+
+def estimate_call_cost(
+    *,
+    max_tokens: int,
+    price_in: float,
+    price_out: float,
+    n_searches: int = 0,
+    price_per_search: float = 0.0,
+) -> float:
+    """Conservative upper bound on the dollar cost of a single agent call.
+
+    Upper bound — assumes ``max_tokens`` are billed at both the input and
+    output rates (a deliberate double-count) and adds the per-search fee.
+    """
+    return max_tokens * (price_in + price_out) + n_searches * price_per_search
+
+
+def enforce_cost_cap(estimated_usd: float, cap_usd: float = 10.0) -> None:
+    """Raise ``CostCapExceeded`` if ``estimated_usd`` exceeds ``cap_usd``."""
+    if estimated_usd > cap_usd:
+        raise CostCapExceeded(f"estimated ${estimated_usd:.4f} exceeds cap ${cap_usd:.2f}")
+
+
+def format_dry_run(payload: dict) -> str:
+    """Return a deterministic pretty-printed JSON representation of ``payload``.
+
+    Keys are sorted so dry-run diffs are stable across adapters.
+    """
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+@runtime_checkable
+class AgentAdapter(Protocol):
+    """Common surface for SOTA-agent adapters (tickets 0167/0168/0169/0173)."""
+
+    def build_request(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_tokens: int,
+        **opts: Any,
+    ) -> dict:
+        """Assemble the provider-specific request payload."""
+        ...
+
+    def parse_response(self, resp: Any, model_meta: dict) -> RunRecord:
+        """Convert a provider response object into a canonical ``RunRecord``."""
+        ...
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        dry_run: bool,
+        **opts: Any,
+    ) -> RunRecord:
+        """Execute one agent call (or print the dry-run payload) and return a record."""
+        ...

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -1,0 +1,198 @@
+"""Unit tests for the shared SOTA adapter scaffold (ticket 0180).
+
+Pure unit tests — no subprocess, no sleep, no network. Belong in
+`make check-fast`.
+"""
+
+from typing import Any
+
+import pytest
+
+from aedist.adapter_base import (
+    AgentAdapter,
+    CostCapExceeded,
+    enforce_cost_cap,
+    estimate_call_cost,
+    format_dry_run,
+)
+from aedist.schema import RunRecord
+
+# ---------------------------------------------------------------------------
+# estimate_call_cost
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_call_cost_no_searches():
+    # Asymmetric numbers so swapping price_in/price_out would still pass,
+    # but swapping max_tokens with a price would not.
+    # 1000 * (0.003 + 0.015) = 18.0
+    assert estimate_call_cost(max_tokens=1000, price_in=0.003, price_out=0.015) == pytest.approx(
+        18.0
+    )
+
+
+def test_estimate_call_cost_search_only():
+    # Token side zero, search side priced.
+    # 7 * 0.025 = 0.175
+    result = estimate_call_cost(
+        max_tokens=0,
+        price_in=0.0,
+        price_out=0.0,
+        n_searches=7,
+        price_per_search=0.025,
+    )
+    assert result == pytest.approx(0.175)
+
+
+def test_estimate_call_cost_mixed():
+    # 500 * (0.001 + 0.004) + 3 * 0.01 = 2.5 + 0.03 = 2.53
+    result = estimate_call_cost(
+        max_tokens=500,
+        price_in=0.001,
+        price_out=0.004,
+        n_searches=3,
+        price_per_search=0.01,
+    )
+    assert result == pytest.approx(2.53)
+
+
+def test_estimate_call_cost_asymmetric_arguments():
+    # Verify operand order matters: swapping max_tokens and n_searches
+    # would yield a different number. This catches accidental
+    # operand-swap regressions.
+    a = estimate_call_cost(
+        max_tokens=100,
+        price_in=0.01,
+        price_out=0.02,
+        n_searches=2,
+        price_per_search=0.5,
+    )
+    b = estimate_call_cost(
+        max_tokens=2,
+        price_in=0.01,
+        price_out=0.02,
+        n_searches=100,
+        price_per_search=0.5,
+    )
+    assert a != b
+    # a = 100 * 0.03 + 2 * 0.5 = 3.0 + 1.0 = 4.0
+    assert a == pytest.approx(4.0)
+    # b = 2 * 0.03 + 100 * 0.5 = 0.06 + 50.0 = 50.06
+    assert b == pytest.approx(50.06)
+
+
+# ---------------------------------------------------------------------------
+# enforce_cost_cap
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_cost_cap_below_cap_returns_silently():
+    # Should not raise.
+    assert enforce_cost_cap(5.0, cap_usd=10.0) is None
+
+
+def test_enforce_cost_cap_at_cap_returns_silently():
+    # Equal is allowed (not greater than).
+    assert enforce_cost_cap(10.0, cap_usd=10.0) is None
+
+
+def test_enforce_cost_cap_above_cap_raises_with_both_numbers():
+    with pytest.raises(CostCapExceeded) as excinfo:
+        enforce_cost_cap(12.3456, cap_usd=10.0)
+    msg = str(excinfo.value)
+    # Both numbers must appear in the message so the operator can see
+    # the estimate and the cap at a glance.
+    assert "12.3456" in msg
+    assert "10.00" in msg
+
+
+def test_enforce_cost_cap_default_cap_is_ten():
+    # Confirms the documented $10 default matches the synopsis budget.
+    with pytest.raises(CostCapExceeded):
+        enforce_cost_cap(10.01)
+
+
+# ---------------------------------------------------------------------------
+# format_dry_run
+# ---------------------------------------------------------------------------
+
+
+def test_format_dry_run_is_deterministic():
+    payload = {"model": "claude-opus-4-7", "max_tokens": 1024, "tools": []}
+    a = format_dry_run(payload)
+    b = format_dry_run(payload)
+    assert a == b
+
+
+def test_format_dry_run_sorts_keys():
+    # Different insertion orders must produce identical output.
+    p1 = {"z": 1, "a": 2, "m": 3}
+    p2 = {"a": 2, "m": 3, "z": 1}
+    out1 = format_dry_run(p1)
+    out2 = format_dry_run(p2)
+    assert out1 == out2
+    # And the order is alphabetical.
+    assert out1.index('"a"') < out1.index('"m"') < out1.index('"z"')
+
+
+def test_format_dry_run_preserves_unicode():
+    payload = {"prompt": "Vietnam — coal plants"}
+    out = format_dry_run(payload)
+    # ensure_ascii=False keeps the em dash readable.
+    assert "—" in out
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class _StubAdapter:
+    """Minimal stub implementing the AgentAdapter Protocol."""
+
+    def build_request(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_tokens: int,
+        **opts: Any,
+    ) -> dict:
+        return {"prompt": prompt, "model": model, "max_tokens": max_tokens}
+
+    def parse_response(self, resp: Any, model_meta: dict) -> RunRecord:
+        return RunRecord(method="frontier", method_params={"model": "stub"})
+
+    def run(self, prompt: str, *, dry_run: bool, **opts: Any) -> RunRecord:
+        return RunRecord(method="frontier", method_params={"model": "stub"})
+
+
+def test_stub_adapter_satisfies_protocol():
+    stub = _StubAdapter()
+    assert isinstance(stub, AgentAdapter)
+
+
+def test_stub_adapter_methods_are_actually_callable():
+    # @runtime_checkable only checks method presence, not signatures.
+    # Exercise each method so a broken signature is caught here.
+    stub = _StubAdapter()
+    payload = stub.build_request("hello", model="m", max_tokens=10)
+    assert payload["prompt"] == "hello"
+    assert payload["model"] == "m"
+    assert payload["max_tokens"] == 10
+
+    record = stub.parse_response(resp=None, model_meta={})
+    assert isinstance(record, RunRecord)
+
+    record2 = stub.run("hello", dry_run=True)
+    assert isinstance(record2, RunRecord)
+
+
+def test_non_adapter_object_fails_protocol_check():
+    class _NotAnAdapter:
+        def build_request(self, *a, **k):
+            return {}
+
+        # missing parse_response and run
+
+    assert not isinstance(_NotAnAdapter(), AgentAdapter)

--- a/tickets/0167-adapter-anthropic-web-thinking.erg
+++ b/tickets/0167-adapter-anthropic-web-thinking.erg
@@ -8,6 +8,7 @@ Author: claude
 2026-05-14T13:00Z claude note Imagine: PROCEED. Loosen Action 1 thinking-config wording — Opus 4.7 rejects manual enabled+budget_tokens; use thinking={type:adaptive,display:summarized}. Pin default model claude-opus-4-7. Tool form: tools=[{type:web_search_20250305,name:web_search,max_uses:N}]. tool_choice must be auto or none. Capability verified on docs 2026-05-14.
 
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
+2026-05-20T20:30Z HDMX-coding-agent note Action 1 snippet superseded by 0180 — adaptive thinking, web_search_20250305 tool form.
 --- body ---
 ## Context
 
@@ -28,8 +29,9 @@ SDK directly, not OpenRouter.
 1. Add an `anthropic_agent` driver in `experiments/` (sibling of the
    existing OpenRouter dispatcher). The driver:
    - Loads the key from `~/.config/keys/anthropic.env`.
-   - Calls `messages.create(...)` with `tools=[{"type": "web_search_*"}]`
-     and `thinking={"type": "enabled", "budget_tokens": ...}`.
+   - Calls `messages.create(...)` with `tools=[{"type":
+     "web_search_20250305", "name": "web_search", "max_uses": N}]`
+     and `thinking={"type": "adaptive", "display": "summarized"}`.
    - Returns the raw response, final text, all tool calls + tool
      results (citations), thinking trace tokens, and per-call cost
      computed from input/output/cache tokens against the current

--- a/tickets/0168-adapter-openai-responses-websearch.erg
+++ b/tickets/0168-adapter-openai-responses-websearch.erg
@@ -8,6 +8,7 @@ Author: claude
 2026-05-14T13:00Z claude note Imagine: PROCEED. Tool name is web_search (not web_search_preview — that is a legacy alias). Pre-call cap = max_output_tokens guard, not a fabricated dollar pre-estimate; verify cost post-call from usage. Default model gpt-5.5 (search + reasoning explicitly co-supported). Capability verified on docs 2026-05-14.
 
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
+2026-05-20T20:30Z HDMX-coding-agent note Action 1 snippet superseded by 0180 — tool name is "web_search" (preview alias removed).
 --- body ---
 ## Context
 
@@ -29,7 +30,8 @@ Python SDK against the Responses endpoint, not OpenRouter.
 1. Add an `openai_agent` driver. The driver:
    - Loads the key from `~/.config/keys/openai.env`.
    - Calls `client.responses.create(...)` with `tools=[{"type":
-     "web_search_preview"}]` (or the current production tool name)
+     "web_search"}]` (the current production tool name; the legacy
+     alias `web_search_preview` is no longer accepted)
      and `reasoning={"effort": "high"}`.
    - Returns: final text, all `web_search_call` items (URLs +
      snippets), reasoning summary if available, per-call cost from

--- a/tickets/0180-sota-adapter-base-scaffold.erg
+++ b/tickets/0180-sota-adapter-base-scaffold.erg
@@ -1,0 +1,98 @@
+%erg 0.1
+Title: SOTA adapter base scaffold + sota_smoke dir + fix 0167/0168 spec drift
+Created: 2026-05-20
+Author: claude
+
+--- log ---
+2026-05-20T20:00Z claude created
+
+--- body ---
+## Context
+
+Wave-2 prerequisite for the four SOTA-agent adapters (0167 Anthropic,
+0168 OpenAI Responses, 0169 Mistral Agents, 0173 Qwen DashScope) under
+umbrella 0166. Without this scaffold, four parallel adapter PRs will
+re-invent the same protocol shape, cost-cap math, and dry-run printer
+three or four different ways. Cheap to land first, expensive to
+unify after the fact.
+
+Also folds in two stale spec corrections to 0167 and 0168 that an
+implementer would otherwise follow into a broken first call.
+
+This PR is **tooling only**. No live API calls, no smoke run, no
+adapter implementations. Just the shared surface area.
+
+## Actions
+
+1. **`src/aedist/adapter_base.py`** — one file, no external deps beyond
+   pydantic. Contains:
+   - `AgentAdapter` Protocol declaring `build_request(prompt, *,
+     model, max_tokens, **opts) -> dict`, `parse_response(resp,
+     model_meta) -> RunRecord`, `run(prompt, *, dry_run, ...) ->
+     RunRecord`. Adapters 0167/0168/0169/0173 implement this Protocol.
+   - `estimate_call_cost(*, max_tokens, price_in, price_out,
+     n_searches=0, price_per_search=0.0) -> float` — pre-call upper
+     bound used by the $10 cap. Pure function, fully unit-testable.
+   - `enforce_cost_cap(estimated_usd, cap_usd=10.0)` — raises
+     `CostCapExceeded` with a clear message naming both numbers.
+   - `format_dry_run(payload: dict) -> str` — canonical JSON pretty-print
+     of the assembled request, with key ordering stable across adapters
+     so dry-run diffs are readable.
+   - `CostCapExceeded` exception type.
+
+2. **`experiments/outputs/sota_smoke/`** — create the directory with a
+   short `README.md` describing its purpose (smoke + probe artifacts
+   from adapters 0167/0168/0169/0173, NOT batch runs) and the filename
+   convention (`<agent>_<YYYYMMDDTHHMMZ>.json`).
+
+3. **Fix `tickets/0167-adapter-anthropic-web-thinking.erg` Action 1
+   wording**: replace the `thinking={"type": "enabled",
+   "budget_tokens": ...}` snippet with `thinking={"type": "adaptive",
+   "display": "summarized"}`. Update the `tools=` snippet to
+   `tools=[{"type": "web_search_20250305", "name": "web_search",
+   "max_uses": N}]`. Append a one-line log entry noting the
+   correction supersedes the body text. This brings the body in sync
+   with the 2026-05-14 log note (Opus 4.7 rejects the old form).
+
+4. **Fix `tickets/0168-adapter-openai-responses-websearch.erg` Action 1
+   wording**: replace `"web_search_preview"` with `"web_search"` in the
+   inline code snippet. Append a one-line log entry noting the
+   correction supersedes the body text. Brings body in sync with the
+   2026-05-14 log note (preview is the legacy alias).
+
+## Test
+
+`tests/test_adapter_base.py` (unit, no network):
+
+- `estimate_call_cost` arithmetic: trivial case (no searches),
+  search-only case, mixed case. Use asymmetric numbers so swapped
+  operands would fail.
+- `enforce_cost_cap` raises with both numbers in the message when
+  exceeded; returns silently when below cap.
+- `format_dry_run` output is deterministic (same input → same string)
+  and key-ordered.
+- Protocol conformance: a tiny in-test stub adapter implementing the
+  Protocol passes `isinstance(stub, AgentAdapter)` (use
+  `@runtime_checkable` on the Protocol).
+
+No subprocess, no sleep. Pure unit. Belongs in `make check-fast`.
+
+## Exit criteria
+
+- `src/aedist/adapter_base.py` exists and is importable.
+- `experiments/outputs/sota_smoke/README.md` exists.
+- `tests/test_adapter_base.py` passes locally.
+- Tickets 0167 and 0168 body text reflects the validated 2026-05-14
+  call shape. Log entries record the supersession.
+- No new dependencies in `pyproject.toml`.
+- PR body links 0166 umbrella and notes "Wave-2 prerequisite — unblocks
+  parallel 0167/0168/0169/0173 implementation".
+
+## Notes
+
+- This ticket is **scaffold only**. Do NOT begin any adapter
+  implementation here. Adapter PRs land separately against
+  0167/0168/0169/0173 once this scaffold merges.
+- The Protocol is intentionally minimal. Resist the urge to add
+  retry/backoff/rate-limit primitives now — let the first concrete
+  adapter surface the real needs.

--- a/tickets/closed/0180-sota-adapter-base-scaffold.erg
+++ b/tickets/closed/0180-sota-adapter-base-scaffold.erg
@@ -2,10 +2,12 @@
 Title: SOTA adapter base scaffold + sota_smoke dir + fix 0167/0168 spec drift
 Created: 2026-05-20
 Author: claude
+Closed: autoclosed — PR #337
 
 --- log ---
 2026-05-20T20:00Z claude created
 
+2026-05-20T19:41Z HDMX-coding-agent closed — autoclosed — PR #337
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Wave-2 prerequisite for the four SOTA-agent adapters under umbrella #166 / ticket 0166 (0167 Anthropic, 0168 OpenAI Responses, 0169 Mistral Agents, 0173 Qwen DashScope). Lands the shared surface area **before** the four parallel adapter PRs so they cannot re-invent protocol shape, cost-cap math, and dry-run formatting three different ways.

This PR is **tooling only**. No live API calls, no smoke run, no adapter implementations.

- `src/aedist/adapter_base.py` — `AgentAdapter` Protocol (`@runtime_checkable`), `estimate_call_cost` (conservative upper bound), `enforce_cost_cap` ($10 default), `format_dry_run` (`sort_keys=True`, `ensure_ascii=False`), `CostCapExceeded` exception.
- `experiments/outputs/sota_smoke/README.md` — directory + scope/filename convention (`<agent>_<YYYYMMDDTHHMMZ>.json`). Smoke + probe artifacts only, **not** batch runs.
- `tickets/0167` and `tickets/0168` — Action 1 body text brought in sync with the 2026-05-14 log notes (Opus 4.7 rejects the old `thinking={type:enabled,budget_tokens:...}` form; OpenAI Responses uses `web_search`, not `web_search_preview`). Log entries record the supersession.
- `tests/test_adapter_base.py` — 14 unit tests (no markers, pure unit, belong in `make check-fast`).

**Wave-2 prerequisite — unblocks parallel 0167/0168/0169/0173 implementation.**

No new dependencies in `pyproject.toml`.

**Ticket:** tickets/0180-sota-adapter-base-scaffold.erg

## Test plan

- [x] `uv run ruff check src/aedist/adapter_base.py tests/test_adapter_base.py` — passes
- [x] `uv run pytest tests/test_adapter_base.py -v` — 14 passed
- [x] `tickets/erg validate` on all three touched tickets — PASS
- [x] `tickets/erg check tickets` (corpus-level) — PASS (170 tickets)

## Out of scope

- Concrete adapter implementations (land separately on 0167/0168/0169/0173).
- Retry / backoff / rate-limit primitives (deferred until the first concrete adapter surfaces a real need; see ticket Notes).

Generated with [Claude Code](https://claude.com/claude-code)