### PR TITLE
tickets: 0188/0189/0190 — raid workflow improvements + unblock 0185

### DIFF
--- a/tickets/0185-exp2-interactive-smoke.erg
+++ b/tickets/0185-exp2-interactive-smoke.erg
@@ -2,13 +2,10 @@
 Title: Interactive smoke for Experiment 2 — Phase A + B on one agent at a time
 Created: 2026-05-20
 Author: HDMX-coding-agent
-Blocked-by: 0167
-Blocked-by: 0168
-Blocked-by: 0169
-Blocked-by: 0173
 
 --- log ---
 2026-05-20T22:30Z HDMX-coding-agent created
+2026-05-21T00:20Z HDMX-coding-agent note unblock — all 4 adapter blockers (0167/0168/0169/0173) closed via Wave 2 merges 2026-05-20
 
 --- body ---
 ## Context

--- a/tickets/0188-raid-coordination-pr-step.erg
+++ b/tickets/0188-raid-coordination-pr-step.erg
@@ -1,0 +1,84 @@
+%erg 0.1
+Title: Add coordination-PR step to raid skill — pre-land test allowlists for the wave
+Created: 2026-05-21
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-21T00:15Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Lesson from Wave 2 SOTA-adapter raid (2026-05-20): when 4 parallel
+PRs each add to the same cross-cutting test allowlist (e.g.
+`VALID_ROUTES` in `tests/test_models.py`, `NO_OLLAMA_DISPATCH` in
+`tests/test_ollama_native_api.py`), the verify-gate fixes each
+addition individually — but the **rebase onto sibling-merged main
+drops the PR's own addition**. Result: 3 of 4 merges required a
+"resurrection" agent (+~5 min each, +1 force-push, +1 CI re-run).
+
+The wave-level integration review caught the class but only post-fact.
+A pre-Wave coordination step would prevent the cascade entirely.
+
+Captured as memory `feedback_rebase_drop_cascade.md`.
+
+## Relevant files
+
+- `~/.claude/skills/raid/SKILL.md` (user-level git-erg skill) — needs
+  a Phase 5.0 step inserted before Phase 5 (execute).
+- `tickets/0166-raid-plans.md` (or future raid-plan templates) — show
+  the coordination-PR pattern as an example.
+
+## Actions
+
+1. Add a "Phase 5.0 — Land coordination PR" step to the raid skill:
+   - Identify cross-cutting registries each wave's PRs will touch
+     (test allowlists, dispatch tables, models.yaml structure
+     conventions).
+   - Open a tiny PR that adds ALL wave route entries / dispatch keys
+     / etc. to those registries at once.
+   - Merge it BEFORE any Wave-N PR is opened.
+   - Each Wave-N PR then makes a pure additive change (new file,
+     new models.yaml entry referencing pre-registered route) without
+     mutating the cross-cutting set.
+2. Heuristic for when to insert this step: 3+ PRs in the wave touch
+   the same single file containing a hash-set / dict / dispatch
+   registry. If the count is ≤2, skip — manual rebase is cheaper than
+   the coordination overhead.
+3. Update the raid skill's "Phase 4 — Verify feasibility" step to
+   detect cross-cutting registries proactively and recommend the
+   coordination PR.
+4. Add an example to the skill prose pointing to the Wave 2 incident
+   so future maintainers see the failure mode.
+
+## Test
+
+`~/.claude/skills/raid/SKILL.md` should mention "coordination PR" and
+"cross-cutting registry" at least once. This is a doc change; no
+automated test, but the change is reviewed by user before landing.
+
+## Verification
+
+- [ ] Skill prose includes the new Phase 5.0 step.
+- [ ] Heuristic for when-to-insert is explicit.
+- [ ] Wave 2 example referenced.
+- [ ] Next raid that touches a shared registry uses the pattern.
+
+## Invariants
+
+- Single-PR or 2-PR waves unchanged — no overhead added.
+- Coordination PR itself follows normal verify/merge gates.
+
+## Exit criteria
+
+- Skill update merged.
+- One observation cycle after the next eligible raid: confirm
+  coordination PR pattern fired and prevented the cascade.
+
+## Notes
+
+- This is a user-level skill change (`~/.claude/skills/raid/`),
+  not project-level. PR target is the git-erg skills repo (if one
+  exists) or a manual update to the user's `~/.claude/skills/raid/`.
+- Memory `feedback_rebase_drop_cascade.md` is the source of truth for
+  why this matters until the skill is updated.

--- a/tickets/0189-raid-agent-salvage-step.erg
+++ b/tickets/0189-raid-agent-salvage-step.erg
@@ -1,0 +1,82 @@
+%erg 0.1
+Title: Add killed-agent salvage step to raid skill — commit WIP before worktree remove
+Created: 2026-05-21
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-21T00:16Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Lesson from Wave 2 SOTA-adapter raid (2026-05-20): I killed 4 mid-
+execution raid subagents (TaskStop after the user asked to inspect
+prompts). Each kill left an orphan worktree with locked branch +
+uncommitted WIP (adapter file + tests + fixture). Without salvage,
+`git worktree remove --force` would have lost ~1500 lines of WIP
+across the 4 orphans.
+
+Recovered via this pattern:
+1. `cd` into orphan worktree → `git add -A && git commit -m "WIP: salvaged from interrupted raid"`.
+2. `git push -u origin <branch>` (WIP survives even if worktree dies).
+3. `git worktree unlock <path> && git worktree remove <path>` — branch survives.
+4. Relaunch finisher subagent on the existing branch (`git switch <branch>`, NOT `-c`).
+
+Cost: ~3 min × 4 = 12 min. Without the pattern: rewrite from scratch.
+
+Captured as memory `feedback_killed_agent_salvage.md`.
+
+## Relevant files
+
+- `~/.claude/skills/raid/SKILL.md` (user-level git-erg skill) — add
+  the salvage pattern to the "Circuit breakers" section + a new
+  "Kill / restart" subsection.
+
+## Actions
+
+1. Add to raid skill prose:
+   - When TaskStop is used on a mid-execution raid subagent, the
+     parent MUST run the salvage pattern before any worktree remove:
+     `git add -A && git commit -m "WIP: salvaged from interrupted raid"`
+     in the orphan worktree, push the branch, then `worktree remove`.
+   - Finisher subagent prompt template that knows about WIP commit on
+     the branch (so it inspects via `git show --stat HEAD` first
+     rather than starting from scratch).
+2. Document the failure mode: `git worktree remove --force` on an
+   orphan with uncommitted WIP silently destroys files. The user
+   gets no warning.
+3. Add a check to the "Circuit breakers" section: "Agent timeout"
+   trigger should explicitly include "salvage WIP from killed agent's
+   worktree" as the FIRST step of restart, not the second.
+
+## Test
+
+Skill prose includes "salvage" + "WIP" + "git add -A" in the
+circuit-breakers section. Doc change, reviewed by user.
+
+## Verification
+
+- [ ] Raid skill updated with explicit salvage steps.
+- [ ] Finisher subagent prompt template included.
+- [ ] Next raid that needs to TaskStop a subagent uses the pattern
+      without re-discovering it manually.
+
+## Invariants
+
+- Default raid behaviour unchanged for runs that don't TaskStop
+  anything.
+- Salvage pattern adds 3-5 min per killed agent — much cheaper than
+  rewrite.
+
+## Exit criteria
+
+- Skill update merged.
+- Memory `feedback_killed_agent_salvage.md` referenced from skill
+  prose so future agents see the rationale.
+
+## Notes
+
+- Related to [[killed-agent-salvage]] memory and to ticket 0188
+  (raid coordination PR step) — both surfaced from the same Wave 2
+  incident.
+- User-level skill change (`~/.claude/skills/raid/`).

--- a/tickets/0190-worktree-gc-after-raid.erg
+++ b/tickets/0190-worktree-gc-after-raid.erg
@@ -1,0 +1,94 @@
+%erg 0.1
+Title: Worktree GC pass after raid — prune agent-* worktrees with merged+gone branches
+Created: 2026-05-21
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-21T00:17Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+After Wave 2 SOTA-adapter raid (2026-05-20), `git worktree list`
+showed 23 worktrees. Most were created by `Agent(isolation: "worktree")`
+during the raid: 4 Wave-2 implementers, 4 finishers (post-salvage),
+4 verifiers, 4 merge agents, 1 integration agent, 1 fix-#352 agent,
+1 STATE-update branch, plus 4 from other concurrent raids.
+
+The agent-* worktrees whose branches are now `gone` (squash-merged
+via `deleteBranchOnMerge: true`) accumulate indefinitely. Each one
+holds disk space (~repo size) and clutters `git worktree list`.
+
+The global git rule says:
+  "Skills must not manually delete worktrees created via
+   Agent(isolation:'worktree') — use `git worktree prune` after
+   branch deletion, never `rm -rf`."
+
+But `git worktree prune` only removes worktrees whose **directory**
+is gone. The post-raid orphans have intact directories with merged-
+then-gone branches checked out. They need explicit
+`git worktree remove`.
+
+## Relevant files
+
+- `~/.claude/skills/celebrate/SKILL.md` — add GC step (after step
+  9 "Exit worktree").
+- `~/.claude/skills/housekeeping/SKILL.md` — alternative or
+  complementary location for the recurring GC.
+
+## Actions
+
+1. Add a "Step 9.5 — GC stale agent worktrees" to the celebrate skill:
+   - List all worktrees under `.claude/worktrees/agent-*`.
+   - For each, inspect the branch: if it's gone from origin (squash-
+     merged) AND the worktree has no uncommitted changes, remove it
+     via `git worktree unlock` (if locked) + `git worktree remove`.
+   - Report what was cleaned. Skip silently if nothing to GC.
+2. Alternative: add the GC pass to `~/.claude/skills/housekeeping/`
+   instead of celebrate, so it runs proactively at any housekeeping
+   sweep, not only at celebrate.
+3. Safety rules:
+   - NEVER remove a worktree with uncommitted changes (even if branch
+     is gone — could be user WIP).
+   - NEVER `rm -rf` — always go through `git worktree`.
+   - Locked worktrees: unlock first, then remove. If unlock fails
+     (lock held by another process), skip + report.
+4. Stretch: also detect `t<N>` branches that are gone+orphaned (no
+   ticket file, no worktree referencing them) and offer to delete
+   them locally.
+
+## Test
+
+Manual: after a 4-PR raid, run the new step and verify the agent-*
+worktree count drops to 0 (or only those with uncommitted WIP remain).
+
+Automated: a unit test could mock `git worktree list --porcelain`
+output and verify the skill's filter logic, but probably overkill for
+a doc-and-bash skill.
+
+## Verification
+
+- [ ] Celebrate (or housekeeping) skill includes the GC step.
+- [ ] Safety rules explicit in skill prose.
+- [ ] Next raid's wrap-up reduces post-raid worktree count.
+
+## Invariants
+
+- Never destroys uncommitted work.
+- Never touches worktrees whose branch is still active on origin.
+- Idempotent — running twice removes nothing the second time.
+
+## Exit criteria
+
+- Skill update merged (celebrate or housekeeping, your call — both
+  acceptable).
+- One observation cycle: next post-raid celebrate runs the GC, count
+  of `agent-*` worktrees drops.
+
+## Notes
+
+- Related to memory `feedback_killed_agent_salvage.md` (salvage
+  predates GC — never GC something that has uncommitted work).
+- The user-level git rule about not manually deleting agent
+  worktrees is now sharpened: use `git worktree remove` (NOT `rm
+  -rf`), but DO use it for stale agent worktrees post-merge.


### PR DESCRIPTION
Three workflow-improvement tickets surfaced during /celebrate of the Wave 2 SOTA-adapter raid (PRs #350/#351/#352/#353, all merged 2026-05-20). Plus an unblock on 0185 since its 4 adapter blockers are all closed.

## 0188 — Coordination-PR step for raid skill
Pre-land cross-cutting test allowlists (e.g. `VALID_ROUTES`, `NO_OLLAMA_DISPATCH`) for the wave before any adapter PR opens. Prevents the rebase-drop cascade that hit 3 of 4 Wave 2 merges.

## 0189 — Killed-agent salvage step for raid skill
When TaskStop kills a mid-execution raid subagent, commit WIP (`git add -A && git commit -m "WIP: salvaged"`) and push the branch BEFORE `worktree remove`. Prevents losing in-flight work (~1500 lines saved during Wave 2).

## 0190 — Worktree GC after raid
Add a step to celebrate (or housekeeping) that prunes `agent-*` worktrees whose branches are merged+gone. Wave 2 left 23 worktrees behind. Safety: never destroy uncommitted work, always go through `git worktree remove` (not shell-level recursive deletion).

## Unblock 0185
`Blocked-by: 0167/0168/0169/0173` all now closed via Wave 2 merges. 0185 is unblocked.

Generated with Claude Code
