### PR TITLE
tickets: close 0198, open 0203 (worker-on-429) + 0204 (deepseek-v4-pro null)

### DIFF
--- a/tickets/0198-exp1-reasoning-intensity-topup.erg
+++ b/tickets/0198-exp1-reasoning-intensity-topup.erg
@@ -2,12 +2,14 @@
 Title: Exp 1 reasoning-intensity top-up (canary + 2-rep) with pooled outcome metrics
 Created: 2026-05-21
 Author: claude
+Closed: Merged in PR #386 — reasoning-tokens topup + interday-variability column + Annex A restoration
 
 --- log ---
 2026-05-21T12:00Z claude created — follow-up to 0197 PR #379; capture column needs empirical data, but full N=5 rerun is too expensive in slide-deadline window
 
 2026-05-21T09:20Z HDMX-coding-agent note blocker 0197 closed — Blocked-by removed.
 2026-05-21T13:30Z user note decision: pool all topup reps with the original five unconditionally — no canary gate, no ±2σ comparison. Intra-day variability is absorbed into the reported within-model spread and disclosed in the methods section.
+2026-05-21T11:43Z HDMX-coding-agent closed — Merged in PR #386 — reasoning-tokens topup + interday-variability column + Annex A restoration
 --- body ---
 ## Context
 

--- a/tickets/0203-worker-exits-on-429.erg
+++ b/tickets/0203-worker-exits-on-429.erg
@@ -1,0 +1,63 @@
+%erg 0.1
+Title: Worker exits on 429 instead of marking single job failed and continuing
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T11:40Z claude created — uncovered during ticket 0198 raid
+
+--- body ---
+## Context
+
+During the ticket 0198 topup (2026-05-21), the OpenRouter worker exited
+the entire `--drain` loop on the first 429 response from any model,
+leaving the rest of the pending queue untouched. This cost ~30 minutes
+of session time fighting around `qwen3.6-flash` (free-tier rate-limited)
+and forced a manual "sideline the offending model" pattern.
+
+Concrete sequence observed:
+1. Worker leases pending job for `qwen/qwen3.6-flash`.
+2. OpenRouter returns 429 (upstream Alibaba free-tier rate limit).
+3. OpenAI SDK retries once (0.45s backoff), gets 429 again.
+4. Worker logs "Queue drained, exiting." and exits cleanly (exit 0).
+5. Job remains in `jobs/failed/` with an error log.
+6. **All other pending jobs in the queue are untouched.**
+
+Expected: the rate-limited job moves to `failed/`, the worker continues
+to lease the next pending job, the drain loop only exits when the queue
+is genuinely empty.
+
+## Why it matters
+
+Parallel workers partially mitigate this (a 429 only kills one worker
+slot, not the whole queue), but the bug still loses concurrency on every
+free-tier failure. For sequential drains it's worse — one bad model
+blocks the entire batch.
+
+## Actions
+
+1. Locate the run loop in `experiments/src/aedist/worker.py` that exits
+   on what looks like "queue drained" after a job failure.
+2. Distinguish "job failed" from "queue empty" — only the latter should
+   cause the drain loop to exit.
+3. On 429 specifically, consider exponential backoff before moving to
+   `failed/` — Alibaba's free tier resets within 30-60s in practice.
+4. Add an integration test that fails before the fix: spawn worker
+   against a mock 429, then a mock 200, assert the worker processed
+   both jobs.
+
+## Test
+
+```python
+@pytest.mark.integration
+def test_worker_continues_after_429():
+    # Two pending jobs; first 429s, second 200s
+    # Assert worker processes both, queue ends empty, failed/ has 1, done/ has 1
+```
+
+## Exit criteria
+
+- [ ] Worker continues to next pending job after a 429 failure.
+- [ ] 429-failed jobs land in `failed/` with error log as before.
+- [ ] Integration test guards the behaviour.
+- [ ] `make check` passes.

--- a/tickets/0204-deepseek-v4-pro-provider-null.erg
+++ b/tickets/0204-deepseek-v4-pro-provider-null.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: deepseek-v4-pro returns null content via OpenRouter, hangs the worker
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T11:42Z claude created — observed during ticket 0198 topup; killed 2 worker leases after 25 min each
+
+--- body ---
+## Context
+
+During the ticket 0198 topup (2026-05-21), two worker leases for
+`deepseek/deepseek-v4-pro` ran for ~25 minutes each before being killed
+manually. Output file `bybwzvtfn.output` showed a `200 OK` response
+followed by an internal openai-sdk retry and a second `200 OK`, then
+silence — the worker never wrote the result file and never moved to
+the next job.
+
+A fresh probe outside the worker reproduces the underlying issue:
+
+```
+client.chat.completions.create(model='deepseek/deepseek-v4-pro', ...)
+  -> openai.OpenAIError: 'NoneType' object is not subscriptable
+```
+
+OpenRouter returns a 200 but `choice.message.content` is `None` for this
+model on a non-trivial fraction of calls. The SDK's response parser
+chokes on `None`; the worker has no handler for this provider-side
+null-content pattern.
+
+## Why it matters
+
+`deepseek/deepseek-v4-pro` is in `modelset_ablation_journal` and in the
+frozen `modelset_exp1_baseline`. With the harness in current state, any
+sweep including this model can stall on null content for the duration of
+the SDK's internal retries (which here pushed past 25 minutes per call).
+
+## Actions
+
+1. In `worker._query_and_save` (or a layer above), detect `result["content"] is None` and treat as a hard failure (move to `failed/`, write error log, continue).
+2. Surface the provider-side null in the error message so the operator
+   can distinguish "OpenRouter routed to a broken endpoint" from
+   "network glitch" / "429".
+3. Optional: emit a metric or telemetry line so we can quantify how
+   often this happens to which OpenRouter providers.
+
+## Test
+
+```python
+@pytest.mark.integration
+def test_worker_handles_null_content():
+    # Mock OpenRouter returning 200 + choice.message.content=None
+    # Assert worker writes error log, job lands in failed/, drain continues
+```
+
+## Exit criteria
+
+- [ ] Null content from any model results in a clean failure within ≤2 min
+      (not 25 min).
+- [ ] Failure mode is distinguishable from rate-limit and network errors
+      in the error log.
+- [ ] Integration test guards the behaviour.


### PR DESCRIPTION
## Summary

Housekeeping for ticket 0198 (merged in #386):
- Close ticket 0198 with the merge reference.
- Open follow-up ticket 0203: worker exits the entire drain loop on a 429 from any single model, instead of marking that job failed and continuing. Cost ~30 min of session time during the 0198 raid.
- Open follow-up ticket 0204: `deepseek/deepseek-v4-pro` returns 200 OK with `choice.message.content = None` via OpenRouter; the openai-sdk parser chokes and the worker hangs for 25+ minutes. Reproducible outside the worker.

Both follow-ups were called out in the 0198 PR body as out-of-scope; this PR formalises them as tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)