### PR TITLE
fix(manager+worker): wire model_set, seed, max_tokens (0175 regression)

### DIFF
--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -224,12 +224,14 @@ def _backfill_resource_use(record: RunRecord, json_path: Path) -> None:
     # (ticket 0175 / ADR-7): system_instruction declares the baseline
     # no-web-search regime; reasoning_effort is a per-model capability flag
     # (gpt-oss-*, qwen3-max).
-    for key in ("system_instruction", "reasoning_effort"):
+    for key in ("system_instruction", "reasoning_effort", "seed"):
         if raw.get(key) is not None:
             extra[key] = raw[key]
     record.method_params.extra = extra or None
     if "temperature" in raw:
         record.method_params.temperature = raw["temperature"]
+    if "max_tokens" in raw and raw["max_tokens"] is not None:
+        record.method_params.max_tokens = raw["max_tokens"]
 
 
 def _rel_path(path: Path) -> str:

--- a/src/aedist/manager.py
+++ b/src/aedist/manager.py
@@ -9,7 +9,7 @@ import argparse
 import hashlib
 from pathlib import Path
 
-from .harness import load_models
+from .harness import load_experiments, load_models
 from .schema import JobSpec
 
 _JOB_SUBDIRS = ("pending", "running", "done", "failed")
@@ -47,30 +47,60 @@ def _ensure_dirs(jobs_root: Path) -> None:
         (jobs_root / subdir).mkdir(parents=True, exist_ok=True)
 
 
+def _filter_models_by_set(
+    models: list[dict],
+    model_set: str,
+    experiments_path: str | Path,
+) -> list[dict]:
+    """Restrict the model registry to ids listed in ``[sets.<model_set>]``.
+
+    Resolves ``model_set`` against ``[sets]`` in ``experiments.toml`` and
+    returns only the registry entries whose ``name`` is in the allowed set.
+    Raises KeyError if the named set does not exist.
+    """
+    experiments = load_experiments(experiments_path)
+    sets = experiments.get("sets", {})
+    if model_set not in sets:
+        raise KeyError(f"Unknown model_set {model_set!r}; available: {sorted(sets)}")
+    allowed = set(sets[model_set].get("model_ids", []))
+    filtered = [m for m in models if m["name"] in allowed]
+    missing = allowed - {m["name"] for m in filtered}
+    if missing:
+        raise KeyError(f"model_set {model_set!r} references unknown model ids: {sorted(missing)}")
+    return filtered
+
+
 def generate(
     sweep_path: str | None = None,
     jobs_root: Path | None = None,
     *,
     sweep_config: dict | None = None,
     sweep_name: str | None = None,
+    experiments_path: str | Path = "experiments.toml",
 ) -> tuple[int, int]:
     """Fan out a sweep config into individual job files.
 
     Provide either *sweep_path* (YAML file) or *sweep_config* (dict from TOML).
     When using *sweep_config*, pass *sweep_name* for deterministic job IDs.
+    If the sweep config sets ``model_set``, the model registry is filtered
+    to that named set in *experiments_path* before fan-out.
     Returns (generated_count, skipped_count).
     """
     if sweep_config is not None:
         parent_spec = JobSpec.from_toml_section(sweep_config)
         sweep_key = sweep_name or "toml"
+        model_set = sweep_config.get("model_set")
     elif sweep_path is not None:
         sweep = Path(sweep_path)
         parent_spec = JobSpec.from_sweep_yaml(sweep)
         sweep_key = str(sweep)
+        model_set = None
     else:
         raise ValueError("Provide sweep_path or sweep_config")
 
     models = load_models(parent_spec.models_file)
+    if model_set:
+        models = _filter_models_by_set(models, model_set, experiments_path)
 
     if jobs_root is None:
         jobs_root = Path("jobs")
@@ -105,6 +135,11 @@ def generate(
                 repeat=1,
                 run_number=run,
                 budget_usd=parent_spec.budget_usd,
+                temperature=parent_spec.temperature,
+                seed=parent_spec.seed,
+                max_tokens=parent_spec.max_tokens,
+                web_search=parent_spec.web_search,
+                no_think=parent_spec.no_think,
                 system_instruction=parent_spec.system_instruction,
                 output_dir=parent_spec.output_dir,
                 timeout_seconds=parent_spec.timeout_seconds,
@@ -143,14 +178,13 @@ def main() -> None:
     args = parser.parse_args()
     if args.command == "generate":
         if args.sweep:
-            from .harness import load_experiments
-
             config = load_experiments(args.experiments)
             section = config["sweeps"][args.sweep]
             generated, skipped = generate(
                 jobs_root=Path(args.jobs_dir),
                 sweep_config=section,
                 sweep_name=args.sweep,
+                experiments_path=args.experiments,
             )
         elif args.sweep_yaml:
             generated, skipped = generate(args.sweep_yaml, Path(args.jobs_dir))

--- a/src/aedist/measurements.py
+++ b/src/aedist/measurements.py
@@ -149,9 +149,13 @@ def records_to_metrics(records: list[RunRecord]) -> list[dict]:
         if r.resource_use.tokens_out is not None:
             d["tokens_out"] = r.resource_use.tokens_out
         # --- 0139 fields: included once RunRecord carries them ---
+        # max_tokens lives on the typed MethodParams slot — evaluate.py
+        # routes it there (evaluate.py:233), so read it directly. Reading
+        # only from ``extra`` would silently drop the value (ADR-7 trap).
+        if r.method_params.max_tokens is not None:
+            d["max_tokens"] = r.method_params.max_tokens
         for key in (
             "seed",
-            "max_tokens",
             "num_ctx",
             "provider_order",
             "web_search",

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -375,6 +375,19 @@ class JobSpec(BaseModel):
     )
     budget_usd: float = Field(default=10.0, ge=0)
     temperature: float = Field(default=0.0, ge=0.0, le=2.0, description="Sampling temperature.")
+    seed: int | None = Field(
+        default=None,
+        ge=0,
+        description="RNG seed pinned for reproducibility. "
+        "OpenRouter applies best-effort; combine with provider pinning for MoE models. "
+        "Per-sweep, not per-model.",
+    )
+    max_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum completion tokens. None lets the provider default apply. "
+        "Per-sweep, not per-model.",
+    )
     web_search: bool = Field(
         default=False,
         description="Enable web search tools. Must be explicitly enabled in "

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -174,9 +174,10 @@ class Worker:
         """
         client = self.make_client()
         if job.prompt_modules is not None:
-            modules_dir = (
-                Path(job.modules_dir) if job.modules_dir else Path("experiments/prompts/modules")
-            )
+            # Default resolves relative to cwd; the experiments/Makefile sets
+            # cwd=experiments/ before invoking the worker (see UV_RUN macro),
+            # so "prompts/modules" finds experiments/prompts/modules/*.txt.
+            modules_dir = Path(job.modules_dir) if job.modules_dir else Path("prompts/modules")
             prompt = assemble_prompt(modules_dir, job.prompt_modules)
         else:
             prompt = Path(job.prompt).read_text().strip()
@@ -193,6 +194,8 @@ class Worker:
         api_kwargs = build_api_kwargs(
             model_entry,
             temperature=job.temperature,
+            max_tokens=job.max_tokens,
+            seed=job.seed,
             enable_web_search=job.web_search,
             no_think=job.no_think,
         )
@@ -324,6 +327,8 @@ class Worker:
             "wall_seconds": result["wall_seconds"],
             "cost_usd": cost,
             "temperature": (api_kwargs or {}).get("temperature"),
+            "seed": (api_kwargs or {}).get("seed"),
+            "max_tokens": (api_kwargs or {}).get("max_tokens"),
             "model_metadata": model_metadata(model_entry),
         }
         if model_entry.get("reasoning_effort"):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -154,6 +154,57 @@ def test_prompt_modules_empty_list_propagated(tmp_path: Path):
     assert spec.prompt_modules == []
 
 
+def test_model_set_filters_registry(tmp_path: Path):
+    """sweep_config with model_set restricts fan-out to that set's model_ids.
+
+    Regression: prior to this fix, the manager iterated all models in
+    models.yaml and silently ignored ``model_set`` (the field isn't on
+    JobSpec, and pydantic's default extra='ignore' dropped it). Ticket 0175
+    repointed the journal sweep to a 16-model set; ticket 0177 hit the bug
+    by generating 315 jobs (63 models × 5 reps) instead of 80.
+    """
+    models = [
+        {"name": "provider/model-a", "display_name": "Model A"},
+        {"name": "provider/model-b", "display_name": "Model B"},
+        {"name": "provider/model-c", "display_name": "Model C"},
+    ]
+    models_path = tmp_path / "models.yaml"
+    models_path.write_text(yaml.dump(models))
+
+    experiments_path = tmp_path / "experiments.toml"
+    experiments_path.write_text(
+        '[sets.set_two]\nmodel_ids = ["provider/model-a", "provider/model-c"]\n'
+    )
+
+    sweep_config = {
+        "mode": "single",
+        "prompt_modules": [],
+        "models": str(models_path),
+        "model_set": "set_two",
+        "repeat": 2,
+        "budget_usd": 5,
+        "seed": 42,
+        "max_tokens": 8192,
+        "output": "outputs/ablation/test",
+    }
+    jobs_root = tmp_path / "jobs"
+    generated, _ = generate(
+        jobs_root=jobs_root,
+        sweep_config=sweep_config,
+        sweep_name="ablation_set_filter",
+        experiments_path=experiments_path,
+    )
+    assert generated == 4  # 2 models in set × 2 reps
+
+    filters = set()
+    for job_file in (jobs_root / "pending").iterdir():
+        spec = JobSpec.from_yaml(job_file.read_text())
+        filters.add(spec.model_filter)
+        assert spec.seed == 42
+        assert spec.max_tokens == 8192
+    assert filters == {"provider/model-a", "provider/model-c"}
+
+
 def test_idempotency_across_dirs(tmp_path: Path):
     """Jobs already in running/done/failed are skipped."""
     sweep_path = _write_sweep(tmp_path, repeat=1)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -137,6 +137,31 @@ class TestRecordsToMetrics:
         assert metrics[0]["coverage"] == 0.0
         assert metrics[0]["precision"] == 0.0
 
+    def test_max_tokens_surfaced_from_typed_slot(self):
+        """max_tokens lives on MethodParams (typed slot); evaluate.py routes
+        it there directly (see evaluate.py:233). records_to_metrics must
+        read the typed attribute, not look it up in ``extra``. Without this
+        path the field is silently dropped from measurements.jsonl —
+        the ADR-7 trap the metrics_dict_complete_scientific_record rule
+        is meant to prevent.
+        """
+        record = RunRecord(
+            method=Method.DIRECT,
+            method_params=MethodParams(model="m", max_tokens=8192),
+            result_summary=ResultSummary(tp=1, fp=0, fn=0, f1=1.0),
+            result_file="census/m-run1.csv",
+        )
+        [m] = records_to_metrics([record])
+        assert m["max_tokens"] == 8192
+
+    def test_max_tokens_absent_when_unset(self):
+        """Omit-when-None pattern: a record without max_tokens must not
+        introduce a stray key into the metrics dict (matches the contract
+        already documented for 0139 fields)."""
+        record = _make_record("census/m-run1", tp=1, fp=0, fn=0, f1=1.0)
+        metrics = records_to_metrics([record])
+        assert "max_tokens" not in metrics[0]
+
 
 class TestOutputEquivalence:
     """Pure reporting functions produce identical output from RunRecords."""


### PR DESCRIPTION
## Summary

PR #334 (ticket 0175) added the journal-v2 model set and pointed `sweep_ablation_p1_direct_base` at it (16 × 5 = 80 runs), but the manager + worker pipeline silently dropped four locked knobs. Discovered when ticket 0177's Wave-2 agent ran `manager generate` and got 315 jobs instead of 80, with `qwen3-max-thinking` (legacy set member) appearing in the fan-out.

## Four silent-drop regressions

1. **`model_set`** — `JobSpec` had `extra="ignore"`; pydantic dropped the field, so the manager fanned out *all 63* models in `models.yaml` instead of the 16 in `modelset_ablation_journal`.
2. **`seed=42`** — not on `JobSpec`; `build_api_kwargs(seed=)` never received it. The reproducibility pin documented in 0175 never reached the API.
3. **`max_tokens=8192`** — same path. Provider defaults applied; Opus / GPT-5.5 could legally overrun the cap.
4. **`modules_dir`** — `worker.py` default was `experiments/prompts/modules` resolved relative to cwd. The Makefile runs the worker from `experiments/`, producing `experiments/experiments/prompts/modules` — ValueError on the first job.

## Fixes

- `src/aedist/schema.py` — add `seed: int | None` and `max_tokens: int | None` to `JobSpec`.
- `src/aedist/manager.py` — new `_filter_models_by_set()`; `generate()` propagates `seed`, `max_tokens`, `temperature`, `web_search`, `no_think` into per-job `JobSpec`s.
- `src/aedist/worker.py` — passes `seed=` and `max_tokens=` to `build_api_kwargs()`; records both + temperature in saved JSON for ADR-7; default `modules_dir` is now `prompts/modules` (cwd-relative, matches Makefile).
- `src/aedist/evaluate.py` — surfaces `seed` / `max_tokens` from saved JSON into `RunRecord.method_params` so they reach `measurements.jsonl`.
- `tests/test_manager.py` — new regression `test_model_set_filters_registry` asserting the fan-out respects `model_set` and propagates `seed` + `max_tokens`.

## Verification

- Smoke `mistralai/mistral-small-2603 run 1` after patch: $0.0026, 22.5s, `finish_reason=stop`, 42 table rows, `system_instruction` + `seed=42` + `max_tokens=8192` + `temperature=0.0` all recorded in the .record.json.
- `manager generate --sweep sweep_ablation_p1_direct_base` produces 80 jobs (16 unique models, 5 reps), not 315.
- `make check-fast`: 135 affected tests pass; ruff clean.

## Why this is split from 0177

Ticket 0177's sweep cannot honor 0175's design lock without these fixes. Landing this independently makes the regression fix reviewable on its own and unblocks a clean Wave-2 retry.

## Reroll (2026-05-20)

`/verify` flagged one blocking ADR-7 violation: `evaluate.py:233` routes `max_tokens` to the typed `record.method_params.max_tokens` slot, but `records_to_metrics()` in `src/aedist/measurements.py` only iterated `extra` for the field — so the new value was silently dropped from `measurements.jsonl`. This is exactly the `metrics_dict_complete_scientific_record` trap the rule was written for.

**Fix (commit `2c9f096`)** — `src/aedist/measurements.py`:

- Read `max_tokens` directly from the typed `r.method_params.max_tokens` slot (omit-when-None, matching the existing 0139-fields contract).
- Remove `"max_tokens"` from the `extra`-dict lookup loop so the typed slot is the single source of truth. `seed` stays in the loop — `evaluate.py:227` legitimately routes it through `extra`.

**Tests** — `tests/test_measurements.py`:

- `test_max_tokens_surfaced_from_typed_slot` — builds a `RunRecord` with `MethodParams(max_tokens=8192)` and asserts the metrics dict carries the value. Confirmed to raise `KeyError: 'max_tokens'` on `bd46943` (pre-fix).
- `test_max_tokens_absent_when_unset` — guards the omit-when-None contract.

`make check-fast`: 1194 passed, 2 skipped, 1 xfailed. Non-blocking items from `/verify` (model-set ordering via `set()`, cwd-dependent `modules_dir` default, untested `KeyError` branches in `_filter_models_by_set`) intentionally not addressed here — each is a separate ticket.

**Ticket:** tickets/0177-run-experiment-1-sweep.erg

## Test plan

- [ ] CI lint + tests green
- [ ] Spot-check the new `test_model_set_filters_registry` assertion
- [ ] Confirm a follow-up sweep retry produces exactly 80 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)