### PR TITLE
tickets: dedup 0179/0180 — renumber open tickets to 0191/0192

### DIFF
--- a/tests/test_modules_match_prompt_complete.py
+++ b/tests/test_modules_match_prompt_complete.py
@@ -33,7 +33,7 @@ def _content_lines(text: str) -> set[str]:
     return lines
 
 
-@pytest.mark.skip(reason="prompt_complete.txt drift from 4dc99e5; see ticket 0179")
+@pytest.mark.skip(reason="prompt_complete.txt drift from 4dc99e5; see ticket 0191")
 @pytest.mark.adherence
 def test_modules_cover_prompt_complete():
     """Assembled composite covers every content line of prompt_complete.txt."""

--- a/tickets/0191-refresh-prompt-complete-and-reenable-modules-test.erg
+++ b/tickets/0191-refresh-prompt-complete-and-reenable-modules-test.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-20T00:00Z claude created
+2026-05-21T00:00Z claude note renumbered from 0179 to 0191 to resolve ID collision with closed 0179 (makefile-ablation-extract, PR #342); test_modules_match_prompt_complete.py skip-reason ticket ref updated to match
 
 --- body ---
 ## Context

--- a/tickets/0192-rename-ablation-to-exp1.erg
+++ b/tickets/0192-rename-ablation-to-exp1.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-20T22:10Z claude created
+2026-05-21T00:00Z claude note renumbered from 0180 to 0192 to resolve ID collision with closed 0180 (sota-adapter-base-scaffold, PR #337)
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
- 0179: closed `makefile-ablation-extract` (PR #342) kept its ID; open `refresh-prompt-complete-...` → **0191**
- 0180: closed `sota-adapter-base-scaffold` (PR #337) kept its ID; open `rename-ablation-to-exp1` → **0192**
- `tests/test_modules_match_prompt_complete.py` skip-reason updated `ticket 0179` → `ticket 0191`
- Code refs to "ticket 0180" in `src/aedist/adapter_base.py` and `tests/test_adapter_base.py` unchanged (they correctly point at the closed sota-scaffold)
- No `Blocked-by:` refs to 0179 or 0180 anywhere in the corpus — no further cleanup

## Test plan
- [x] `tickets/erg check tickets` → PASS (182 tickets)
- [ ] `make check-fast` (trivial — only changes are file renames + one decorator string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)