### PR TITLE
ticket(0209): worker fail-fast on route=claude-code-cli

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -1028,6 +1028,15 @@ seed = 42
 # Anthropic subscription/plan, not registry pricing. Useful for
 # qualitative capability checks; not suitable for controlled sweeps
 # (no T=0/seed/max_tokens control).
+#
+# IMPORTANT (ticket 0209): this sweep runs via the legacy
+# `python -m aedist.query_direct --sweep sweep_smoke_claude_cli` path
+# ONLY. The job-board worker (`aedist.worker`) raises NotImplementedError
+# for route=claude-code-cli — the route's lack of T=0/seed/max_tokens
+# control is incompatible with the worker's budget / reproducibility
+# semantics. Do not run `aedist.manager generate --sweep
+# sweep_smoke_claude_cli && aedist.worker openrouter --drain` with this
+# config; you'll get a fast-failing NotImplementedError per job.
 [sets.modelset_claude_cli_smoke]
 model_ids = [
     "claude-sonnet-4-6-cli",

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -335,6 +335,23 @@ class Worker:
         ``query_model`` so Ollama IDs dispatch through native /api/chat
         with ``num_ctx`` honoured (ticket 0139).
         """
+        # Ticket 0209: the claude-code-cli route (ticket 0160) is wired
+        # through ``aedist.query_direct.main`` only — not through the
+        # job-board worker. The route's adapter has no temperature,
+        # seed, or max_tokens control and bills against the user's
+        # Claude Code subscription, both of which conflict with the
+        # job-board's budget / reproducibility semantics. Fail fast
+        # here with a clear pointer instead of letting the call fall
+        # through ``query_model`` and crash with a NoneType client.
+        if (model_entry or {}).get("route") == "claude-code-cli":
+            raise NotImplementedError(  # noqa: hygiene — documented design choice
+                f"model {model_id!r} uses route=claude-code-cli, which is "
+                "not supported by the job-board worker. Run via "
+                "`python -m aedist.query_direct --model <id>` instead "
+                "(see ticket 0160 / PR #395 and the claude-code-cli row "
+                "in README.md → Model routes)."
+            )
+
         num_ctx = job.num_ctx if job is not None else 32768
         result = query_model(
             client,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1022,3 +1022,51 @@ def test_execute_threads_timeout_into_api_kwargs(tmp_path: Path) -> None:
 
     call_kwargs = patches["query_model"].call_args.kwargs
     assert call_kwargs.get("timeout") == 123
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0209: worker rejects route=claude-code-cli with a clear pointer.
+# ---------------------------------------------------------------------------
+
+
+def test_worker_rejects_claude_code_cli_route(tmp_path: Path) -> None:
+    """A model entry with route=claude-code-cli must fail fast in the worker.
+
+    Ticket 0160 wired the route through ``aedist.query_direct`` only.
+    The job-board worker (this module) raises NotImplementedError with
+    a clear pointer instead of crashing inside ``query_model`` on a
+    None client.
+    """
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("hello")
+
+    job = JobSpec(
+        job_id="cli-reject",
+        priority=50,
+        mode=Method.SINGLE,
+        prompt=str(prompt_file),
+        models_file="models.yaml",
+        model_filter="claude-sonnet-4-6-cli",
+        output_dir=str(tmp_path / "out"),
+        repeat=1,
+        budget_usd=1.0,
+    )
+
+    cli_model = {
+        "name": "claude-sonnet-4-6-cli",
+        "route": "claude-code-cli",
+        "model_id": "claude-sonnet-4-6",
+    }
+    patches = _harness_patches(tmp_path)
+    patches["load_models"] = MagicMock(return_value=[cli_model])
+    patches["query_model"] = MagicMock(
+        side_effect=AssertionError("query_model must not be called")
+    )
+
+    worker = OpenRouterWorker(jobs_root=tmp_path / "jobs")
+    with patch.multiple("aedist.worker", **patches):
+        with pytest.raises(NotImplementedError, match="claude-code-cli"):
+            worker.execute(job)
+
+    # Confirm query_model was never reached.
+    patches["query_model"].assert_not_called()

--- a/tickets/closed/0209-worker-cli-route-dispatch-gap.erg
+++ b/tickets/closed/0209-worker-cli-route-dispatch-gap.erg
@@ -2,10 +2,12 @@
 Title: Worker job-board dispatch lacks claude-code-cli branch (route only works via query_direct.py)
 Created: 2026-05-21
 Author: claude
+Closed: autoclosed — PR #397
 
 --- log ---
 2026-05-21T13:35Z claude created — coverage gap found during 0160 celebrate sweep
 
+2026-05-21T14:35Z HDMX-coding-agent closed — autoclosed — PR #397
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Picks up the follow-up ticket 0209 (filed during 0160 celebrate sweep) with **option 2 — fail-fast NotImplementedError**.

The job-board worker now refuses to dispatch jobs whose model entry has `route: claude-code-cli`. Without this guard, `manager generate --sweep sweep_smoke_claude_cli && worker openrouter --drain` would crash inside `query_model` on a None client; now it fails immediately with a pointer at `aedist.query_direct` and the README route table.

## Why option 2 (not option 1)

The route (ticket 0160) has no temperature, seed, or max_tokens control and bills against the user's Claude Code subscription. Both are incompatible with the job-board's budget / reproducibility semantics. Wiring it through the worker (option 1) would silently produce non-reproducible job-board sweeps. Option 2 enforces the design choice from the registry side.

## Changes

- `src/aedist/worker.py` — `_query_and_save` checks `model_entry["route"] == "claude-code-cli"` before calling `query_model`, raises `NotImplementedError` with a pointer to `query_direct.py`. Marked `# noqa: hygiene — documented design choice` (existing convention for verification-mode guard).
- `experiments/experiments.toml` — `[sweeps.sweep_smoke_claude_cli]` comment now flags it as `query_direct.py --sweep` only.
- `tests/test_worker.py` — new test `test_worker_rejects_claude_code_cli_route` asserts the error fires and `query_model` is never called.

## Test

`uv run pytest -q -m "not slow and not integration"` → 1338 passed.

**Ticket:** tickets/0209-worker-cli-route-dispatch-gap.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)