### PR TITLE
ticket(0160): claude-code-cli route adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ Minh Ha-Duong, CIRED – CNRS
 └── pyproject.toml           # Python package config
 ```
 
+## Model routes
+
+Each entry in `experiments/models.yaml` declares a `route:` field telling
+the runner how to reach the model. Available routes:
+
+| Route             | Auth                                | Notes                                                                                  |
+|-------------------|-------------------------------------|----------------------------------------------------------------------------------------|
+| `openrouter`      | `OPENROUTER_API_KEY`                | Default; OpenAI-compatible API. Covers most cloud models. Also the dispatch path for local `llama_server` (point `base_url` at the local endpoint). |
+| `ollama`          | none (local)                        | Native `/api/chat` to honour `num_ctx`; serial only (Padme has one GPU). **Deprecated** in favour of `llama_server` via `openrouter` (OpenAI-compatible, no special path needed). |
+| `anthropic`       | `ANTHROPIC_API_KEY`                 | Direct Anthropic Messages API; web-search via official tool. Ticket 0167.             |
+| `openai-responses`| `OPENAI_API_KEY`                    | Direct OpenAI Responses API; web-search + reasoning. Ticket 0168.                     |
+| `mistral-agents`  | `MISTRAL_API_KEY`                   | Direct Mistral Agents API; web-search connector. Ticket 0169.                         |
+| `qwen-dashscope`  | `DASHSCOPE_API_KEY`                 | Direct Alibaba DashScope; thinking + web_search. Ticket 0173.                         |
+| `claude-code-cli` | user's existing Claude Code session | Subprocess wrapper around `claude --print --bare`; no API key in sweep env. Ticket 0160. |
+
+The `claude-code-cli` route is convenient for capability checks that
+should not consume an `ANTHROPIC_API_KEY` budget: bills against the
+user's subscription, runs in `--bare` mode (no hooks, no tools, no
+`CLAUDE.md` context). Limitations: no temperature/seed/`max_tokens`
+control, single-turn only. Registry entries:
+`claude-sonnet-4-6-cli`, `claude-opus-4-7-cli`. Example sweep:
+`sweep_smoke_claude_cli` in `experiments/experiments.toml`.
+
 ## Building
 
 Requires [Tectonic](https://tectonic-typesetting.github.io/) and [uv](https://docs.astral.sh/uv/).

--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -1021,3 +1021,27 @@ corpus = "data/rag_corpus"
 reference = "data/reference/vietnam_thermal_v1.csv"
 output = "derived/fusion_proto_dev"
 seed = 42
+
+# Ticket 0160: example sweep exercising the claude-code-cli route.
+# Authenticates via the user's existing Claude Code session — no
+# API key needed in the sweep environment. Bills against the user's
+# Anthropic subscription/plan, not registry pricing. Useful for
+# qualitative capability checks; not suitable for controlled sweeps
+# (no T=0/seed/max_tokens control).
+[sets.modelset_claude_cli_smoke]
+model_ids = [
+    "claude-sonnet-4-6-cli",
+]
+
+[sweeps.sweep_smoke_claude_cli]
+mode = "single"
+prompt_modules = []
+models = "models.yaml"
+model_set = "modelset_claude_cli_smoke"
+repeat = 1
+temperature = 0.0
+seed = 42
+budget_usd = 1
+max_tokens = 4096
+system_instruction = "You have no web search capability. Do not claim to perform searches, do not invoke tools, do not fabricate URLs. Answer from parametric knowledge only."
+output = "outputs/smoke/claude_cli"

--- a/experiments/models.yaml
+++ b/experiments/models.yaml
@@ -988,6 +988,41 @@
   license: commercial
   web_search: false
 
+# Ticket 0160: claude-code-cli route. Authenticates via the user's
+# existing Claude Code session (no API key required in the sweep
+# environment). Pricing is billed against the user's Anthropic
+# subscription / API plan, not the registry's price_per_mtok_* fields —
+# the CLI reports actual cost in `total_cost_usd` per call and the
+# runner uses that value instead of compute_cost(). The registry prices
+# are kept at 0 to surface any accidental misuse via compute_cost().
+- name: "claude-sonnet-4-6-cli"
+  route: claude-code-cli
+  model_id: "claude-sonnet-4-6"
+  display_name: "Claude Sonnet 4.6 (CLI)"
+  provider: Anthropic
+  country: US
+  architecture: dense
+  context_window: 1000000
+  price_per_mtok_in: 0.0
+  price_per_mtok_out: 0.0
+  size_class: frontier
+  license: commercial
+  web_search: false
+
+- name: "claude-opus-4-7-cli"
+  route: claude-code-cli
+  model_id: "claude-opus-4-7"
+  display_name: "Claude Opus 4.7 (CLI)"
+  provider: Anthropic
+  country: US
+  architecture: dense
+  context_window: 1000000
+  price_per_mtok_in: 0.0
+  price_per_mtok_out: 0.0
+  size_class: frontier
+  license: commercial
+  web_search: false
+
 - name: "openai/gpt-5.5"
   route: openrouter
   base_url: "https://openrouter.ai/api/v1"

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -355,6 +355,99 @@ def query_ollama_native(
 
 
 # ---------------------------------------------------------------------------
+# Claude Code CLI (subprocess, --print mode)
+# ---------------------------------------------------------------------------
+
+
+def query_claude_cli(
+    model_id: str,
+    messages: list[dict],
+    *,
+    timeout: float = 600.0,
+    max_budget_usd: float | None = None,
+) -> dict:
+    """Query via Claude Code CLI in non-interactive --print mode.
+
+    Authenticates via the user's existing Claude Code session (no API key
+    in the sweep environment). Runs with --bare to skip hooks, plugin
+    sync, CLAUDE.md auto-discovery, and other interactive-mode overhead;
+    --allowedTools "" to disallow every tool so the model answers from
+    parametric knowledge only (matches the no-web Exp 1 discipline).
+
+    Cost is reported by the CLI itself in `total_cost_usd`; pricing is
+    governed by the user's Anthropic subscription / API plan, not by the
+    registry's price_per_mtok_* fields.
+
+    Messages: a single system message (optional) plus one user message
+    are supported; multi-turn is not. The CLI takes the prompt on stdin.
+
+    Limitations:
+    - No temperature, seed, or max_tokens control — runs use CLI defaults.
+    - Single user turn only (no conversation history).
+    - Reasoning tokens are not surfaced separately by the CLI's JSON.
+    """
+    import subprocess
+
+    system_text = ""
+    user_text = ""
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if role == "system":
+            system_text = content
+        elif role == "user":
+            user_text = content
+    if not user_text:
+        raise ValueError("query_claude_cli: messages must include a user turn")
+
+    cmd = [
+        "claude",
+        "--print",
+        "--bare",
+        "--model",
+        model_id,
+        "--output-format",
+        "json",
+        "--allowedTools",
+        "",
+        "--no-session-persistence",
+    ]
+    if system_text:
+        cmd.extend(["--append-system-prompt", system_text])
+    if max_budget_usd is not None:
+        cmd.extend(["--max-budget-usd", f"{max_budget_usd:.4f}"])
+
+    t0 = time.monotonic()
+    proc = subprocess.run(
+        cmd,
+        input=user_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    wall_seconds = round(time.monotonic() - t0, 3)
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude CLI exited {proc.returncode}: {proc.stderr[:500]}")
+
+    data = json.loads(proc.stdout)
+    if data.get("is_error"):
+        raise RuntimeError(f"claude CLI error: {data.get('result', 'unknown')}")
+
+    usage = data.get("usage", {})
+    return {
+        "content": data.get("result", ""),
+        "finish_reason": data.get("stop_reason", "stop"),
+        "usage": {
+            "prompt_tokens": usage.get("input_tokens", 0),
+            "completion_tokens": usage.get("output_tokens", 0),
+        },
+        "wall_seconds": wall_seconds,
+        "cost_usd": data.get("total_cost_usd", 0.0),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Capability-driven API kwargs
 # ---------------------------------------------------------------------------
 

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -38,6 +38,7 @@ from .harness import (
     make_client_for_route,
     model_metadata,
     output_path,
+    query_claude_cli,
     query_ollama_native,
     query_single_turn,
     save_json,
@@ -183,8 +184,15 @@ def main():
         route = model.get("route")
         if args.model_set and route:
             if route not in clients:
-                clients[route] = make_client_for_route(model)
+                if route == "claude-code-cli":
+                    # Adapter is a subprocess; no OpenAI-style client needed.
+                    clients[route] = None
+                else:
+                    clients[route] = make_client_for_route(model)
             client = clients[route]
+        elif route == "claude-code-cli":
+            # Legacy path also supports claude-code-cli (no client needed).
+            client = None
         else:
             if legacy_client is None:
                 raise SystemExit(
@@ -234,6 +242,14 @@ def main():
                         num_predict=args.max_tokens,
                         no_think=args.no_think,
                     )
+                elif model.get("route") == "claude-code-cli":
+                    # Subprocess adapter; auth via user's Claude Code session.
+                    # Temperature/seed/max_tokens are not configurable via the
+                    # CLI — sweep flags are ignored on this route.
+                    result = query_claude_cli(
+                        api_model_id,
+                        messages,
+                    )
                 else:
                     result = query_single_turn(
                         client,
@@ -242,7 +258,12 @@ def main():
                         **api_kwargs,
                     )
                 usage = result.get("usage") or {}
-                cost = compute_cost(usage, model)
+                # Claude CLI reports cost in the result; other routes
+                # compute from registry pricing.
+                if model.get("route") == "claude-code-cli":
+                    cost = float(result.get("cost_usd") or 0.0)
+                else:
+                    cost = compute_cost(usage, model)
                 budget.add(cost)
 
                 filepath = output_path(output_dir, model_id, run)

--- a/tests/test_query_claude_cli.py
+++ b/tests/test_query_claude_cli.py
@@ -1,0 +1,176 @@
+"""Unit tests for the Claude Code CLI route adapter (ticket 0160).
+
+Pure unit tests — no real subprocess, no real claude binary required.
+Belong in ``make check-fast``. Integration smoke (calls the real binary)
+is in ``test_query_claude_cli_smoke.py`` and is marked ``@pytest.mark.slow``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from aedist.harness import query_claude_cli
+
+# A minimal recorded shape of `claude --print --output-format json` stdout,
+# verified live against claude-sonnet-4-6 on 2026-05-21 in the 0160 raid.
+SAMPLE_RESPONSE = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "duration_ms": 4662,
+    "duration_api_ms": 4623,
+    "result": "pong",
+    "stop_reason": "end_turn",
+    "session_id": "5494c3ae-5a36-4637-ae5f-4304747f220d",
+    "total_cost_usd": 0.0711507,
+    "usage": {
+        "input_tokens": 2,
+        "output_tokens": 5,
+        "cache_creation_input_tokens": 17848,
+        "cache_read_input_tokens": 13799,
+    },
+}
+
+
+def _completed_process(stdout: str, stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_command_assembly_minimal():
+    """User-only messages produce a command without --append-system-prompt."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        return _completed_process(json.dumps(SAMPLE_RESPONSE))
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        query_claude_cli("claude-sonnet-4-6", [{"role": "user", "content": "ping"}])
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "claude"
+    assert "--print" in cmd
+    assert "--bare" in cmd
+    assert "--model" in cmd and "claude-sonnet-4-6" in cmd
+    assert "--output-format" in cmd and "json" in cmd
+    assert "--allowedTools" in cmd
+    assert "--no-session-persistence" in cmd
+    assert "--append-system-prompt" not in cmd
+    assert captured["input"] == "ping"
+
+
+def test_command_assembly_with_system_prompt():
+    """System message lands on --append-system-prompt; user on stdin."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        return _completed_process(json.dumps(SAMPLE_RESPONSE))
+
+    messages = [
+        {"role": "system", "content": "no web search."},
+        {"role": "user", "content": "list plants"},
+    ]
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        query_claude_cli("claude-sonnet-4-6", messages)
+
+    cmd = captured["cmd"]
+    assert "--append-system-prompt" in cmd
+    idx = cmd.index("--append-system-prompt")
+    assert cmd[idx + 1] == "no web search."
+    assert captured["input"] == "list plants"
+
+
+def test_command_assembly_with_max_budget():
+    """max_budget_usd kwarg adds --max-budget-usd to the command."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _completed_process(json.dumps(SAMPLE_RESPONSE))
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        query_claude_cli(
+            "claude-sonnet-4-6",
+            [{"role": "user", "content": "ping"}],
+            max_budget_usd=0.50,
+        )
+
+    cmd = captured["cmd"]
+    assert "--max-budget-usd" in cmd
+    idx = cmd.index("--max-budget-usd")
+    assert cmd[idx + 1] == "0.5000"
+
+
+def test_response_parsing():
+    """JSON stdout maps onto the standard result dict shape."""
+    with patch.object(
+        subprocess, "run", return_value=_completed_process(json.dumps(SAMPLE_RESPONSE))
+    ):
+        result = query_claude_cli("claude-sonnet-4-6", [{"role": "user", "content": "ping"}])
+
+    assert result["content"] == "pong"
+    assert result["finish_reason"] == "end_turn"
+    assert result["usage"]["prompt_tokens"] == 2
+    assert result["usage"]["completion_tokens"] == 5
+    assert result["cost_usd"] == pytest.approx(0.0711507)
+    assert result["wall_seconds"] >= 0
+
+
+def test_nonzero_exit_raises():
+    """Subprocess non-zero exit surfaces as RuntimeError with stderr tail."""
+    with patch.object(
+        subprocess,
+        "run",
+        return_value=_completed_process("", stderr="boom", returncode=1),
+    ):
+        with pytest.raises(RuntimeError, match="claude CLI exited 1"):
+            query_claude_cli("claude-sonnet-4-6", [{"role": "user", "content": "ping"}])
+
+
+def test_is_error_in_payload_raises():
+    """A 200 OK with is_error=true in the JSON is treated as a hard failure."""
+    payload = {**SAMPLE_RESPONSE, "is_error": True, "result": "model overloaded"}
+    with patch.object(subprocess, "run", return_value=_completed_process(json.dumps(payload))):
+        with pytest.raises(RuntimeError, match="claude CLI error: model overloaded"):
+            query_claude_cli("claude-sonnet-4-6", [{"role": "user", "content": "ping"}])
+
+
+def test_missing_user_message_raises():
+    """Messages without a user turn fail before invoking the CLI."""
+    with pytest.raises(ValueError, match="must include a user turn"):
+        query_claude_cli("claude-sonnet-4-6", [{"role": "system", "content": "only system"}])
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke — opt-in via the slow marker, skipped when CLI absent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_smoke_real_cli():
+    """One real call against the local claude CLI.
+
+    Skipped when the binary is absent (CI without Claude Code installed).
+    Costs a few cents on the user's Anthropic subscription.
+    """
+    if shutil.which("claude") is None:
+        pytest.skip("claude CLI not installed")
+
+    result = query_claude_cli(
+        "claude-sonnet-4-6",
+        [{"role": "user", "content": "Reply with exactly one word: pong"}],
+        timeout=60.0,
+    )
+    assert result["content"].strip().lower().startswith("pong")
+    assert result["usage"]["completion_tokens"] > 0
+    assert result["cost_usd"] >= 0

--- a/tickets/closed/0160-claude-code-cli-route.erg
+++ b/tickets/closed/0160-claude-code-cli-route.erg
@@ -2,11 +2,13 @@
 Title: Implement claude-code-cli route in experiment runner
 Created: 2026-05-01
 Author: claude
+Closed: autoclosed — PR #395
 
 --- log ---
 2026-05-01T10:15Z claude created — split from 0156 amendment
 2026-05-04T10:45Z claude note removed Blocked-by: 0156 — 0156 is closed (PR #322)
 
+2026-05-21T13:31Z HDMX-coding-agent closed — autoclosed — PR #395
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Implements the `claude-code-cli` route reserved by ticket 0156 (route enum). Adds `query_claude_cli()` in `src/aedist/harness.py` — a subprocess wrapper around `claude --print --bare --output-format json` that authenticates via the user's existing Claude Code session (no API key in the sweep environment) and disallows all tools to match the no-web Exp 1 discipline.

## Dispatch

`query_direct.main()` now:
- Skips OpenAI client construction for `route: claude-code-cli` (subprocess adapter — no client needed).
- Calls `query_claude_cli(api_model_id, messages)` instead of `query_single_turn(...)`.
- Bills against `result["cost_usd"]` (reported by the CLI per call) instead of `compute_cost(usage, model)`.
- Legacy non-`model_set` path also handles the route as a fallback.

## Registry

Two entries added in `experiments/models.yaml`:
- `claude-sonnet-4-6-cli` → `claude-sonnet-4-6`
- `claude-opus-4-7-cli` → `claude-opus-4-7`

`price_per_mtok_*` kept at 0.0 to surface accidental `compute_cost()` misuse; real cost comes from the CLI per call.

## Tests

- `tests/test_query_claude_cli.py` — 7 unit tests (mocked subprocess):
  - command assembly (minimal, with system prompt, with max-budget)
  - JSON response parsing
  - non-zero exit raises
  - `is_error: true` payload raises
  - missing user-turn raises
- `@pytest.mark.slow` smoke that calls the real CLI; skips gracefully when the binary is absent.

`uv run pytest -q -m "not slow and not integration"` → 1319 passed.

## Limitations (documented in docstring)

- No temperature / seed / max_tokens control — CLI uses defaults.
- Single-turn only (no conversation history).
- `reasoning_tokens` not surfaced separately by the CLI's JSON output.

Suitable for capability checks; not for controlled sweeps that need T=0 reproducibility.

## Smoke verification

Live call against `claude-sonnet-4-6` on 2026-05-21 returned the expected JSON shape: `result`, `stop_reason`, `usage.{input,output}_tokens`, `total_cost_usd`. Fixture in `test_query_claude_cli.py` was derived from this real response.

**Ticket:** tickets/0160-claude-code-cli-route.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)