### PR TITLE
chore: close tickets 0232, 0233

### DIFF
--- a/tickets/0232-alibaba-stage3-prose-absent-diverges-csv.erg
+++ b/tickets/0232-alibaba-stage3-prose-absent-diverges-csv.erg
@@ -1,10 +1,13 @@
 %erg 0.1
 Title: Fix Alibaba stage-3 prose: CSV has 2025-03-07 but matrix says absent
+Closed: fixed in PR #426 — CSV set to absent (demo ≠ consumer product)
 Created: 2026-05-22
 Author: claude
 
 --- log ---
 2026-05-22T00:00Z claude created
+2026-05-22T12:00Z claude note PR #426 merged; CSV and prose both show absent
+2026-05-22T12:00Z claude closed
 
 --- body ---
 ## Context

--- a/tickets/0233-test-csv-prose-date-sync.erg
+++ b/tickets/0233-test-csv-prose-date-sync.erg
@@ -1,10 +1,13 @@
 %erg 0.1
 Title: Add adherence test: capability_timeline.csv dates must appear in prose matrix
+Closed: fixed in PR #426 — test_capability_timeline_sync.py added
 Created: 2026-05-22
 Author: claude
 
 --- log ---
 2026-05-22T00:00Z claude created
+2026-05-22T12:00Z claude note PR #426 merged; 11 adherence tests pass including sync test
+2026-05-22T12:00Z claude closed
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Close tickets 0232 and 0233 which were already fixed by PR #426 but left open
- PR #426 had two `**Ticket:**` lines; `erg-pr-merge` only processed the first

**Ticket:** tickets/0232-alibaba-stage3-prose-absent-diverges-csv.erg
**Ticket:** tickets/0233-test-csv-prose-date-sync.erg

## Test plan

- [x] All 1414 tests pass (1 skipped, 1 xfailed)
- [x] 11 adherence tests pass including the sync test from 0233
- [x] CSV and prose matrix agree on Alibaba stage-3 (both absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)