### PR TITLE
feat(smoke): --promote-as-production flag (salvaged from t0181)

### DIFF
--- a/src/aedist/smoke.py
+++ b/src/aedist/smoke.py
@@ -98,10 +98,22 @@ def smoke_one(
     api_kwargs: dict,
     call_number: int,
     output_dir: Path,
+    *,
+    promote_as_production: bool = False,
 ) -> dict:
-    """Run a single smoke call, save the full record, return a summary dict."""
+    """Run a single smoke call, save the full record, return a summary dict.
+
+    When *promote_as_production* is True, the saved file follows the worker
+    naming convention ({slug}-run{N}.json) and omits the ``smoke: True``
+    marker, so the record is indistinguishable from one produced by
+    ``aedist.worker``. Use this only when the smoke call is intentionally
+    serving as one of the configured ``repeat`` reps for a production
+    sweep (e.g. to skip a redundant job-board drain for a model that has
+    already passed a separate smoke check).
+    """
     model_id = model_entry["name"]
-    log.info("Calling %s (smoke %d) ...", model_id, call_number)
+    mode = "production" if promote_as_production else "smoke"
+    log.info("Calling %s (%s %d) ...", model_id, mode, call_number)
     t0 = time.monotonic()
     result = query_single_turn(client, model_id, messages, **api_kwargs)
     wall = round(time.monotonic() - t0, 3)
@@ -113,7 +125,6 @@ def smoke_one(
         "model": model_id,
         "date": date.today().isoformat(),
         "run": call_number,
-        "smoke": True,  # explicit marker so consumers can filter out
         "response": result["content"],  # FULL response, not just a tail
         "finish_reason": result["finish_reason"],
         "usage": usage,
@@ -128,10 +139,14 @@ def smoke_one(
         if messages and messages[0].get("role") == "system"
         else None,
     }
+    if not promote_as_production:
+        # explicit marker so consumers can filter out; absent in production mode
+        record["smoke"] = True
 
     slug = model_id.split("/")[-1].replace(":", "-")
     output_dir.mkdir(parents=True, exist_ok=True)
-    filepath = output_dir / f"{slug}-smoke{call_number}.json"
+    suffix = "run" if promote_as_production else "smoke"
+    filepath = output_dir / f"{slug}-{suffix}{call_number}.json"
     filepath.write_text(json.dumps(record, indent=2))
     log.info("Saved %s", filepath)
 
@@ -214,6 +229,15 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Optional path to write a JSON summary (one row per call). Default: stdout only.",
     )
+    parser.add_argument(
+        "--promote-as-production",
+        action="store_true",
+        help="Save records under the worker naming convention "
+        "({slug}-run{N}.json) and omit the 'smoke: True' marker, so the "
+        "files are indistinguishable from production worker output. Use "
+        "only when the smoke calls are intentionally serving as production "
+        "reps for a sweep (e.g. to skip a redundant job-board drain).",
+    )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -233,13 +257,22 @@ def main(argv: list[str] | None = None) -> int:
     log.info("model: %s", args.model)
     log.info("calls: %d", args.calls)
     log.info("output: %s", args.output)
+    log.info("mode: %s", "production" if args.promote_as_production else "smoke")
     log.info("api_kwargs: %s", api_kwargs)
 
     client = make_client()
     summaries = []
     for n in range(1, args.calls + 1):
         try:
-            summary = smoke_one(client, model_entry, messages, api_kwargs, n, args.output)
+            summary = smoke_one(
+                client,
+                model_entry,
+                messages,
+                api_kwargs,
+                n,
+                args.output,
+                promote_as_production=args.promote_as_production,
+            )
             summaries.append(summary)
         except Exception as exc:  # surfaces auth, rate-limit, timeout, etc.
             log.error("Call %d failed: %s: %s", n, type(exc).__name__, exc)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -54,6 +54,26 @@ def test_record_saves_full_response_not_tail():
 def test_smoke_marker_in_record():
     """Smoke records carry an explicit smoke=True marker so a downstream
     rebuild-measurements run can filter them out and not treat them as
-    production reps."""
+    production reps. The marker is omitted only when
+    --promote-as-production is set."""
     src = inspect.getsource(smoke.smoke_one)
-    assert '"smoke": True' in src
+    assert 'record["smoke"] = True' in src
+
+
+def test_promote_as_production_flag_present():
+    """The --promote-as-production flag must be wired through main() so a
+    smoke run can be intentionally claimed as a production rep."""
+    src = inspect.getsource(smoke.main)
+    assert "--promote-as-production" in src
+    assert "promote_as_production=args.promote_as_production" in src
+
+
+def test_promote_changes_filename_and_strips_marker():
+    """smoke_one's promote_as_production branch must name files {slug}-run{N}.json
+    (matching the worker convention) and must NOT include the smoke marker
+    when in production mode."""
+    src = inspect.getsource(smoke.smoke_one)
+    # Conditional suffix
+    assert '"run" if promote_as_production' in src
+    # Marker is gated behind the not-promote branch
+    assert "if not promote_as_production" in src

--- a/tickets/0193-smoke-promote-as-production.erg
+++ b/tickets/0193-smoke-promote-as-production.erg
@@ -1,0 +1,52 @@
+%erg 0.1
+Title: smoke: add --promote-as-production flag to reuse smoke calls as sweep reps
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T00:30Z claude created — salvaged from locked t0181 worktree (agent-abeb2c877); no other worktree carries this work
+
+--- body ---
+## Context
+
+`src/aedist/smoke.py` writes one-off probe records under
+`{slug}-smoke{N}.json` and stamps each record with `"smoke": True` so a
+downstream `rebuild-measurements` pass can filter them out. That's the
+right default — smoke runs should never be confused with production reps.
+
+But it forces a redundant job-board drain in one practical case: a model
+that passes its smoke check (e.g. 5 calls all `finish=stop`, cost within
+cap, structured output well-formed) still needs the worker to redo those
+same 5 calls to count as production reps. For the journal lineup, this
+doubles the cost of every model that needs a pre-sweep smoke gate.
+
+Adds an opt-in `--promote-as-production` flag that:
+
+1. Saves files under `{slug}-run{N}.json` (matches the worker convention)
+2. Omits the `"smoke": True` marker, so the records are
+   indistinguishable from worker output
+3. Logs `mode: production` so the run is unambiguous in logs
+
+Default behaviour is unchanged — the flag is opt-in and the smoke marker
+remains present unless `--promote-as-production` is set.
+
+## Provenance
+
+The patch existed only as uncommitted changes in the locked salvage
+worktree `agent-abeb2c877ac0b4075` (branch `t0181`). t0181 itself is
+closed and squash-merged via PR #349 + #360 + #362; this feature was
+not part of any of those merges. Searched all 17 active worktrees:
+no other copy. This ticket rescues the patch onto a fresh branch.
+
+## Exit criteria
+
+- [x] `--promote-as-production` CLI flag wired through `main()` into
+      `smoke_one()`
+- [x] When flag set: file naming follows `{slug}-run{N}.json`, `"smoke"`
+      marker omitted
+- [x] When flag unset: existing behaviour unchanged (`{slug}-smoke{N}.json`
+      + `"smoke": True`)
+- [x] Three new unit tests in `tests/test_smoke.py` verify wiring,
+      filename, and marker semantics
+- [x] `uv run ruff check` clean
+- [x] `uv run pytest tests/test_smoke.py` green (7/7)


### PR DESCRIPTION
## Summary

- Adds `--promote-as-production` to `src/aedist/smoke.py` — saves records under `{slug}-run{N}.json` and omits the `smoke: True` marker so a smoke run can stand in for its production reps.
- Default behaviour unchanged (`{slug}-smoke{N}.json` + marker).
- Skips a redundant job-board drain when a model already passed smoke.

## Provenance

This patch existed only as uncommitted changes in the locked salvage worktree `agent-abeb2c877ac0b4075` (branch `t0181`). t0181 itself is closed and squash-merged via PR #349 + #360 + #362; this feature was *not* part of any of those merges. A sweep of all 17 active worktrees confirmed no other copy existed. New branch off current `origin/main`.

## Test plan

- [x] `uv run ruff check src/aedist/smoke.py tests/test_smoke.py` — All checks passed
- [x] `uv run pytest tests/test_smoke.py -q` — 7/7 green
- [ ] CI green
- [ ] Manual smoke with `--promote-as-production` writes a `{slug}-run1.json` without the `smoke` key (deferred — author-gated)

**Ticket:** tickets/0193-smoke-promote-as-production.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)