### PR TITLE
fig(census-direct): show min/median/max TP reps per model

### DIFF
--- a/src/aedist/plot_method_convergence.py
+++ b/src/aedist/plot_method_convergence.py
@@ -16,7 +16,7 @@ import argparse
 import csv
 import logging
 import re
-from collections import Counter, defaultdict
+from collections import defaultdict
 from pathlib import Path
 
 from .measurements import SYNTHETIC_SUFFIXES, load
@@ -147,6 +147,28 @@ def write_csv(rows: list[dict], output: Path) -> None:
     log.info("Wrote %d rows to %s", len(rows), output)
 
 
+def _select_min_median_max(rows: list[dict]) -> list[dict]:
+    """Pick min, median, and max TP reps per model.
+
+    For each model, sort its reps by TP ascending and return three
+    representatives: the worst (index 0), the median (index len//2),
+    and the best (index -1). Models with ≤3 reps are returned in full.
+    This is the honest summary of within-model variance — top-N hides
+    the low-TP tail (e.g. GPT-OSS-20B ranges 21 → 163 across 5 reps).
+    """
+    by_model: dict[str, list[dict]] = {}
+    for r in rows:
+        by_model.setdefault(r["model"], []).append(r)
+    out: list[dict] = []
+    for runs in by_model.values():
+        runs_sorted = sorted(runs, key=lambda r: r["tp"])
+        if len(runs_sorted) <= 3:
+            out.extend(runs_sorted)
+        else:
+            out.extend([runs_sorted[0], runs_sorted[len(runs_sorted) // 2], runs_sorted[-1]])
+    return out
+
+
 def write_pdf(
     rows: list[dict],
     output: Path,
@@ -174,11 +196,7 @@ def write_pdf(
         method_rows = [r for r in rows if r["method"] == method]
         if models:
             method_rows = [r for r in method_rows if r["model"] in models]
-        model_count: Counter[str] = Counter()
-        for r in method_rows:
-            if model_count[r["model"]] < max_runs_per_model:
-                model_count[r["model"]] += 1
-        total_runs += sum(model_count.values())
+        total_runs += len(_select_min_median_max(method_rows))
     fig_height = max(4.2, 0.08 * total_runs + 0.5 * len(order))
 
     fig, ax = plt.subplots(figsize=(10, fig_height))
@@ -194,14 +212,8 @@ def write_pdf(
         if not method_rows:
             continue
 
-        # Limit runs per model
-        model_count = Counter()
-        filtered = []
-        for r in method_rows:
-            if model_count[r["model"]] < max_runs_per_model:
-                filtered.append(r)
-                model_count[r["model"]] += 1
-        method_rows = filtered
+        # Pick representative reps per model: min / median / max TP.
+        method_rows = _select_min_median_max(method_rows)
 
         # Resolve size per model (not per record). Different reps of the same
         # model can carry different size_class values in the data — take the

--- a/tests/test_plot_method_convergence.py
+++ b/tests/test_plot_method_convergence.py
@@ -111,6 +111,30 @@ def test_core_models_requires_all_methods(tmp_path, monkeypatch):
     assert core == set()
 
 
+def test_select_min_median_max_picks_three_representatives():
+    """Per-model selection surfaces the min / median / max TP rep — not top-N."""
+    from aedist.plot_method_convergence import _select_min_median_max
+
+    rows = [
+        {"model": "M", "tp": 21},
+        {"model": "M", "tp": 65},
+        {"model": "M", "tp": 70},
+        {"model": "M", "tp": 100},
+        {"model": "M", "tp": 163},
+    ]
+    picks = _select_min_median_max(rows)
+    assert [r["tp"] for r in picks] == [21, 70, 163]
+
+
+def test_select_min_median_max_passthrough_for_small_groups():
+    """Models with ≤3 reps are returned in TP-ascending order, no down-selection."""
+    from aedist.plot_method_convergence import _select_min_median_max
+
+    rows = [{"model": "M", "tp": 50}, {"model": "M", "tp": 10}, {"model": "M", "tp": 30}]
+    picks = _select_min_median_max(rows)
+    assert [r["tp"] for r in picks] == [10, 30, 50]
+
+
 def test_main_writes_csv(tmp_path, monkeypatch):
     """CLI writes well-formed CSV with expected columns."""
     input_path = tmp_path / "measurements.jsonl"


### PR DESCRIPTION
## Summary
Figure 1 used to show the first 3 reps of each model in arbitrary input order, then sorted by family + size for display. Which 3 reps you got was implicit and not always representative — for GPT-OSS-20B (5 reps spanning TP=21 to TP=163) it happened to show the high tail and hide the low.

Switch the per-model selector to **min / median / max TP** explicitly. The within-model spread that drives the *Non-déterministe* failure mode is now visible by construction.

Same sort + family grouping as PR #387. The \`max_runs_per_model\` parameter stays in the signature for external callers but is a no-op once a model has ≥3 reps.

## Test plan
- [x] \`uv run pytest tests/test_plot_method_convergence.py -q\` → 7 passed (2 new)
- [x] \`make slides/inputs/generated/fig_census_direct.pdf\` regenerates cleanly
- [ ] Eyeball: GPT-OSS-20B and Qwen 3.6-27B should now each show one bar at TP=163 (max) plus one short bar near 20–30 (min) plus the median.

🤖 Generated with [Claude Code](https://claude.com/claude-code)