### PR TITLE
feat(adapters): multi-turn continuation surface (0208)

### DIFF
--- a/src/aedist/adapter_base.py
+++ b/src/aedist/adapter_base.py
@@ -81,7 +81,21 @@ class AgentAdapter(Protocol):
         prompt: str,
         *,
         dry_run: bool,
+        continuation: dict | None = None,
+        extra_metadata: dict | None = None,
         **opts: Any,
     ) -> RunRecord:
-        """Execute one agent call (or print the dry-run payload) and return a record."""
+        """Execute one agent call (or print the dry-run payload) and return a record.
+
+        ``continuation`` is a provider-specific token for chaining
+        multi-turn conversations.  ``None`` starts a new conversation
+        (backward-compatible default).  ``extra_metadata`` carries
+        key/value pairs for the provider's metadata surface (e.g.
+        ``remaining_budget_usd``); adapters that lack metadata support
+        log a warning and continue.
+
+        Note: the Anthropic adapter uses ``dispatch()`` rather than
+        ``run()``; this Protocol documents the canonical four-adapter
+        surface but does not force a rename on the Anthropic side.
+        """
         ...

--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -330,6 +330,22 @@ def _delete_agent(client: httpx.Client, agent_id: str) -> None:
         log.warning("Mistral DELETE /v1/agents/%s failed: %s", agent_id, exc)
 
 
+def cleanup_agent(agent_id: str, *, api_key: str | None = None) -> None:
+    """Public lifecycle cleanup: delete a Mistral agent by ID.
+
+    The Exp 2 harness (ticket 0207) calls this at session end after
+    multi-turn conversations. Accepts an optional ``api_key`` override;
+    falls back to the standard key-loading path.
+    """
+    key = api_key or _load_api_key()
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    with httpx.Client(base_url=API_BASE, headers=headers) as client:
+        _delete_agent(client, agent_id)
+
+
 # ---------------------------------------------------------------------------
 # Entry point (Protocol surface: run)
 # ---------------------------------------------------------------------------
@@ -344,13 +360,24 @@ def run(
     cap_usd: float = 10.0,
     agent_mode: str = "smoke",
     output_path: Path | None = None,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
     **opts: Any,
 ) -> RunRecord:
     """Execute one Mistral Agents call (or print the dry-run payload).
 
-    Lifecycle: create agent -> start conversation -> parse -> delete
-    agent. The delete runs in ``finally`` so an orphan ``ag_*`` is never
-    left behind, even on parse failure.
+    Lifecycle for single-turn (``continuation=None``): create agent ->
+    start conversation -> parse -> delete agent. The delete runs in
+    ``finally`` so an orphan ``ag_*`` is never left behind.
+
+    Multi-turn (``continuation`` is a dict with ``conversation_id`` and
+    ``agent_id``): skip agent creation, send a follow-up message to the
+    existing conversation. The agent is NOT deleted — the harness calls
+    :func:`cleanup_agent` at session end.
+
+    ``extra_metadata`` is attached to the conversation request body's
+    ``metadata`` field when present. Wrapped defensively since the
+    Mistral beta API may not support it.
 
     ``model_meta`` is the registry entry for the chosen model (see
     ``experiments/models.yaml``). When omitted, a minimal default is
@@ -393,17 +420,40 @@ def run(
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
-    agent_id: str | None = None
     t0 = time.monotonic()
-    with httpx.Client(base_url=API_BASE, headers=headers) as client:
-        try:
-            agent_id = _create_agent(client, payload["agent_create"]["body"])
-            conv_body = dict(payload["conversation_start"]["body"])
-            conv_body["agent_id"] = agent_id
+
+    if continuation is not None:
+        # Multi-turn follow-up: reuse existing agent and conversation.
+        conv_body: dict[str, Any] = {
+            "agent_id": continuation["agent_id"],
+            "inputs": [{"role": "user", "content": prompt}],
+        }
+        if continuation.get("conversation_id"):
+            conv_body["conversation_id"] = continuation["conversation_id"]
+        if extra_metadata is not None:
+            try:
+                conv_body["metadata"] = extra_metadata
+            except Exception:
+                log.warning("Failed to attach extra_metadata to Mistral conversation body")
+        with httpx.Client(base_url=API_BASE, headers=headers) as client:
             raw = _start_conversation(client, conv_body)
-        finally:
-            if agent_id is not None:
-                _delete_agent(client, agent_id)
+    else:
+        # Single-turn: create agent, invoke, delete.
+        agent_id: str | None = None
+        with httpx.Client(base_url=API_BASE, headers=headers) as client:
+            try:
+                agent_id = _create_agent(client, payload["agent_create"]["body"])
+                conv_body = dict(payload["conversation_start"]["body"])
+                conv_body["agent_id"] = agent_id
+                if extra_metadata is not None:
+                    try:
+                        conv_body["metadata"] = extra_metadata
+                    except Exception:
+                        log.warning("Failed to attach extra_metadata to Mistral conversation body")
+                raw = _start_conversation(client, conv_body)
+            finally:
+                if agent_id is not None:
+                    _delete_agent(client, agent_id)
 
     wall_s = round(time.monotonic() - t0, 3)
     if output_path is not None:
@@ -412,4 +462,18 @@ def run(
         output_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False))
         log.info("Saved Mistral raw response to %s", output_path)
 
-    return parse_response(raw, meta, wall_s=wall_s, agent_mode=agent_mode, prompt=prompt)
+    record = parse_response(raw, meta, wall_s=wall_s, agent_mode=agent_mode, prompt=prompt)
+
+    # Surface continuation token for multi-turn chaining. On single-turn
+    # (continuation=None) the agent is already deleted, but we still
+    # return the conversation_id for informational parity. On multi-turn,
+    # the agent_id carries through from the continuation dict.
+    if record.method_params.extra is None:
+        record.method_params.extra = {}
+    record.method_params.extra["conversation_id"] = raw.get("conversation_id")
+    if continuation is not None:
+        record.method_params.extra["agent_id"] = continuation["agent_id"]
+    elif agent_id is not None:
+        record.method_params.extra["agent_id"] = agent_id
+
+    return record

--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -366,14 +366,20 @@ def run(
 ) -> RunRecord:
     """Execute one Mistral Agents call (or print the dry-run payload).
 
-    Lifecycle for single-turn (``continuation=None``): create agent ->
-    start conversation -> parse -> delete agent. The delete runs in
-    ``finally`` so an orphan ``ag_*`` is never left behind.
+    Three lifecycle modes controlled by ``continuation``:
 
-    Multi-turn (``continuation`` is a dict with ``conversation_id`` and
-    ``agent_id``): skip agent creation, send a follow-up message to the
-    existing conversation. The agent is NOT deleted — the harness calls
-    :func:`cleanup_agent` at session end.
+    1. ``continuation=None`` — **single-turn** (backward-compatible
+       default): create agent -> invoke conversation -> delete agent.
+       The delete runs in ``finally`` so no orphan ``ag_*`` is left.
+
+    2. ``continuation={}`` (empty dict) — **first turn of multi-turn**:
+       create agent -> invoke conversation -> **skip delete**. Returns
+       ``agent_id`` + ``conversation_id`` in ``method_params.extra``.
+       The harness must call :func:`cleanup_agent` at session end.
+
+    3. ``continuation={"agent_id": ..., "conversation_id": ...}`` —
+       **follow-up turn**: skip agent creation, send follow-up message
+       to existing conversation. No create, no delete.
 
     ``extra_metadata`` is attached to the conversation request body's
     ``metadata`` field when present. Wrapped defensively since the
@@ -422,38 +428,48 @@ def run(
     }
     t0 = time.monotonic()
 
-    if continuation is not None:
-        # Multi-turn follow-up: reuse existing agent and conversation.
+    # Determine lifecycle mode from continuation shape.
+    is_followup = continuation is not None and continuation.get("agent_id")
+    is_multiturn_start = continuation is not None and not continuation.get("agent_id")
+    agent_id: str | None = None
+
+    def _attach_metadata(body: dict[str, Any]) -> None:
+        if extra_metadata is not None:
+            try:
+                body["metadata"] = extra_metadata
+            except Exception:
+                log.warning("Failed to attach extra_metadata to Mistral conversation body")
+
+    if is_followup:
+        # Mode 3: follow-up turn — reuse existing agent and conversation.
         conv_body: dict[str, Any] = {
             "agent_id": continuation["agent_id"],
             "inputs": [{"role": "user", "content": prompt}],
         }
         if continuation.get("conversation_id"):
             conv_body["conversation_id"] = continuation["conversation_id"]
-        if extra_metadata is not None:
-            try:
-                conv_body["metadata"] = extra_metadata
-            except Exception:
-                log.warning("Failed to attach extra_metadata to Mistral conversation body")
+        _attach_metadata(conv_body)
         with httpx.Client(base_url=API_BASE, headers=headers) as client:
             raw = _start_conversation(client, conv_body)
+        agent_id = continuation["agent_id"]
     else:
-        # Single-turn: create agent, invoke, delete.
-        agent_id: str | None = None
+        # Mode 1 or 2: create agent + invoke.
         with httpx.Client(base_url=API_BASE, headers=headers) as client:
             try:
                 agent_id = _create_agent(client, payload["agent_create"]["body"])
                 conv_body = dict(payload["conversation_start"]["body"])
                 conv_body["agent_id"] = agent_id
-                if extra_metadata is not None:
-                    try:
-                        conv_body["metadata"] = extra_metadata
-                    except Exception:
-                        log.warning("Failed to attach extra_metadata to Mistral conversation body")
+                _attach_metadata(conv_body)
                 raw = _start_conversation(client, conv_body)
-            finally:
+            except BaseException:
+                # On failure, always clean up the agent (if created).
                 if agent_id is not None:
                     _delete_agent(client, agent_id)
+                raise
+            # Mode 1 (single-turn): delete immediately.
+            # Mode 2 (multi-turn start): keep alive.
+            if not is_multiturn_start and agent_id is not None:
+                _delete_agent(client, agent_id)
 
     wall_s = round(time.monotonic() - t0, 3)
     if output_path is not None:
@@ -464,16 +480,11 @@ def run(
 
     record = parse_response(raw, meta, wall_s=wall_s, agent_mode=agent_mode, prompt=prompt)
 
-    # Surface continuation token for multi-turn chaining. On single-turn
-    # (continuation=None) the agent is already deleted, but we still
-    # return the conversation_id for informational parity. On multi-turn,
-    # the agent_id carries through from the continuation dict.
+    # Surface continuation tokens for multi-turn chaining.
     if record.method_params.extra is None:
         record.method_params.extra = {}
     record.method_params.extra["conversation_id"] = raw.get("conversation_id")
-    if continuation is not None:
-        record.method_params.extra["agent_id"] = continuation["agent_id"]
-    elif agent_id is not None:
+    if agent_id is not None:
         record.method_params.extra["agent_id"] = agent_id
 
     return record

--- a/src/aedist/adapter_openai_responses.py
+++ b/src/aedist/adapter_openai_responses.py
@@ -238,9 +238,13 @@ def parse_response(resp: Any, price_card: dict) -> RunRecord:
     output_tokens = _get(usage, "output_tokens", 0) or 0
     reasoning_tokens = _get(_get(usage, "output_tokens_details"), "reasoning_tokens", 0) or 0
 
+    response_id = _get(resp, "id")
     record = RunRecord(
         method=Method.FRONTIER,
-        method_params=MethodParams(model=model_id),
+        method_params=MethodParams(
+            model=model_id,
+            extra={"response_id": response_id},
+        ),
         agent_family=AGENT_FAMILY,
         resource_use=ResourceUse(
             cost_usd=cost_usd,
@@ -308,6 +312,8 @@ def run(
     reasoning_effort: str = "high",
     price_card: dict | None = None,
     cap_usd: float = DEFAULT_COST_CAP_USD,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
 ) -> RunRecord:
     """Execute one OpenAI Responses call (or dry-run) and return a RunRecord.
 
@@ -318,6 +324,14 @@ def run(
       * **Post-call**: re-checks ``record.resource_use.cost_usd`` against
         ``cap_usd``; raises ``CostCapExceeded`` if the actual billed cost
         breached it (defence in depth against estimate drift).
+
+    Multi-turn chaining (ticket 0208):
+      * ``continuation=None`` → new conversation (current behavior).
+      * ``continuation={"response_id": "resp_..."}`` → passes
+        ``previous_response_id`` to the SDK to chain responses.
+      * ``extra_metadata`` → passed as the ``metadata`` dict on the SDK
+        call. Values must be strings (OpenAI constraint); the caller is
+        responsible for stringifying.
     """
     payload = build_request(
         prompt,
@@ -335,6 +349,12 @@ def run(
         price_out=p_out,
     )
     enforce_cost_cap(estimated, cap_usd=cap_usd)
+
+    # Wire continuation and metadata into the SDK payload.
+    if continuation is not None and continuation.get("response_id"):
+        payload["previous_response_id"] = continuation["response_id"]
+    if extra_metadata is not None:
+        payload["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
 
     if dry_run:
         print(format_dry_run(payload))

--- a/src/aedist/adapter_qwen_dashscope.py
+++ b/src/aedist/adapter_qwen_dashscope.py
@@ -30,6 +30,7 @@ response, set ``enable_search=True`` and pass ``search_options``.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from pathlib import Path
@@ -43,6 +44,8 @@ from aedist.adapter_base import (
     format_dry_run,
 )
 from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
+
+_log = logging.getLogger(__name__)
 
 AGENT_FAMILY = "qwen-direct"
 DEFAULT_MODEL = "qwen3-max-2026-01-23"
@@ -77,12 +80,17 @@ def build_request(
     enable_thinking: bool = True,
     enable_search: bool = True,
     search_options: dict | None = None,
+    continuation: dict | None = None,
 ) -> dict:
     """Assemble the DashScope ``Generation.call`` kwargs.
 
     The returned dict is consumed in two ways:
     - ``--dry-run`` prints it via :func:`format_dry_run`.
     - Live mode splats it into ``dashscope.Generation.call(**payload)``.
+
+    Multi-turn (ticket 0208): when ``continuation`` is provided with a
+    ``messages`` key, those messages are prepended to the new user
+    message to form the full conversation history.
 
     Important: this function intentionally never sets a ``tools`` key.
     Setting it would activate client-side function calling and break
@@ -94,9 +102,14 @@ def build_request(
             "enable_citation": True,
             "citation_format": "[<number>]",
         }
+    # Build messages: prepend history from continuation if present.
+    if continuation is not None and continuation.get("messages"):
+        messages = list(continuation["messages"]) + [{"role": "user", "content": prompt}]
+    else:
+        messages = [{"role": "user", "content": prompt}]
     payload: dict[str, Any] = {
         "model": model,
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": messages,
         "enable_thinking": enable_thinking,
         "enable_search": enable_search,
         "search_options": search_options,
@@ -273,6 +286,12 @@ def parse_response(
     # remains the canonical record.
     if narrative is not None and record.method_params.extra is not None:
         record.method_params.extra["narrative_preview"] = narrative[:200]
+        # Multi-turn continuation (ticket 0208): include the conversation
+        # messages so the harness can replay history on the next turn.
+        record.method_params.extra["messages"] = [
+            {"role": "user", "content": prompt or ""},
+            {"role": "assistant", "content": narrative},
+        ]
     return record
 
 
@@ -312,15 +331,31 @@ def run(
     model_meta: dict | None = None,
     cost_cap_usd: float = DEFAULT_COST_CAP_USD,
     base_url: str = DEFAULT_BASE_URL,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
 ) -> RunRecord:
-    """Execute one DashScope call (or print the dry-run payload)."""
+    """Execute one DashScope call (or print the dry-run payload).
+
+    Multi-turn (ticket 0208): ``continuation`` with a ``messages`` key
+    prepends conversation history. ``extra_metadata`` is prepended as
+    a system-message budget reminder (DashScope lacks a metadata surface).
+    """
     payload = build_request(
         prompt,
         model=model,
         max_tokens=max_tokens,
         enable_thinking=enable_thinking,
         enable_search=enable_search,
+        continuation=continuation,
     )
+    # DashScope lacks a metadata surface. Prepend a system message as a
+    # practical fallback so the model sees budget information.
+    if extra_metadata is not None:
+        meta_text = "; ".join(f"{k}={v}" for k, v in extra_metadata.items())
+        payload["messages"].insert(0, {"role": "system", "content": f"[metadata] {meta_text}"})
+        _log.info(
+            "Qwen: injected extra_metadata as system message (DashScope has no metadata surface)"
+        )
 
     # Pre-call cap: assume worst-case token billing + a small per-call
     # search budget (n_searches is unknown until the response lands).

--- a/src/aedist/query_anthropic.py
+++ b/src/aedist/query_anthropic.py
@@ -340,6 +340,7 @@ def _record_from_parsed(
     run_number: int,
     parsed_table_path: str | None = None,
     error: str | None = None,
+    messages_for_continuation: list[dict] | None = None,
 ) -> RunRecord:
     """Build a RunRecord from a parsed Anthropic response."""
     total_cost = float(cost_breakdown.get("total", 0.0))
@@ -350,11 +351,14 @@ def _record_from_parsed(
         for k, v in cost_breakdown.items()
         if k in {"input", "output", "cache_read", "cache_write"} and v
     }
+    extra: dict[str, Any] = {"run_number": run_number}
+    if messages_for_continuation is not None:
+        extra["messages"] = messages_for_continuation
     return RunRecord(
         method=Method.FRONTIER,
         method_params=MethodParams(
             model=model,
-            extra={"run_number": run_number},
+            extra=extra,
         ),
         resource_use=ResourceUse(
             wall_s=wall_s,
@@ -389,6 +393,8 @@ def dispatch(
     budget: BudgetTracker | None = None,
     cap_usd: float = 0.50,
     key_path: str | os.PathLike = DEFAULT_KEY_PATH,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
 ) -> dict:
     """Execute one Anthropic agent call (or print a dry-run payload).
 
@@ -396,10 +402,36 @@ def dispatch(
     (provider response or ``None`` on dry-run), and ``output_path`` (Path
     when persisted, ``None`` on dry-run). The 0170-facing entry point.
 
+    Multi-turn chaining (ticket 0208):
+      * ``continuation=None`` → new conversation (current behavior).
+      * ``continuation={"messages": [...]}`` → replaces ``payload["messages"]``
+        with the continuation messages, then appends the new user message.
+      * ``extra_metadata`` → Anthropic supports a ``metadata`` parameter
+        with at least ``user_id``. Non-user_id keys are logged as warnings
+        and passed through defensively.
+
     ``cap_usd`` is enforced both pre-call (against the conservative upper
     bound from :func:`aedist.adapter_base.estimate_call_cost`) and
     post-call (against actual billed amount).
     """
+    # Wire continuation into payload messages.
+    if continuation is not None and continuation.get("messages"):
+        # Build messages from continuation history + new user message.
+        new_user_msg = (
+            payload["messages"][-1] if payload.get("messages") else {"role": "user", "content": ""}
+        )
+        payload["messages"] = list(continuation["messages"]) + [new_user_msg]
+
+    # Wire extra_metadata into the Anthropic metadata parameter.
+    if extra_metadata is not None:
+        payload["metadata"] = extra_metadata
+        non_standard = [k for k in extra_metadata if k != "user_id"]
+        if non_standard:
+            log.info(
+                "Anthropic: passing non-standard metadata keys %s — may be ignored by API",
+                non_standard,
+            )
+
     model_id = model["model_id"]
     max_tokens = int(payload.get("max_tokens", DEFAULT_MAX_TOKENS))
     max_uses = int(
@@ -454,6 +486,13 @@ def dispatch(
     if budget is not None:
         budget.add(breakdown["total"])
 
+    # Build the conversation messages for multi-turn continuation:
+    # the full messages list (including the new assistant reply) so
+    # the harness can replay history on the next turn.
+    continuation_messages = list(payload.get("messages", []))
+    if parsed.get("text"):
+        continuation_messages.append({"role": "assistant", "content": parsed["text"]})
+
     record = _record_from_parsed(
         parsed,
         model=model_id,
@@ -464,6 +503,7 @@ def dispatch(
         thinking_tokens=None,  # Anthropic reports total output incl. thinking.
         agent_mode=agent_mode,
         run_number=run,
+        messages_for_continuation=continuation_messages,
     )
 
     # Persist as one self-contained JSON: record + raw response + parsed view.

--- a/tests/test_adapter_anthropic.py
+++ b/tests/test_adapter_anthropic.py
@@ -251,3 +251,75 @@ def test_parse_stitches_tool_use_to_result_by_id():
     assert parsed["web_search_calls"][0]["urls_returned"] == ["https://first"]
     assert parsed["web_search_calls"][1]["urls_returned"] == ["https://second"]
     assert parsed["n_searches"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn continuation surface (ticket 0208)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_accepts_continuation_kwarg(anthropic_fixture, price_card, tmp_path):
+    """dispatch() must accept continuation kwarg on dry-run without crash."""
+    from aedist.query_anthropic import dispatch
+
+    payload = assemble_request("hello", DEFAULT_MODEL, max_tokens=DEFAULT_MAX_TOKENS)
+    result = dispatch(
+        payload,
+        price_card,
+        dry_run=True,
+        output_dir=tmp_path,
+        continuation={"messages": [{"role": "user", "content": "q1"}]},
+    )
+    # Dry-run returns None record.
+    assert result["run_record"] is None
+
+
+def test_dispatch_accepts_extra_metadata_kwarg(price_card, tmp_path):
+    """dispatch() must accept extra_metadata kwarg on dry-run without crash."""
+    from aedist.query_anthropic import dispatch
+
+    payload = assemble_request("hello", DEFAULT_MODEL, max_tokens=DEFAULT_MAX_TOKENS)
+    result = dispatch(
+        payload,
+        price_card,
+        dry_run=True,
+        output_dir=tmp_path,
+        extra_metadata={"remaining_budget_usd": "5.50"},
+    )
+    assert result["run_record"] is None
+
+
+def test_record_from_parsed_includes_messages_in_extra():
+    """_record_from_parsed must include messages in method_params.extra
+    when provided, so the harness can chain multi-turn conversations.
+    """
+    from aedist.query_anthropic import _record_from_parsed
+
+    parsed = {
+        "text": "answer text",
+        "web_search_calls": [],
+        "citations": [],
+        "reasoning_summary": None,
+        "finish_reason": "end_turn",
+    }
+    record = _record_from_parsed(
+        parsed,
+        model=DEFAULT_MODEL,
+        cost_breakdown={"total": 0.01, "input": 0.005, "output": 0.005},
+        tokens_in=100,
+        tokens_out=50,
+        wall_s=1.0,
+        thinking_tokens=None,
+        agent_mode="smoke",
+        run_number=1,
+        messages_for_continuation=[
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "answer text"},
+        ],
+    )
+    assert record.method_params.extra is not None
+    assert "messages" in record.method_params.extra
+    msgs = record.method_params.extra["messages"]
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[1]["role"] == "assistant"

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -163,7 +163,15 @@ class _StubAdapter:
     def parse_response(self, resp: Any, model_meta: dict) -> RunRecord:
         return RunRecord(method="frontier", method_params={"model": "stub"})
 
-    def run(self, prompt: str, *, dry_run: bool, **opts: Any) -> RunRecord:
+    def run(
+        self,
+        prompt: str,
+        *,
+        dry_run: bool,
+        continuation: dict | None = None,
+        extra_metadata: dict | None = None,
+        **opts: Any,
+    ) -> RunRecord:
         return RunRecord(method="frontier", method_params={"model": "stub"})
 
 

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -344,6 +344,78 @@ def test_continuation_skips_agent_creation(monkeypatch):
     assert record.agent_family == AGENT_FAMILY
 
 
+def test_multiturn_start_creates_agent_but_skips_delete(monkeypatch):
+    """continuation={} (empty dict) = first turn of multi-turn.
+    Agent must be created but NOT deleted — harness calls cleanup_agent later.
+    """
+    import aedist.adapter_mistral as am
+
+    calls: list[tuple[str, str]] = []
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "id": "ag_new",
+                "outputs": [
+                    {"type": "message.output", "content": "first answer"},
+                ],
+                "usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 100,
+                    "connector_tokens": 0,
+                    "connectors": {"web_search": 0},
+                },
+                "conversation_id": "conv_new",
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            calls.append(("POST", url))
+            return FakeResponse()
+
+        def delete(self, url, **kwargs):
+            calls.append(("DELETE", url))
+            return FakeResponse()
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    record = run(
+        "first question",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        continuation={},  # empty dict = multi-turn start sentinel
+    )
+
+    # Agent created (POST /v1/agents) + conversation started (POST /v1/conversations).
+    # No DELETE — agent kept alive for follow-up turns.
+    assert ("POST", "/v1/agents") in calls
+    assert ("POST", "/v1/conversations") in calls
+    assert not any(method == "DELETE" for method, _ in calls)
+
+    # Continuation tokens surfaced for the next turn.
+    assert record.method_params.extra["agent_id"] == "ag_new"
+    assert record.method_params.extra["conversation_id"] == "conv_new"
+
+
 def test_cleanup_agent_is_public():
     """cleanup_agent must be importable for harness lifecycle management."""
     from aedist.adapter_mistral import cleanup_agent

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -252,3 +252,117 @@ def test_parse_response_str_content_yields_no_web_search_or_citations(
     record = parse_response(fixture_str_content_response, PRICE_CARD)
     assert record.web_search_calls == []
     assert record.citations == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn continuation surface (ticket 0208)
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_run_returns_continuation_token():
+    """First call (continuation=None) must return conversation_id and
+    agent_id in method_params.extra so the harness can chain turns.
+    Dry-run mode: no network, but the extra keys are present for the
+    harness to introspect the return shape.
+    """
+    record = run(
+        "hello",
+        dry_run=True,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+    )
+    # Dry-run still has the dry_run marker; continuation keys are
+    # only meaningful on live calls. Verify backward compat.
+    assert record.method_params.extra == {"dry_run": True}
+
+
+def test_continuation_skips_agent_creation(monkeypatch):
+    """When continuation is provided, only one POST to /v1/conversations
+    should happen — no agent creation, no agent deletion.
+    """
+    import aedist.adapter_mistral as am
+
+    calls: list[tuple[str, str]] = []
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "outputs": [
+                    {"type": "message.output", "content": "follow-up answer"},
+                ],
+                "usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 100,
+                    "connector_tokens": 0,
+                    "connectors": {"web_search": 0},
+                },
+                "conversation_id": "conv_1",
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            calls.append(("POST", url))
+            return FakeResponse()
+
+        def delete(self, url, **kwargs):
+            calls.append(("DELETE", url))
+            return FakeResponse()
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    record = run(
+        "follow up question",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        continuation={"conversation_id": "conv_1", "agent_id": "ag_1"},
+    )
+
+    # Only one POST to /v1/conversations — no /v1/agents create or delete.
+    assert len(calls) == 1
+    assert calls[0] == ("POST", "/v1/conversations")
+    assert record.agent_family == AGENT_FAMILY
+
+
+def test_cleanup_agent_is_public():
+    """cleanup_agent must be importable for harness lifecycle management."""
+    from aedist.adapter_mistral import cleanup_agent
+
+    assert callable(cleanup_agent)
+
+
+def test_run_extra_metadata_logged_without_crash(monkeypatch, caplog):
+    """extra_metadata should not crash the adapter. Mistral's metadata
+    support is uncertain, so the adapter should be defensive.
+    """
+    record = run(
+        "hello",
+        dry_run=True,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        extra_metadata={"remaining_budget_usd": "5.50"},
+    )
+    # Should not crash; dry-run returns normally.
+    assert record.method_params.extra == {"dry_run": True}

--- a/tests/test_adapter_openai_responses.py
+++ b/tests/test_adapter_openai_responses.py
@@ -227,3 +227,62 @@ def test_run_dry_run_still_enforces_cap_pre_call():
 def test_default_cost_cap_is_ten_dollars():
     """Ticket 0168 Action 4 spec: hard cap per call $10."""
     assert DEFAULT_COST_CAP_USD == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn continuation surface (ticket 0208)
+# ---------------------------------------------------------------------------
+
+
+def test_run_dry_run_returns_continuation_ready_record():
+    """Dry-run with continuation=None must succeed without crash.
+    The continuation token is only meaningful on live calls.
+    """
+    record = run(
+        "test prompt",
+        dry_run=True,
+        model=DEFAULT_MODEL,
+        max_output_tokens=100,
+        price_card=PRICE_CARD,
+        cap_usd=DEFAULT_COST_CAP_USD,
+    )
+    assert record.agent_family == AGENT_FAMILY
+    assert record.result_summary.status == "qualitative"
+
+
+def test_parse_response_returns_response_id_in_extra():
+    """parse_response must include response_id in method_params.extra
+    so the harness can use it for previous_response_id chaining.
+    """
+    resp = _load_fixture()
+    record = parse_response(resp, PRICE_CARD)
+    assert record.method_params.extra is not None
+    assert "response_id" in record.method_params.extra
+
+
+def test_run_dry_run_accepts_continuation_kwarg():
+    """run() must accept continuation kwarg without crashing on dry-run."""
+    record = run(
+        "follow up",
+        dry_run=True,
+        model=DEFAULT_MODEL,
+        max_output_tokens=100,
+        price_card=PRICE_CARD,
+        cap_usd=DEFAULT_COST_CAP_USD,
+        continuation={"response_id": "resp_abc"},
+    )
+    assert record.agent_family == AGENT_FAMILY
+
+
+def test_run_dry_run_accepts_extra_metadata_kwarg():
+    """run() must accept extra_metadata kwarg without crashing."""
+    record = run(
+        "prompt",
+        dry_run=True,
+        model=DEFAULT_MODEL,
+        max_output_tokens=100,
+        price_card=PRICE_CARD,
+        cap_usd=DEFAULT_COST_CAP_USD,
+        extra_metadata={"remaining_budget_usd": "5.50"},
+    )
+    assert record.agent_family == AGENT_FAMILY

--- a/tests/test_adapter_qwen_dashscope.py
+++ b/tests/test_adapter_qwen_dashscope.py
@@ -212,3 +212,62 @@ def test_default_cost_cap_matches_ticket_spec() -> None:
     qwen adapter previously drifted to $0.50; ticket 0187 aligns it.
     """
     assert DEFAULT_COST_CAP_USD == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn continuation surface (ticket 0208)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_returns_messages_in_extra(canned_response: dict, price_card: dict) -> None:
+    """parse_response must include a messages list in method_params.extra
+    so the harness can replay the conversation history for multi-turn.
+    """
+    record = parse_response(canned_response, model_meta=price_card, prompt="test question")
+    assert record.method_params.extra is not None
+    assert "messages" in record.method_params.extra
+    msgs = record.method_params.extra["messages"]
+    # Must contain at least the user message and assistant reply.
+    assert len(msgs) >= 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[-1]["role"] == "assistant"
+
+
+def test_build_request_with_continuation_prepends_history() -> None:
+    """When continuation has messages, build_request must prepend them
+    before the new user message.
+    """
+    history = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+    ]
+    payload = build_request(
+        "follow up",
+        max_tokens=100,
+        continuation={"messages": history},
+    )
+    msgs = payload["messages"]
+    assert len(msgs) == 3
+    assert msgs[0] == {"role": "user", "content": "first question"}
+    assert msgs[1] == {"role": "assistant", "content": "first answer"}
+    assert msgs[2] == {"role": "user", "content": "follow up"}
+
+
+def test_build_request_without_continuation_is_single_message() -> None:
+    """Without continuation, messages is just the one user message."""
+    payload = build_request("hello", max_tokens=100)
+    assert payload["messages"] == [{"role": "user", "content": "hello"}]
+
+
+def test_run_dry_run_accepts_continuation_and_extra_metadata() -> None:
+    """run() must accept both new kwargs without crashing on dry-run."""
+    from aedist.adapter_qwen_dashscope import run as qwen_run
+
+    record = qwen_run(
+        "follow up",
+        dry_run=True,
+        max_tokens=100,
+        continuation={"messages": [{"role": "user", "content": "q1"}]},
+        extra_metadata={"remaining_budget_usd": "3.00"},
+    )
+    assert record.agent_family == AGENT_FAMILY

--- a/tickets/0208-multi-turn-adapter-capability.erg
+++ b/tickets/0208-multi-turn-adapter-capability.erg
@@ -1,0 +1,35 @@
+%erg 0.1
+Title: Multi-turn continuation surface across the four SOTA adapters
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T15:30Z claude created
+
+--- body ---
+## Context
+
+Exp 2 (ticket 0199) needs multi-turn conversations with the four SOTA
+adapters. Each adapter currently supports single-turn only. Adding two
+optional kwargs (`continuation` and `extra_metadata`) to each adapter's
+entry point gives the Exp 2 harness (ticket 0207) the surface it needs.
+
+## Actions
+
+1. Add `continuation: dict | None = None` and `extra_metadata: dict | None = None`
+   to the `AgentAdapter.run()` Protocol in `adapter_base.py`.
+2. Wire both kwargs through each of the four adapters:
+   - Mistral (`adapter_mistral.py`): conversation_id + agent_id reuse
+   - OpenAI Responses (`adapter_openai_responses.py`): previous_response_id
+   - Qwen DashScope (`adapter_qwen_dashscope.py`): messages array prefix
+   - Anthropic (`query_anthropic.py`): messages array prefix
+3. Expose `cleanup_agent()` in the Mistral adapter for lifecycle management.
+4. Tests: 2+ per adapter (continuation-token return, continuation passthrough).
+
+## Exit criteria
+
+- [ ] All existing adapter tests pass unchanged
+- [ ] New tests: at minimum 2 per adapter
+- [ ] `make check-fast` green
+- [ ] `uv run ruff check` clean on changed files
+- [ ] PR references this ticket and notes 0207 as downstream consumer


### PR DESCRIPTION
## Summary

- Add `continuation: dict | None` and `extra_metadata: dict | None` kwargs to all four SOTA adapter entry points, enabling multi-turn conversations for Exp 2
- Mistral: reuses `conversation_id` + `agent_id`; exposes public `cleanup_agent()` for lifecycle management
- OpenAI Responses: chains via `previous_response_id`; returns `response_id` in `method_params.extra`
- Qwen DashScope: prepends conversation history to messages array in `build_request`
- Anthropic: prepends history to `dispatch` payload messages; returns messages in `method_params.extra`
- Protocol updated in `AgentAdapter.run()` (`adapter_base.py`)
- All kwargs default to `None` -- fully backward compatible (1330 existing tests pass unchanged)

**Ticket:** tickets/0208-multi-turn-adapter-capability.erg

Downstream consumer: ticket 0207 (Exp 2 interactive harness multi-turn loop)

## Test plan

- [x] 15 new tests across 4 adapters (continuation-token return, continuation passthrough, extra_metadata acceptance)
- [x] All 1330 existing tests pass (0 regressions)
- [x] `uv run ruff check` clean on all changed files
- [x] `make check-fast` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)