### PR TITLE
ticket(0183): pass explicit httpx timeout + cap retries to unwedge workers

### DIFF
--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -187,6 +187,13 @@ def make_client(base_url: str | None = None) -> OpenAI:
 
     When *base_url* is provided (e.g. Ollama), use it directly with a
     dummy API key.  Otherwise default to OpenRouter.
+
+    ``max_retries=1`` (ticket 0183): openai-python defaults to 2, which —
+    combined with the worker's 600s per-call timeout — gives a worst-case
+    wall time around 30 minutes per wedged call. One retry caps that to
+    roughly 20 minutes while still tolerating a single transient network
+    blip. The worker-level requeue (failed/ → manual rerun) is the real
+    backstop, so we don't need aggressive in-client retries.
     """
     if base_url:
         from urllib.parse import urlparse
@@ -198,13 +205,14 @@ def make_client(base_url: str | None = None) -> OpenAI:
                 raise SystemExit("Set OPENROUTER_API_KEY environment variable")
         else:
             api_key = "ollama"
-        return OpenAI(base_url=base_url, api_key=api_key)
+        return OpenAI(base_url=base_url, api_key=api_key, max_retries=1)
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         raise SystemExit("Set OPENROUTER_API_KEY environment variable")
     return OpenAI(
         base_url="https://openrouter.ai/api/v1",
         api_key=api_key,
+        max_retries=1,
     )
 
 
@@ -223,7 +231,7 @@ def make_client_for_route(model: dict) -> OpenAI:
             raise SystemExit(f"Set {env_key} environment variable")
     else:
         api_key = "ollama"
-    kwargs: dict = {"base_url": base_url, "api_key": api_key}
+    kwargs: dict = {"base_url": base_url, "api_key": api_key, "max_retries": 1}
     if not env_key:
         import httpx
 

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -208,6 +208,15 @@ class Worker:
             enable_web_search=job.web_search,
             no_think=job.no_think,
         )
+        # Thread the job's timeout into every chat.completions.create() call
+        # (ticket 0183). The OpenAI client's `timeout` kwarg maps to httpx's
+        # socket-level timeout, which actually interrupts wedged network reads
+        # — unlike SIGALRM, which the C extension ignores. All mode handlers
+        # (single/RAG/web/decomposed/multiturn) unpack api_kwargs into
+        # query_single_turn(...), so this single line covers them all. Fusion
+        # mode is the lone exception: run_fusion() builds its own client and
+        # api_kw locally — out of scope here, tracked separately.
+        api_kwargs["timeout"] = job.timeout_seconds
 
         pool_label = self.worker_id
         if should_skip(output_dir, model_id, run, pool_label):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -107,6 +107,7 @@ def test_make_client_custom_base_url():
         mock_cls.assert_called_once_with(
             base_url="http://localhost:11434/v1",
             api_key="ollama",
+            max_retries=1,
         )
 
 
@@ -418,3 +419,76 @@ def test_query_model_ollama_local_sweep_jobspec_end_to_end(monkeypatch, tmp_path
         "no_think=true on local sweep must reach the Ollama wire — "
         "regression for ticket 0139 silent-drop"
     )
+
+
+# ---------------------------------------------------------------------------
+# query_single_turn timeout propagation (ticket 0183)
+# ---------------------------------------------------------------------------
+
+
+def test_query_single_turn_forwards_timeout_kwarg():
+    """A ``timeout=`` kwarg given to query_single_turn reaches the OpenAI call.
+
+    Worker.execute() injects ``api_kwargs["timeout"] = job.timeout_seconds`` so
+    that httpx can interrupt wedged network reads. This test pins the contract:
+    if the kwarg silently disappears on the way down, the wedge-fix is dead.
+    """
+    from unittest.mock import MagicMock
+
+    from aedist.harness import query_single_turn
+
+    client = MagicMock()
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+    response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+    client.chat.completions.create.return_value = response
+
+    query_single_turn(client, "test/m", [{"role": "user", "content": "hi"}], timeout=42.0)
+    call_kwargs = client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["timeout"] == 42.0
+
+
+def test_query_single_turn_surfaces_api_timeout_error():
+    """APITimeoutError from the OpenAI client propagates unwrapped to the caller.
+
+    The worker's exception handler relies on this: an unswallowed timeout moves
+    the job from running/ to failed/ and frees the worker for the next job.
+    Wrapping or hiding the exception would re-create the wedge this ticket
+    fixes.
+    """
+    from unittest.mock import MagicMock
+
+    import httpx
+    import openai
+    import pytest
+
+    from aedist.harness import query_single_turn
+
+    client = MagicMock()
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    client.chat.completions.create.side_effect = openai.APITimeoutError(request)
+
+    with pytest.raises(openai.APITimeoutError):
+        query_single_turn(
+            client,
+            "test/m",
+            [{"role": "user", "content": "hi"}],
+            timeout=1.0,
+        )
+
+
+def test_make_client_default_sets_max_retries():
+    """make_client() (OpenRouter default) pins max_retries=1 on the OpenAI client."""
+    import os
+    from unittest.mock import patch
+
+    with (
+        patch("aedist.harness.OpenAI") as mock_cls,
+        patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
+    ):
+        from aedist.harness import make_client
+
+        make_client()
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["max_retries"] == 1
+        assert call_kwargs["base_url"] == "https://openrouter.ai/api/v1"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -298,4 +298,5 @@ def test_base_url_passed_to_client(mock_openai_cls, tmp_path):
     mock_openai_cls.assert_called_with(
         base_url="http://localhost:11434/v1",
         api_key="ollama",
+        max_retries=1,
     )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -991,3 +991,34 @@ def test_rag_empty_corpus_raises_runtime_error(tmp_path: Path) -> None:
     with patch.multiple("aedist.worker", **patches):
         with pytest.raises(RuntimeError, match="RAG corpus load failed"):
             worker.execute(job)
+
+
+# ---------------------------------------------------------------------------
+# Timeout threading (Ticket 0183)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_threads_timeout_into_api_kwargs(tmp_path: Path) -> None:
+    """Worker.execute() injects job.timeout_seconds into api_kwargs (ticket 0183).
+
+    This is the load-bearing single-line fix: without it, openai-python's
+    httpx layer holds the socket open and SIGALRM cannot interrupt the wedge.
+    Pin the contract so a future refactor cannot drop the kwarg silently.
+    """
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(
+        mode="single",
+        model_filter="qwen3:8b",
+        timeout_seconds=123,
+    )
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
+
+    call_kwargs = patches["query_model"].call_args.kwargs
+    assert call_kwargs.get("timeout") == 123

--- a/tickets/0183-worker-httpx-timeout.erg
+++ b/tickets/0183-worker-httpx-timeout.erg
@@ -5,6 +5,8 @@ Author: claude
 
 --- log ---
 2026-05-20T20:58Z claude created — discovered while diagnosing 0181's slow throughput. Three worker leases observed past their 600s SIGALRM timeout, two of them 130–200s into expired status, all wedged on deepseek/deepseek-v4-pro. SIGALRM does not reliably interrupt openai-python's underlying httpx network call.
+2026-05-21T13:00Z claude note imagine-narrowed to single insertion in worker.execute (api_kwargs["timeout"] = job.timeout_seconds) + max_retries=1 on OpenAI client + unit test mocking APITimeoutError. SIGALRM kept as backstop. Reclaim-expired-leases logic deferred to separate ticket.
+2026-05-21T13:30Z claude note implemented on t0183-httpx-timeout — single edit in worker.py threads timeout into every mode (single/RAG/web/decomposed/multiturn via shared api_kwargs); make_client + make_client_for_route get max_retries=1; 3 new unit tests in tests/test_harness.py; 2 existing OpenAI() mock-assertion tests updated.
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Inject `api_kwargs["timeout"] = job.timeout_seconds` in `Worker.execute()` so every chat-completions call (single / RAG / web / decomposed / multiturn) has a socket-level timeout that httpx will actually honour — unlike the SIGALRM backstop, which the C extension ignores.
- Set `max_retries=1` on the OpenAI client (`make_client` and `make_client_for_route`) to cap the worst-case wall time of a wedged call (was ~30 min with the default 2 retries × 600 s).
- Add three unit tests pinning the contract (kwarg forwarding, `APITimeoutError` propagation, `max_retries=1`) plus one worker-level test pinning the single load-bearing line in `execute()`.

Fusion mode is the lone code path not covered — `run_fusion()` builds its own client locally — and is scoped out for a separate ticket. Reclaim-expired-leases logic for killed workers is also a separate concern.

## Background

During the 0181 sweep, three of eight workers were observed stuck on `deepseek/deepseek-v4-pro` with lease ages of 285 s / 733 s / 798 s — well past the 600 s SIGALRM timeout. SIGALRM does not interrupt openai-python's underlying httpx C-level network read; the OpenAI client's `timeout=` kwarg (mapped to httpx's socket timeout) does.

## Test plan

- [x] `uv run pytest tests/test_harness.py tests/test_worker.py tests/test_query.py` — all pass
- [x] `make check-fast` — 1258 passed, 2 skipped, 1 xfailed
- [x] `uv run ruff check .` — clean
- [ ] Soak verification: next concurrent sweep should show no workers stranded past `timeout_seconds + ~10 s` even when a provider hangs.

**Ticket:** tickets/0183-worker-httpx-timeout.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)