### PR TITLE
tickets: 0185 + 0186 + 0187 — raid follow-ups (interactive smoke, erg next-id, Qwen adapter)

### DIFF
--- a/tickets/0185-exp2-interactive-smoke.erg
+++ b/tickets/0185-exp2-interactive-smoke.erg
@@ -1,0 +1,181 @@
+%erg 0.1
+Title: Interactive smoke for Experiment 2 — Phase A + B on one agent at a time
+Created: 2026-05-20
+Author: HDMX-coding-agent
+Blocked-by: 0167
+Blocked-by: 0168
+Blocked-by: 0169
+Blocked-by: 0173
+
+--- log ---
+2026-05-20T22:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Experiment 2 (SOTA frontier, umbrella 0166) prevoit ~$140 d'echanges
+LLM repartis sur Phase A (reflexive prompt design) + Phase B (execution
+N=3) + Phase C (cross-evaluation). Avant d'automatiser tout cela via
+0170 (Phase A harness) et de lancer Phase B en batch, on veut faire
+**un smoke interactif end-to-end sur un seul agent**, avec arrets
+PRESS SPACE TO CONTINUE entre chaque echange LLM, pour que l'auteur
+puisse:
+
+1. Inspecter le meta-prompt assemble avant l'envoi (verifier baseline +
+   quality bar + task statement + JSON envelope).
+2. Inspecter la reponse Phase A (designed prompt + settings + rationale)
+   avant de l'utiliser pour Phase B.
+3. Inspecter la requete Phase B (designed prompt + tools + thinking
+   config) avant l'envoi.
+4. Inspecter la reponse Phase B (narrative + table + citations + cost)
+   et decider si Phase B-full (N=3) est justifiee.
+
+Ordre par cost-ascending (smoke Wave-2 baseline):
+
+| Agent | Baseline smoke | Budget Phase A+B |
+|---|---|---|
+| Mistral | $0.025 | ~$11 |
+| Qwen | $0.038 | ~$11 |
+| OpenAI | $0.084 | ~$11 |
+| Anthropic | $0.088 | ~$11 |
+
+Total cap: $44. Aucun envoi sans appui SPACE explicite.
+
+C'est l'application litterale de la regle projet "Test one before
+blasting" (`.claude/rules/workflow.md`) au niveau experiment design,
+pas seulement par-call.
+
+Lien aux tickets connexes:
+- Substitue partiellement 0170 (Phase A harness automatise) — les
+  artefacts produits ici informent le design de 0170. 0170 reste
+  ouvert et automatise apres validation manuelle.
+- Pre-requis a Phase B-0 (1 rep × 4 agents) et Phase B-full (3 reps ×
+  4 agents) de l'umbrella 0166.
+
+## Relevant files
+
+- `experiments/prompts/prompt_complete.txt` — baseline prompt verbatim
+  pour {baseline}
+- `docs/synopsis.md` §2 — quality bar (4 dimensions) verbatim pour
+  {quality_bar}
+- `src/aedist/adapter_mistral.py` — adapter cible #1 (cheapest)
+- `src/aedist/adapter_qwen_dashscope.py` — adapter cible #2
+- `src/aedist/adapter_openai_responses.py` — adapter cible #3
+- `src/aedist/query_anthropic.py` — adapter cible #4
+- `src/aedist/schema.py` — RunRecord pour serialisation des outputs
+- `experiments/outputs/sota_smoke/` — repertoire pour les artefacts
+  (sortir vers `sota_exp2_smoke/` pour distinguer du smoke adapter)
+
+## Actions
+
+1. Creer `experiments/sota/exp2_interactive_smoke.py`:
+   - argparse: `--agent {mistral,qwen,openai,anthropic}` (required),
+     `--output-dir` (defaut `experiments/outputs/sota_exp2_smoke/`),
+     `--no-confirm` (skip SPACE gates pour rerun apres validation
+     interactive prealable), `--budget-cap` (defaut $15 par run).
+   - Helper `wait_for_space(prompt: str)` — affiche le prompt + "PRESS
+     SPACE to continue, or 'q' to abort > ", lit stdin, abort propre
+     si 'q'.
+   - Pipeline par run:
+     a. Assembler le meta-prompt Phase A (baseline + quality bar +
+        task + JSON envelope spec).
+     b. AFFICHER meta-prompt assemble (long → tronquer + sauver
+        version complete a un path affiche).
+     c. SPACE gate.
+     d. Envoyer Phase A via adapter selectionne (sans web_search).
+     e. AFFICHER reponse Phase A (designed_prompt, settings,
+        rationale) + cost effectif.
+     f. SPACE gate.
+     g. Assembler Phase B request a partir du designed_prompt +
+        settings extraits.
+     h. AFFICHER Phase B request (truncated).
+     i. SPACE gate.
+     j. Envoyer Phase B via adapter (avec web_search + thinking selon
+        settings designed).
+     k. AFFICHER reponse Phase B (narrative summary, citations
+        count, table-row count si parseable, cost, wall time).
+     l. SPACE gate.
+     m. Sauvegarder artefact `<agent>_phase_a.json` +
+        `<agent>_phase_b.json` (RunRecord serialise).
+   - Pre-call cap par phase: Phase A $1, Phase B $15. Abort si
+     estime depasse.
+
+2. Documenter le layout d'output dans
+   `experiments/outputs/sota_exp2_smoke/README.md`.
+
+3. Pas de test d'integration automatise (la nature interactive l'exclut).
+   Test unitaire seulement:
+   `tests/test_exp2_interactive_smoke.py` — verifier que
+   `assemble_meta_prompt()` produit un texte non-vide contenant baseline
+   + quality bar; verifier `wait_for_space` retourne sur 'q'.
+
+4. Ordre d'execution recommande:
+   `--agent mistral` (premier — moins cher, validation initiale du
+   meta-prompt et du shape des reponses).
+   Puis Qwen, OpenAI, Anthropic dans cet ordre.
+
+5. Quand les 4 ont passe le smoke, ouvrir une ticket de suite:
+   "Phase B-0 batch (N=1 × 4 agents)" en mode non-interactif via
+   `--no-confirm`, qui prend les prompts deja valides comme baseline.
+
+## Test
+
+`tests/test_exp2_interactive_smoke.py`:
+- `test_assemble_meta_prompt_contains_baseline_and_quality_bar` —
+  appeler l'assembleur, asserter que le texte resultant contient une
+  ancre de `prompt_complete.txt` ("senior energy analyst") et une
+  ancre de la quality-bar synopsis §2 ("Accuracy" ou "Temporality").
+- `test_wait_for_space_aborts_on_q` — patcher stdin avec "q\n",
+  asserter que la fonction leve SystemExit ou retourne False
+  selon la convention choisie.
+
+Aucun test d'integration (sortirait du scope `check-fast`; l'usage
+est interactif par construction).
+
+## Verification
+
+- [ ] `uv run python -m aedist.experiments.exp2_interactive_smoke --agent mistral`
+      affiche le meta-prompt assemble puis attend SPACE.
+- [ ] 'q' avorte proprement (pas d'appel API, exit code 0 ou 1
+      documente).
+- [ ] SPACE envoie a Mistral, recoit la reponse Phase A, affiche le
+      designed_prompt extrait.
+- [ ] SPACE suivant assemble Phase B request avec settings designed,
+      l'affiche.
+- [ ] SPACE final envoie Phase B, affiche la reponse + cost effectif,
+      sauve artefact.
+- [ ] Total cost run < $15.
+- [ ] Repeter avec `--agent qwen`, `--agent openai`, `--agent anthropic`.
+
+## Invariants
+
+- Aucun call API sans appui SPACE explicite (sauf `--no-confirm`).
+- Budget cap par phase enforce pre-call.
+- Artefacts sauvegardes sous schema RunRecord — Phase B-0 batch
+  pourra les replayer/agréger.
+- N'edite aucun adapter source — c'est un consommateur read-only des
+  4 modules adapter.
+
+## Exit criteria
+
+- Script `exp2_interactive_smoke.py` + tests unitaires verts.
+- README documente l'output layout.
+- 4 paires d'artefacts (Phase A + Phase B, 1 par agent) sauvees sous
+  `experiments/outputs/sota_exp2_smoke/`.
+- Validation utilisateur explicite sur chaque echange (oeil humain
+  approuve le meta-prompt, le designed_prompt, et la reponse Phase B
+  pour les 4 agents).
+- Ticket de suite pour Phase B-0 batch ouvert.
+
+## Notes
+
+- L'argument "test one before blasting" est ici applique a deux
+  niveaux: (a) un agent a la fois (vs 4 en parallele), (b) chaque
+  echange LLM est gate par humain (vs pipeline automatise).
+- 0170 reste l'objectif a terme (harness automatise reproductible).
+  Ce ticket produit les premieres execution-traces qui rendent 0170
+  bien specifie.
+- "PRESS SPACE TO CONTINUE" — au sens UNIX, on lira une ligne complete
+  (l'utilisateur tape entree). Si vrai SPACE single-key est demande,
+  utiliser `termios` raw mode + read 1 byte. Defaut: ligne (plus
+  portable, ESC ne casse pas le terminal).

--- a/tickets/0186-erg-next-id-cross-worktree.erg
+++ b/tickets/0186-erg-next-id-cross-worktree.erg
@@ -1,0 +1,136 @@
+%erg 0.1
+Title: erg next-id must scan tickets across all worktrees to avoid ID collisions
+Created: 2026-05-20
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-20T23:35Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`./tickets/erg next-id tickets/` returns the next free ID by scanning
+the **current worktree**'s `tickets/` directory. When other worktrees of
+the same repo have uncommitted/unpushed tickets at higher IDs, those
+slots look free here — and `next-id` hands them out.
+
+Live incident 2026-05-20 in raid-sota-adapters worktree:
+- `erg next-id tickets/` → `0181`.
+- Sibling worktree `agent-abeb2c877ac0b4075` had drafted (not yet
+  committed) tickets 0180-0184.
+- The new ticket was created as 0181 → collision.
+- Manual scan across worktrees + rename to 0185 + amend commit.
+
+Recovery cost was small here (one rename, one amend), but the cost
+scales: any time a raid spawns parallel agents that each create
+tickets, every agent risks the same ID. Pre-commit validator catches
+duplicate IDs only **after** both files are committed to the same
+branch — between worktrees on different branches, both commits are
+valid until the merge.
+
+The skill `tickets-new` says "Always use `erg next-id` — never compute
+or guess the ID manually." That guidance is currently a footgun in
+worktree-heavy workflows.
+
+## Relevant files
+
+- `tickets/tools/go/cmd/next-id` (or equivalent in the `erg` source
+  tree under `tickets/tools/go/`) — the command that needs to broaden
+  its scan.
+- `tickets/erg` — committed binary (Linux x86-64) that gets rebuilt
+  from the Go source.
+- `~/.claude/skills/ticket-new/SKILL.md` (user-level git-erg skill
+  package) — pour ajuster la doc une fois le fix livré.
+- `.claude/rules/tickets.md` — project ticket spec, may want to
+  mention cross-worktree behaviour.
+
+## Actions
+
+1. Extend `erg next-id <dir>` to enumerate ticket IDs across all
+   worktrees of the current repo, not just `<dir>` in the current
+   worktree. The natural source is `git worktree list --porcelain` →
+   for each worktree path, scan `<path>/<dir>` (typically
+   `<path>/tickets/`) for `NNNN-*.erg` files.
+2. Also include the union of ticket IDs visible on **all local branches**
+   (so a previously-committed ticket on an unrelated branch doesn't get
+   recycled). Implementation: `git ls-tree -r --name-only $(git
+   for-each-ref --format='%(refname)' refs/heads/) | grep -oE
+   'tickets/[0-9]{4}-' | sort -u`. Cap at 200ms — bail to current
+   behaviour with a warning if the scan times out.
+3. Optionally include `git ls-remote origin 'refs/heads/t*'` to catch
+   IDs reserved by branch names (e.g. `t0181` on origin without a
+   corresponding ticket file). Off by default; enable with
+   `--include-remote-branches`.
+4. Update `next-id`'s help text + the `ticket-new` skill instructions
+   to mention the cross-worktree guarantee.
+5. Add an integration test (or smoke test in the Go suite) that
+   creates a second worktree, drops a fake ticket, runs `next-id`,
+   asserts the returned ID skips past it.
+
+## Test
+
+`tickets/tools/go/internal/nextid/nextid_test.go` (or wherever the
+existing `next-id` tests live):
+
+```go
+func TestNextID_SkipsIDsInOtherWorktrees(t *testing.T) {
+    repo := setupTempRepo(t)
+    worktreeAdd(t, repo, "wt2", "feature-branch")
+    writeTicket(t, repo+"/wt2/tickets", "0123-other-worktree.erg")
+    got := NextID(repo + "/tickets")
+    if got <= "0123" {
+        t.Fatalf("next-id %s did not skip past 0123 in sibling worktree", got)
+    }
+}
+```
+
+First failing test: drop a `0123-x.erg` file in a sibling worktree's
+`tickets/`, run `next-id` from the main worktree, expect ≥`0124`.
+Today's implementation returns `0001` (or whatever is local-max+1),
+demonstrating the bug.
+
+## Verification
+
+- [ ] `erg next-id` in worktree A returns an ID greater than any
+      ticket present in worktree B's tree.
+- [ ] `erg next-id` in a fresh worktree returns an ID greater than any
+      ticket on any local branch's tip.
+- [ ] Live regression: in this raid scenario, `erg next-id` would
+      have returned `0185` (or higher) rather than `0181`.
+- [ ] Integration test green.
+- [ ] Help text updated.
+
+## Invariants
+
+- Behaviour in a single-worktree repo unchanged.
+- Performance: total `next-id` runtime stays sub-second on a 200-ticket
+  repo with up to 10 worktrees. (Current implementation is O(N tickets);
+  cross-worktree scan adds O(N tickets × M worktrees) — acceptable at
+  these scales.)
+- No new dependencies on shell commands beyond `git`.
+- `--include-remote-branches` opt-in only — default never makes a
+  network call.
+
+## Exit criteria
+
+- `next-id` honours cross-worktree IDs by default.
+- Test covering the cross-worktree case lands green.
+- Rebuilt binary committed at `tickets/erg`.
+- `ticket-new` skill prose updated to drop the "be careful in
+  worktrees" caveat (since the tool now does it).
+- This ticket closes after the patch lands and the local repo's
+  bootstrap binary is refreshed.
+
+## Notes
+
+- This bug is upstream to `git-erg` itself, not specific to this
+  project. If `git-erg` is maintained as a separate repo, the fix
+  lands there and gets pulled in via binary refresh; if it's
+  vendored, fix lives under `tickets/tools/go/`.
+- Adjacent improvement (out of scope, separate ticket if needed):
+  `erg claim <id>` (or similar) to reserve an ID atomically across
+  worktrees via a tiny lockfile — would close the residual race
+  between two simultaneous `next-id` calls in different worktrees.
+- The pre-commit validator catching duplicate IDs **on the same
+  branch** is already correct; this ticket is only about the
+  inter-branch / inter-worktree case.

--- a/tickets/0187-qwen-adapter-followups.erg
+++ b/tickets/0187-qwen-adapter-followups.erg
@@ -1,0 +1,83 @@
+%erg 0.1
+Title: Qwen adapter follow-ups — ADR-7 metrics, cost cap default, dashscope pin
+Created: 2026-05-20
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-20T23:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Three non-blocking findings raised during PR #352 (ticket 0173)
+second-round verify, pre-existing in the WIP commit and inherited
+through the merge. Not regressions, but worth closing.
+
+## Relevant files
+
+- `src/aedist/adapter_qwen_dashscope.py` — parse_response, cost cap default
+- `pyproject.toml` — `dashscope>=1.20` line (no upper pin)
+- `src/aedist/schema.py` — RunRecord.method_params for ADR-7 reference
+
+## Actions
+
+1. **Thread call-site values into method_params.extra** (not literals).
+   `parse_response` currently writes `enable_thinking=True` and
+   `enable_search=True` into `method_params.extra` as hardcoded
+   literals. If a future caller invokes the adapter with either
+   disabled, the record will misreport the actual run conditions
+   (violates ADR-7: "metrics dict is the complete scientific record").
+   Fix: pass the actual call-site values through.
+
+2. **Align cost_cap_usd default with ticket cap.** Adapter default is
+   `cost_cap_usd=0.50`. Ticket 0173 specifies `$10` cap per call (same
+   as sibling adapters 0167/0168/0169). Smoke happens to be ≤$0.50 by
+   the canonical prompt + max_tokens choice, but the cap is a separate
+   guardrail. Raise default to `10.0` or wire it from a config; do
+   NOT silently allow $10 calls under a $0.50 default.
+
+3. **Pin dashscope upper bound.** Currently `dashscope>=1.20` —
+   floor only. Add a sane upper, e.g. `dashscope>=1.20,<2.0` to
+   prevent surprise major-version upgrade.
+
+## Test
+
+`tests/test_adapter_qwen_dashscope.py`:
+- New `test_method_params_extra_reflects_call_site_args` — call
+  `parse_response` on a fixture that was generated with
+  `enable_thinking=False` (i.e. minimal reasoning-tokens), assert
+  `record.method_params.extra["enable_thinking"] == False`.
+  Repeat for `enable_search=False`.
+- New `test_default_cost_cap_matches_ticket_spec` — read the module's
+  `DEFAULT_COST_CAP_USD` (or equivalent), assert `== 10.0`.
+
+## Verification
+
+- [ ] parse_response surfaces actual call-site flags, verified by test.
+- [ ] cost_cap_usd default raised, all sibling adapters checked for
+      the same drift class.
+- [ ] dashscope upper-bound pin landed in pyproject.toml + uv.lock
+      regenerated.
+- [ ] No change in adapter behaviour for existing callers (smoke
+      output regression-free against `qwen_1a3a34a9f1bb.json`).
+
+## Invariants
+
+- Existing smoke artifact `experiments/outputs/sota_smoke/qwen_1a3a34a9f1bb.json`
+  remains a valid regression baseline.
+- No new API calls during this fix (offline-only change).
+
+## Exit criteria
+
+- Three sub-fixes landed, tests green, ruff clean.
+- Sister adapters (0167/0168/0169) audited for the same patterns and
+  fixed in the same PR if applicable (most likely 0168 cost_cap_usd
+  default — check during audit).
+
+## Notes
+
+- Discovered during verify on PR #352 (commit `291f8b3`, fix +
+  re-verify pass). Verify recommended NOT to block merge of #352;
+  this ticket carries the work forward.
+- Audit scope: limit to direct-API adapters under `src/aedist/`
+  (anthropic / openai / mistral / qwen).


### PR DESCRIPTION
Three follow-up tickets surfaced during the Wave 2 SOTA-adapter raid (PRs #350/#351/#352/#353, all merged).

## 0185 — Interactive smoke for Experiment 2 (Phase A + B)
Author-gated end-to-end smoke on one agent at a time, starting with Mistral (cheapest). PRESS-SPACE between each LLM exchange. Test-one-before-blasting applied to the experiment design itself, before the automated Phase A harness in 0170.

## 0186 — `erg next-id` must scan across worktrees
Live regression in this session: `erg next-id` returned 0181 while a sibling worktree had drafts up to 0184 uncommitted. Manual rename to 0185 recovered. Bug is in `erg next-id` — proposed fix walks `git worktree list --porcelain` + union of ticket IDs on all local branch tips. Includes a Go integration test demonstrating the regression in current code.

## 0187 — Qwen adapter follow-ups
Three non-blocking findings raised during PR #352 round-2 verify: (1) `parse_response` hardcodes `enable_thinking=True`/`enable_search=True` as literals (ADR-7 violation), (2) `cost_cap_usd=0.50` default vs ticket-stated $10 cap, (3) `dashscope` without upper version pin. Audit sister adapters for same patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)