### PR TITLE
fix(qwen-adapter): thread call-site flags, align cost cap, pin dashscope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.40",
-    "dashscope>=1.20",
+    "dashscope>=1.20,<2.0",
     "pydantic>=2.0",
     "rapidfuzz>=3.0",
     "pandas>=2.0",

--- a/src/aedist/adapter_qwen_dashscope.py
+++ b/src/aedist/adapter_qwen_dashscope.py
@@ -62,6 +62,12 @@ DEFAULT_PRICE_PER_MTOK_OUT = 6.0
 DEFAULT_PRICE_PER_MTOK_REASONING = 6.0
 DEFAULT_PRICE_PER_WEB_SEARCH_CALL_USD = 0.010
 
+# Hard cap per call — ticket 0173 / 0187 alignment with sibling adapters
+# (adapter_openai_responses.DEFAULT_COST_CAP_USD, adapter_mistral.run cap_usd).
+# Previously 0.50 (drift): smoke happens to stay under that, but the cap is a
+# guardrail separate from the canonical smoke prompt/max_tokens choice.
+DEFAULT_COST_CAP_USD = 10.0
+
 
 def build_request(
     prompt: str,
@@ -143,6 +149,8 @@ def parse_response(
     prompt: str | None = None,
     max_tokens: int | None = None,
     wall_s: float | None = None,
+    enable_thinking: bool = True,
+    enable_search: bool = True,
 ) -> RunRecord:
     """Convert a DashScope response into a canonical ``RunRecord``.
 
@@ -236,8 +244,8 @@ def parse_response(
             model=meta.get("model_id", DEFAULT_MODEL),
             max_tokens=max_tokens,
             extra={
-                "enable_thinking": True,
-                "enable_search": True,
+                "enable_thinking": enable_thinking,
+                "enable_search": enable_search,
                 "endpoint": meta.get("base_url", DEFAULT_BASE_URL),
                 "prompt_preview": (prompt or "")[:200] if prompt else None,
             },
@@ -302,7 +310,7 @@ def run(
     enable_thinking: bool = True,
     enable_search: bool = True,
     model_meta: dict | None = None,
-    cost_cap_usd: float = 0.50,
+    cost_cap_usd: float = DEFAULT_COST_CAP_USD,
     base_url: str = DEFAULT_BASE_URL,
 ) -> RunRecord:
     """Execute one DashScope call (or print the dry-run payload)."""
@@ -350,4 +358,6 @@ def run(
         prompt=prompt,
         max_tokens=max_tokens,
         wall_s=wall_s,
+        enable_thinking=enable_thinking,
+        enable_search=enable_search,
     )

--- a/tests/test_adapter_qwen_dashscope.py
+++ b/tests/test_adapter_qwen_dashscope.py
@@ -19,6 +19,7 @@ import pytest
 
 from aedist.adapter_qwen_dashscope import (
     AGENT_FAMILY,
+    DEFAULT_COST_CAP_USD,
     DEFAULT_MODEL,
     build_request,
     parse_response,
@@ -179,3 +180,35 @@ def test_build_request_uses_message_result_format() -> None:
     """
     payload = build_request("hello", max_tokens=100)
     assert payload["result_format"] == "message"
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0187 follow-ups — ADR-7 call-site fidelity + cost-cap default
+# ---------------------------------------------------------------------------
+
+
+def test_method_params_extra_reflects_call_site_args(
+    canned_response: dict, price_card: dict
+) -> None:
+    """ADR-7: ``method_params.extra`` must record the *actual* call-site flags,
+    not hardcoded literals. Before ticket 0187, ``parse_response`` always
+    wrote ``enable_thinking=True`` and ``enable_search=True`` regardless of
+    how the adapter was invoked. A future caller running with reasoning or
+    search disabled would have its run misclassified in the scientific record.
+    """
+    record = parse_response(
+        canned_response,
+        model_meta=price_card,
+        enable_thinking=False,
+        enable_search=False,
+    )
+    assert record.method_params.extra is not None
+    assert record.method_params.extra["enable_thinking"] is False
+    assert record.method_params.extra["enable_search"] is False
+
+
+def test_default_cost_cap_matches_ticket_spec() -> None:
+    """Sibling adapters (mistral, openai-responses) use $10 per call. The
+    qwen adapter previously drifted to $0.50; ticket 0187 aligns it.
+    """
+    assert DEFAULT_COST_CAP_USD == 10.0

--- a/tickets/0187-qwen-adapter-followups.erg
+++ b/tickets/0187-qwen-adapter-followups.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-05-20T23:55Z HDMX-coding-agent created
+2026-05-21T00:00Z HDMX-coding-agent note Three fixes landed on t0187-qwen-adapter-followups; sister audit confirmed mistral/openai already at $10 cap, only qwen drifted.
 
 --- body ---
 ## Context

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
-    { name = "dashscope", specifier = ">=1.20" },
+    { name = "dashscope", specifier = ">=1.20,<2.0" },
     { name = "deepagents", marker = "extra == 'v1-prototype'", specifier = ">=0.5.3" },
     { name = "httpx" },
     { name = "langchain", marker = "extra == 'v1-prototype'", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

Three small follow-up findings from PR #352 verify, all in the Qwen DashScope adapter. Each fix is independent; bundled because they share the file and ticket.

1. **ADR-7 call-site fidelity** — `parse_response` previously hardcoded `enable_thinking=True` and `enable_search=True` in `method_params.extra`. Now threaded through from the call site (same pattern as `prompt`, `max_tokens`, `wall_s`). A future caller running with reasoning or search disabled would otherwise have its run misclassified in the scientific record.

2. **Cost-cap alignment** — `cost_cap_usd` default raised from `0.50` to `10.0` to match siblings. Promoted to module-level `DEFAULT_COST_CAP_USD` constant and referenced from `run()`.

3. **Dashscope upper-bound pin** — `dashscope>=1.20` → `dashscope>=1.20,<2.0` in `pyproject.toml`. `uv.lock` regenerated (audit only — no resolved package changes).

## Sister-adapter audit

Per Exit criteria, audited direct-API adapters under `src/aedist/` for the same cost-cap drift class:

| Adapter | Default cap | Status |
|---|---|---|
| `adapter_qwen_dashscope.py` (this PR) | was `0.50`, now `10.0` | Fixed |
| `adapter_openai_responses.py:70` | `DEFAULT_COST_CAP_USD = 10.0` | Already aligned |
| `adapter_mistral.py:335` | `cap_usd: float = 10.0` | Already aligned |

**Verdict: no drift found in sibling adapters.** Only the qwen adapter required the cap-default fix.

## Test plan

- [x] `test_method_params_extra_reflects_call_site_args` — calls `parse_response` with `enable_thinking=False` and `enable_search=False`, asserts the record's `method_params.extra` reflects those values
- [x] `test_default_cost_cap_matches_ticket_spec` — pins `DEFAULT_COST_CAP_USD == 10.0` so drift surfaces at unit-test time
- [x] All 11 qwen adapter tests pass
- [x] `make check-fast` passes (1256 passed, 2 skipped, 1 xfailed)
- [x] `uv run ruff check .` clean
- [x] No new API calls — fixture `experiments/outputs/sota_smoke/qwen_1a3a34a9f1bb.json` was recorded with the prior `True/True` defaults, which the new code also writes; regression-free baseline preserved

**Ticket:** tickets/0187-qwen-adapter-followups.erg