### PR TITLE
fix(adapter-mistral): handle str-typed content (0206)

### DIFF
--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -196,11 +196,14 @@ def parse_response(
     - ``type == "tool.execution"`` with ``name == "web_search"`` → one
       entry in :attr:`RunRecord.web_search_calls`. The search query is
       parsed from the JSON-encoded ``arguments`` string.
-    - ``type == "message.output"`` → iterate its ``content[]``:
-        * ``type == "text"`` → append to the narrative.
-        * ``type == "tool_reference"`` → one entry in
-          :attr:`RunRecord.citations` with ``url`` + ``snippet`` derived
-          from ``description``.
+    - ``type == "message.output"`` → ``content`` is empirically one of
+      two shapes:
+        * ``list[dict]`` of typed chunks (2026-05-20 derisk fixture) —
+          iterate; ``type == "text"`` chunks join the narrative,
+          ``type == "tool_reference"`` chunks become citations.
+        * ``str`` — a flat narrative inline (observed live 2026-05-21
+          in the Exp 2 smoke, ticket 0185 / fix 0206). The whole string
+          is the narrative; no tool-reference markup is carried.
     """
     web_search_calls: list[dict] = []
     citations: list[dict] = []
@@ -212,7 +215,13 @@ def parse_response(
             query = _extract_query(item.get("arguments"))
             web_search_calls.append({"query": query, "urls_returned": []})
         elif kind == "message.output":
-            for chunk in item.get("content", []) or []:
+            content = item.get("content")
+            # Flat-string shape (ticket 0206) — whole string is the
+            # narrative; nothing else to extract.
+            if isinstance(content, str):
+                narrative_chunks.append(content)
+                continue
+            for chunk in content or []:
                 ctype = chunk.get("type")
                 if ctype == "text":
                     narrative_chunks.append(chunk.get("text", ""))

--- a/tests/fixtures/mistral_conversation_response_str_content.json
+++ b/tests/fixtures/mistral_conversation_response_str_content.json
@@ -1,0 +1,20 @@
+{
+  "object": "conversation.response",
+  "conversation_id": "conv_test_str_shape",
+  "outputs": [
+    {
+      "object": "entry",
+      "type": "message.output",
+      "created_at": "2026-05-21T00:00:00Z",
+      "completed_at": "2026-05-21T00:00:05Z",
+      "agent_id": "ag_test_str_shape",
+      "model": "mistral-large-2512",
+      "id": "msg_test_str_shape",
+      "role": "assistant",
+      "content": "Hello — this is a flat string narrative without typed chunks. No tool refs, no citation markup."
+    }
+  ],
+  "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+  "guardrails": null,
+  "_provenance": "Synthesised 2026-05-21 from the structural shape observed live in the Exp 2 smoke (ticket 0185). Mirrors the shape of the real Phase A response without copying its 16K-char narrative content."
+}

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -28,6 +28,9 @@ from aedist.adapter_mistral import (
 )
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "mistral_conversation_response.json"
+FIXTURE_STR_CONTENT_PATH = (
+    Path(__file__).parent / "fixtures" / "mistral_conversation_response_str_content.json"
+)
 
 
 # Pricing card mirrored from the models.yaml entry registered in this
@@ -43,6 +46,18 @@ PRICE_CARD = {
 @pytest.fixture
 def fixture_response() -> dict:
     return json.loads(FIXTURE_PATH.read_text())
+
+
+@pytest.fixture
+def fixture_str_content_response() -> dict:
+    """Fixture for the flat-string content shape (ticket 0206).
+
+    The Mistral Conversations API empirically returns two content
+    shapes: ``list[dict]`` of typed chunks (the 2026-05-20 derisk
+    fixture) and ``str`` (observed live 2026-05-21 in the Exp 2 smoke,
+    ticket 0185). This fixture exercises the second shape.
+    """
+    return json.loads(FIXTURE_STR_CONTENT_PATH.read_text())
 
 
 def test_run_dry_run_short_circuits_before_network():
@@ -207,3 +222,33 @@ def test_parse_response_falls_back_to_flat_per_call_price(fixture_response):
     record = parse_response(fixture_response, card)
     # 2 web_search calls × $0.025 = $0.050
     assert record.tool_calls_cost_usd == pytest.approx(0.05, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# parse_response — flat string content shape (ticket 0206)
+#
+# Empirically Mistral returns ``outputs[*].content`` in two shapes:
+#   1. ``list[dict]`` of typed chunks (the 2026-05-20 derisk fixture).
+#   2. ``str`` — a flat narrative inline (observed live 2026-05-21 in
+#      the Exp 2 smoke, ticket 0185). The parser must handle both
+#      without raising ``AttributeError: 'str' object has no attribute
+#      'get'``.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_handles_str_content_shape(fixture_str_content_response):
+    """The flat-string shape must parse cleanly with status == "ok"."""
+    record = parse_response(fixture_str_content_response, PRICE_CARD)
+    assert record.result_summary.status == "ok"
+    # Usage round-trip — the str-shape still carries a usage block.
+    assert record.resource_use.tokens_in == 100
+    assert record.resource_use.tokens_out == 50
+
+
+def test_parse_response_str_content_yields_no_web_search_or_citations(
+    fixture_str_content_response,
+):
+    """The flat-string shape carries no tool-reference markup."""
+    record = parse_response(fixture_str_content_response, PRICE_CARD)
+    assert record.web_search_calls == []
+    assert record.citations == []

--- a/tickets/0206-adapter-mistral-content-str-bug.erg
+++ b/tickets/0206-adapter-mistral-content-str-bug.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: adapter_mistral.parse_response crashes on string-typed content
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T13:00Z claude created — observed live three times in the Exp 2 smoke (0185); blocks every Mistral SOTA cloud call
+
+--- body ---
+## Context
+
+`src/aedist/adapter_mistral.py:parse_response` (lines ~184–256) assumes
+`outputs[*].content` is always `list[dict]` of typed chunks. The
+2026-05-20 derisk fixture (`tests/fixtures/mistral_conversation_response.json`)
+captured exactly that shape.
+
+But the Mistral Conversations API also returns a second, flat shape:
+
+- `content` as a `str` — the entire narrative inline, no typed chunks.
+
+Observed live three times in a row on 2026-05-21 in the Exp 2 smoke
+(ticket 0185). The current parser iterates with `chunk.get("type")` and
+raises `AttributeError: 'str' object has no attribute 'get'`. Every
+Mistral SOTA cloud call is blocked.
+
+## Actions
+
+1. Add a `str`-branch in `parse_response`: when `content` is a `str`,
+   treat the whole string as the narrative; no `web_search_calls` or
+   `citations` to extract (the flat shape carries no tool-reference
+   markup).
+2. Keep the existing `list[dict]` branch intact.
+
+## Test
+
+`tests/test_adapter_mistral.py::test_parse_response_handles_str_content_shape`
+— load the new fixture, parse, assert no raise and `status == "ok"`.
+
+## Exit criteria
+
+- [ ] Both content shapes covered by separate fixtures and dedicated tests
+- [ ] `uv run pytest tests/test_adapter_mistral.py` all green
+- [ ] `uv run ruff check src/aedist/adapter_mistral.py tests/test_adapter_mistral.py` clean
+- [ ] `make check-fast` green
+
+## Related
+
+- Bug surfaced from ticket 0185 (Exp 2 interactive smoke).
+- Ticket 0207 tracks the consumer-side defensive code in
+  `experiments/sota/exp2_interactive_smoke.py` that masked the symptom.


### PR DESCRIPTION
## Summary

- The Mistral Conversations API empirically returns `outputs[*].content` in two shapes: `list[dict]` of typed chunks (captured 2026-05-20) and `str` (observed live 3x in a row 2026-05-21 in the Exp 2 smoke under ticket 0185).
- `adapter_mistral.parse_response` assumed only the list shape and crashed on the str shape with `AttributeError: 'str' object has no attribute 'get'`, blocking every Mistral SOTA cloud call.
- Adds a `str`-branch that treats the whole string as the narrative (no tool-reference markup is carried in that shape), keeps the existing list-of-chunks branch intact.
- New fixture `tests/fixtures/mistral_conversation_response_str_content.json` + two dedicated tests (`test_parse_response_handles_str_content_shape`, `test_parse_response_str_content_yields_no_web_search_or_citations`). All 13 mistral-adapter tests green; full `make check-fast` green (1315 passed).

## Out of scope

- `experiments/sota/exp2_interactive_smoke.py` — its consumer-side defensive recovery code masked this bug. Tracked under ticket 0207 (separate concern).
- Other adapters (Anthropic, OpenAI, Qwen) — separate tickets if any have analogous bugs.

## Test plan

- [x] `uv run pytest tests/test_adapter_mistral.py` — 13 passed (was 11, +2 new)
- [x] `uv run ruff check src/aedist/adapter_mistral.py tests/test_adapter_mistral.py` — clean
- [x] `make check-fast` — 1315 passed, 1 skipped, 1 xfailed
- [x] TDD discipline: new tests added first, confirmed red against the bug, then fix flips them green.

**Ticket:** tickets/0206-adapter-mistral-content-str-bug.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)