### PR TITLE
tickets review: dedup cleanup (0138 exit criteria, 0143)

### DIFF
--- a/tickets/0138-no-think-confound-audit.erg
+++ b/tickets/0138-no-think-confound-audit.erg
@@ -7,6 +7,7 @@ Blocked-by: 0139
 --- log ---
 2026-04-30T10:00Z claude created
 2026-04-30T11:00Z claude note expanded scope: seed/provider_order silent-drop bug discovered; max_tokens and num_ctx added as confounds; title updated
+2026-05-21T07:00Z claude note dedup with 0139 — dropped schema/wiring bullets from Exit criteria; the fix lives in 0139 (already Blocked-by)
 
 --- body ---
 
@@ -170,11 +171,9 @@ c. **Summary tables**: add a column or footnote marking which runs used
 
 ## Exit criteria
 
-- `seed`, `provider_order`, `max_tokens`, `num_ctx`, `web_search` (effective)
-  declared in `JobSpec` with sensible defaults.
-- `JobSpec.model_config` has `extra='forbid'`.
-- All five parameters written to raw JSON output and backfilled into
-  `RunRecord.method_params.extra` by `evaluate.py`.
+- Schema + wiring fix (`seed`, `provider_order`, `max_tokens`, `num_ctx`,
+  `web_search` declared in `JobSpec`, `extra='forbid'`, raw-JSON write +
+  `RunRecord` backfill) tracked in 0139 — not duplicated here.
 - Every existing sweep classified A/B/C/D for `no_think` in the table above,
   reviewed by user.
 - Redo decisions for seed-uncontrolled MoE sweeps documented here.

--- a/tickets/0143-ablation-rerun-with-verbatim-modules.erg
+++ b/tickets/0143-ablation-rerun-with-verbatim-modules.erg
@@ -2,10 +2,12 @@
 Title: Re-run ablation Phase 1 + Phase 2 with verbatim-from-complete modules
 Created: 2026-04-30
 Author: claude
+Closed: superseded by 0174 (Exp 1 baseline rerun) + framing change in 0192 (no ablation in three-experiment framing); Phase 2 ablation rerun not planned
 
 --- log ---
 2026-04-30T13:26Z claude created — gated on 0142 module rewrite
 
+2026-05-21T06:51Z HDMX-coding-agent closed — superseded by 0174 (Exp 1 baseline rerun) + framing change in 0192 (no ablation in three-experiment framing); Phase 2 ablation rerun not planned
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Cleanup pass after a duplicate-ticket review of the open `tickets/` queue.

- **0138** (`no-think-confound-audit`): drop the three schema/wiring bullets from Exit criteria — they duplicated 0139's scope, which 0138 already declared as `Blocked-by`. 0138 now closes on the audit + sweep classification + redo policy alone.
- **0143** (`ablation-rerun-with-verbatim-modules`): close — superseded by 0174 (Exp 1 baseline rerun) and the framing change in 0192 ("there is no ablation" under the three-experiment framing). Phase 2 ablation rerun is not planned.

(0149 was also flagged during the review but PR #364 closed it on main during this session — the duplicate commit was dropped during rebase.)

## Test plan

- [x] `ticket-close-impl` validator passed on 0143
- [x] 0138 / 0139 split: 0138 still `Blocked-by: 0139`; schema bullets removed; audit/policy bullets retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)