### PR TITLE
feat(adapter-mistral): exponential-backoff retry on transient 5xx (0215)

### DIFF
--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -35,6 +35,7 @@ Pricing notes:
 import json
 import logging
 import os
+import random
 import time
 from pathlib import Path
 from typing import Any
@@ -291,10 +292,94 @@ def _extract_query(arguments: Any) -> str:
 # HTTP transport
 # ---------------------------------------------------------------------------
 
+# Retry policy for transient gateway / network failures on the Mistral
+# Agents beta API (ticket 0215). The 2026-05-21 multi-turn smoke
+# (ticket 0185) was killed by a single HTTP 502 from
+# POST /v1/conversations/{id}; that endpoint is empirically flaky.
+#
+# Policy: max 3 retries, exponential backoff 1s/2s/4s with ±10% jitter.
+# Retry only on transient signals — never on 4xx (a 4xx is a request
+# bug, not a server hiccup; retrying would have papered over the 422
+# bugs fixed in tickets 0211/0212).
+RETRYABLE_STATUSES = frozenset({502, 503, 504})
+RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    httpx.ReadTimeout,
+    httpx.ConnectTimeout,
+    httpx.RemoteProtocolError,
+)
+MAX_RETRIES = 3
+BACKOFF_BASE_S = 1.0
+
+
+def _sleep_with_backoff(attempt: int) -> None:
+    """Sleep for ``BACKOFF_BASE_S * 2**attempt`` seconds, ±10% jitter.
+
+    ``attempt`` is the zero-indexed retry number (0 → ~1s, 1 → ~2s,
+    2 → ~4s). Extracted so tests can monkeypatch ``time.sleep`` to a
+    no-op and still cover the retry control flow.
+    """
+    delay = BACKOFF_BASE_S * (2**attempt) * (1.0 + random.uniform(-0.1, 0.1))
+    time.sleep(delay)
+
+
+def _request_with_retry(
+    method: str,
+    client: httpx.Client,
+    url: str,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Issue an HTTP request with the transient-failure retry policy.
+
+    Wraps ``client.post``/``client.delete``. Retries on the statuses in
+    :data:`RETRYABLE_STATUSES` and on the exceptions in
+    :data:`RETRYABLE_EXCEPTIONS`. On 4xx (or any other non-retryable
+    status), raises immediately via ``raise_for_status``. Logs every
+    retry attempt with the URL and the reason so post-mortems are
+    tractable. On exhaustion, raises the final status's
+    ``HTTPStatusError`` (or re-raises the final exception).
+    """
+    last_exc: Exception | None = None
+    for attempt in range(MAX_RETRIES + 1):  # 1 initial + up to MAX_RETRIES
+        try:
+            resp = getattr(client, method)(url, **kwargs)
+        except RETRYABLE_EXCEPTIONS as exc:
+            last_exc = exc
+            if attempt < MAX_RETRIES:
+                log.warning(
+                    "Mistral %s %s transient failure (%s); retry %d/%d",
+                    method.upper(),
+                    url,
+                    type(exc).__name__,
+                    attempt + 1,
+                    MAX_RETRIES,
+                )
+                _sleep_with_backoff(attempt)
+                continue
+            raise
+        if resp.status_code not in RETRYABLE_STATUSES:
+            return resp
+        if attempt < MAX_RETRIES:
+            log.warning(
+                "Mistral %s %s returned HTTP %d; retry %d/%d",
+                method.upper(),
+                url,
+                resp.status_code,
+                attempt + 1,
+                MAX_RETRIES,
+            )
+            _sleep_with_backoff(attempt)
+            continue
+        # Out of retries — surface the final response as an HTTPStatusError.
+        resp.raise_for_status()
+        return resp  # unreachable; for type-checker peace of mind
+    # Loop exited without return — only possible if MAX_RETRIES < 0.
+    assert last_exc is not None
+    raise last_exc
+
 
 def _create_agent(client: httpx.Client, body: dict) -> str:
     """POST /v1/agents — returns the new agent_id (``ag_*``)."""
-    resp = client.post("/v1/agents", json=body, timeout=60.0)
+    resp = _request_with_retry("post", client, "/v1/agents", json=body, timeout=60.0)
     resp.raise_for_status()
     data = resp.json()
     agent_id = data.get("id")
@@ -305,7 +390,26 @@ def _create_agent(client: httpx.Client, body: dict) -> str:
 
 def _start_conversation(client: httpx.Client, body: dict) -> dict:
     """POST /v1/conversations — returns the parsed response body."""
-    resp = client.post("/v1/conversations", json=body, timeout=600.0)
+    resp = _request_with_retry("post", client, "/v1/conversations", json=body, timeout=600.0)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _append_conversation(client: httpx.Client, conversation_id: str, body: dict) -> dict:
+    """POST /v1/conversations/{id} — append a turn to an existing conversation.
+
+    Path-bound append endpoint (Mistral Agents beta API, verified
+    2026-05-21). The agent is implied by the conversation; ``agent_id``
+    and ``conversation_id`` MUST NOT appear in ``body`` (HTTP 422
+    otherwise — see tickets 0211/0212).
+    """
+    resp = _request_with_retry(
+        "post",
+        client,
+        f"/v1/conversations/{conversation_id}",
+        json=body,
+        timeout=600.0,
+    )
     resp.raise_for_status()
     return resp.json()
 
@@ -315,10 +419,12 @@ def _delete_agent(client: httpx.Client, agent_id: str) -> None:
 
     Cleanup must never raise to the caller — a failed delete is a
     hygiene issue, not a result failure. Orphans can be swept later via
-    the Mistral console.
+    the Mistral console. The retry wrapper may raise ``HTTPStatusError``
+    on exhaustion; ``httpx.HTTPError`` covers that subclass plus all
+    transport exceptions so the contract holds.
     """
     try:
-        resp = client.delete(f"/v1/agents/{agent_id}", timeout=30.0)
+        resp = _request_with_retry("delete", client, f"/v1/agents/{agent_id}", timeout=30.0)
         if resp.status_code not in (200, 204):
             log.warning(
                 "Mistral DELETE /v1/agents/%s returned HTTP %s: %s",
@@ -459,13 +565,7 @@ def run(
         }
         _attach_metadata(conv_body)
         with httpx.Client(base_url=API_BASE, headers=headers) as client:
-            resp = client.post(
-                f"/v1/conversations/{conversation_id}",
-                json=conv_body,
-                timeout=600.0,
-            )
-            resp.raise_for_status()
-            raw = resp.json()
+            raw = _append_conversation(client, conversation_id, conv_body)
         agent_id = continuation["agent_id"]
     else:
         # Mode 1 or 2: create agent + invoke.

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -17,11 +17,14 @@ its `_provenance` field and the ticket log entry.
 import json
 from pathlib import Path
 
+import httpx
 import pytest
 
 from aedist.adapter_mistral import (
     AGENT_FAMILY,
     DEFAULT_MODEL,
+    _append_conversation,
+    _create_agent,
     build_request,
     parse_response,
     run,
@@ -524,3 +527,126 @@ def test_run_extra_metadata_logged_without_crash(monkeypatch, caplog):
     )
     # Should not crash; dry-run returns normally.
     assert record.method_params.extra == {"dry_run": True}
+
+
+# ---------------------------------------------------------------------------
+# Retry policy (ticket 0215)
+#
+# The Mistral Agents beta API is empirically flaky on 5xx (the 2026-05-21
+# multi-turn smoke turn-3 was killed by a single HTTP 502; ticket 0185).
+# The adapter wraps each POST/DELETE with an exponential-backoff retry
+# that triggers ONLY on transient signals (502/503/504, ReadTimeout,
+# ConnectTimeout, RemoteProtocolError). 4xx — and 422 in particular —
+# must NEVER be retried; that would have papered over the request-shape
+# bugs fixed in tickets 0211/0212.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponseSequence:
+    """Drives a queued list of (status_code, body_json) pairs.
+
+    Each ``post``/``delete`` pops the next entry and returns a response
+    whose ``raise_for_status`` raises an authentic
+    :class:`httpx.HTTPStatusError` (subclass of ``httpx.HTTPError``) for
+    non-2xx — so the retry-vs-no-retry tests actually exercise the same
+    exception type the live API produces.
+    """
+
+    def __init__(self, entries: list[tuple[int, dict]]):
+        self._entries = list(entries)
+        self.calls: list[tuple[str, str]] = []
+
+    def _next(self, method: str, url: str) -> httpx.Response:
+        self.calls.append((method, url))
+        status, body = self._entries.pop(0)
+        request = httpx.Request(method.upper(), f"https://example.invalid{url}")
+        return httpx.Response(status, json=body, request=request)
+
+    def post(self, url: str, **_kwargs: object) -> httpx.Response:
+        return self._next("POST", url)
+
+    def delete(self, url: str, **_kwargs: object) -> httpx.Response:
+        return self._next("DELETE", url)
+
+
+@pytest.fixture
+def _no_sleep(monkeypatch):
+    """Skip the backoff sleeps so retry tests run instantly."""
+    monkeypatch.setattr("aedist.adapter_mistral.time.sleep", lambda _s: None)
+
+
+def test_create_agent_retries_on_502(_no_sleep):
+    """502 twice → 200 ok: ``_create_agent`` retries and returns the id."""
+    client = _FakeResponseSequence(
+        [
+            (502, {"error": "bad gateway"}),
+            (502, {"error": "bad gateway"}),
+            (200, {"id": "ag_retry_success"}),
+        ]
+    )
+    agent_id = _create_agent(client, {"model": DEFAULT_MODEL})
+    assert agent_id == "ag_retry_success"
+    # 1 initial + 2 retries = 3 attempts total.
+    assert len(client.calls) == 3
+    assert all(m == "POST" and u == "/v1/agents" for m, u in client.calls)
+
+
+def test_create_agent_gives_up_after_3_retries(_no_sleep):
+    """502 × 4: ``_create_agent`` exhausts retries and raises ``HTTPStatusError``."""
+    client = _FakeResponseSequence([(502, {"error": "bad gateway"})] * 4)
+    with pytest.raises(httpx.HTTPStatusError):
+        _create_agent(client, {"model": DEFAULT_MODEL})
+    # 1 initial + 3 retries = 4 attempts; then raise.
+    assert len(client.calls) == 4
+
+
+def test_create_agent_does_not_retry_on_422(_no_sleep):
+    """422 (client error) must raise immediately — no retry.
+
+    Retrying 4xx would have papered over the request-shape bugs fixed
+    in tickets 0211/0212; the regression guard is load-bearing.
+    """
+    client = _FakeResponseSequence(
+        [
+            (422, {"detail": "Extra inputs are not permitted"}),
+            # Extras intentionally present — if a retry leaked in we'd
+            # see a second call and the test would still fail on the
+            # call-count assertion.
+            (200, {"id": "ag_should_not_reach"}),
+        ]
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        _create_agent(client, {"model": DEFAULT_MODEL})
+    assert len(client.calls) == 1, "422 must not trigger any retry"
+
+
+def test_append_conversation_retries_on_503(_no_sleep):
+    """The path-bound follow-up POST also goes through the retry wrapper.
+
+    Bonus coverage per the ticket: this is the endpoint that killed the
+    0185 multi-turn smoke (POST /v1/conversations/{id}).
+    """
+    client = _FakeResponseSequence(
+        [
+            (503, {"error": "service unavailable"}),
+            (
+                200,
+                {
+                    "outputs": [
+                        {"type": "message.output", "content": "follow-up ok"},
+                    ],
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "connector_tokens": 0,
+                        "connectors": {"web_search": 0},
+                    },
+                },
+            ),
+        ]
+    )
+    raw = _append_conversation(client, "conv_abc", {"inputs": []})
+    assert raw["outputs"][0]["content"] == "follow-up ok"
+    assert len(client.calls) == 2
+    # All calls hit the path-bound URL — not bare /v1/conversations.
+    assert all(u == "/v1/conversations/conv_abc" for _, u in client.calls)

--- a/tickets/0215-adapter-mistral-5xx-retry.erg
+++ b/tickets/0215-adapter-mistral-5xx-retry.erg
@@ -1,0 +1,105 @@
+%erg 0.1
+Title: adapter_mistral (and harness) retry on transient 5xx with exponential backoff
+Created: 2026-05-21
+Author: claude
+
+--- log ---
+2026-05-21T17:00Z claude created — turn 3 of 0185 multi-turn smoke (2026-05-21) lost to HTTP 502 Bad Gateway from Mistral
+2026-05-21T18:30Z claude note implementing retry wrapper at adapter layer; 4 POST sites + 3 retry-policy tests + 1 bonus on path-bound append
+
+--- body ---
+
+## Context
+
+The 2026-05-21 multi-turn smoke on Mistral produced a 25.4K-char
+inventory on turn 1, planned an upgrade on turn 2, and then the
+turn-3 follow-up (which would have executed the upgrade) was
+killed by an HTTP 502 Bad Gateway from
+`POST /v1/conversations/{conversation_id}`. The 502 is server-side
+flakiness of the Mistral Agents beta API — not a request-shape bug.
+
+The harness has no retry policy. A single 5xx aborts the entire
+multi-turn loop and forfeits whatever the agent would have
+produced. With the conference push depending on at least one
+clean multi-turn run per agent, this is a quality risk for the
+§4 evidence.
+
+## Scope
+
+Add a small retry policy at the **adapter** layer for both Mistral
+endpoints used in the multi-turn flow:
+
+- `POST /v1/conversations` (create)
+- `POST /v1/conversations/{id}` (append)
+
+Retry on:
+
+- HTTP 502, 503, 504 (transient gateway / availability)
+- `httpx.ReadTimeout`, `httpx.ConnectTimeout`, `httpx.RemoteProtocolError`
+
+Do NOT retry on:
+
+- 4xx (client error — our request is wrong, retry won't help)
+- 422 specifically (the previous 0211/0212 bugs would have been
+  papered over by retry)
+
+Policy: at most 3 retries; exponential backoff
+(1s, 2s, 4s, with ±10% jitter). Log each retry attempt.
+
+## Per-adapter footprint
+
+| Adapter | HTTP transport | Retry surface |
+|---|---|---|
+| Mistral Agents | raw httpx | wrap `_create_agent`, `_start_conversation`, the new path-bound append, and `_delete_agent` |
+| Anthropic | Anthropic SDK | SDK has built-in retries; verify config |
+| OpenAI Responses | OpenAI SDK | SDK has built-in retries; verify config |
+| Qwen DashScope | DashScope SDK | unclear; verify |
+
+This ticket targets Mistral specifically since that's where the
+empirical 502 happened and Mistral's transport is raw httpx (no
+SDK-level retry). The other three adapters get a sibling audit if
+they're missing retries — file separately if so.
+
+## Relevant files
+
+- `src/aedist/adapter_mistral.py:286-321` — the three transport
+  helpers (`_create_agent`, `_start_conversation`, `_delete_agent`)
+  and the new follow-up POST inline in `run()` post-#398
+- `tests/test_adapter_mistral.py` — extend with retry-on-5xx test
+  using monkeypatched httpx that returns 502 once then 200
+
+## Actions
+
+1. Add a `_retry_post()` helper (or extract a tiny retry decorator)
+   in `adapter_mistral.py` that wraps an httpx call with the policy
+   above. Reuse for all 4 endpoints.
+2. Apply to `_create_agent`, `_start_conversation`, the inline
+   follow-up POST, and `_delete_agent` (last one's failure is
+   already non-raising; the retry just makes it more likely to
+   succeed).
+3. Tests:
+   - `test_create_agent_retries_on_502` — mock httpx to return 502
+     twice then 200; assert single record returned
+   - `test_create_agent_gives_up_after_3_retries` — return 502 ×4;
+     assert raises `httpx.HTTPStatusError`
+   - `test_create_agent_does_not_retry_on_422` — return 422; assert
+     raises immediately, no retry
+4. Re-smoke 0185 if the May-21 smoke turn-3 scenario recurs.
+
+## Out of scope
+
+- Tenacity or third-party retry libraries — a hand-rolled loop in
+  <20 lines is enough and avoids a new dependency.
+- Idempotency-key support — Mistral's API is idempotent-by-design
+  on the create endpoints (different agent_id per call); the
+  append endpoint is conversation-scoped so a duplicate is at
+  worst an extra user turn (not silently destructive).
+- Adapter-level retry policy for the other 3 adapters (audit
+  ticket sibling, file if/when needed).
+
+## Exit criteria
+
+- [ ] All four Mistral POSTs go through the retry wrapper
+- [ ] Three unit tests cover retry, gives-up, no-retry-on-4xx
+- [ ] `make check-fast` green
+- [ ] Logs show retry attempts so post-mortems are tractable


### PR DESCRIPTION
## Summary

- Add a hand-rolled `_request_with_retry` wrapper to `adapter_mistral.py` with max 3 retries, 1s/2s/4s exponential backoff, ±10% jitter.
- Apply to all 4 outgoing httpx requests: `_create_agent`, `_start_conversation`, the new `_append_conversation` (extracted from the inline path-bound follow-up POST in `run()`), and `_delete_agent`.
- Retry only on transient signals: HTTP 502/503/504 and `httpx.ReadTimeout`/`ConnectTimeout`/`RemoteProtocolError`. Never on 4xx — 422 in particular would have papered over the request-shape bugs fixed in tickets 0211/0212.

## Why

The 2026-05-21 multi-turn smoke (ticket 0185) lost its turn-3 follow-up to a single HTTP 502 from `POST /v1/conversations/{id}`. The Mistral Agents beta API is empirically flaky on 5xx; without a retry policy at the adapter layer, a single transient gateway error aborts the entire multi-turn loop and forfeits whatever the agent would have produced.

The other 3 adapters (OpenAI / Anthropic / Qwen) are out of scope per the ticket — their SDKs have built-in retries; a sibling audit ticket can be filed if a gap surfaces empirically.

## Tests

4 new unit tests in `tests/test_adapter_mistral.py`:

- `test_create_agent_retries_on_502` — 502 × 2 → 200; asserts 3 attempts total.
- `test_create_agent_gives_up_after_3_retries` — 502 × 4; asserts `httpx.HTTPStatusError`.
- `test_create_agent_does_not_retry_on_422` — 422 → immediate raise, no retry. Regression guard for 0211/0212.
- `test_append_conversation_retries_on_503` — bonus, exercises the path-bound append helper that was the actual 0185 failure site.

Tests bypass `run()` and drive the helpers directly with a queued-response fake client; `time.sleep` is monkeypatched to a no-op so the suite stays sub-second.

## Coordination

One of three sibling raids on `rebuild-exp2-smoke` (0213, 0214, 0215). Merge order: 0215 first.

**Ticket:** tickets/0215-adapter-mistral-5xx-retry.erg

## Test plan

- [x] `make check-fast` green (1345 passed, 1 skipped, 1 xfailed)
- [x] Ruff clean
- [x] All 4 Mistral POSTs go through the retry wrapper
- [x] 3+ new tests covering retry / give-up / no-retry-on-4xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)