### PR TITLE
tickets(0166/0167/0168): fold Phase B-0 (N=1) + Anthropic & OpenAI derisk PASS

### DIFF
--- a/tickets/0166-sota-frontier-experiment.erg
+++ b/tickets/0166-sota-frontier-experiment.erg
@@ -15,6 +15,7 @@ Blocked-by: 0173
 2026-05-14T14:30Z claude note Expanded from 3 to 4 SOTA agents on user decision after 2026-05-14 field survey. Added Qwen3-Max via DashScope (CN, ticket 0173) as 4th slot for corpus diversity (Chinese-language sources under-indexed by Western search; hypothesis-relevant for Vietnamese power sector). Kimi K2.6 disqualified (thinking+web_search mutually exclusive). Wave 2 now: 0167/0168/0169/0173 parallel. Budget cap raised from ~$100 to ~$140. Cross-eval matrix 4x3 (was 3x3).
 
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
+2026-05-20T22:45Z HDMX-coding-agent note Derisk pass complete (Wave-2 prereqs landed via #337, #339, #340): Qwen and Mistral probes PASS with full billing transparency; Anthropic and OpenAI funded (Anthropic +$25, OpenAI +$30, balances current). Anthropic compose verified — claude-opus-4-7 + web_search_20250305 + adaptive thinking match the corrected spec. OpenAI compose verified — gpt-5.5 + web_search + reasoning, with two parser-blocking gotchas folded into 0168 (must pass include=['web_search_call.action.sources'] to surface URLs; reasoning.summary stays empty even at effort=high/summary=detailed). Phase B-0 (N=1) folded into experiment structure as a gate before Phase B (N=3).
 --- body ---
 ## Context
 
@@ -70,10 +71,27 @@ the quality of the resulting statistical report it can produce within
 ≤$10 and an overnight wall-clock budget. Each model designs its own
 prompt; the prompts are not shared across models. (Ticket 0170.)
 
-**Phase B — Execution.** Each model's designed prompt is run 3 times.
-For closed-weight SOTA agents (single provider each), the three runs
-use the same provider; for open-weight agents (if added later) use
-different providers. Document the asymmetry in the run record.
+**Phase B-0 — Single-rep smoke.** Before the full N=3 execution, run
+each model's designed prompt **once** end-to-end. This is the project's
+"Test one before blasting" rule (`.claude/rules/workflow.md`) applied
+at the experiment level: 4 outputs surface parser bugs, prompt
+failures, model refusals, and real per-call cost before triple-budget
+commitment. Phase C scoring runs on these 4 outputs as a structural
+test of the cross-eval harness. Gate to Phase B: a review pass that
+confirms (i) all 4 adapters produced valid RunRecords, (ii) the
+parsed tables are non-empty, (iii) costs match the ≤$10/call budget
+empirically. If any agent fails, fix at N=1 cost — do not graduate
+to N=3 until the smoke is clean.
+
+**Phase B — Execution (N=3).** Each model's designed prompt is run
+3 times. For closed-weight SOTA agents (single provider each), the
+three runs use the same provider; for open-weight agents (if added
+later) use different providers. Document the asymmetry in the run
+record. Phase B is gated on a clean Phase B-0 review.
+
+The single-rep claim in Phase B-0 cannot stand in for variance
+analysis — N=1 cannot report "model X is consistently better than Y".
+Only the post-Phase-B N=3 dataset supports such comparisons.
 
 **Phase C — Cross-evaluation.** For each output, the two *other* agents
 score it along the four dimensions (Accuracy, Coherence, Provenance,
@@ -95,13 +113,18 @@ reads from it directly.
 ## Budget envelope (4-agent expansion)
 
 - Phase A (prompt design): ≤ $1 per model × 4 = $4.
-- Phase B (3 reps × $10 cap): ≤ $30 per model × 4 = $120.
+- Phase B-0 (1 rep × $10 cap): ≤ $10 per model × 4 = $40. Gate to B.
+- Phase B (3 reps × $10 cap, includes B-0's run): incremental ≤ $20
+  per model × 4 = $80 on top of B-0.
 - Phase C (cross-eval, cheap chat completions): ≤ $10 total
   (12 subject runs × 3 evaluators ≈ 36 calls + baseline scoring).
 - Smoke + probe: 4 × $0.50 = $2 + Mistral probe ≤ $0.50 = $2.50.
-- **Cap: ~$140 total.** Hard cap enforced per-run by adapters; soft
-  cap monitored at the umbrella by inspecting cost totals after Phase A
-  before launching Phase B.
+  Derisk probes 2026-05-20 (Qwen, Mistral, Anthropic, OpenAI):
+  ~$0.50 actually spent.
+- **Cap: ~$140 total (B-0 first ≤ $60; gate to N=3 then ≤ $90 more).**
+  Hard cap enforced per-run by adapters; soft cap monitored at the
+  umbrella by inspecting cost totals after Phase A and again after
+  Phase B-0 before launching Phase B-full.
 
 ## Exit criteria
 

--- a/tickets/0167-adapter-anthropic-web-thinking.erg
+++ b/tickets/0167-adapter-anthropic-web-thinking.erg
@@ -9,6 +9,7 @@ Author: claude
 
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 2026-05-20T20:30Z HDMX-coding-agent note Action 1 snippet superseded by 0180 — adaptive thinking, web_search_20250305 tool form.
+2026-05-20T22:50Z HDMX-coding-agent note Derisk pass PASS — live probe against claude-opus-4-7 with corrected spec (adaptive thinking + tools=[{type:web_search_20250305, name:web_search, max_uses:N}]) returned HTTP 200, all three capabilities composed. Response shape: content[] mixing types thinking / server_tool_use (per query) / web_search_tool_result (with N URLs) / text (with citations[] on cited segments). usage.server_tool_use.web_search_requests is the search count. Per-call cost ~$0.20 with max_tokens=2048 and modest input (search results balloon input_tokens to ~12k). Account funded +$25 on 2026-05-20.
 --- body ---
 ## Context
 

--- a/tickets/0168-adapter-openai-responses-websearch.erg
+++ b/tickets/0168-adapter-openai-responses-websearch.erg
@@ -9,6 +9,7 @@ Author: claude
 
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 2026-05-20T20:30Z HDMX-coding-agent note Action 1 snippet superseded by 0180 — tool name is "web_search" (preview alias removed).
+2026-05-20T22:55Z HDMX-coding-agent note Derisk pass — live probe against gpt-5.5 via Responses API surfaced two parser-blocking gotchas now folded into the spec: (1) include=["web_search_call.action.sources"] is mandatory — without it response carries the query only, output_text.annotations is empty, URLs are lost; (2) reasoning.summary stays empty even at effort=high/summary=detailed, so RunRecord.reasoning_summary will typically be None for this adapter. Compose works (web_search + reasoning on same call). billing field on response is informational only ({payer: developer}); cost still derived from usage × price card. Account funded +$30 on 2026-05-20.
 --- body ---
 ## Context
 
@@ -28,14 +29,27 @@ Python SDK against the Responses endpoint, not OpenRouter.
 ## Actions
 
 1. Add an `openai_agent` driver. The driver:
-   - Loads the key from `~/.config/keys/openai.env`.
-   - Calls `client.responses.create(...)` with `tools=[{"type":
-     "web_search"}]` (the current production tool name; the legacy
-     alias `web_search_preview` is no longer accepted)
-     and `reasoning={"effort": "high"}`.
-   - Returns: final text, all `web_search_call` items (URLs +
-     snippets), reasoning summary if available, per-call cost from
-     input/output/reasoning token usage against the OpenAI price card.
+   - Loads `OPENAI_API_KEY` from `~/.config/keys/openai.env`.
+   - Calls `client.responses.create(...)` with:
+     ```python
+     tools=[{"type": "web_search"}]
+     reasoning={"effort": "high"}
+     include=["web_search_call.action.sources"]
+     ```
+     The `include` directive is **mandatory** to surface URLs —
+     without it the response's `web_search_call.action` carries only
+     the query and `output_text.annotations` stays empty (verified
+     empirically 2026-05-20 against `gpt-5.5`).
+   - Returns: final text (from `message.content[].output_text`), all
+     `web_search_call` entries (each with `action.query` and
+     `action.sources[]` of URLs), per-call cost from
+     `usage.input_tokens` / `output_tokens` /
+     `output_tokens_details.reasoning_tokens` against the OpenAI
+     price card. Note: `reasoning.summary` items are empirically
+     empty even at `effort=high, summary=detailed` — the model
+     reasons (reasoning_tokens > 0) but does not surface a textual
+     summary, so RunRecord.`reasoning_summary` will typically be
+     None for this adapter.
 2. Choose the model. Default to the most capable production GPT-5
    variant (`gpt-5.4`, `gpt-5-pro`, or current equivalent). Verify the
    chosen ID supports both `web_search` and high reasoning effort on
@@ -50,10 +64,34 @@ Python SDK against the Responses endpoint, not OpenRouter.
 ## Test
 
 `tests/test_adapter_openai.py`:
-- `--dry-run` payload contains model ID, web_search tool, reasoning
-  config.
-- Canned response parses into the run-record schema (0172).
-- Cost calculation matches fixture pricing.
+- `--dry-run` payload contains the model ID, `tools=[{"type":"web_search"}]`,
+  `reasoning={"effort":"high"}`, and `include=["web_search_call.action.sources"]`.
+  Assert the `include` key is present — missing it is the #1 way to
+  ship a silent-citation-loss bug.
+- Canned response parses correctly using the verified native shape:
+  - `output[*]` with `type: "web_search_call"`: each entry's
+    `action.query` is the search query; `action.sources[]` carries
+    URL objects. Aggregate into RunRecord `web_search_calls`
+    (per-execution) and `citations` (flattened across sources).
+  - `output[*]` with `type: "reasoning"`: reasoning ran, but
+    `summary` is typically empty. Use `usage.output_tokens_details.reasoning_tokens`
+    as the reasoning-magnitude signal; `reasoning_summary` may be
+    None.
+  - `output[*]` with `type: "message"`: `content[].output_text` is
+    the narrative; do NOT depend on `output_text.annotations[]` for
+    citations (empirically empty even on full effort).
+  - `usage.input_tokens` + `output_tokens` + `reasoning_tokens` for
+    cost.
+  - `usage.input_tokens_details.cached_tokens` for cache-hit accounting.
+  Use a fixture under `tests/fixtures/openai_responses_response.json`
+  built from a recorded probe (do not invent the shape).
+- Cost arithmetic matches a fixture price card (input fresh, input
+  cached, output, reasoning tokens, n_searches × per-search price).
+- **Non-tautological assertion**: fixture with 2 distinct
+  `web_search_call` entries totaling 7 unique URLs across both
+  `action.sources` arrays. Assert `len(record.web_search_calls) == 2`
+  AND `len(record.citations) == 7`. Asymmetric counts catch
+  parser bugs that confuse search invocations with URL aggregation.
 
 ## Exit criteria
 


### PR DESCRIPTION
## Summary

Supersedes #343 (closed for clean rebase). Three coordinated text-only edits closing out the Wave-2 derisk pass for tickets under umbrella 0166.

### 0166 — Phase B-0 (N=1) folded into experiment structure

User decision: run N=1 across all 4 agents as a smoke before committing to N=3 Phase B. Codifies the project's "Test one before blasting" rule at the experiment level. Gate to Phase B is a review pass on Phase B-0.

Budget envelope updated: Phase B-0 ≤ \$40, incremental Phase B ≤ \$80, total cap unchanged (~\$140).

### 0167 — Anthropic derisk PASS

Live probe against \`claude-opus-4-7\` with the corrected (post-#337) spec returned HTTP 200; thinking + web_search + citations all composed. Body matches empirical shape — log entry only, no body changes.

### 0168 — OpenAI derisk PASS + spec correction

Two parser-blocking findings folded into the spec:

1. **\`include=[\"web_search_call.action.sources\"]\` is mandatory.** Without it, the response carries the query only, \`output_text.annotations\` stays empty, URLs are silently lost.
2. **\`reasoning.summary\` items are empirically empty** even at \`effort=high, summary=detailed\`. \`RunRecord.reasoning_summary\` will typically be None; use \`reasoning_tokens\` as the magnitude signal.

Account funding logged: Anthropic +\$25, OpenAI +\$30 on 2026-05-20.

## Test plan

- [x] \`tickets/erg validate\` passes on all three files
- [x] Diff text-only inside three \`.erg\` files
- [x] Empirical probes confirmed the field shapes claimed in 0167 and 0168
- [x] Probe spend total: ~\$0.50 across all four providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)