### PR TITLE
tickets(0166/0167): pin Anthropic slot to claude-opus-4-6

### DIFF
--- a/tickets/0166-sota-frontier-experiment.erg
+++ b/tickets/0166-sota-frontier-experiment.erg
@@ -16,6 +16,7 @@ Blocked-by: 0173
 
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 2026-05-20T22:45Z HDMX-coding-agent note Derisk pass complete (Wave-2 prereqs landed via #337, #339, #340): Qwen and Mistral probes PASS with full billing transparency; Anthropic and OpenAI funded (Anthropic +$25, OpenAI +$30, balances current). Anthropic compose verified — claude-opus-4-7 + web_search_20250305 + adaptive thinking match the corrected spec. OpenAI compose verified — gpt-5.5 + web_search + reasoning, with two parser-blocking gotchas folded into 0168 (must pass include=['web_search_call.action.sources'] to surface URLs; reasoning.summary stays empty even at effort=high/summary=detailed). Phase B-0 (N=1) folded into experiment structure as a gate before Phase B (N=3).
+2026-05-20T23:30Z HDMX-coding-agent note Anthropic slot pinned to claude-opus-4-6 (was 4.7). Compose re-verified on 4.6: identical shape, ~40% cheaper per call. See 0167 log.
 --- body ---
 ## Context
 
@@ -38,8 +39,10 @@ work tickets close AND the experiment has been run and analyzed.
 
 API path only — no browser automation. Direct-API keys at `~/.config/keys/`:
 
-1. **Anthropic Claude Opus 4.7** (US) — `anthropic.env`, web_search tool
-   + adaptive thinking (ticket 0167).
+1. **Anthropic Claude Opus 4.6** (US) — `anthropic.env`, web_search tool
+   + adaptive thinking (ticket 0167). Pinned to 4.6 (not 4.7) per
+   2026-05-20 decision; compose verified on 4.6 identical to 4.7
+   with lower per-call cost.
 2. **OpenAI GPT-5.5** (US) — `openai.env`, Responses API + web_search +
    reasoning (ticket 0168).
 3. **Mistral Large 2512** (FR) — `mistral.env`, Agents API + web_search

--- a/tickets/0167-adapter-anthropic-web-thinking.erg
+++ b/tickets/0167-adapter-anthropic-web-thinking.erg
@@ -10,6 +10,7 @@ Author: claude
 2026-05-14T19:11Z HDMX-coding-agent note blocker 0172 closed — Blocked-by removed.
 2026-05-20T20:30Z HDMX-coding-agent note Action 1 snippet superseded by 0180 — adaptive thinking, web_search_20250305 tool form.
 2026-05-20T22:50Z HDMX-coding-agent note Derisk pass PASS — live probe against claude-opus-4-7 with corrected spec (adaptive thinking + tools=[{type:web_search_20250305, name:web_search, max_uses:N}]) returned HTTP 200, all three capabilities composed. Response shape: content[] mixing types thinking / server_tool_use (per query) / web_search_tool_result (with N URLs) / text (with citations[] on cited segments). usage.server_tool_use.web_search_requests is the search count. Per-call cost ~$0.20 with max_tokens=2048 and modest input (search results balloon input_tokens to ~12k). Account funded +$25 on 2026-05-20.
+2026-05-20T23:30Z HDMX-coding-agent note Model pinned to claude-opus-4-6 (user decision). Compose re-verified on 4.6: identical response shape (2 thinking blocks, 1 server_tool_use, 1 web_search_tool_result, 3 text with 1 citation), same usage block, lower per-call cost (~$0.12 vs ~$0.20). Action 2 updated to pin 4.6 explicitly; do not silently upgrade.
 --- body ---
 ## Context
 
@@ -37,10 +38,12 @@ SDK directly, not OpenRouter.
      results (citations), thinking trace tokens, and per-call cost
      computed from input/output/cache tokens against the current
      Anthropic price card.
-2. Choose the model. Default to the most capable production Opus
-   currently available (`claude-opus-4-6` or `claude-opus-4-7`).
-   Verify the chosen ID supports both `web_search` and `thinking` in
-   the same call before locking it in.
+2. Model: pinned to `claude-opus-4-6`. Decision recorded 2026-05-20:
+   compose (adaptive thinking + web_search_20250305) verified on
+   `claude-opus-4-6` with identical response shape to 4.7 and lower
+   per-call cost (~$0.12 vs ~$0.20 in the smoke probe). Do not
+   silently upgrade to 4.7 without re-verifying compose; the API
+   surface may diverge in future point releases.
 3. Register the model in `experiments/models.yaml` under a new family
    `anthropic-direct` (separate from the OpenRouter route).
 4. Hard cost cap per call: $10. Computed pre-call from `max_tokens` +


### PR DESCRIPTION
## Summary

User decision 2026-05-20: pin the Anthropic SOTA slot to \`claude-opus-4-6\` rather than 4.7.

Compose (adaptive thinking + web_search_20250305) re-verified on \`claude-opus-4-6\`:

- Identical response shape: 2 thinking blocks, 1 server_tool_use, 1 web_search_tool_result with 10 URLs, 3 text blocks with 1 citation
- Identical usage block structure (input_tokens, output_tokens, server_tool_use.web_search_requests)
- Per-call cost ~\$0.12 vs ~\$0.20 on 4.7 (~40% cheaper)

Updates:
- 0166 §4 agent list: \"Anthropic Claude Opus 4.7\" → \"Opus 4.6\" with rationale
- 0167 Action 2: pinned to \`claude-opus-4-6\` explicitly; \"do not silently upgrade to 4.7\" note added
- Log entries on both tickets record the decision and the empirical re-verification
- Historical log entries referencing 4.7 are preserved as written (point-in-time record)

## Test plan

- [x] \`tickets/erg validate\` passes on both files
- [x] Diff is text-only inside two \`.erg\` files
- [x] Compose probe on claude-opus-4-6 confirms identical API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)