### PR TITLE
experiments: add ablation/direct leaf dirs to STRUCTURED_DIRS (ticket 0179)

### DIFF
--- a/experiments/Makefile
+++ b/experiments/Makefile
@@ -151,7 +151,8 @@ EVAL      := $(UV_RUN) python -m aedist.evaluate
 REFERENCE := ../data/reference/vietnam_thermal_v1.csv
 
 STRUCTURED_DIRS := census multiturn web rag \
-                   decomposed decomposed_v2 sourced frontier
+                   decomposed decomposed_v2 sourced frontier \
+                   ablation/direct/p1_base ablation/direct/p1_composite
 
 OUTPUT_FILES := $(filter-out %.record.json,$(wildcard outputs/*/*.json) $(wildcard derived/*/*.json)) \
                 $(wildcard outputs/*/*.csv) $(wildcard derived/*/*.csv)
@@ -182,7 +183,7 @@ evaluate-all-records:
 	@$(MAKE) --no-print-directory -j$$(nproc) \
 	    $$(find outputs derived -name '*.csv' ! -name 'reconciliation_*' ! -path '*/_extracted/*' | sed 's/\.csv$$/.record.json/')
 	@shopt -s nullglob; \
-	for f in outputs/*/*-run*.json derived/*/*-run*.json; do \
+	for f in outputs/*/*-run*.json outputs/*/*/*-run*.json derived/*/*-run*.json; do \
 	    [ -f "$${f%.json}.csv" ] && continue; \
 	    rec="$${f%.json}.record.json"; \
 	    [ -f "$$rec" ] && [ "$$rec" -nt "$$f" ] && continue; \

--- a/tickets/0179-makefile-ablation-extract.erg
+++ b/tickets/0179-makefile-ablation-extract.erg
@@ -1,0 +1,32 @@
+%erg v1
+Title: Add ablation/direct to Makefile STRUCTURED_DIRS
+Created: 2026-05-20
+Author: claude
+
+--- log ---
+2026-05-20T21:00Z claude created
+
+--- body ---
+## Context
+
+`make extract` covers a hardcoded `STRUCTURED_DIRS` list in `experiments/Makefile`
+that excludes `ablation`. Exp 1 sweep (`sweep_ablation_p1_direct_base`) writes to
+`outputs/ablation/direct/p1_base/`. Models that return JSON without a CSV companion
+(e.g. gpt-5-mini) are not extracted and stay as orphan JSONs scored as
+`refusal`/`error`/`empty` instead of F1.
+
+`rebuild-measurements` finds existing `.record.json` files under `outputs/ablation/`
+but does not trigger extraction for JSON-only runs.
+
+## Actions
+
+1. Add `ablation/direct` to `STRUCTURED_DIRS` in `experiments/Makefile`.
+2. Verify `make extract` now processes `outputs/ablation/direct/p1_base/*.json`.
+3. Confirm `gpt-5-mini-run*.json` (already present) produce CSVs and valid records.
+
+## Exit criteria
+
+- [ ] `STRUCTURED_DIRS` includes `ablation/direct` (or the specific subdirectory)
+- [ ] `make extract` produces CSVs for existing JSON-only runs in `outputs/ablation/direct/p1_base/`
+- [ ] `make rebuild-measurements` assembles all ablation records into `measurements.jsonl`
+- [ ] `make check` passes


### PR DESCRIPTION
## Summary

- Add `ablation/direct/p1_base` and `ablation/direct/p1_composite` to `STRUCTURED_DIRS` in `experiments/Makefile`, so `make extract` processes JSON outputs in those directories.
- Extend the orphan-eval glob in `evaluate-all-records` to also cover 3-level-deep paths (`outputs/*/*/*-run*.json`), so JSON-only runs (e.g. gpt-5-mini refusals with no CSV companion) still get `.record.json` entries via the evaluate fallback.

## Why leaf dirs, not `ablation/direct`

`iter_model_replies` uses `Path.glob("*.json")` (non-recursive). Passing `ablation/direct` would silently process the empty top-level dir. The exit criteria in the ticket explicitly allow "the specific subdirectory" — adding leaf dirs is correct.

## Test plan

- [x] `make extract` runs and processes `outputs/ablation/direct/p1_base/*.json` and `outputs/ablation/direct/p1_composite/*.json`
- [x] `make check` passes with same failure count as baseline (3 pre-existing failures unrelated to this change: `prompts/modules/base.txt` missing)
- [ ] `make rebuild-measurements` assembles ablation records into `measurements.jsonl` (verify by grepping for `gpt-5-mini` rows with ablation/direct sweep config)

## Follow-up

`outputs/ablation/livesearch/` has similar orphan JSONs (deepseek-v3.2, kimi-k2-thinking without CSVs). Those are out of scope for this ticket but would need the same treatment in a follow-up.

**Ticket:** tickets/0179-makefile-ablation-extract.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)