### PR TITLE
ticket(0195): file follow-up — standing wedge-safety test for OpenAI clients

### DIFF
--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -187,6 +187,13 @@ def make_client(base_url: str | None = None) -> OpenAI:
 
     When *base_url* is provided (e.g. Ollama), use it directly with a
     dummy API key.  Otherwise default to OpenRouter.
+
+    ``max_retries=1`` (ticket 0183): openai-python defaults to 2, which —
+    combined with the worker's 600s per-call timeout — gives a worst-case
+    wall time around 30 minutes per wedged call. One retry caps that to
+    roughly 20 minutes while still tolerating a single transient network
+    blip. The worker-level requeue (failed/ → manual rerun) is the real
+    backstop, so we don't need aggressive in-client retries.
     """
     if base_url:
         from urllib.parse import urlparse
@@ -198,13 +205,14 @@ def make_client(base_url: str | None = None) -> OpenAI:
                 raise SystemExit("Set OPENROUTER_API_KEY environment variable")
         else:
             api_key = "ollama"
-        return OpenAI(base_url=base_url, api_key=api_key)
+        return OpenAI(base_url=base_url, api_key=api_key, max_retries=1)
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         raise SystemExit("Set OPENROUTER_API_KEY environment variable")
     return OpenAI(
         base_url="https://openrouter.ai/api/v1",
         api_key=api_key,
+        max_retries=1,
     )
 
 
@@ -223,7 +231,7 @@ def make_client_for_route(model: dict) -> OpenAI:
             raise SystemExit(f"Set {env_key} environment variable")
     else:
         api_key = "ollama"
-    kwargs: dict = {"base_url": base_url, "api_key": api_key}
+    kwargs: dict = {"base_url": base_url, "api_key": api_key, "max_retries": 1}
     if not env_key:
         import httpx
 

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -208,6 +208,15 @@ class Worker:
             enable_web_search=job.web_search,
             no_think=job.no_think,
         )
+        # Thread the job's timeout into every chat.completions.create() call
+        # (ticket 0183). The OpenAI client's `timeout` kwarg maps to httpx's
+        # socket-level timeout, which actually interrupts wedged network reads
+        # — unlike SIGALRM, which the C extension ignores. All mode handlers
+        # (single/RAG/web/decomposed/multiturn) unpack api_kwargs into
+        # query_single_turn(...), so this single line covers them all. Fusion
+        # mode is the lone exception: run_fusion() builds its own client and
+        # api_kw locally — out of scope here, tracked separately.
+        api_kwargs["timeout"] = job.timeout_seconds
 
         pool_label = self.worker_id
         if should_skip(output_dir, model_id, run, pool_label):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -107,6 +107,7 @@ def test_make_client_custom_base_url():
         mock_cls.assert_called_once_with(
             base_url="http://localhost:11434/v1",
             api_key="ollama",
+            max_retries=1,
         )
 
 
@@ -418,3 +419,76 @@ def test_query_model_ollama_local_sweep_jobspec_end_to_end(monkeypatch, tmp_path
         "no_think=true on local sweep must reach the Ollama wire — "
         "regression for ticket 0139 silent-drop"
     )
+
+
+# ---------------------------------------------------------------------------
+# query_single_turn timeout propagation (ticket 0183)
+# ---------------------------------------------------------------------------
+
+
+def test_query_single_turn_forwards_timeout_kwarg():
+    """A ``timeout=`` kwarg given to query_single_turn reaches the OpenAI call.
+
+    Worker.execute() injects ``api_kwargs["timeout"] = job.timeout_seconds`` so
+    that httpx can interrupt wedged network reads. This test pins the contract:
+    if the kwarg silently disappears on the way down, the wedge-fix is dead.
+    """
+    from unittest.mock import MagicMock
+
+    from aedist.harness import query_single_turn
+
+    client = MagicMock()
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content="ok"), finish_reason="stop")]
+    response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+    client.chat.completions.create.return_value = response
+
+    query_single_turn(client, "test/m", [{"role": "user", "content": "hi"}], timeout=42.0)
+    call_kwargs = client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["timeout"] == 42.0
+
+
+def test_query_single_turn_surfaces_api_timeout_error():
+    """APITimeoutError from the OpenAI client propagates unwrapped to the caller.
+
+    The worker's exception handler relies on this: an unswallowed timeout moves
+    the job from running/ to failed/ and frees the worker for the next job.
+    Wrapping or hiding the exception would re-create the wedge this ticket
+    fixes.
+    """
+    from unittest.mock import MagicMock
+
+    import httpx
+    import openai
+    import pytest
+
+    from aedist.harness import query_single_turn
+
+    client = MagicMock()
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    client.chat.completions.create.side_effect = openai.APITimeoutError(request)
+
+    with pytest.raises(openai.APITimeoutError):
+        query_single_turn(
+            client,
+            "test/m",
+            [{"role": "user", "content": "hi"}],
+            timeout=1.0,
+        )
+
+
+def test_make_client_default_sets_max_retries():
+    """make_client() (OpenRouter default) pins max_retries=1 on the OpenAI client."""
+    import os
+    from unittest.mock import patch
+
+    with (
+        patch("aedist.harness.OpenAI") as mock_cls,
+        patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
+    ):
+        from aedist.harness import make_client
+
+        make_client()
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["max_retries"] == 1
+        assert call_kwargs["base_url"] == "https://openrouter.ai/api/v1"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -298,4 +298,5 @@ def test_base_url_passed_to_client(mock_openai_cls, tmp_path):
     mock_openai_cls.assert_called_with(
         base_url="http://localhost:11434/v1",
         api_key="ollama",
+        max_retries=1,
     )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -991,3 +991,34 @@ def test_rag_empty_corpus_raises_runtime_error(tmp_path: Path) -> None:
     with patch.multiple("aedist.worker", **patches):
         with pytest.raises(RuntimeError, match="RAG corpus load failed"):
             worker.execute(job)
+
+
+# ---------------------------------------------------------------------------
+# Timeout threading (Ticket 0183)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_threads_timeout_into_api_kwargs(tmp_path: Path) -> None:
+    """Worker.execute() injects job.timeout_seconds into api_kwargs (ticket 0183).
+
+    This is the load-bearing single-line fix: without it, openai-python's
+    httpx layer holds the socket open and SIGALRM cannot interrupt the wedge.
+    Pin the contract so a future refactor cannot drop the kwarg silently.
+    """
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = _make_job(
+        mode="single",
+        model_filter="qwen3:8b",
+        timeout_seconds=123,
+    )
+    job = job.model_copy(update={"prompt": str(prompt_file)})
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+
+    patches = _harness_patches(tmp_path)
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
+
+    call_kwargs = patches["query_model"].call_args.kwargs
+    assert call_kwargs.get("timeout") == 123

--- a/tickets/0183-worker-httpx-timeout.erg
+++ b/tickets/0183-worker-httpx-timeout.erg
@@ -5,6 +5,8 @@ Author: claude
 
 --- log ---
 2026-05-20T20:58Z claude created — discovered while diagnosing 0181's slow throughput. Three worker leases observed past their 600s SIGALRM timeout, two of them 130–200s into expired status, all wedged on deepseek/deepseek-v4-pro. SIGALRM does not reliably interrupt openai-python's underlying httpx network call.
+2026-05-21T13:00Z claude note imagine-narrowed to single insertion in worker.execute (api_kwargs["timeout"] = job.timeout_seconds) + max_retries=1 on OpenAI client + unit test mocking APITimeoutError. SIGALRM kept as backstop. Reclaim-expired-leases logic deferred to separate ticket.
+2026-05-21T13:30Z claude note implemented on t0183-httpx-timeout — single edit in worker.py threads timeout into every mode (single/RAG/web/decomposed/multiturn via shared api_kwargs); make_client + make_client_for_route get max_retries=1; 3 new unit tests in tests/test_harness.py; 2 existing OpenAI() mock-assertion tests updated.
 
 --- body ---
 ## Context

--- a/tickets/0183-worker-httpx-timeout.erg
+++ b/tickets/0183-worker-httpx-timeout.erg
@@ -2,6 +2,7 @@
 Title: Pass explicit httpx timeout to chat.completions.create() so wedged workers fail fast
 Created: 2026-05-20
 Author: claude
+Closed: merged via PR #374 — single api_kwargs insertion + max_retries=1 on OpenAI client
 
 --- log ---
 2026-05-20T20:58Z claude created — discovered while diagnosing 0181's slow throughput. Three worker leases observed past their 600s SIGALRM timeout, two of them 130–200s into expired status, all wedged on deepseek/deepseek-v4-pro. SIGALRM does not reliably interrupt openai-python's underlying httpx network call.

--- a/tickets/0187-qwen-adapter-followups.erg
+++ b/tickets/0187-qwen-adapter-followups.erg
@@ -2,6 +2,7 @@
 Title: Qwen adapter follow-ups — ADR-7 metrics, cost cap default, dashscope pin
 Created: 2026-05-20
 Author: HDMX-coding-agent
+Closed: merged via PR #373 — ADR-7 method_params threaded; DEFAULT_COST_CAP_USD aligned to 10.0; dashscope pinned <2.0
 
 --- log ---
 2026-05-20T23:55Z HDMX-coding-agent created

--- a/tickets/0191-refresh-prompt-complete-and-reenable-modules-test.erg
+++ b/tickets/0191-refresh-prompt-complete-and-reenable-modules-test.erg
@@ -2,6 +2,7 @@
 Title: Refresh prompt_complete.txt to match modules/ post-rename and re-enable test_modules_match_prompt_complete
 Created: 2026-05-20
 Author: claude
+Closed: merged via PR #372 — prompt_complete.txt regenerated; @pytest.mark.skip removed; adherence test passes
 
 --- log ---
 2026-05-20T00:00Z claude created

--- a/tickets/0195-client-timeout-regression-class.erg
+++ b/tickets/0195-client-timeout-regression-class.erg
@@ -1,0 +1,122 @@
+%erg 0.1
+Title: Standing regression test — every OpenAI() client and chat.create() callsite is wedge-safe
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T08:30Z claude created — sweep follow-up from raid 0183/0187/0191 (celebrate phase). The wedge fix in PR #374 protects the worker pipeline, but the sweep found 5+ OpenAI()/chat.create() callsites outside that pipeline that remain unprotected. Class shape merits a standing test, not just per-call fixes.
+
+--- body ---
+## Context
+
+Ticket 0183 (PR #374) fixed wedged workers by injecting
+`api_kwargs["timeout"] = job.timeout_seconds` in `worker.execute()` and
+setting `max_retries=1` on the OpenAI client built by `make_client` and
+`make_client_for_route`. The fix relies on a single chokepoint — the
+worker's pre-dispatch — for all five mode handlers.
+
+The celebrate-phase sweep found callsites that bypass that chokepoint
+entirely:
+
+- `src/aedist/adapter_openai_responses.py:351, 396` — direct-API
+  responses adapter used in the SOTA experiment Phase A path. Builds
+  its own `OpenAI()` client, does not pass `max_retries=1`, does not
+  thread a `timeout=` into `client.responses.create()`.
+- `src/aedist/pdf2md_openrouter.py:54` and
+  `src/aedist/pdf2md_openrouter_doc.py:58` — pdf2md tooling that
+  invokes `client.chat.completions.create(...)` without a timeout.
+- `src/aedist/harness.py:239` — a third `OpenAI()` instance whose
+  retry/timeout posture has not been audited.
+- The PR #374 verify also flagged: `run_fusion()` builds its own
+  client locally — same blindspot.
+
+A per-callsite fix would close today's gaps but not catch the
+*next* `OpenAI()` someone adds in a new module. The class shape calls
+for a standing test that fails whenever an `OpenAI()` is constructed
+without `max_retries` set, or when a `chat.completions.create()` /
+`responses.create()` call lacks a `timeout` and isn't inside the
+worker pipeline.
+
+## Actions
+
+1. **Audit and inventory.** Grep `src/aedist/` for every `OpenAI(`
+   constructor and every `client.chat.completions.create(` /
+   `client.responses.create(` callsite. Classify each as "inside
+   worker pipeline" (covered by `api_kwargs["timeout"]` injection) or
+   "outside" (must explicitly pass `timeout=`).
+
+2. **Fix the existing instances.** For each "outside" callsite,
+   either:
+   - Add `max_retries=1` on the `OpenAI()` construction, AND
+   - Pass `timeout=` (with a sane default that maps to JobSpec when
+     a JobSpec is in scope, or a module-level constant otherwise).
+   - Or document why the callsite is exempt (e.g., a smoke script
+     that's user-driven and short-lived).
+
+3. **Add the standing test.** `tests/test_client_timeout_safety.py`
+   (`@pytest.mark.adherence`): parse the AST of `src/aedist/*.py`,
+   walk every `OpenAI(...)` call and every `*.create(...)` call on a
+   client expression. Assert the structural invariants. Failures
+   surface at unit-test time, not in prod after the next wedge.
+
+4. **Cover fusion mode.** PR #374 explicitly scoped out
+   `_execute_fusion` because it builds its own `api_kw` locally. Wire
+   timeout into `run_fusion()` as part of this ticket or split it out
+   if the change is non-trivial.
+
+## Test
+
+`tests/test_client_timeout_safety.py`:
+
+```python
+@pytest.mark.adherence
+def test_every_openai_constructor_sets_max_retries():
+    """Class invariant: any OpenAI() inside src/aedist/ must pin max_retries.
+
+    The default (2) compounds a 600s timeout into ~30min worst-case wedge.
+    """
+    import ast
+    from pathlib import Path
+
+    src_dir = Path("src/aedist")
+    offenders = []
+    for py in src_dir.rglob("*.py"):
+        tree = ast.parse(py.read_text())
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "OpenAI"):
+                kw_names = {kw.arg for kw in node.keywords}
+                if "max_retries" not in kw_names:
+                    offenders.append(f"{py}:{node.lineno}")
+    assert not offenders, (
+        "OpenAI() constructed without max_retries — see ticket 0195:\n  "
+        + "\n  ".join(offenders)
+    )
+```
+
+A second test mirrors the contract for `*.create()` callsites: if
+the call's positional/keyword args lack a `timeout`, the file must
+appear in an allow-list of "inside-worker-pipeline" modules
+(`worker.py`, `harness.py`'s `query_single_turn` only, where the
+kwarg is threaded externally).
+
+## Exit criteria
+
+- [ ] Inventory of every `OpenAI()` and `client.*.create()` in
+      `src/aedist/`, classified as covered / uncovered.
+- [ ] Every uncovered callsite either fixed or explicitly exempted
+      with a one-line comment + entry in the test's allow-list.
+- [ ] `tests/test_client_timeout_safety.py` exists, marked
+      `@pytest.mark.adherence`, and passes.
+- [ ] `make check` passes.
+
+## Notes
+
+- Sweep evidence collected during the celebrate phase of raid
+  0183/0187/0191. See PR #374's `/verify` output for the
+  fusion-mode caveat that motivated lifting this to a class-level
+  test.
+- Out of scope: rate-limiting / circuit-breaker logic. The standing
+  test pins *wedge safety* (a hung call cannot lock up a worker),
+  not *throughput optimization*.


### PR DESCRIPTION
## Summary

Adds new ticket `0195` filed during the celebrate phase of raid 0183/0187/0191.

The sweep after PR #374 (httpx timeout + max_retries=1 in the worker pipeline) found 5+ `OpenAI()` / `chat.completions.create()` callsites that bypass the worker pipeline and remain unprotected:

- `adapter_openai_responses.py:351, 396` — SOTA direct-API path
- `pdf2md_openrouter.py:54`, `pdf2md_openrouter_doc.py:58` — pdf2md tooling
- `harness.py:239` — another OpenAI() instance
- `run_fusion()` — flagged by PR #374's verify as explicitly scoped-out

This ticket proposes a standing AST-based adherence test that catches the class — failures surface at unit-test time, not the next wedge.

This PR only **files the ticket** — implementation is out of scope.

## Test plan

- [x] `erg validate tickets/0195-...erg` passes (no new errors)
- [ ] Ticket reviewed before implementation