### PR TITLE
t0236: wire Qwen DashScope into Exp 2 Phase B state machine

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -509,6 +509,131 @@ def run_anthropic_call(
     return record
 
 
+def run_qwen_call(
+    prompt: str,
+    *,
+    cap_usd: float,
+    agent_mode: str,
+    raw_output_path: Path,
+    max_tokens: int,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
+) -> RunRecord:
+    """Single Qwen DashScope call with full-history resend for multi-turn.
+
+    Continuation shape: ``{"messages": list[dict]}`` — complete conversation
+    history including the leading system message (when present) and each
+    assistant reply. DashScope is stateless on the wire; the client
+    resends everything every call.
+
+    ``system_prompt`` is injected as the first ``{"role": "system", ...}``
+    message on turn 1; turn 2+ inherits it via the replayed history.
+    """
+    import dashscope
+
+    from aedist import adapter_qwen_dashscope
+    from aedist.adapter_base import enforce_cost_cap, estimate_call_cost
+
+    meta = load_model_meta("qwen")
+    model_id = meta.get("model_id")
+    is_followup = bool(continuation and continuation.get("messages"))
+
+    # Build the messages list: history + new user, or (turn 1) system + user.
+    if is_followup:
+        messages = list(continuation["messages"]) + [{"role": "user", "content": prompt}]
+    else:
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+    # Use the adapter's payload assembly, then override the messages list
+    # with our explicit history (build_request consults ``continuation``
+    # but stores only [user] without preserving an explicit system role).
+    payload = adapter_qwen_dashscope.build_request(
+        prompt,
+        model=model_id,
+        max_tokens=max_tokens,
+        enable_thinking=True,  # capability default for the optimized arm
+        enable_search=True,
+    )
+    payload["messages"] = messages
+    if extra_metadata is not None:
+        # DashScope lacks a metadata surface; inject as a leading system
+        # message. Mirrors ``adapter_qwen_dashscope.run``'s fallback path.
+        meta_text = "; ".join(f"{k}={v}" for k, v in extra_metadata.items())
+        payload["messages"] = [{"role": "system", "content": f"[metadata] {meta_text}"}] + payload[
+            "messages"
+        ]
+
+    # Pre-call cap.
+    p_in = (
+        float(meta.get("price_per_mtok_in", adapter_qwen_dashscope.DEFAULT_PRICE_PER_MTOK_IN))
+        / _TOKENS_PER_MTOK
+    )
+    p_out = (
+        float(meta.get("price_per_mtok_out", adapter_qwen_dashscope.DEFAULT_PRICE_PER_MTOK_OUT))
+        / _TOKENS_PER_MTOK
+    )
+    p_search = float(
+        meta.get(
+            "price_per_web_search_call_usd",
+            adapter_qwen_dashscope.DEFAULT_PRICE_PER_WEB_SEARCH_CALL_USD,
+        )
+    )
+    estimated = estimate_call_cost(
+        max_tokens=max_tokens,
+        price_in=p_in,
+        price_out=p_out,
+        n_searches=5,
+        price_per_search=p_search,
+    )
+    enforce_cost_cap(estimated, cap_usd=cap_usd)
+
+    dashscope.api_key = adapter_qwen_dashscope._resolve_api_key()
+    dashscope.base_http_api_url = adapter_qwen_dashscope.DEFAULT_BASE_URL
+    t0 = time.monotonic()
+    resp = dashscope.Generation.call(**payload)
+    wall = round(time.monotonic() - t0, 3)
+
+    raw_dump = adapter_qwen_dashscope._response_to_dict(resp)
+    raw_output_path.write_text(json.dumps(raw_dump, indent=2, default=str), encoding="utf-8")
+
+    record = adapter_qwen_dashscope.parse_response(
+        resp,
+        model_meta=meta,
+        prompt=prompt,
+        max_tokens=max_tokens,
+        wall_s=wall,
+        enable_thinking=True,
+        enable_search=True,
+    )
+    record.agent_mode = agent_mode
+
+    # Extract narrative from the raw dump for the continuation + classifier paths.
+    output = raw_dump.get("output") or {}
+    choices = output.get("choices") or []
+    narrative = (choices[0].get("message", {}).get("content")) if choices else None
+
+    # Overwrite parse_response's [user, assistant]-only messages with the
+    # complete history we just sent + the assistant reply. The CONTINUATION
+    # extractor then consumes this on the next turn.
+    extra = record.method_params.extra or {}
+    full_history = list(messages)
+    if narrative:
+        full_history.append({"role": "assistant", "content": narrative})
+    extra["messages"] = full_history
+    record.method_params.extra = extra
+
+    # Stash narrative so the classifier's record-first path skips raw-file parse.
+    record.justification = {"output_text": narrative or ""}
+
+    # Post-call cap recheck (actual billed total).
+    enforce_cost_cap(record.resource_use.cost_usd or 0.0, cap_usd=cap_usd)
+    return record
+
+
 def total_cost(record: RunRecord) -> float:
     """Token cost + connector (web_search) cost."""
     return (record.resource_use.cost_usd or 0.0) + (record.tool_calls_cost_usd or 0.0)
@@ -698,30 +823,40 @@ def _extract_anthropic_continuation(record: RunRecord, current: dict | None) -> 
     return current
 
 
+def _extract_qwen_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """Qwen: full conversation messages list (stateless DashScope — client resends history)."""
+    extra = record.method_params.extra or {}
+    if extra.get("messages"):
+        return {"messages": list(extra["messages"])}
+    return current
+
+
 CALL_FNS = {
     "mistral": run_mistral_call,
     "openai": run_openai_call,
     "anthropic": run_anthropic_call,
+    "qwen": run_qwen_call,
 }
 
 CONTINUATION_EXTRACTORS = {
     "mistral": _extract_mistral_continuation,
     "openai": _extract_openai_continuation,
     "anthropic": _extract_anthropic_continuation,
+    "qwen": _extract_qwen_continuation,
 }
 
 # Should ``system_prompt`` be passed on follow-up turns (turn > 1)?
 #  - mistral / openai: no — adapter raises (Mistral) or server-side state
 #    inherits via previous_response_id (OpenAI).
-#  - anthropic: yes — server does NOT persist system across calls;
-#    identical bytes must be resent every turn or model behaviour drifts.
-#  - qwen (ticket 0236): yes — stateless API, client resends the full
-#    conversation including the system message every turn.
+#  - anthropic / qwen: yes — both APIs are stateless on the wire; the
+#    client resends the full conversation history (including the system
+#    message) every turn.
 # Default: False (drop on follow-up).
 SYSTEM_PROMPT_PASSTHROUGH = {
     "mistral": False,
     "openai": False,
     "anthropic": True,
+    "qwen": True,
 }
 
 

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -560,12 +560,21 @@ def run_qwen_call(
     )
     payload["messages"] = messages
     if extra_metadata is not None:
-        # DashScope lacks a metadata surface; inject as a leading system
-        # message. Mirrors ``adapter_qwen_dashscope.run``'s fallback path.
+        # DashScope lacks a metadata surface AND allows at most one
+        # ``role=system`` entry. If one is already present (e.g. carried
+        # by ``system_prompt`` or by the continuation), append the metadata
+        # to its content; otherwise prepend a fresh system message.
         meta_text = "; ".join(f"{k}={v}" for k, v in extra_metadata.items())
-        payload["messages"] = [{"role": "system", "content": f"[metadata] {meta_text}"}] + payload[
-            "messages"
-        ]
+        meta_line = f"\n[metadata] {meta_text}"
+        if payload["messages"] and payload["messages"][0].get("role") == "system":
+            payload["messages"][0] = {
+                "role": "system",
+                "content": payload["messages"][0].get("content", "") + meta_line,
+            }
+        else:
+            payload["messages"] = [
+                {"role": "system", "content": f"[metadata] {meta_text}"}
+            ] + payload["messages"]
 
     # Pre-call cap.
     p_in = (

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -498,8 +498,10 @@ def run_anthropic_call(
         run_number=1,
         messages_for_continuation=continuation_messages,
     )
-    # Surface web_search billing separately into total_cost() via tool_calls_cost_usd.
-    record.tool_calls_cost_usd = float(breakdown.get("web_search", 0.0)) or None
+    # _record_from_parsed already populates ``record.tool_calls_cost_usd``
+    # from ``cost_breakdown["web_search"]`` (see query_anthropic.py:381) —
+    # no need to re-assign here. Surfacing it into total_cost() works
+    # through that field.
     # Stash narrative so the classifier's record-first path skips raw-file parse.
     record.justification = {"output_text": parsed.get("text", "") or ""}
     # Post-call cap recheck (actual billed total). Defense in depth.

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -647,7 +647,6 @@ def run_phase_b_multiturn(
     remaining_tokens = cap_tokens
     elapsed_s = 0.0
     continuation: dict | None = {}  # empty dict = start multi-turn, keep Mistral agent alive
-    agent_id: str | None = None
     terminal_sent = False
     records: list[RunRecord] = []
     verify_used = False
@@ -753,14 +752,13 @@ def run_phase_b_multiturn(
         # Provider-specific continuation extraction (Mistral: agent_id +
         # conversation_id; OpenAI: previous_response_id; future Anthropic /
         # Qwen: their own shapes). Each extractor returns the opaque dict
-        # the dispatcher will pass to ``call_fn`` on the next turn.
+        # the dispatcher will pass to ``call_fn`` on the next turn. The
+        # dispatcher never introspects the continuation shape — see the
+        # return value below for the only consumer-facing field
+        # (``agent_id``) that is pulled out by canonical key.
         new_continuation = CONTINUATION_EXTRACTORS[agent](record, continuation)
         if new_continuation is not None:
             continuation = new_continuation
-        # Mistral-specific: keep ``agent_id`` available for caller-side
-        # cleanup (the caller closes the conversation via the returned dict).
-        if agent == "mistral" and continuation and continuation.get("agent_id"):
-            agent_id = continuation["agent_id"]
 
         log.info(
             "Phase B turn %d (%s): spent=$%.4f remaining=$%.4f tokens_out=%s "
@@ -821,7 +819,11 @@ def run_phase_b_multiturn(
         "total_spent_usd": cap_usd - remaining - initial_spent_usd,
         "total_tokens_used": cap_tokens - remaining_tokens,
         "terminal_sent": terminal_sent,
-        "agent_id": agent_id,
+        # Mistral exposes ``agent_id`` for caller-side conversation cleanup;
+        # other providers omit the key (None for OpenAI / Anthropic / Qwen).
+        # The dispatcher pulls it by canonical name rather than tracking it
+        # in a local variable — keeps the loop body provider-agnostic.
+        "agent_id": (continuation or {}).get("agent_id"),
         "total_classifier_cost_usd": total_classifier_cost_usd,
     }
 

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -330,6 +330,63 @@ def run_mistral_call(
         return _runrecord_from_raw(raw_output_path, meta, agent_mode=agent_mode, wall_s=wall_s)
 
 
+def run_openai_call(
+    prompt: str,
+    *,
+    cap_usd: float,  # noqa: ARG001  # parity with run_mistral_call; OpenAI cap is enforced by parse_response cost cap
+    agent_mode: str,
+    raw_output_path: Path,
+    max_tokens: int,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
+) -> RunRecord:
+    """Single OpenAI Responses call with continuation chaining for multi-turn.
+
+    Continuation shape: ``{"response_id": str}``. On follow-up turns the SDK
+    receives ``previous_response_id``, which restores server-side state.
+    The ``system_prompt`` becomes ``instructions=`` on turn 1 only —
+    follow-up turns inherit it via the chained response.
+
+    Cost accounting per Doc 02 CONTEXT > Budget: ``tokens_out +
+    thinking_tokens`` count against the 50K token cap; ``cost_usd``
+    against the $3 dollar guard. OpenAI bundles web_search billing into
+    reasoning/output tokens for gpt-5.x (see :mod:`aedist.adapter_openai_responses`),
+    so there is no separate ``tool_calls_cost_usd`` bucket for this provider.
+    """
+    from openai import OpenAI
+
+    from aedist import adapter_openai_responses
+
+    meta = load_model_meta("openai")
+    is_followup = bool(continuation and continuation.get("response_id"))
+
+    payload = adapter_openai_responses.build_request(
+        prompt,
+        model=meta.get("model_id"),
+        max_output_tokens=max_tokens,
+        reasoning_effort="low",  # web_search rejects "minimal"; "low" is the docs floor
+    )
+    if system_prompt and not is_followup:
+        payload["instructions"] = system_prompt
+    if is_followup:
+        payload["previous_response_id"] = continuation["response_id"]
+    if extra_metadata is not None:
+        payload["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
+
+    client = OpenAI(api_key=adapter_openai_responses._load_openai_key())
+    t0 = time.monotonic()
+    resp = client.responses.create(**payload)
+    wall = round(time.monotonic() - t0, 3)
+
+    raw_output_path.write_text(resp.model_dump_json(indent=2), encoding="utf-8")
+
+    record = adapter_openai_responses.parse_response(resp, meta)
+    record.agent_mode = agent_mode
+    record.resource_use.wall_s = wall
+    return record
+
+
 def total_cost(record: RunRecord) -> float:
     """Token cost + connector (web_search) cost."""
     return (record.resource_use.cost_usd or 0.0) + (record.tool_calls_cost_usd or 0.0)
@@ -463,6 +520,77 @@ def _extract_narrative_from_raw_path(raw_path: Path) -> str:
     return extract_narrative_from_mistral_raw(raw)
 
 
+def _narrative_from_record_or_raw(record: RunRecord, raw_path: Path) -> str:
+    """Pull narrative from the RunRecord if present, else parse the raw artefact.
+
+    OpenAI (and future Anthropic / Qwen) adapters populate
+    ``record.justification["output_text"]`` with the assistant narrative.
+    The Mistral adapter does not, so we fall back to re-reading the raw
+    artefact and parsing it via :func:`extract_narrative_from_mistral_raw`.
+    The dispatch path is provider-agnostic — only the data source differs.
+    """
+    just = record.justification or {}
+    if isinstance(just, dict) and just.get("output_text"):
+        return just["output_text"]
+    return _extract_narrative_from_raw_path(raw_path)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider dispatch tables (ticket 0234)
+#
+# Each adapter exposes one ``run_*_call`` with the unified signature and
+# one continuation extractor that translates its ``record.method_params.extra``
+# into the opaque ``continuation`` dict consumed on the next turn. The
+# dispatcher routes purely by these tables and never introspects the
+# continuation shape. Adding a new provider = three additions (call_fn,
+# extractor, SYSTEM_PROMPT_PASSTHROUGH policy).
+# ---------------------------------------------------------------------------
+
+
+def _extract_mistral_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """Mistral: persist agent_id across turns, refresh conversation_id."""
+    extra = record.method_params.extra or {}
+    cur = current or {}
+    agent_id = cur.get("agent_id")
+    if agent_id is None and extra.get("agent_id"):
+        agent_id = str(extra["agent_id"])
+    conv_id = extra.get("conversation_id")
+    if conv_id and agent_id:
+        return {"agent_id": agent_id, "conversation_id": conv_id}
+    return current
+
+
+def _extract_openai_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """OpenAI: chain previous_response_id from the just-returned response."""
+    extra = record.method_params.extra or {}
+    if extra.get("response_id"):
+        return {"response_id": str(extra["response_id"])}
+    return current
+
+
+CALL_FNS = {
+    "mistral": run_mistral_call,
+    "openai": run_openai_call,
+}
+
+CONTINUATION_EXTRACTORS = {
+    "mistral": _extract_mistral_continuation,
+    "openai": _extract_openai_continuation,
+}
+
+# Should ``system_prompt`` be passed on follow-up turns (turn > 1)?
+#  - mistral / openai: no — adapter raises (Mistral) or server-side state
+#    inherits via previous_response_id (OpenAI).
+#  - anthropic / qwen (wired in 0235 / 0236): yes — Anthropic requires
+#    identical bytes every call; Qwen is stateless and resends the full
+#    conversation including the system message every turn.
+# Default: False (drop on follow-up).
+SYSTEM_PROMPT_PASSTHROUGH = {
+    "mistral": False,
+    "openai": False,
+}
+
+
 def run_phase_b_multiturn(
     designed_prompt: str,
     *,
@@ -497,7 +625,8 @@ def run_phase_b_multiturn(
     ``terminal_sent``, ``agent_id`` (for caller-side cleanup), and
     ``total_classifier_cost_usd``.
     """
-    if agent != "mistral":
+    call_fn = CALL_FNS.get(agent)
+    if call_fn is None:
         raise NotImplementedError(f"--agent {agent!r} not wired for multi-turn yet")
 
     remaining = cap_usd - initial_spent_usd
@@ -535,22 +664,23 @@ def run_phase_b_multiturn(
             "remaining_usd": f"{remaining:.2f}",
             "cap_usd": f"{cap_usd:.2f}",
         }
-        # Per ticket 0218: Mistral's path-bound append endpoint rejects
-        # body-level `metadata` with HTTP 422 (empirically confirmed
-        # 2026-05-21). On follow-up turns (when `continuation` carries
-        # an agent_id), suppress the structured metadata signal — the
-        # chat-text status prefix still informs the model. Adapter-side
-        # fix is 0218's scope.
-        is_followup_turn = bool(continuation and continuation.get("agent_id"))
+        is_followup_turn = turn > 1
+        # Per-provider quirks on follow-up turns:
+        #  - Mistral 422s on body-level ``metadata`` against the append endpoint
+        #    (ticket 0218); OpenAI accepts it but we drop for symmetry — the
+        #    user-text status prefix already conveys the same info to the model.
         if is_followup_turn:
             extra_metadata = None
+        # ``system_prompt`` on follow-up: drop unless the adapter requires
+        # identical bytes every call (Anthropic, Qwen — see
+        # ``SYSTEM_PROMPT_PASSTHROUGH``).
+        turn_system_prompt = (
+            system_prompt
+            if not is_followup_turn or SYSTEM_PROMPT_PASSTHROUGH.get(agent, False)
+            else None
+        )
 
-        # System prompt is installed at agent-create time (turn 1, when
-        # continuation={}). Follow-up turns reuse the agent and must pass
-        # None — the adapter raises ValueError otherwise (ticket 0213).
-        turn_system_prompt = system_prompt if not is_followup_turn else None
-
-        record = run_mistral_call(
+        record = call_fn(
             user_text,
             cap_usd=max(remaining, 0.01),  # adapter wants positive cap
             agent_mode="phase_b_run",
@@ -577,7 +707,7 @@ def run_phase_b_multiturn(
 
         # Classify the assistant's response. Classifier cost is harness
         # overhead, tracked separately from the SOTA agent's spend.
-        narrative = _extract_narrative_from_raw_path(paths["raw"])
+        narrative = _narrative_from_record_or_raw(record, paths["raw"])
         cls_result = dialogue_classifier.classify_report(narrative)
         total_classifier_cost_usd += cls_result.classifier_cost_usd
         paths["classification"].write_text(
@@ -606,12 +736,17 @@ def run_phase_b_multiturn(
             encoding="utf-8",
         )
 
-        extra = record.method_params.extra or {}
-        if agent_id is None and extra.get("agent_id"):
-            agent_id = str(extra["agent_id"])
-        conv_id = extra.get("conversation_id")
-        if conv_id and agent_id:
-            continuation = {"agent_id": agent_id, "conversation_id": conv_id}
+        # Provider-specific continuation extraction (Mistral: agent_id +
+        # conversation_id; OpenAI: previous_response_id; future Anthropic /
+        # Qwen: their own shapes). Each extractor returns the opaque dict
+        # the dispatcher will pass to ``call_fn`` on the next turn.
+        new_continuation = CONTINUATION_EXTRACTORS[agent](record, continuation)
+        if new_continuation is not None:
+            continuation = new_continuation
+        # Mistral-specific: keep ``agent_id`` available for caller-side
+        # cleanup (the caller closes the conversation via the returned dict).
+        if agent == "mistral" and continuation and continuation.get("agent_id"):
+            agent_id = continuation["agent_id"]
 
         log.info(
             "Phase B turn %d (%s): spent=$%.4f remaining=$%.4f tokens_out=%s "
@@ -683,7 +818,12 @@ def main(argv: list[str] | None = None) -> int:
         "--agent",
         required=True,
         choices=sorted(FAMILY_BY_AGENT),
-        help="Which SOTA agent to smoke (only 'mistral' wired in this iteration).",
+        help=(
+            "Which SOTA agent to smoke. main() end-to-end currently runs only "
+            "'mistral' (Phase A narrative extraction is Mistral-shape; multi-agent "
+            "main() wiring is ticket 0237). Phase B dispatch supports 'mistral' "
+            "and 'openai' programmatically via run_phase_b_multiturn()."
+        ),
     )
     p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
     p.add_argument("--no-confirm", action="store_true", help="Skip SPACE gates.")
@@ -702,7 +842,12 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     if args.agent != "mistral":
-        sys.exit(f"Only --agent mistral is wired in this iteration; got {args.agent!r}.")
+        sys.exit(
+            f"main() end-to-end only wires 'mistral' "
+            f"(Phase A narrative is Mistral-shape; multi-agent main() is ticket 0237). "
+            f"Got --agent {args.agent!r}. For OpenAI Phase B dispatch, call "
+            f"run_phase_b_multiturn() programmatically."
+        )
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -401,6 +401,112 @@ def run_openai_call(
     return record
 
 
+def run_anthropic_call(
+    prompt: str,
+    *,
+    cap_usd: float,
+    agent_mode: str,
+    raw_output_path: Path,
+    max_tokens: int,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
+) -> RunRecord:
+    """Single Anthropic Messages call with full-history resend for multi-turn.
+
+    Continuation shape: ``{"messages": list[dict]}`` — the complete
+    conversation history including each prior assistant reply. Anthropic
+    is stateless on the wire; the client resends everything each call.
+    The ``system_prompt`` MUST be passed as identical bytes on every
+    turn (server does NOT persist it across calls; absence on a
+    follow-up turn changes model behaviour).
+
+    Cost accounting: ``cost_usd`` excludes ``web_search`` server-tool
+    fees, which go into ``tool_calls_cost_usd``. The dual-axis budget
+    cap then deducts the full session bill via :func:`total_cost`.
+    ``tokens_out`` includes any thinking output (Anthropic reports it
+    bundled in the output count).
+    """
+    import anthropic
+
+    from aedist import query_anthropic
+    from aedist.adapter_base import enforce_cost_cap, estimate_call_cost
+
+    meta = load_model_meta("anthropic")
+    model_id = meta.get("model_id")
+    is_followup = bool(continuation and continuation.get("messages"))
+
+    payload = query_anthropic.assemble_request(
+        prompt,
+        model=model_id,
+        max_tokens=max_tokens,
+        max_uses=3,
+    )
+    if system_prompt:
+        payload["system"] = system_prompt
+    if is_followup:
+        new_user_msg = payload["messages"][-1]
+        payload["messages"] = list(continuation["messages"]) + [new_user_msg]
+    if extra_metadata is not None:
+        # Anthropic only honours ``user_id`` natively; other keys pass through.
+        payload["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
+
+    # Pre-call cap. n_searches uses the provisioned ``max_uses=3`` as the
+    # conservative ceiling; the post-call recheck below tightens against
+    # actual web_search invocations.
+    p_in = float(meta.get("price_per_mtok_in", 0.0)) / _TOKENS_PER_MTOK
+    p_out = float(meta.get("price_per_mtok_out", 0.0)) / _TOKENS_PER_MTOK
+    p_search = float(meta.get("price_per_web_search", 0.01))
+    estimated = estimate_call_cost(
+        max_tokens=max_tokens,
+        price_in=p_in,
+        price_out=p_out,
+        n_searches=3,
+        price_per_search=p_search,
+    )
+    enforce_cost_cap(estimated, cap_usd=cap_usd)
+
+    api_key = query_anthropic._load_key(query_anthropic.DEFAULT_KEY_PATH)
+    client = anthropic.Anthropic(api_key=api_key)
+    t0 = time.monotonic()
+    resp = client.messages.create(**payload)
+    wall = round(time.monotonic() - t0, 3)
+
+    raw_output_path.write_text(
+        json.dumps(query_anthropic._response_to_dict(resp), indent=2, default=str),
+        encoding="utf-8",
+    )
+
+    parsed = query_anthropic._parse_anthropic_response(resp)
+    usage = query_anthropic._usage_dict(resp)
+    breakdown = query_anthropic._compute_anthropic_cost(usage, meta, parsed["n_searches"])
+
+    # Build conversation messages for the next turn (full history replay).
+    continuation_messages = list(payload.get("messages", []))
+    if parsed.get("text"):
+        continuation_messages.append({"role": "assistant", "content": parsed["text"]})
+
+    record = query_anthropic._record_from_parsed(
+        parsed,
+        model=model_id,
+        cost_breakdown=breakdown,
+        tokens_in=parsed["tokens_in"],
+        tokens_out=parsed["tokens_out"],
+        wall_s=wall,
+        thinking_tokens=None,
+        agent_mode=agent_mode,
+        run_number=1,
+        messages_for_continuation=continuation_messages,
+    )
+    # Surface web_search billing separately into total_cost() via tool_calls_cost_usd.
+    record.tool_calls_cost_usd = float(breakdown.get("web_search", 0.0)) or None
+    # Stash narrative so the classifier's record-first path skips raw-file parse.
+    record.justification = {"output_text": parsed.get("text", "") or ""}
+    # Post-call cap recheck (actual billed total). Defense in depth.
+    enforce_cost_cap(float(breakdown.get("total", 0.0)), cap_usd=cap_usd)
+    return record
+
+
 def total_cost(record: RunRecord) -> float:
     """Token cost + connector (web_search) cost."""
     return (record.resource_use.cost_usd or 0.0) + (record.tool_calls_cost_usd or 0.0)
@@ -582,26 +688,38 @@ def _extract_openai_continuation(record: RunRecord, current: dict | None) -> dic
     return current
 
 
+def _extract_anthropic_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """Anthropic: full conversation messages list (stateless API — client resends history)."""
+    extra = record.method_params.extra or {}
+    if extra.get("messages"):
+        return {"messages": list(extra["messages"])}
+    return current
+
+
 CALL_FNS = {
     "mistral": run_mistral_call,
     "openai": run_openai_call,
+    "anthropic": run_anthropic_call,
 }
 
 CONTINUATION_EXTRACTORS = {
     "mistral": _extract_mistral_continuation,
     "openai": _extract_openai_continuation,
+    "anthropic": _extract_anthropic_continuation,
 }
 
 # Should ``system_prompt`` be passed on follow-up turns (turn > 1)?
 #  - mistral / openai: no — adapter raises (Mistral) or server-side state
 #    inherits via previous_response_id (OpenAI).
-#  - anthropic / qwen (wired in 0235 / 0236): yes — Anthropic requires
-#    identical bytes every call; Qwen is stateless and resends the full
+#  - anthropic: yes — server does NOT persist system across calls;
+#    identical bytes must be resent every turn or model behaviour drifts.
+#  - qwen (ticket 0236): yes — stateless API, client resends the full
 #    conversation including the system message every turn.
 # Default: False (drop on follow-up).
 SYSTEM_PROMPT_PASSTHROUGH = {
     "mistral": False,
     "openai": False,
+    "anthropic": True,
 }
 
 

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -333,7 +333,7 @@ def run_mistral_call(
 def run_openai_call(
     prompt: str,
     *,
-    cap_usd: float,  # noqa: ARG001  # parity with run_mistral_call; OpenAI cap is enforced by parse_response cost cap
+    cap_usd: float,
     agent_mode: str,
     raw_output_path: Path,
     max_tokens: int,
@@ -353,10 +353,15 @@ def run_openai_call(
     against the $3 dollar guard. OpenAI bundles web_search billing into
     reasoning/output tokens for gpt-5.x (see :mod:`aedist.adapter_openai_responses`),
     so there is no separate ``tool_calls_cost_usd`` bucket for this provider.
+
+    Hard cap enforcement mirrors :func:`adapter_openai_responses.run`'s
+    defense-in-depth pattern: pre-call cost estimate against ``cap_usd``,
+    then a post-call recheck of the billed cost.
     """
     from openai import OpenAI
 
     from aedist import adapter_openai_responses
+    from aedist.adapter_base import enforce_cost_cap, estimate_call_cost
 
     meta = load_model_meta("openai")
     is_followup = bool(continuation and continuation.get("response_id"))
@@ -374,6 +379,13 @@ def run_openai_call(
     if extra_metadata is not None:
         payload["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
 
+    # Pre-call cap check (estimate). Mirrors adapter_openai_responses.run
+    # so single-turn callers and multi-turn dispatch enforce the same ceiling.
+    p_in = meta.get("price_per_mtok_in_fresh", meta.get("price_per_mtok_in", 0.0)) / 1_000_000
+    p_out = meta.get("price_per_mtok_out", 0.0) / 1_000_000
+    estimated = estimate_call_cost(max_tokens=max_tokens, price_in=p_in, price_out=p_out)
+    enforce_cost_cap(estimated, cap_usd=cap_usd)
+
     client = OpenAI(api_key=adapter_openai_responses._load_openai_key())
     t0 = time.monotonic()
     resp = client.responses.create(**payload)
@@ -384,6 +396,8 @@ def run_openai_call(
     record = adapter_openai_responses.parse_response(resp, meta)
     record.agent_mode = agent_mode
     record.resource_use.wall_s = wall
+    # Post-call cap recheck (actual). Catches estimate-vs-billed drift.
+    enforce_cost_cap(record.resource_use.cost_usd or 0.0, cap_usd=cap_usd)
     return record
 
 

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -241,20 +241,17 @@ def test_wait_for_space_continues_on_enter(monkeypatch):
 
 
 def test_module_imports_only_wired_adapters():
-    """The smoke imports only adapters it actually dispatches multi-turn through.
+    """The smoke imports the four wired adapters and nothing else.
 
-    Mistral wired in ticket 0214; OpenAI wired in ticket 0234; Anthropic
-    wired in ticket 0235. Qwen multi-turn wiring is tracked under ticket
-    0236 and must NOT be imported until that lands — keeps the dependency
-    surface honest.
+    Mistral (0214), OpenAI (0234), Anthropic (0235), Qwen (0236) — the
+    full optimized-arm cohort for Exp 2 protocol v3.
     """
     src = Path(__file__).parent.parent / "experiments" / "sota" / "exp2_interactive_smoke.py"
     text = src.read_text()
     assert "adapter_mistral" in text
-    assert "adapter_openai_responses" in text  # 0234 wired OpenAI
-    assert "query_anthropic" in text  # 0235 wired Anthropic
-    for forbidden in ("adapter_qwen_dashscope",):
-        assert forbidden not in text, f"unexpected import: {forbidden}"
+    assert "adapter_openai_responses" in text  # 0234
+    assert "query_anthropic" in text  # 0235
+    assert "adapter_qwen_dashscope" in text  # 0236
 
 
 # ---------------------------------------------------------------------------
@@ -1061,4 +1058,198 @@ def test_state_machine_anthropic_dispatch_chains_messages(monkeypatch, tmp_path)
     assert msgs[0] == {"role": "user", "content": "the designed prompt"}
     assert msgs[1] == {"role": "assistant", "content": "reply-1"}
     # SYSTEM_PROMPT_PASSTHROUGH=True for Anthropic — system re-sent on turn 2.
+    assert call_log[1]["system_prompt"] == "designed system text"
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0236: Qwen DashScope adapter for multi-turn Phase B
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_qwen_resp(*, narrative: str = "stub-qwen"):
+    """Minimal stand-in for ``dashscope.Generation.call()`` return value.
+
+    Mirrors the dict-shape DashScope returns: nested ``output.choices[0].message``
+    plus a top-level ``usage`` dict. Built to exercise
+    ``adapter_qwen_dashscope.parse_response``.
+    """
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "content": narrative,
+                        "reasoning_content": None,
+                    },
+                    "finish_reason": "stop",
+                },
+            ],
+            "search_info": {"search_results": []},
+        },
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "plugins": {"search": {"count": 0}},
+        },
+        "request_id": "req_test_001",
+        "status_code": 200,
+    }
+
+
+def test_run_qwen_call_turn1_injects_system(monkeypatch, tmp_path):
+    """Turn 1 Qwen call: messages = [system, user]; enable_search=True; thinking on."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_call(**payload):
+        captured.update(payload)
+        return _make_fake_qwen_resp()
+
+    monkeypatch.setattr("dashscope.Generation.call", fake_call)
+    monkeypatch.setattr("aedist.adapter_qwen_dashscope._resolve_api_key", lambda: "sk-qwen-test")
+
+    record = mod.run_qwen_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    assert captured["messages"] == [
+        {"role": "system", "content": "you are an analyst"},
+        {"role": "user", "content": "the prompt"},
+    ]
+    assert captured["enable_search"] is True
+    assert captured["enable_thinking"] is True
+    # Continuation messages (post-parse override) include system + user + assistant.
+    extra_msgs = (record.method_params.extra or {}).get("messages", [])
+    assert extra_msgs[0] == {"role": "system", "content": "you are an analyst"}
+    assert extra_msgs[1] == {"role": "user", "content": "the prompt"}
+    assert extra_msgs[2] == {"role": "assistant", "content": "stub-qwen"}
+    # Narrative reachable via the record-first classifier path.
+    assert (record.justification or {}).get("output_text") == "stub-qwen"
+
+
+def test_run_qwen_call_turn2_replays_full_history(monkeypatch, tmp_path):
+    """Turn 2+: messages list replays prior history (including system) + new user."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_call(**payload):
+        captured.update(payload)
+        return _make_fake_qwen_resp(narrative="turn-2 reply")
+
+    monkeypatch.setattr("dashscope.Generation.call", fake_call)
+    monkeypatch.setattr("aedist.adapter_qwen_dashscope._resolve_api_key", lambda: "sk-qwen-test")
+
+    prior_history = [
+        {"role": "system", "content": "you are an analyst"},
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+    ]
+
+    mod.run_qwen_call(
+        "second user message",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw_turn2.json",
+        max_tokens=1000,
+        continuation={"messages": prior_history},
+        extra_metadata=None,
+        system_prompt="you are an analyst",  # ignored because continuation carries it
+    )
+
+    # Full history (incl. system) + new user message sent on the wire.
+    assert captured["messages"] == [
+        {"role": "system", "content": "you are an analyst"},
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+        {"role": "user", "content": "second user message"},
+    ]
+
+
+def test_state_machine_qwen_dispatch_chains_messages(monkeypatch, tmp_path):
+    """Dispatcher routes --agent qwen, replays full conversation, re-sends system on turn 2."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    call_log: list[dict] = []
+
+    def fake_run_qwen(
+        prompt,
+        *,
+        cap_usd,  # noqa: ARG001
+        agent_mode,
+        raw_output_path,
+        max_tokens,  # noqa: ARG001
+        continuation=None,
+        extra_metadata=None,
+        system_prompt=None,
+    ):
+        from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
+
+        call_log.append(
+            {
+                "prompt": prompt,
+                "continuation": continuation,
+                "extra_metadata": extra_metadata,
+                "system_prompt": system_prompt,
+            }
+        )
+        # Build the full history for the next-turn continuation.
+        if continuation and continuation.get("messages"):
+            history = list(continuation["messages"])
+        else:
+            history = [{"role": "system", "content": system_prompt}] if system_prompt else []
+        history.append({"role": "user", "content": prompt})
+        history.append({"role": "assistant", "content": f"reply-{len(call_log)}"})
+        raw_output_path.write_text(json.dumps({"request_id": f"req_t{len(call_log)}"}))
+        return RunRecord(
+            method="frontier",
+            method_params=MethodParams(
+                model="qwen3-max",
+                max_tokens=100,
+                extra={"messages": history},
+            ),
+            resource_use=ResourceUse(cost_usd=0.10, wall_s=1.0, tokens_in=10, tokens_out=20),
+            result_summary=ResultSummary(status="ok"),
+            agent_family="qwen-direct",
+            agent_mode=agent_mode,
+            justification={"output_text": f"reply-{len(call_log)}"},
+        )
+
+    monkeypatch.setitem(mod.CALL_FNS, "qwen", fake_run_qwen)
+    monkeypatch.setattr(
+        mod.dialogue_classifier,
+        "classify_report",
+        _fake_classifier_factory(["report", "no_report"]),
+    )
+
+    result = run_phase_b_multiturn(
+        "the designed prompt",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="qwen",
+        system_prompt="designed system text",
+    )
+
+    assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
+    # Turn 1: empty continuation, system installed.
+    assert not call_log[0]["continuation"] or "messages" not in call_log[0]["continuation"]
+    assert call_log[0]["system_prompt"] == "designed system text"
+    # Turn 2: full history (system + user1 + assistant1) replayed.
+    msgs = (call_log[1]["continuation"] or {}).get("messages", [])
+    assert msgs[0] == {"role": "system", "content": "designed system text"}
+    assert msgs[1] == {"role": "user", "content": "the designed prompt"}
+    assert msgs[2] == {"role": "assistant", "content": "reply-1"}
+    # SYSTEM_PROMPT_PASSTHROUGH=True for Qwen — system re-sent on turn 2.
     assert call_log[1]["system_prompt"] == "designed system text"

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -1136,6 +1136,53 @@ def test_run_qwen_call_turn1_injects_system(monkeypatch, tmp_path):
     assert (record.justification or {}).get("output_text") == "stub-qwen"
 
 
+def test_run_qwen_call_merges_metadata_into_existing_system(monkeypatch, tmp_path):
+    """When system_prompt AND extra_metadata are both set, exactly one system message.
+
+    Regression: an earlier implementation prepended a SECOND
+    ``{"role": "system"}`` entry when extra_metadata was set, producing
+    payload [metadata-system, real-system, user]. DashScope honours at
+    most one leading system message and would silently drop one of them.
+
+    Correct behaviour: append the [metadata] line to the existing
+    system message content, keeping a single system entry at index 0.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_call(**payload):
+        captured.update(payload)
+        return _make_fake_qwen_resp()
+
+    monkeypatch.setattr("dashscope.Generation.call", fake_call)
+    monkeypatch.setattr("aedist.adapter_qwen_dashscope._resolve_api_key", lambda: "sk-qwen-test")
+
+    mod.run_qwen_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata={"remaining_usd": "2.50", "cap_usd": "3.00"},
+        system_prompt="you are an analyst",
+    )
+
+    # Exactly one system message at index 0.
+    system_messages = [m for m in captured["messages"] if m.get("role") == "system"]
+    assert len(system_messages) == 1, (
+        f"expected exactly 1 system message, got {len(system_messages)}: "
+        f"{[m for m in captured['messages']]}"
+    )
+    assert captured["messages"][0]["role"] == "system"
+    # Both the agent's system_prompt AND the [metadata] line must be present.
+    sys_content = captured["messages"][0]["content"]
+    assert "you are an analyst" in sys_content
+    assert "[metadata]" in sys_content
+    assert "remaining_usd=2.50" in sys_content
+
+
 def test_run_qwen_call_turn2_replays_full_history(monkeypatch, tmp_path):
     """Turn 2+: messages list replays prior history (including system) + new user."""
     from experiments.sota import exp2_interactive_smoke as mod

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -243,15 +243,17 @@ def test_wait_for_space_continues_on_enter(monkeypatch):
 def test_module_imports_only_wired_adapters():
     """The smoke imports only adapters it actually dispatches multi-turn through.
 
-    Mistral wired in ticket 0214; OpenAI wired in ticket 0234. Anthropic and
-    Qwen multi-turn wiring is tracked under tickets 0235 / 0236 and must NOT
-    be imported until those land — keeps the dependency surface honest.
+    Mistral wired in ticket 0214; OpenAI wired in ticket 0234; Anthropic
+    wired in ticket 0235. Qwen multi-turn wiring is tracked under ticket
+    0236 and must NOT be imported until that lands — keeps the dependency
+    surface honest.
     """
     src = Path(__file__).parent.parent / "experiments" / "sota" / "exp2_interactive_smoke.py"
     text = src.read_text()
     assert "adapter_mistral" in text
     assert "adapter_openai_responses" in text  # 0234 wired OpenAI
-    for forbidden in ("adapter_qwen_dashscope", "query_anthropic"):
+    assert "query_anthropic" in text  # 0235 wired Anthropic
+    for forbidden in ("adapter_qwen_dashscope",):
         assert forbidden not in text, f"unexpected import: {forbidden}"
 
 
@@ -864,3 +866,199 @@ def test_dispatch_tables_share_provider_set():
     # SYSTEM_PROMPT_PASSTHROUGH may be a subset (missing entry = default False),
     # but every key in it must be a known provider.
     assert set(mod.SYSTEM_PROMPT_PASSTHROUGH).issubset(set(mod.CALL_FNS))
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0235: Anthropic Messages API adapter for multi-turn Phase B
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_anthropic_resp(*, narrative: str = "stub"):
+    """Minimal stand-in for ``anthropic.messages.create()`` return value."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id="msg_test_001",
+        model="claude-opus-4-6",
+        stop_reason="end_turn",
+        content=[
+            SimpleNamespace(type="text", text=narrative, citations=[]),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            server_tool_use=SimpleNamespace(web_search_requests=2),
+        ),
+    )
+
+
+def test_run_anthropic_call_turn1_sends_system_and_messages(monkeypatch, tmp_path):
+    """Turn 1: system installed, messages = [{user, prompt}], no replayed history."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_anthropic_resp()
+
+    fake_client = type("C", (), {})()
+    fake_client.messages = type("M", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("anthropic.Anthropic", lambda **kw: fake_client)  # noqa: ARG005
+    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda _: "sk-ant-test")
+
+    record = mod.run_anthropic_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    assert captured["system"] == "you are an analyst"
+    assert captured["messages"] == [{"role": "user", "content": "the prompt"}]
+    # Single web_search tool installed at turn 1 (max_uses=3 default).
+    assert any(t.get("name") == "web_search" for t in captured["tools"])
+    assert record.agent_mode == "phase_b_run"
+    # Narrative stashed for the record-first classifier path.
+    assert (record.justification or {}).get("output_text") == "stub"
+
+
+def test_run_anthropic_call_turn2_replays_full_history(monkeypatch, tmp_path):
+    """Turn 2+: messages list contains prior turns AND system is re-sent identically.
+
+    Anthropic is stateless on the wire: every call must replay the full
+    conversation history including each previous assistant reply, AND the
+    ``system`` parameter must be passed as identical bytes every turn.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_anthropic_resp(narrative="turn-2 reply")
+
+    fake_client = type("C", (), {})()
+    fake_client.messages = type("M", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("anthropic.Anthropic", lambda **kw: fake_client)  # noqa: ARG005
+    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda _: "sk-ant-test")
+
+    prior_history = [
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+    ]
+
+    mod.run_anthropic_call(
+        "second user message",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw_turn2.json",
+        max_tokens=1000,
+        continuation={"messages": prior_history},
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    # Full history replayed: prior 2 + new user = 3 messages.
+    assert captured["messages"] == [
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+        {"role": "user", "content": "second user message"},
+    ]
+    # System bytes identical to turn 1 (required by Anthropic).
+    assert captured["system"] == "you are an analyst"
+
+
+def test_state_machine_anthropic_dispatch_chains_messages(monkeypatch, tmp_path):
+    """Dispatcher routes --agent anthropic and appends turn-1 reply into turn-2 messages.
+
+    Two-turn trace under ``[report, no_report]``: turn-1 is the designed
+    prompt; the classifier returns "report" → VERIFY fires on turn-2.
+    On turn-2 the dispatcher must pass ``continuation["messages"]`` that
+    contains the turn-1 user message AND the turn-1 assistant reply.
+    System prompt MUST be re-sent on turn-2 (SYSTEM_PROMPT_PASSTHROUGH).
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    call_log: list[dict] = []
+
+    def fake_run_anthropic(
+        prompt,
+        *,
+        cap_usd,  # noqa: ARG001
+        agent_mode,
+        raw_output_path,
+        max_tokens,  # noqa: ARG001
+        continuation=None,
+        extra_metadata=None,
+        system_prompt=None,
+    ):
+        from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
+
+        call_log.append(
+            {
+                "prompt": prompt,
+                "continuation": continuation,
+                "extra_metadata": extra_metadata,
+                "system_prompt": system_prompt,
+            }
+        )
+        # Build the next-turn messages list: prior history (if any) + this turn.
+        history = list((continuation or {}).get("messages", []))
+        history.append({"role": "user", "content": prompt})
+        history.append({"role": "assistant", "content": f"reply-{len(call_log)}"})
+        raw_output_path.write_text(json.dumps({"id": f"msg_t{len(call_log)}"}))
+        return RunRecord(
+            method="frontier",
+            method_params=MethodParams(
+                model="claude-opus-4-6",
+                max_tokens=100,
+                extra={"run_number": 1, "messages": history},
+            ),
+            resource_use=ResourceUse(
+                cost_usd=0.10,
+                wall_s=1.0,
+                tokens_in=10,
+                tokens_out=20,
+                thinking_tokens=None,
+            ),
+            result_summary=ResultSummary(status="ok"),
+            agent_family="anthropic-direct",
+            agent_mode=agent_mode,
+            justification={"output_text": f"reply-{len(call_log)}"},
+        )
+
+    monkeypatch.setitem(mod.CALL_FNS, "anthropic", fake_run_anthropic)
+    monkeypatch.setattr(
+        mod.dialogue_classifier,
+        "classify_report",
+        _fake_classifier_factory(["report", "no_report"]),
+    )
+
+    result = run_phase_b_multiturn(
+        "the designed prompt",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="anthropic",
+        system_prompt="designed system text",
+    )
+
+    assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
+    # Turn 1: empty continuation, system installed.
+    assert not call_log[0]["continuation"] or "messages" not in call_log[0]["continuation"]
+    assert call_log[0]["system_prompt"] == "designed system text"
+    # Turn 2: messages list contains turn-1 user + turn-1 assistant.
+    msgs = (call_log[1]["continuation"] or {}).get("messages", [])
+    assert msgs[0] == {"role": "user", "content": "the designed prompt"}
+    assert msgs[1] == {"role": "assistant", "content": "reply-1"}
+    # SYSTEM_PROMPT_PASSTHROUGH=True for Anthropic — system re-sent on turn 2.
+    assert call_log[1]["system_prompt"] == "designed system text"

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -240,13 +240,18 @@ def test_wait_for_space_continues_on_enter(monkeypatch):
     wait_for_space("test gate", no_confirm=False)
 
 
-def test_module_imports_adapter_mistral_only():
-    """The smoke must not import or edit the other 3 adapters in this iteration."""
+def test_module_imports_only_wired_adapters():
+    """The smoke imports only adapters it actually dispatches multi-turn through.
+
+    Mistral wired in ticket 0214; OpenAI wired in ticket 0234. Anthropic and
+    Qwen multi-turn wiring is tracked under tickets 0235 / 0236 and must NOT
+    be imported until those land — keeps the dependency surface honest.
+    """
     src = Path(__file__).parent.parent / "experiments" / "sota" / "exp2_interactive_smoke.py"
     text = src.read_text()
     assert "adapter_mistral" in text
-    # Only mistral dispatch is wired; others should not be imported here.
-    for forbidden in ("adapter_openai_responses", "adapter_qwen_dashscope", "query_anthropic"):
+    assert "adapter_openai_responses" in text  # 0234 wired OpenAI
+    for forbidden in ("adapter_qwen_dashscope", "query_anthropic"):
         assert forbidden not in text, f"unexpected import: {forbidden}"
 
 
@@ -379,7 +384,7 @@ def test_state_machine_report_then_verify_then_stop(monkeypatch, tmp_path):
 
     fake_run = _fake_run_factory(cost_per_call=0.10)
     fake_classify = _fake_classifier_factory(["report", "no_report"])
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -448,7 +453,7 @@ def test_state_machine_three_no_reports_then_terminal(monkeypatch, tmp_path):
     fake_run = _fake_run_factory(cost_per_call=0.10)
     # Four classifications consumed (one per turn) — all no_report.
     fake_classify = _fake_classifier_factory(["no_report"] * 4)
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -502,7 +507,7 @@ def test_state_machine_token_cap_overrides(monkeypatch, tmp_path):
 
     fake_run = _fake_run_factory(cost_per_call=0.01)  # cheap; dollar cap won't bind
     fake_classify = _fake_classifier_factory(["no_report"] * 10)
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -537,7 +542,7 @@ def test_state_machine_budget_overrides(monkeypatch, tmp_path):
 
     fake_run = _fake_run_factory(cost_per_call=3.0)
     fake_classify = _fake_classifier_factory(["no_report"] * 10)
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -638,3 +643,224 @@ def test_classification_result_to_artefact_dict_uses_class_key():
         "classifier_model": "mock",
         "wall_s": 0.5,
     }
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0234: OpenAI Responses API adapter for multi-turn Phase B
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_openai_resp(*, resp_id: str = "resp_test_001", narrative: str = "stub"):
+    """Minimal stand-in for ``openai.responses.create()`` return value.
+
+    Built to exercise :func:`adapter_openai_responses.parse_response`,
+    which is the same parser :func:`run_openai_call` uses.
+    """
+    from types import SimpleNamespace
+
+    class _Resp(SimpleNamespace):
+        def model_dump_json(self, indent: int | None = None) -> str:
+            return json.dumps({"id": resp_id, "narrative": narrative}, indent=indent)
+
+    return _Resp(
+        id=resp_id,
+        model="gpt-5.5",
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=narrative)],
+            ),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            output_tokens_details=SimpleNamespace(reasoning_tokens=200),
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+        ),
+    )
+
+
+def test_run_openai_call_turn1_no_continuation(monkeypatch, tmp_path):
+    """Turn 1: instructions=system_prompt; tools includes web_search; no previous_response_id."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_openai_resp()
+
+    fake_client = type("C", (), {})()
+    fake_client.responses = type("R", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("openai.OpenAI", lambda **kw: fake_client)  # noqa: ARG005
+    monkeypatch.setattr(
+        "aedist.adapter_openai_responses._load_openai_key", lambda: "sk-test-fixture"
+    )
+
+    record = mod.run_openai_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    assert captured["input"] == "the prompt"
+    assert captured["instructions"] == "you are an analyst"
+    assert {"type": "web_search"} in captured["tools"]
+    assert "previous_response_id" not in captured
+    # Cost cap accounting (Doc 02 CONTEXT > Budget): tokens_out (50) + thinking (200) = 250.
+    assert record.resource_use.tokens_out == 50
+    assert record.resource_use.thinking_tokens == 200
+    assert record.agent_mode == "phase_b_run"
+    # Raw artefact written for downstream classifier read paths.
+    assert (tmp_path / "raw.json").exists()
+    # Justification carries the narrative for the record-first classifier path.
+    assert (record.justification or {}).get("output_text") == "stub"
+
+
+def test_run_openai_call_turn2_uses_previous_response_id(monkeypatch, tmp_path):
+    """Turn 2+: previous_response_id is forwarded; instructions NOT re-sent."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_openai_resp(resp_id="resp_test_turn2")
+
+    fake_client = type("C", (), {})()
+    fake_client.responses = type("R", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("openai.OpenAI", lambda **kw: fake_client)  # noqa: ARG005
+    monkeypatch.setattr(
+        "aedist.adapter_openai_responses._load_openai_key", lambda: "sk-test-fixture"
+    )
+
+    mod.run_openai_call(
+        "follow-up prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw_turn2.json",
+        max_tokens=1000,
+        continuation={"response_id": "resp_test_turn1"},
+        extra_metadata=None,
+        system_prompt="you are an analyst",  # passed but should be ignored on followup
+    )
+
+    assert captured["previous_response_id"] == "resp_test_turn1"
+    assert "instructions" not in captured, (
+        "follow-up turn must not re-send instructions — server-side state inherits"
+    )
+
+
+def test_state_machine_openai_dispatch_chains_response_id(monkeypatch, tmp_path):
+    """Dispatcher routes --agent openai through run_openai_call and chains response_id.
+
+    Turn-1 has empty continuation. Turn-2's call must receive
+    ``continuation={"response_id": <turn1_resp_id>}`` — proving the
+    CONTINUATION_EXTRACTORS table replaces the Mistral-specific
+    agent_id / conversation_id extraction without code branching in
+    the dispatcher body.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    call_log: list[dict] = []
+
+    def fake_run_openai(
+        prompt,
+        *,
+        cap_usd,  # noqa: ARG001  # signature parity; cap enforced inside the real call
+        agent_mode,
+        raw_output_path,
+        max_tokens,  # noqa: ARG001
+        continuation=None,
+        extra_metadata=None,
+        system_prompt=None,
+    ):
+        from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
+
+        call_log.append(
+            {
+                "prompt": prompt,
+                "continuation": continuation,
+                "extra_metadata": extra_metadata,
+                "system_prompt": system_prompt,
+            }
+        )
+        raw_output_path.write_text(json.dumps({"id": f"resp_t{len(call_log)}"}))
+        return RunRecord(
+            method="frontier",
+            method_params=MethodParams(
+                model="gpt-5.5",
+                max_tokens=100,
+                extra={"response_id": f"resp_t{len(call_log)}"},
+            ),
+            resource_use=ResourceUse(
+                cost_usd=0.10,
+                wall_s=1.0,
+                tokens_in=10,
+                tokens_out=20,
+                thinking_tokens=5,
+            ),
+            result_summary=ResultSummary(status="ok"),
+            agent_family="openai-direct",
+            agent_mode=agent_mode,
+            justification={"output_text": "stub narrative"},
+        )
+
+    monkeypatch.setitem(mod.CALL_FNS, "openai", fake_run_openai)
+    monkeypatch.setattr(
+        mod.dialogue_classifier,
+        "classify_report",
+        _fake_classifier_factory(["report", "no_report"]),
+    )
+
+    result = run_phase_b_multiturn(
+        "the designed prompt",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="openai",
+        system_prompt="designed system text",
+    )
+
+    assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
+    # Turn 1: continuation is the initial empty dict — no response_id yet.
+    assert not call_log[0]["continuation"] or "response_id" not in call_log[0]["continuation"]
+    # System prompt installed on turn 1.
+    assert call_log[0]["system_prompt"] == "designed system text"
+    # Turn 2: continuation carries the turn-1 response_id.
+    assert call_log[1]["continuation"] == {"response_id": "resp_t1"}
+    # OpenAI is in SYSTEM_PROMPT_PASSTHROUGH = False group → system masked on follow-up.
+    assert call_log[1]["system_prompt"] is None
+    # Per-turn artefacts present for both turns.
+    for turn in (1, 2):
+        for suffix in (".user.txt", ".raw.json", ".record.json", ".classification.json"):
+            assert (tmp_path / f"openai_turn_{turn:02d}{suffix}").exists(), (
+                f"missing artefact openai_turn_{turn:02d}{suffix}"
+            )
+
+
+def test_dispatch_tables_share_provider_set():
+    """CALL_FNS and CONTINUATION_EXTRACTORS must cover the same providers.
+
+    Catches drift where someone adds a new provider to one table but
+    forgets the other — a partial wiring would crash at runtime with
+    a KeyError. Cheap structural invariant.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    assert set(mod.CALL_FNS) == set(mod.CONTINUATION_EXTRACTORS), (
+        f"CALL_FNS={set(mod.CALL_FNS)} but "
+        f"CONTINUATION_EXTRACTORS={set(mod.CONTINUATION_EXTRACTORS)} — "
+        "every wired provider needs both"
+    )
+    # SYSTEM_PROMPT_PASSTHROUGH may be a subset (missing entry = default False),
+    # but every key in it must be a known provider.
+    assert set(mod.SYSTEM_PROMPT_PASSTHROUGH).issubset(set(mod.CALL_FNS))


### PR DESCRIPTION
**Ticket:** tickets/0236-wire-qwen-multi-turn.erg

⚠️ **Stacked PR.** Base = \`t0235-fg\` (PR #430). Merge order: #429 → main, then retarget #430 to main and merge, then retarget this PR to main and merge.

## Summary

Completes the four-provider optimized-arm cohort. Same stateless full-history pattern as Anthropic (#430); DashScope differs only in:

- the SDK call shape (\`dashscope.Generation.call\` vs \`anthropic.messages.create\`),
- lack of a native \`metadata\` channel — metadata is injected as a leading \`{\"role\": \"system\", \"content\": \"[metadata] ...\"}\` message (mirrors \`adapter_qwen_dashscope.run\`'s fallback).

| Table | Value |
|---|---|
| \`CALL_FNS[\"qwen\"]\` | \`run_qwen_call\` |
| \`CONTINUATION_EXTRACTORS[\"qwen\"]\` | \`{\"messages\": list[dict]}\` |
| \`SYSTEM_PROMPT_PASSTHROUGH[\"qwen\"]\` | **True** — resend every turn |

## Implementation note

The adapter's \`parse_response\` stores only \`[user, assistant]\` in \`extra[\"messages\"]\`. \`run_qwen_call\` overrides this after parsing with the COMPLETE history (\`system + user + assistant\`) so the continuation extractor doesn't lose the system message on turn 2+.

## Test plan

- [x] \`make check-fast\`: 1431 passed, ruff clean
- [x] New tests:
  - \`test_run_qwen_call_turn1_injects_system\` (asserts system + user shape on wire, enable_search/thinking flags)
  - \`test_run_qwen_call_turn2_replays_full_history\` (full history incl. system replayed)
  - \`test_state_machine_qwen_dispatch_chains_messages\` (dispatcher routes; system passes through every turn)
- [x] \`test_module_imports_only_wired_adapters\` expanded to four positive assertions (no remaining forbidden imports)
- [ ] Live N=1 dispatch — deferred to ticket 0237 (Phase B-0 smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)