### PR TITLE
feat(exp2): Phase A designs the system prompt (0213)

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -137,6 +137,7 @@ Return ONLY a single JSON object with this exact shape:
 
 {{
   "designed_prompt": "<the prompt you want to receive next turn — sent to you verbatim>",
+  "system_prompt": "<the system prompt that will be installed on you before the next turn — sent to you verbatim>",
   "settings": {{
     "thinking": true_or_false,
     "max_tokens": <int>,
@@ -144,6 +145,8 @@ Return ONLY a single JSON object with this exact shape:
   }},
   "rationale": "<2-4 sentences naming which of the four dimensions your changes target and how>"
 }}
+
+The `system_prompt` field MUST be a plain JSON string (a single quoted text value), not a nested JSON object or list. The harness installs it verbatim as the agent's system-level instruction (e.g. Mistral's agent `description`, Anthropic's `system` parameter, OpenAI's `instructions`). Persistent behavioural directives (per-cell sourcing, never-decline, voice) belong here; per-turn task framing belongs in `designed_prompt`.
 
 Output ONLY the JSON object. No markdown fence, no prose around it.
 """
@@ -247,9 +250,13 @@ def extract_phase_a_design(response_text: str) -> dict:
             raise ValueError(
                 f"Phase A response is not valid JSON: {exc}; first 400 chars: {preview!r}"
             ) from exc
-    for key in ("designed_prompt", "settings", "rationale"):
+    for key in ("designed_prompt", "system_prompt", "settings", "rationale"):
         if key not in obj:
             raise ValueError(f"Phase A JSON missing required key {key!r}; got keys {list(obj)}")
+    if not isinstance(obj["system_prompt"], str):
+        raise ValueError(
+            f"Phase A 'system_prompt' must be a string, got {type(obj['system_prompt']).__name__}"
+        )
     return obj
 
 
@@ -301,6 +308,7 @@ def run_mistral_call(
     max_tokens: int,
     continuation: dict | None = None,
     extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
 ) -> RunRecord:
     """Single Mistral Agents call, with the registry-driven model metadata.
 
@@ -308,7 +316,10 @@ def run_mistral_call(
     ``parse_response`` raises on an unexpected content shape (str-content
     bug is fixed on main via PR #394 but defense in depth stays). The
     ``continuation`` and ``extra_metadata`` kwargs were added to the four
-    SOTA adapters in PR #396 (ticket 0208); we forward them.
+    SOTA adapters in PR #396 (ticket 0208); we forward them. The
+    ``system_prompt`` kwarg (ticket 0213) is forwarded as the agent
+    ``description`` at multi-turn-start or single-turn create time;
+    follow-up turns must pass ``None`` (the adapter raises otherwise).
     """
     meta = load_model_meta("mistral")
     t0 = time.monotonic()
@@ -323,6 +334,7 @@ def run_mistral_call(
             output_path=raw_output_path,
             continuation=continuation,
             extra_metadata=extra_metadata,
+            system_prompt=system_prompt,
         )
     except AttributeError as exc:
         if not raw_output_path.exists():
@@ -456,6 +468,7 @@ def run_phase_b_multiturn(
     initial_spent_usd: float,
     max_tokens: int,
     agent: str = "mistral",
+    system_prompt: str | None = None,
 ) -> dict:
     """Run the Phase B dialogue as a state machine on a single agent.
 
@@ -471,6 +484,10 @@ def run_phase_b_multiturn(
     Classifier cost is **harness overhead** — accumulated under
     ``total_classifier_cost_usd`` but never deducted from the SOTA
     agent's budget.
+
+    Per ticket 0213, ``system_prompt`` is installed on the agent at
+    creation time (turn 1 only). Follow-up turns must not re-send it —
+    the agent is already created.
 
     Returns a dict with ``records``, ``turns``, ``total_spent_usd``,
     ``terminal_sent``, ``agent_id`` (for caller-side cleanup), and
@@ -516,6 +533,11 @@ def run_phase_b_multiturn(
         if is_followup_turn:
             extra_metadata = None
 
+        # System prompt is installed at agent-create time (turn 1, when
+        # continuation={}). Follow-up turns reuse the agent and must pass
+        # None — the adapter raises ValueError otherwise (ticket 0213).
+        turn_system_prompt = system_prompt if not is_followup_turn else None
+
         record = run_mistral_call(
             user_text,
             cap_usd=max(remaining, 0.01),  # adapter wants positive cap
@@ -524,6 +546,7 @@ def run_phase_b_multiturn(
             max_tokens=max_tokens,
             continuation=continuation,
             extra_metadata=extra_metadata,
+            system_prompt=turn_system_prompt,
         )
         records.append(record)
 
@@ -729,6 +752,11 @@ def main(argv: list[str] | None = None) -> int:
     requested_max_tokens = int(
         design.get("settings", {}).get("max_tokens") or args.phase_b_max_tokens
     )
+    designed_system_prompt = design["system_prompt"]
+    log.info(
+        "Phase B system prompt: str/%d chars (installed on agent at create time).",
+        len(designed_system_prompt),
+    )
 
     phase_b = run_phase_b_multiturn(
         designed_prompt,
@@ -737,6 +765,7 @@ def main(argv: list[str] | None = None) -> int:
         initial_spent_usd=total_cost(phase_a),
         max_tokens=requested_max_tokens,
         agent=args.agent,
+        system_prompt=designed_system_prompt,
     )
 
     if phase_b["agent_id"]:

--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -468,6 +468,7 @@ def run(
     output_path: Path | None = None,
     continuation: dict | None = None,
     extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
     **opts: Any,
 ) -> RunRecord:
     """Execute one Mistral Agents call (or print the dry-run payload).
@@ -491,15 +492,53 @@ def run(
     ``metadata`` field when present. Wrapped defensively since the
     Mistral beta API may not support it.
 
+    ``system_prompt`` (ticket 0213) installs a designed system-level
+    instruction on the Mistral agent at create time by overriding the
+    default ``agent.description``. Only meaningful in modes 1 and 2 —
+    the follow-up mode reuses an already-created agent, so passing
+    ``system_prompt`` alongside ``continuation['agent_id']`` raises
+    ``ValueError`` (fail-fast matching this codebase's history of
+    dict-vs-string and HTTP 422 silent-accept incidents).
+
+    **System-prompt surface across SOTA adapters** (for future extension
+    by 0214 etc. — keep this table in sync when adding new adapters):
+
+    +----------------+--------------------------------------------------+
+    | Adapter        | Where the system prompt lives                    |
+    +================+==================================================+
+    | Mistral Agents | ``POST /v1/agents`` body ``description`` field   |
+    +----------------+--------------------------------------------------+
+    | Anthropic      | ``messages.create`` ``system`` parameter         |
+    +----------------+--------------------------------------------------+
+    | OpenAI         | ``instructions`` parameter on                    |
+    | Responses      | ``responses.create``                             |
+    +----------------+--------------------------------------------------+
+    | Qwen           | ``messages[0]`` with ``role: "system"``          |
+    | DashScope      |                                                  |
+    +----------------+--------------------------------------------------+
+
     ``model_meta`` is the registry entry for the chosen model (see
     ``experiments/models.yaml``). When omitted, a minimal default is
     used so the dry-run path is still usable for ad-hoc smokes.
     """
     del opts  # reserved for forward-compat
+    # Fail-fast: system_prompt cannot be set on a follow-up turn (agent
+    # is already created with its description fixed). Ticket 0213.
+    is_followup_call = (
+        continuation is not None and continuation.get("agent_id") and system_prompt is not None
+    )
+    if is_followup_call:
+        raise ValueError(
+            "system_prompt cannot be set on a follow-up turn: the Mistral agent "
+            "is already created and its description is fixed. Pass system_prompt "
+            "only on the first turn (continuation=None or continuation={})."
+        )
     meta = model_meta or {"model_id": DEFAULT_MODEL}
     payload = build_request(
         prompt, model=meta.get("model_id", DEFAULT_MODEL), max_tokens=max_tokens
     )
+    if system_prompt is not None:
+        payload["agent_create"]["body"]["description"] = system_prompt
 
     # Conservative cost cap — assume worst-case token usage and a few
     # connector calls. enforce_cost_cap raises CostCapExceeded if over.

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -512,6 +512,257 @@ def test_cleanup_agent_is_public():
     assert callable(cleanup_agent)
 
 
+# ---------------------------------------------------------------------------
+# system_prompt kwarg (ticket 0213)
+# ---------------------------------------------------------------------------
+
+
+def test_run_threads_system_prompt_to_agent_description(monkeypatch):
+    """Ticket 0213: ``system_prompt`` kwarg must populate the
+    ``agent_create`` body's ``description`` field on multi-turn-start
+    mode (continuation={}). The body is the only Mistral surface where
+    a system-level instruction lives — see the adapter docstring's
+    cross-adapter table.
+    """
+    import aedist.adapter_mistral as am
+
+    bodies: dict[str, dict] = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            body = kwargs.get("json") or {}
+            if url == "/v1/agents":
+                bodies["agent_create"] = body
+                return FakeResponse({"id": "ag_X"})
+            if url == "/v1/conversations":
+                bodies["conversation_start"] = body
+                return FakeResponse(
+                    {
+                        "outputs": [{"type": "message.output", "content": "ok"}],
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 20,
+                            "connector_tokens": 0,
+                            "connectors": {"web_search": 0},
+                        },
+                        "conversation_id": "conv_X",
+                    }
+                )
+            raise AssertionError(f"unexpected POST to {url}")
+
+        def delete(self, url, **kwargs):
+            return FakeResponse({})
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    run(
+        "first prompt",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        continuation={},  # multi-turn start
+        system_prompt="custom system text",
+    )
+
+    assert "agent_create" in bodies
+    assert bodies["agent_create"]["description"] == "custom system text", (
+        f"expected description='custom system text'; got {bodies['agent_create']!r}"
+    )
+
+
+def test_run_threads_system_prompt_in_single_turn_mode(monkeypatch):
+    """Single-turn mode (continuation=None) also accepts system_prompt
+    and threads it through the agent body's description. Backward
+    compatibility: omitting the kwarg leaves the default description in
+    place (covered by every existing test).
+    """
+    import aedist.adapter_mistral as am
+
+    captured: dict[str, dict] = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            body = kwargs.get("json") or {}
+            if url == "/v1/agents":
+                captured["agent_create"] = body
+                return FakeResponse({"id": "ag_X"})
+            return FakeResponse(
+                {
+                    "outputs": [{"type": "message.output", "content": "ok"}],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 7,
+                        "connector_tokens": 0,
+                        "connectors": {"web_search": 0},
+                    },
+                    "conversation_id": "conv_X",
+                }
+            )
+
+        def delete(self, url, **kwargs):
+            return FakeResponse({})
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    run(
+        "single-turn prompt",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        system_prompt="ST-only system text",
+    )
+
+    assert captured["agent_create"]["description"] == "ST-only system text"
+
+
+def test_run_followup_rejects_system_prompt_kwarg(monkeypatch):
+    """Ticket 0213: passing system_prompt on a follow-up turn (when the
+    agent is already created) must raise ValueError. The agent's
+    description is fixed at creation time; silently ignoring would mask
+    a programmer error (matching the codebase's history of dict-vs-string
+    and HTTP 422 silent-accept incidents).
+    """
+    import aedist.adapter_mistral as am
+
+    # No HTTP should be issued — the validation happens before the
+    # transport block. Still stub the key loader to guard against the
+    # SystemExit path masking a different failure.
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+
+    with pytest.raises(ValueError, match="system_prompt cannot be set on a follow-up turn"):
+        run(
+            "follow up question",
+            dry_run=False,
+            model_meta=PRICE_CARD,
+            max_tokens=600,
+            cap_usd=10.0,
+            agent_mode="smoke",
+            continuation={"conversation_id": "conv_1", "agent_id": "ag_1"},
+            system_prompt="should be rejected",
+        )
+
+
+def test_run_default_description_when_no_system_prompt(monkeypatch):
+    """Backward compat: when ``system_prompt`` is omitted, the agent
+    body's description falls back to ``build_request``'s default. This
+    locks in the no-change-for-existing-callers contract.
+    """
+    import aedist.adapter_mistral as am
+
+    captured: dict[str, dict] = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            body = kwargs.get("json") or {}
+            if url == "/v1/agents":
+                captured["agent_create"] = body
+                return FakeResponse({"id": "ag_X"})
+            return FakeResponse(
+                {
+                    "outputs": [{"type": "message.output", "content": "ok"}],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 7,
+                        "connector_tokens": 0,
+                        "connectors": {"web_search": 0},
+                    },
+                    "conversation_id": "conv_X",
+                }
+            )
+
+        def delete(self, url, **kwargs):
+            return FakeResponse({})
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    run(
+        "no system prompt here",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+    )
+
+    # The default description from build_request — unchanged.
+    assert captured["agent_create"]["description"] == (
+        "AEDIST SOTA experiment agent with web_search connector."
+    )
+
+
 def test_run_extra_metadata_logged_without_crash(monkeypatch, caplog):
     """extra_metadata should not crash the adapter. Mistral's metadata
     support is uncertain, so the adapter should be defensive.

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -52,34 +52,56 @@ def test_assemble_meta_prompt_contains_baseline_and_quality_bar():
     assert "Output ONLY" in prompt  # explicit no-prose instruction
 
 
+def test_assemble_meta_prompt_announces_system_prompt_field():
+    """Ticket 0213: the Phase A envelope must include `system_prompt` as a
+    required string key, with an explicit instruction that it MUST be a
+    string (not a JSON object) — the dict-vs-string ambiguity already
+    cost us one turn during 0185.
+    """
+    prompt = assemble_meta_prompt(BASELINE_PATH, QUALITY_BAR_PATH)
+    assert "system_prompt" in prompt, "envelope spec must announce system_prompt key"
+    # The string-only constraint must be explicit in the prose.
+    assert "MUST be a plain JSON string" in prompt, (
+        "envelope spec must say system_prompt is a string, not a dict"
+    )
+
+
 def test_extract_phase_a_design_parses_clean_json():
     payload = json.dumps(
         {
             "designed_prompt": "X",
+            "system_prompt": "sys",
             "settings": {"thinking": True, "max_tokens": 8000, "rationale_for_settings": "y"},
             "rationale": "targets accuracy and provenance",
         }
     )
     obj = extract_phase_a_design(payload)
     assert obj["designed_prompt"] == "X"
+    assert obj["system_prompt"] == "sys"
     assert obj["settings"]["thinking"] is True
 
 
 def test_extract_phase_a_design_strips_markdown_fence():
     """Model sometimes wraps JSON in ```json ... ``` despite instructions."""
-    raw = '```json\n{"designed_prompt":"X","settings":{},"rationale":"z"}\n```'
+    raw = '```json\n{"designed_prompt":"X","system_prompt":"S","settings":{},"rationale":"z"}\n```'
     obj = extract_phase_a_design(raw)
     assert obj["designed_prompt"] == "X"
+    assert obj["system_prompt"] == "S"
 
 
 def test_extract_phase_a_design_tolerates_prose_preamble():
-    raw = 'Sure! Here is my design:\n{"designed_prompt":"X","settings":{},"rationale":"y"}'
+    raw = (
+        "Sure! Here is my design:\n"
+        '{"designed_prompt":"X","system_prompt":"S","settings":{},"rationale":"y"}'
+    )
     obj = extract_phase_a_design(raw)
     assert obj["designed_prompt"] == "X"
 
 
 def test_extract_phase_a_design_tolerates_prose_postamble():
-    raw = '{"designed_prompt":"X","settings":{},"rationale":"y"}\n\nLet me know!'
+    raw = (
+        '{"designed_prompt":"X","system_prompt":"S","settings":{},"rationale":"y"}\n\nLet me know!'
+    )
     obj = extract_phase_a_design(raw)
     assert obj["designed_prompt"] == "X"
 
@@ -92,6 +114,39 @@ def test_extract_phase_a_design_raises_on_invalid_json():
 def test_extract_phase_a_design_raises_on_missing_keys():
     with pytest.raises(ValueError, match="missing required key"):
         extract_phase_a_design('{"designed_prompt":"X"}')
+
+
+def test_extract_phase_a_design_requires_system_prompt_key():
+    """Ticket 0213: system_prompt is a required key in the Phase A envelope."""
+    payload = json.dumps(
+        {
+            "designed_prompt": "X",
+            # system_prompt deliberately absent
+            "settings": {"thinking": True, "max_tokens": 8000},
+            "rationale": "no system prompt provided",
+        }
+    )
+    with pytest.raises(ValueError, match="missing required key 'system_prompt'"):
+        extract_phase_a_design(payload)
+
+
+def test_extract_phase_a_design_rejects_system_prompt_as_dict():
+    """Ticket 0213: system_prompt must be a plain string, not a dict.
+
+    The dict-vs-string burn earlier in 0185 motivated explicit type
+    enforcement here — the harness threads this value verbatim into the
+    Mistral agent description field, which is a string.
+    """
+    payload = json.dumps(
+        {
+            "designed_prompt": "X",
+            "system_prompt": {"role": "system", "content": "S"},
+            "settings": {"thinking": True, "max_tokens": 8000},
+            "rationale": "structured",
+        }
+    )
+    with pytest.raises(ValueError, match="'system_prompt' must be a string"):
+        extract_phase_a_design(payload)
 
 
 def test_extract_narrative_from_mistral_raw_concatenates_text_chunks():
@@ -119,7 +174,10 @@ def test_extract_narrative_from_mistral_raw_handles_string_content():
 
 def test_extract_phase_a_design_handles_python_triple_quotes():
     """SOTA models occasionally use Python ``\"\"\"`` inside JSON; we normalise."""
-    raw = '{"designed_prompt": """multi\nline\nprompt""", "settings": {}, "rationale": "y"}'
+    raw = (
+        '{"designed_prompt": """multi\nline\nprompt""", '
+        '"system_prompt": "S", "settings": {}, "rationale": "y"}'
+    )
     obj = extract_phase_a_design(raw)
     assert obj["designed_prompt"] == "multi\nline\nprompt"
 
@@ -203,6 +261,7 @@ def _fake_run_factory(cost_per_call: float = 0.10):
         max_tokens,
         continuation=None,
         extra_metadata=None,
+        system_prompt=None,
     ):
         from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
 
@@ -212,6 +271,7 @@ def _fake_run_factory(cost_per_call: float = 0.10):
                 "prompt_starts_with_status": prompt.startswith("Status:"),
                 "continuation": continuation,
                 "extra_metadata": extra_metadata,
+                "system_prompt": system_prompt,
             }
         )
         # Write a minimal raw artefact the classifier-narrative extractor can read.
@@ -281,6 +341,7 @@ def test_state_machine_report_then_verify_then_stop(monkeypatch, tmp_path):
         initial_spent_usd=0.0,
         max_tokens=100,
         agent="mistral",
+        system_prompt="designed system text",
     )
 
     assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
@@ -291,6 +352,14 @@ def test_state_machine_report_then_verify_then_stop(monkeypatch, tmp_path):
     assert fake_run.calls[0]["prompt_starts_with_status"] is False  # type: ignore[attr-defined]
     # Turn 2 is status-prefixed.
     assert fake_run.calls[1]["prompt_starts_with_status"] is True  # type: ignore[attr-defined]
+    # Ticket 0213: system_prompt is forwarded only on the multi-turn-start
+    # turn (turn 1); follow-up turns must pass None because the agent is
+    # already created with its description fixed.
+    assert fake_run.calls[0]["system_prompt"] == "designed system text"  # type: ignore[attr-defined]
+    for entry in fake_run.calls[1:]:  # type: ignore[attr-defined]
+        assert entry["system_prompt"] is None, (
+            "follow-up turns must not pass system_prompt (agent already created)"
+        )
     # Per-turn artefacts including the new .classification.json.
     for turn in (1, 2):
         for suffix in (

--- a/tickets/0213-phase-a-designs-system-prompt.erg
+++ b/tickets/0213-phase-a-designs-system-prompt.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-21T17:00Z claude created — author quality review of 0185 turn-1 inventory, 2026-05-21
+2026-05-21T18:00Z claude note implemented: Phase A envelope gains required system_prompt key; Mistral adapter run() takes system_prompt kwarg, threads to agent.description on create; follow-up turns raise ValueError (fail-fast per dict-vs-string history). Strict ValueError on missing key (deviates from ticket invariant about fallback — see PR body).
 
 --- body ---
 


### PR DESCRIPTION
## Summary

- Phase A envelope spec now requires a fourth key `system_prompt` (string only — explicit anti-dict instruction inline in the prompt). The dict-vs-string burn during 0185 motivated explicit type enforcement.
- `adapter_mistral.run()` gains a `system_prompt: str | None = None` kwarg that overrides the agent body's `description` field at create time. Documented the cross-adapter system-prompt surface (Mistral / Anthropic / OpenAI / Qwen) in the docstring so future adapter extensions inherit the convention.
- Follow-up turn behaviour: **raise** `ValueError` if `system_prompt` is passed alongside `continuation['agent_id']`. The agent is already created with its description fixed; silently ignoring would mask a programmer error and matches this codebase's history of dict-vs-string and HTTP 422 silent-accept incidents (0185, 0212).
- End-to-end wiring: `main()` reads `design['system_prompt']`, forwards through `run_phase_b_multiturn` to `run_mistral_call` to the adapter; only turn 1 (multi-turn-start) carries the value.

## Deviation from ticket invariant

The ticket body's Invariants section says: *"if Phase A doesn't return a `system_prompt` key (older saved designs), the smoke must fall back to the adapter's default and log the fallback."* This PR instead **raises** `ValueError` on missing key — per the user's instruction (2026-05-21) and per the wider codebase preference for fail-fast on shape errors. Old saved Phase A artefacts are not replay-compatible; this is acceptable because the artefact format change happens alongside the live behaviour change in one PR.

## Files touched

- `experiments/sota/exp2_interactive_smoke.py` — envelope spec, `extract_phase_a_design` keys + type check, `run_phase_b_multiturn` and `run_mistral_call` plumbing, `main()` extraction.
- `src/aedist/adapter_mistral.py` — `run()` gains `system_prompt` kwarg, follow-up fail-fast, agent.description override, per-adapter surface table in docstring.
- `tests/test_exp2_interactive_smoke.py` — new tests + existing envelope tests updated for the required key.
- `tests/test_adapter_mistral.py` — four new tests for the adapter kwarg.

## Coordination

Sibling raids on `rebuild-exp2-smoke`:
- **0214** touches Phase B loop + classifier — different functions, should rebase cleanly.
- **0215** touches Mistral transport helpers (`_create_agent` etc.) — different regions from my `run()` body edit, should rebase cleanly.

Merge order documented: 0215 → 0214 → 0213.

## Test plan

- [x] `make check-fast`: 1371 passed, 1 skipped, 1 xfailed, 0 failed.
- [x] `uv run ruff check .`: All checks passed.
- [x] Inspected rendered meta-prompt — envelope includes `system_prompt` with the string-only constraint.

**Ticket:** tickets/0213-phase-a-designs-system-prompt.erg