### PR TITLE
fix(adapter-mistral): follow-up turn must POST /v1/conversations/{id} (0211)

### DIFF
--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -442,15 +442,30 @@ def run(
 
     if is_followup:
         # Mode 3: follow-up turn — reuse existing agent and conversation.
+        # Mistral's append-to-conversation endpoint is path-bound:
+        # POST /v1/conversations/{conversation_id} with body {"inputs": [...]}.
+        # The agent is implied by the existing conversation; agent_id and
+        # conversation_id MUST NOT appear in the body (HTTP 422 otherwise).
+        # Docs verified 2026-05-21:
+        # https://docs.mistral.ai/api/endpoint/beta/conversations
+        conversation_id = continuation.get("conversation_id")
+        if not conversation_id:
+            raise ValueError(
+                "Mistral follow-up turn requires continuation['conversation_id']; "
+                f"got {continuation!r}"
+            )
         conv_body: dict[str, Any] = {
-            "agent_id": continuation["agent_id"],
             "inputs": [{"role": "user", "content": prompt}],
         }
-        if continuation.get("conversation_id"):
-            conv_body["conversation_id"] = continuation["conversation_id"]
         _attach_metadata(conv_body)
         with httpx.Client(base_url=API_BASE, headers=headers) as client:
-            raw = _start_conversation(client, conv_body)
+            resp = client.post(
+                f"/v1/conversations/{conversation_id}",
+                json=conv_body,
+                timeout=600.0,
+            )
+            resp.raise_for_status()
+            raw = resp.json()
         agent_id = continuation["agent_id"]
     else:
         # Mode 1 or 2: create agent + invoke.
@@ -483,7 +498,11 @@ def run(
     # Surface continuation tokens for multi-turn chaining.
     if record.method_params.extra is None:
         record.method_params.extra = {}
-    record.method_params.extra["conversation_id"] = raw.get("conversation_id")
+    # The path-bound append endpoint does not echo conversation_id in
+    # its response (the caller already knew it — it was in the URL).
+    # Fall back to the value we sent so >2-turn chains stay robust.
+    followup_conv_id = continuation.get("conversation_id") if continuation else None
+    record.method_params.extra["conversation_id"] = raw.get("conversation_id") or followup_conv_id
     if agent_id is not None:
         record.method_params.extra["agent_id"] = agent_id
 

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -279,12 +279,18 @@ def test_run_dry_run_returns_continuation_token():
 
 
 def test_continuation_skips_agent_creation(monkeypatch):
-    """When continuation is provided, only one POST to /v1/conversations
+    """When continuation is provided, only one POST to /v1/conversations/{id}
     should happen — no agent creation, no agent deletion.
+
+    Mistral's append-to-conversation endpoint is path-bound. This test
+    asserts the URL path explicitly so a regression to the create-shape
+    endpoint (which returns HTTP 422 live — ticket 0211) cannot sneak
+    back in. The previous version of this test only counted POSTs,
+    which is why the 0208 bug went unnoticed in unit tests.
     """
     import aedist.adapter_mistral as am
 
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, dict]] = []
 
     class FakeResponse:
         status_code = 200
@@ -318,11 +324,11 @@ def test_continuation_skips_agent_creation(monkeypatch):
             pass
 
         def post(self, url, **kwargs):
-            calls.append(("POST", url))
+            calls.append(("POST", url, kwargs.get("json") or {}))
             return FakeResponse()
 
         def delete(self, url, **kwargs):
-            calls.append(("DELETE", url))
+            calls.append(("DELETE", url, {}))
             return FakeResponse()
 
     monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
@@ -338,10 +344,90 @@ def test_continuation_skips_agent_creation(monkeypatch):
         continuation={"conversation_id": "conv_1", "agent_id": "ag_1"},
     )
 
-    # Only one POST to /v1/conversations — no /v1/agents create or delete.
+    # Only one POST — no /v1/agents create or delete.
     assert len(calls) == 1
-    assert calls[0] == ("POST", "/v1/conversations")
+    method, url, _body = calls[0]
+    assert method == "POST"
+    # Path-bound endpoint (ticket 0211): must include the conversation id.
+    assert url == "/v1/conversations/conv_1", (
+        f"follow-up should POST to /v1/conversations/{{id}}, got: {calls}"
+    )
+    # Bare /v1/conversations is the *create* endpoint — would 422 live.
+    assert not any(u == "/v1/conversations" for _, u, _ in calls), (
+        f"follow-up must not POST to bare /v1/conversations (creates new), got: {calls}"
+    )
     assert record.agent_family == AGENT_FAMILY
+
+
+def test_continuation_body_omits_agent_id_and_conversation_id(monkeypatch):
+    """Path-bound append endpoint rejects agent_id and conversation_id in
+    the body (HTTP 422 live — ticket 0211). The body must contain only
+    `inputs` (plus optional `metadata`).
+    """
+    import aedist.adapter_mistral as am
+
+    bodies: list[dict] = []
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "outputs": [
+                    {"type": "message.output", "content": "follow-up answer"},
+                ],
+                "usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 100,
+                    "connector_tokens": 0,
+                    "connectors": {"web_search": 0},
+                },
+                "conversation_id": "conv_1",
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            bodies.append(kwargs.get("json") or {})
+            return FakeResponse()
+
+        def delete(self, url, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    run(
+        "follow up question",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        continuation={"conversation_id": "conv_1", "agent_id": "ag_1"},
+    )
+
+    assert len(bodies) == 1
+    body = bodies[0]
+    assert "inputs" in body
+    assert "agent_id" not in body, (
+        f"agent_id is rejected by the path-bound append endpoint; body={body}"
+    )
+    assert "conversation_id" not in body, (
+        f"conversation_id belongs in the URL, not the body; body={body}"
+    )
 
 
 def test_multiturn_start_creates_agent_but_skips_delete(monkeypatch):

--- a/tickets/0211-adapter-mistral-continuation-422.erg
+++ b/tickets/0211-adapter-mistral-continuation-422.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: adapter_mistral follow-up turn raises HTTP 422 on POST /v1/conversations
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T00:00Z claude created
+
+--- body ---
+## Context
+
+PR #396 (ticket 0208) added a `continuation` kwarg to
+`adapter_mistral.run()` so the Exp 2 SOTA harness (ticket 0185) can do
+multi-turn conversations against the Mistral Agents API. The follow-up
+turn code path currently POSTs to `/v1/conversations` with the
+`agent_id` and `conversation_id` in the request body. That endpoint
+shape is the **create** shape, not the **append** shape — Mistral
+returns HTTP 422 because:
+- the `agent_id` field is rejected on appends, and
+- the `conversation_id` belongs in the URL path, not the body.
+
+Per the live docs (https://docs.mistral.ai/api/endpoint/beta/conversations,
+verified 2026-05-21):
+
+```
+POST /v1/conversations/{conversation_id}
+Body: {"inputs": [{"role": "user", "content": "<text>"}]}
+```
+
+The single-turn path (`continuation=None`) and the multi-turn-start
+path (`continuation={}`) are correct as-is — only the follow-up branch
+is wrong.
+
+## Actions
+
+1. Fix the `is_followup` branch in `src/aedist/adapter_mistral.py`:
+   - POST to `/v1/conversations/{conversation_id}` (path-bound).
+   - Body becomes `{"inputs": [{"role": "user", "content": prompt}]}`.
+   - Keep the `metadata` attachment via `_attach_metadata`.
+2. Strengthen
+   `tests/test_adapter_mistral.py::test_continuation_skips_agent_creation`
+   to assert the URL path explicitly (path-bound, never bare
+   `/v1/conversations`).
+3. Run `make check-fast`; iterate until green.
+
+## Exit criteria
+
+- [ ] is_followup posts to `/v1/conversations/{conversation_id}`
+- [ ] body contains `inputs` only (no `agent_id`, no `conversation_id`)
+- [ ] test asserts the URL path explicitly
+- [ ] `make check-fast` green
+- [ ] ruff clean
+- [ ] PR opened with ticket marker; ticket 0185 unblocks on landing


### PR DESCRIPTION
## Summary

PR #396 (ticket 0208) added a multi-turn `continuation` kwarg to `adapter_mistral.run()`. The follow-up branch posted to bare `/v1/conversations` with `agent_id` and `conversation_id` in the body — the *create* shape, not the *append* shape. Mistral returns HTTP 422 because the append endpoint is path-bound and rejects those body fields.

Per the live docs (verified 2026-05-21, https://docs.mistral.ai/api/endpoint/beta/conversations):

```
POST /v1/conversations/{conversation_id}
Body: {"inputs": [{"role": "user", "content": "..."}]}
```

The agent is implied by the existing conversation; `agent_id` is not a body field at append time, and `conversation_id` lives in the URL path.

## Changes

- `adapter_mistral.run()` `is_followup` branch posts to the path-bound URL with only `inputs` (+ optional `metadata`) in the body.
- Raise `ValueError` if `continuation` is missing `conversation_id` rather than silently posting to a 422-returning URL.
- Preserve `conversation_id` on the returned record even when the append response omits it (it lived in the URL on the way in), so >2-turn chains stay robust.
- Strengthen `test_continuation_skips_agent_creation`: asserts the exact URL path (`/v1/conversations/conv_1`) rather than only counting POSTs.
- Add sibling test `test_continuation_body_omits_agent_id_and_conversation_id`.

Single-turn (`continuation=None`) and multi-turn-start (`continuation={}`) paths are unchanged.

## Known unknown

The docs list `inputs`, `completion_args`, `handoff_execution`, `store`, `stream`, `tool_confirmations` as the append-body fields — `metadata` is **not** in that list. `_attach_metadata` is preserved (per the ticket) and current callers attach metadata on the first turn only, so this is not an active bug. If a future caller attaches metadata on a follow-up and gets 422, the fix is to drop the attach on the followup path.

## Test plan

- [x] `uv run pytest tests/test_adapter_mistral.py -q` — 19 passed
- [x] `uv run pytest -q` (full suite) — 1340 passed, 1 skipped, 1 xfailed
- [x] `uv run ruff check src/aedist/adapter_mistral.py tests/test_adapter_mistral.py` — clean
- [ ] Live 2-turn check via the 0185 smoke harness (deferred to ticket 0185 owner; mock now asserts exact URL path so the regression cannot sneak back)

## Unblocks

Ticket 0185 (Exp 2 multi-turn smoke) — needs the follow-up turn to work to do >1 turn.

**Ticket:** tickets/0211-adapter-mistral-continuation-422.erg