### PR TITLE
ticket(0191): regenerate prompt_complete.txt and re-enable adherence test

### DIFF
--- a/experiments/prompts/prompt_complete.txt
+++ b/experiments/prompts/prompt_complete.txt
@@ -4,7 +4,7 @@ You are a senior energy analyst preparing a comprehensive technical inventory of
 
 ## Goal
 
-Produce a complete, primary-sourced reference inventory of Vietnam's thermal power plants (>30MW) structured as follows:
+Produce a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30MWe) structured as follows:
 
 ## Sector Overview
 
@@ -15,6 +15,13 @@ Provide introductory context on Vietnam's thermal power sector covering:
 - Key institutional actors: Generation-Transmission-Distribution companies, Energy and Mining companies, Local authorities, Ministerial authorities, other stakeholders... Position, influence, relationships.
 - Current challenges: energy trilemma, international markets...
 
+## Per-plant discussion
+
+Provide a sourced narrative for each plant (or plant complex) covering:
+- Development history and timeline (original plan, actual progress)
+- Notable issues: delays, financing changes, ownership transfers, legal issues, controversies, technology changes
+- Current status confidence: HIGH (verified by government decision or company annual report), MEDIUM (confirmed by multiple news sources), LOW (only found in older plans, status uncertain)
+
 ## Structured power plants table
 
 Tabulate for every thermal power plant in Vietnam:
@@ -23,29 +30,14 @@ Tabulate for every thermal power plant in Vietnam:
 
 Where:
 - Fuel: Coal / Domestic gas / Imported LNG
-- Technology: Subcritical / Supercritical / USC / CCGT / OCGT / CFB
+- Technology (coal): Subcritical / Supercritical / USC
+- Technology (gas): CCGT / OCGT
 - Status: Approved / Planned / Operational / Under construction / Suspended / Cancelled / Retired
-- COD: Actual commercial operation date or expected date
-- Sources: primary source references (specify where in the document)
+- Total MWe: Include units > 30MWe.
+- COD: Actual or expected commercial operation date
+- Sources: specify where in the document, include URL
 
 Output format: Markdown.
-
-## Per-plant discussion
-
-Provide a sourced narrative for each plant (or plant complex) covering:
-- Development history and timeline (original plan, actual progress)
-- Notable issues: delays, financing changes, ownership transfers, legal issues, controversies, technology changes
-- Current status confidence: HIGH (verified by government decision or company annual report), MEDIUM (confirmed by multiple news sources), LOW (only found in older plans, status uncertain)
-
-## Statistical Summary Tables
-
-Produce these cross-tabulations from your inventory:
-a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operational/Under construction/Approved/Planned columns), with row and column totals
-b) **Top provinces**: The 15 provinces with highest total thermal capacity (all statuses combined), showing breakdown by fuel
-c) **Timeline of additions**: Capacity entering service by period — pre-2005, 2005–2010, 2011–2015, 2016–2020, 2021–2025, 2026–2030, post-2030 — by fuel type
-d) **Data quality summary**: Count of plants by confidence level (High/Medium/Low) and fuel type
-
-Reconcile results with reference documents you may have.
 
 ## Annotated Bibliography
 
@@ -58,6 +50,16 @@ For each source provide:
 - URL if available online (do NOT fabricate URLs — if you are unsure of the exact URL, say "URL not verified")
 - For non English-language sources: original title in original language, then English translation in brackets
 - Summary annotation: what specific information was drawn from this source
+
+## Statistical Summary Tables
+
+Produce these cross-tabulations from your inventory:
+a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operational/Under construction/Approved/Planned columns), with row and column totals
+b) **Top provinces**: The 15 provinces with highest total thermal capacity (all statuses combined), showing breakdown by fuel
+c) **Timeline of additions**: Capacity entering service by period — pre-2005, 2005–2010, 2011–2015, 2016–2020, 2021–2025, 2026–2030, post-2030 — by fuel type
+d) **Data quality summary**: Count of plants by confidence level (High/Medium/Low) and fuel type
+
+Reconcile results with reference documents you may have.
 
 ## Condition materiality
 

--- a/tests/test_modules_match_prompt_complete.py
+++ b/tests/test_modules_match_prompt_complete.py
@@ -5,11 +5,9 @@ assembled composite, and vice versa.  Headers and blank lines are stripped
 for comparison since assembly joins modules with \\n\\n (which may differ
 from the original whitespace).
 
-NOTE (ticket 0175): the post-rename modules drifted from prompt_complete.txt
-(content edits in 5_table.txt, 2_goal.txt that were not back-propagated). The
-test is currently skipped pending a refresh of prompt_complete.txt to match
-the new modules. The invariant is still meaningful as a regression guard
-once the two sides are reconciled.
+Reconciled in ticket 0191: prompt_complete.txt was regenerated from the
+post-rename modules via ``assemble_prompt`` so this adherence test is
+active again as the regression guard against future module-rename drift.
 """
 
 import re
@@ -33,7 +31,6 @@ def _content_lines(text: str) -> set[str]:
     return lines
 
 
-@pytest.mark.skip(reason="prompt_complete.txt drift from 4dc99e5; see ticket 0191")
 @pytest.mark.adherence
 def test_modules_cover_prompt_complete():
     """Assembled composite covers every content line of prompt_complete.txt."""


### PR DESCRIPTION
## Summary

- Regenerated `experiments/prompts/prompt_complete.txt` from the post-rename modules via `aedist.harness.assemble_prompt`, with the canonical optional set from `sweep_ablation_p1_direct_composite` (1_persona, 3_overview, 4_narratives, 6_bibliography, A_Statistics, B_Temporality, C_Uncertainty, D_Completeness). ALWAYS_MODULES (`2_goal`, `5_table`) are auto-injected by `assemble_prompt`.
- Removed `@pytest.mark.skip` from `tests/test_modules_match_prompt_complete.py`; kept `@pytest.mark.adherence`. Refreshed the file docstring to reflect the reconciled state.

The drift was introduced by commit 4dc99e5 (modules rename) and PR #334 marked the failing test skipped while the harness rewrite landed. With the composite regenerated the test is the regression guard against future module-rename drift again.

## Test plan

- [x] `uv run pytest tests/test_modules_match_prompt_complete.py -v` → PASSED (not skipped)
- [x] `uv run pytest -q` → 1255 passed, 1 skipped, 1 xfailed (one fewer skip than before)
- [x] `uv run ruff check .` → clean
- [x] `make check-fast` → exit 0

**Ticket:** tickets/0191-refresh-prompt-complete-and-reenable-modules-test.erg

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>