### PR TITLE
exp2 smoke: restore Anthropic + Qwen adapter wiring lost in #433

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -78,7 +78,7 @@ BASELINE_PATH = REPO_ROOT / "experiments" / "prompts" / "prompt_complete.txt"
 QUALITY_BAR_PATH = REPO_ROOT / "slides" / "manuscript" / "main.md"
 METAPROMPT_PATH = REPO_ROOT / "experiments" / "sota" / "protocol_02_metaprompt.md"
 MODELS_YAML = REPO_ROOT / "experiments" / "models.yaml"
-DEFAULT_OUTPUT_DIR = REPO_ROOT / "experiments" / "outputs" / "sota_exp2_smoke"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "experiments" / "outputs" / "sota_exp2_phase_b0"
 
 QUALITY_BAR_START = "## Second, the quality bar"
 QUALITY_BAR_END = "## Third,"
@@ -197,6 +197,51 @@ def _normalize_python_triple_quotes(text: str) -> str:
     return _TRIPLE_QUOTE_RE.sub(lambda m: json.dumps(m.group(1)), text)
 
 
+def _escape_json_control_chars_in_strings(text: str) -> str:
+    """Escape literal control characters that appear inside JSON strings.
+
+    Some Phase A Mistral replies are almost-JSON but include raw newlines inside
+    quoted values (for example inside ``designed_prompt``), which is invalid JSON
+    even though the envelope shape is otherwise correct. Escape only control
+    characters observed while inside a quoted string, preserving structural
+    whitespace outside strings.
+    """
+    escaped_text: list[str] = []
+    in_string = False
+    escape_next = False
+
+    for char in text:
+        if in_string:
+            if escape_next:
+                escaped_text.append(char)
+                escape_next = False
+                continue
+            if char == "\\":
+                escaped_text.append(char)
+                escape_next = True
+                continue
+            if char == '"':
+                escaped_text.append(char)
+                in_string = False
+                continue
+            if ord(char) < 0x20:
+                if char == "\n":
+                    escaped_text.append("\\n")
+                elif char == "\r":
+                    escaped_text.append("\\r")
+                elif char == "\t":
+                    escaped_text.append("\\t")
+                else:
+                    escaped_text.append(f"\\u{ord(char):04x}")
+                continue
+        else:
+            if char == '"':
+                in_string = True
+        escaped_text.append(char)
+
+    return "".join(escaped_text)
+
+
 def extract_phase_a_design(response_text: str) -> dict:
     """Parse the JSON envelope out of Phase A's narrative response.
 
@@ -215,7 +260,7 @@ def extract_phase_a_design(response_text: str) -> dict:
         if text.endswith("```"):
             text = text.rsplit("```", 1)[0]
         text = text.strip()
-    text = _normalize_python_triple_quotes(text)
+    text = _escape_json_control_chars_in_strings(_normalize_python_triple_quotes(text))
     try:
         obj = json.loads(text)
     except json.JSONDecodeError:
@@ -330,35 +375,8 @@ def run_mistral_call(
         return _runrecord_from_raw(raw_output_path, meta, agent_mode=agent_mode, wall_s=wall_s)
 
 
-def _load_openai_key() -> str:
-    """Load OpenAI key from env or ``~/.config/keys/openai.env``.
-
-    Accepts only ``OPENAI_API_KEY_AEDIST``.
-    """
-    key = os.environ.get("OPENAI_API_KEY_AEDIST")
-    if key:
-        return key
-    env_file = Path.home() / ".config" / "keys" / "openai.env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                k, _, v = line.partition("=")
-                if k.strip() == "OPENAI_API_KEY_AEDIST":
-                    return v.strip().strip('"').strip("'")
-    raise SystemExit(
-        "OpenAI key not set (expected OPENAI_API_KEY_AEDIST) "
-        "and not found in ~/.config/keys/openai.env"
-    )
-
-
-_TOKENS_PER_MTOK_F = 1_000_000.0
-
-
 def run_openai_call(
-    user_text: str,
+    prompt: str,
     *,
     cap_usd: float,
     agent_mode: str,
@@ -368,161 +386,305 @@ def run_openai_call(
     extra_metadata: dict | None = None,
     system_prompt: str | None = None,
 ) -> RunRecord:
-    """Single OpenAI Responses API call for Exp 2 Phase B multi-turn.
+    """Single OpenAI Responses call with continuation chaining for multi-turn.
 
-    Uses ``previous_response_id`` chaining for turns 2+: server-side state
-    is preserved and only the new user message needs to be sent. This is the
-    cheapest multi-turn pattern for the Responses API and is the reason OpenAI
-    is the easiest provider to wire.
+    Continuation shape: ``{"response_id": str}``. On follow-up turns the SDK
+    receives ``previous_response_id``, which restores server-side state.
+    The ``system_prompt`` becomes ``instructions=`` on turn 1 only —
+    follow-up turns inherit it via the chained response.
 
-    Dispatch contract (shared across all per-provider call shims):
-    - ``continuation`` is opaque per-provider state: ``None`` or ``{}`` means
-      turn 1; ``{"previous_response_id": str}`` means follow-up turn.
-    - ``system_prompt`` is only sent on turn 1 (as ``instructions``); callers
-      must pass ``None`` on follow-up turns.
-    - The returned record's ``method_params.extra`` carries
-      ``{"previous_response_id": resp.id}`` so the dispatcher can pass it
-      as ``continuation`` on the next turn without inspecting its contents.
+    Cost accounting per Doc 02 CONTEXT > Budget: ``tokens_out +
+    thinking_tokens`` count against the 50K token cap; ``cost_usd``
+    against the $3 dollar guard. OpenAI bundles web_search billing into
+    reasoning/output tokens for gpt-5.x (see :mod:`aedist.adapter_openai_responses`),
+    so there is no separate ``tool_calls_cost_usd`` bucket for this provider.
 
-    Cost accounting: ``tokens_out`` = visible output tokens;
-    ``thinking_tokens`` = reasoning tokens from
-    ``usage.output_tokens_details.reasoning_tokens``. Both flow into the
-    dual-axis budget cap in ``run_phase_b_multiturn`` (50K tokens OR $3).
-    OpenAI bundles web_search billing into reasoning/output tokens for
-    gpt-5.x — ``tool_calls_cost_usd`` is 0 for this model. If a
-    ``price_per_web_search`` key ever appears in models.yaml, this
-    function will use it automatically.
+    Hard cap enforcement mirrors :func:`adapter_openai_responses.run`'s
+    defense-in-depth pattern: pre-call cost estimate against ``cap_usd``,
+    then a post-call recheck of the billed cost.
     """
     from openai import OpenAI
 
+    from aedist import adapter_openai_responses
+    from aedist.adapter_base import enforce_cost_cap, estimate_call_cost
+
     meta = load_model_meta("openai")
-    model_id = meta.get("model_id", "gpt-5.5")
-    p_out = float(meta.get("price_per_mtok_out", 15.0)) / _TOKENS_PER_MTOK_F
-    p_reasoning = (
-        float(meta.get("price_per_mtok_reasoning", meta.get("price_per_mtok_out", 15.0)))
-        / _TOKENS_PER_MTOK_F
-    )
-    p_in_fresh = (
-        float(meta.get("price_per_mtok_in_fresh", meta.get("price_per_mtok_in", 2.5)))
-        / _TOKENS_PER_MTOK_F
-    )
-    p_in_cached = (
-        float(meta.get("price_per_mtok_in_cached", p_in_fresh * _TOKENS_PER_MTOK_F))
-        / _TOKENS_PER_MTOK_F
-    )
-    price_per_web_search = float(meta.get("price_per_web_search", 0.0))
+    is_followup = bool(continuation and continuation.get("response_id"))
 
-    is_followup = bool(continuation and continuation.get("previous_response_id"))
-
-    # Build the request kwargs.
-    kwargs: dict = {
-        "model": model_id,
-        "input": user_text,
-        "tools": [{"type": "web_search"}],
-        # reasoning.effort="low" is used in Phase B for cost control.
-        # "minimal" is rejected by OpenAI when web_search is active.
-        "reasoning": {"effort": "low"},
-        "include": ["web_search_call.action.sources"],
-        "max_output_tokens": max_tokens,
-    }
-
+    payload = adapter_openai_responses.build_request(
+        prompt,
+        model=meta.get("model_id"),
+        max_output_tokens=max_tokens,
+        reasoning_effort="low",  # web_search rejects "minimal"; "low" is the docs floor
+    )
+    if system_prompt and not is_followup:
+        payload["instructions"] = system_prompt
     if is_followup:
-        kwargs["previous_response_id"] = continuation["previous_response_id"]  # type: ignore[index]
-    else:
-        # Turn 1: install the system prompt as the session instructions.
-        if system_prompt is not None:
-            kwargs["instructions"] = system_prompt
-
+        payload["previous_response_id"] = continuation["response_id"]
     if extra_metadata is not None:
-        kwargs["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
+        payload["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
 
-    client = OpenAI(api_key=_load_openai_key())
+    # Pre-call cap check (estimate). Mirrors adapter_openai_responses.run
+    # so single-turn callers and multi-turn dispatch enforce the same ceiling.
+    p_in = meta.get("price_per_mtok_in_fresh", meta.get("price_per_mtok_in", 0.0)) / 1_000_000
+    p_out = meta.get("price_per_mtok_out", 0.0) / 1_000_000
+    estimated = estimate_call_cost(max_tokens=max_tokens, price_in=p_in, price_out=p_out)
+    enforce_cost_cap(estimated, cap_usd=cap_usd)
+
+    client = OpenAI(api_key=adapter_openai_responses._load_openai_key())
     t0 = time.monotonic()
-    resp = client.responses.create(**kwargs)
-    wall_s = round(time.monotonic() - t0, 3)
-
-    # --- Parse usage ---
-    usage = resp.usage
-    input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
-    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
-    output_details = getattr(usage, "output_tokens_details", None)
-    reasoning_tokens = int(getattr(output_details, "reasoning_tokens", 0) or 0)
-    input_details = getattr(usage, "input_tokens_details", None)
-    cached_tokens = int(getattr(input_details, "cached_tokens", 0) or 0)
-    fresh_in = max(input_tokens - cached_tokens, 0)
-
-    cost_usd = (
-        fresh_in * p_in_fresh
-        + cached_tokens * p_in_cached
-        + output_tokens * p_out
-        + reasoning_tokens * p_reasoning
-    )
-    cost_breakdown = {
-        "input": round(fresh_in * p_in_fresh, 8),
-        "cached": round(cached_tokens * p_in_cached, 8),
-        "output": round(output_tokens * p_out, 8),
-        "reasoning": round(reasoning_tokens * p_reasoning, 8),
-    }
-
-    # --- Parse web search calls ---
-    web_search_calls: list[dict] = []
-    citations: list[dict] = []
-    narrative_parts: list[str] = []
-    for item in resp.output or []:
-        item_type = getattr(item, "type", "")
-        if item_type == "web_search_call":
-            action = getattr(item, "action", None)
-            query = getattr(action, "query", "") if action else ""
-            sources = getattr(action, "sources", []) or [] if action else []
-            urls: list[str] = []
-            for src in sources:
-                url = getattr(src, "url", None)
-                if url:
-                    urls.append(url)
-                    citations.append({"url": url, "snippet": None, "supports_claim": None})
-            web_search_calls.append({"query": query, "urls_returned": urls})
-        elif item_type == "message":
-            for block in getattr(item, "content", []) or []:
-                if getattr(block, "type", "") == "output_text":
-                    text = getattr(block, "text", "")
-                    if text:
-                        narrative_parts.append(text)
-
-    narrative = "\n\n".join(narrative_parts)
-
-    # Web search cost: OpenAI bundles this into token billing for gpt-5.x;
-    # price_per_web_search is 0.0 in models.yaml. Forward-compatible if key
-    # is added later.
-    n_web_searches = len(web_search_calls)
-    tool_calls_cost_usd = price_per_web_search * n_web_searches if price_per_web_search else None
+    resp = client.responses.create(**payload)
+    wall = round(time.monotonic() - t0, 3)
 
     raw_output_path.write_text(resp.model_dump_json(indent=2), encoding="utf-8")
 
-    record = RunRecord(
-        method="frontier",
-        method_params=MethodParams(
-            model=model_id,
-            max_tokens=max_tokens,
-            # Continuation token for the next turn — opaque to the dispatcher.
-            extra={"previous_response_id": resp.id},
-        ),
-        resource_use=ResourceUse(
-            wall_s=wall_s,
-            cost_usd=cost_usd,
-            tokens_in=input_tokens,
-            tokens_out=output_tokens,
-            thinking_tokens=reasoning_tokens,
-            cost_breakdown=cost_breakdown,
-        ),
-        result_summary=ResultSummary(status="ok" if narrative else "empty"),
-        agent_family="openai-direct",
-        agent_mode=agent_mode,
-        finish_reason=getattr(resp, "status", None),
-        web_search_calls=web_search_calls or None,
-        citations=citations or None,
-        tool_calls_cost_usd=tool_calls_cost_usd,
-        justification={"output_text": narrative},
+    record = adapter_openai_responses.parse_response(resp, meta)
+    record.agent_mode = agent_mode
+    record.resource_use.wall_s = wall
+    # Post-call cap recheck (actual). Catches estimate-vs-billed drift.
+    enforce_cost_cap(record.resource_use.cost_usd or 0.0, cap_usd=cap_usd)
+    return record
+
+
+def run_anthropic_call(
+    prompt: str,
+    *,
+    cap_usd: float,
+    agent_mode: str,
+    raw_output_path: Path,
+    max_tokens: int,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
+) -> RunRecord:
+    """Single Anthropic Messages call with full-history resend for multi-turn.
+
+    Continuation shape: ``{"messages": list[dict]}`` — the complete
+    conversation history including each prior assistant reply. Anthropic
+    is stateless on the wire; the client resends everything each call.
+    The ``system_prompt`` MUST be passed as identical bytes on every
+    turn (server does NOT persist it across calls; absence on a
+    follow-up turn changes model behaviour).
+
+    Cost accounting: ``cost_usd`` excludes ``web_search`` server-tool
+    fees, which go into ``tool_calls_cost_usd``. The dual-axis budget
+    cap then deducts the full session bill via :func:`total_cost`.
+    ``tokens_out`` includes any thinking output (Anthropic reports it
+    bundled in the output count).
+    """
+    import anthropic
+
+    from aedist import query_anthropic
+    from aedist.adapter_base import enforce_cost_cap, estimate_call_cost
+
+    meta = load_model_meta("anthropic")
+    model_id = meta.get("model_id")
+    is_followup = bool(continuation and continuation.get("messages"))
+
+    payload = query_anthropic.assemble_request(
+        prompt,
+        model=model_id,
+        max_tokens=max_tokens,
+        max_uses=3,
     )
+    if system_prompt:
+        payload["system"] = system_prompt
+    if is_followup:
+        new_user_msg = payload["messages"][-1]
+        payload["messages"] = list(continuation["messages"]) + [new_user_msg]
+    if extra_metadata is not None:
+        # Anthropic only honours ``user_id`` natively; other keys pass through.
+        payload["metadata"] = {k: str(v) for k, v in extra_metadata.items()}
+
+    # Pre-call cap. n_searches uses the provisioned ``max_uses=3`` as the
+    # conservative ceiling; the post-call recheck below tightens against
+    # actual web_search invocations.
+    p_in = float(meta.get("price_per_mtok_in", 0.0)) / _TOKENS_PER_MTOK
+    p_out = float(meta.get("price_per_mtok_out", 0.0)) / _TOKENS_PER_MTOK
+    p_search = float(meta.get("price_per_web_search", 0.01))
+    estimated = estimate_call_cost(
+        max_tokens=max_tokens,
+        price_in=p_in,
+        price_out=p_out,
+        n_searches=3,
+        price_per_search=p_search,
+    )
+    enforce_cost_cap(estimated, cap_usd=cap_usd)
+
+    api_key = query_anthropic._load_key(query_anthropic.DEFAULT_KEY_PATH)
+    client = anthropic.Anthropic(api_key=api_key)
+    t0 = time.monotonic()
+    resp = client.messages.create(**payload)
+    wall = round(time.monotonic() - t0, 3)
+
+    raw_output_path.write_text(
+        json.dumps(query_anthropic._response_to_dict(resp), indent=2, default=str),
+        encoding="utf-8",
+    )
+
+    parsed = query_anthropic._parse_anthropic_response(resp)
+    usage = query_anthropic._usage_dict(resp)
+    breakdown = query_anthropic._compute_anthropic_cost(usage, meta, parsed["n_searches"])
+
+    # Build conversation messages for the next turn (full history replay).
+    continuation_messages = list(payload.get("messages", []))
+    if parsed.get("text"):
+        continuation_messages.append({"role": "assistant", "content": parsed["text"]})
+
+    record = query_anthropic._record_from_parsed(
+        parsed,
+        model=model_id,
+        cost_breakdown=breakdown,
+        tokens_in=parsed["tokens_in"],
+        tokens_out=parsed["tokens_out"],
+        wall_s=wall,
+        thinking_tokens=None,
+        agent_mode=agent_mode,
+        run_number=1,
+        messages_for_continuation=continuation_messages,
+    )
+    # _record_from_parsed already populates ``record.tool_calls_cost_usd``
+    # from ``cost_breakdown["web_search"]`` (see query_anthropic.py:381) —
+    # no need to re-assign here. Surfacing it into total_cost() works
+    # through that field.
+    # Stash narrative so the classifier's record-first path skips raw-file parse.
+    record.justification = {"output_text": parsed.get("text", "") or ""}
+    # Post-call cap recheck (actual billed total). Defense in depth.
+    enforce_cost_cap(float(breakdown.get("total", 0.0)), cap_usd=cap_usd)
+    return record
+
+
+def run_qwen_call(
+    prompt: str,
+    *,
+    cap_usd: float,
+    agent_mode: str,
+    raw_output_path: Path,
+    max_tokens: int,
+    continuation: dict | None = None,
+    extra_metadata: dict | None = None,
+    system_prompt: str | None = None,
+) -> RunRecord:
+    """Single Qwen DashScope call with full-history resend for multi-turn.
+
+    Continuation shape: ``{"messages": list[dict]}`` — complete conversation
+    history including the leading system message (when present) and each
+    assistant reply. DashScope is stateless on the wire; the client
+    resends everything every call.
+
+    ``system_prompt`` is injected as the first ``{"role": "system", ...}``
+    message on turn 1; turn 2+ inherits it via the replayed history.
+    """
+    import dashscope
+
+    from aedist import adapter_qwen_dashscope
+    from aedist.adapter_base import enforce_cost_cap, estimate_call_cost
+
+    meta = load_model_meta("qwen")
+    model_id = meta.get("model_id")
+    is_followup = bool(continuation and continuation.get("messages"))
+
+    # Build the messages list: history + new user, or (turn 1) system + user.
+    if is_followup:
+        messages = list(continuation["messages"]) + [{"role": "user", "content": prompt}]
+    else:
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+    # Use the adapter's payload assembly, then override the messages list
+    # with our explicit history (build_request consults ``continuation``
+    # but stores only [user] without preserving an explicit system role).
+    payload = adapter_qwen_dashscope.build_request(
+        prompt,
+        model=model_id,
+        max_tokens=max_tokens,
+        enable_thinking=True,  # capability default for the optimized arm
+        enable_search=True,
+    )
+    payload["messages"] = messages
+    if extra_metadata is not None:
+        # DashScope lacks a metadata surface AND allows at most one
+        # ``role=system`` entry. If one is already present (e.g. carried
+        # by ``system_prompt`` or by the continuation), append the metadata
+        # to its content; otherwise prepend a fresh system message.
+        meta_text = "; ".join(f"{k}={v}" for k, v in extra_metadata.items())
+        meta_line = f"\n[metadata] {meta_text}"
+        if payload["messages"] and payload["messages"][0].get("role") == "system":
+            payload["messages"][0] = {
+                "role": "system",
+                "content": payload["messages"][0].get("content", "") + meta_line,
+            }
+        else:
+            payload["messages"] = [
+                {"role": "system", "content": f"[metadata] {meta_text}"}
+            ] + payload["messages"]
+
+    # Pre-call cap.
+    p_in = (
+        float(meta.get("price_per_mtok_in", adapter_qwen_dashscope.DEFAULT_PRICE_PER_MTOK_IN))
+        / _TOKENS_PER_MTOK
+    )
+    p_out = (
+        float(meta.get("price_per_mtok_out", adapter_qwen_dashscope.DEFAULT_PRICE_PER_MTOK_OUT))
+        / _TOKENS_PER_MTOK
+    )
+    p_search = float(
+        meta.get(
+            "price_per_web_search_call_usd",
+            adapter_qwen_dashscope.DEFAULT_PRICE_PER_WEB_SEARCH_CALL_USD,
+        )
+    )
+    estimated = estimate_call_cost(
+        max_tokens=max_tokens,
+        price_in=p_in,
+        price_out=p_out,
+        n_searches=5,
+        price_per_search=p_search,
+    )
+    enforce_cost_cap(estimated, cap_usd=cap_usd)
+
+    dashscope.api_key = adapter_qwen_dashscope._resolve_api_key()
+    dashscope.base_http_api_url = adapter_qwen_dashscope.DEFAULT_BASE_URL
+    t0 = time.monotonic()
+    resp = dashscope.Generation.call(**payload)
+    wall = round(time.monotonic() - t0, 3)
+
+    raw_dump = adapter_qwen_dashscope._response_to_dict(resp)
+    raw_output_path.write_text(json.dumps(raw_dump, indent=2, default=str), encoding="utf-8")
+
+    record = adapter_qwen_dashscope.parse_response(
+        resp,
+        model_meta=meta,
+        prompt=prompt,
+        max_tokens=max_tokens,
+        wall_s=wall,
+        enable_thinking=True,
+        enable_search=True,
+    )
+    record.agent_mode = agent_mode
+
+    # Extract narrative from the raw dump for the continuation + classifier paths.
+    output = raw_dump.get("output") or {}
+    choices = output.get("choices") or []
+    narrative = (choices[0].get("message", {}).get("content")) if choices else None
+
+    # Overwrite parse_response's [user, assistant]-only messages with the
+    # complete history we just sent + the assistant reply. The CONTINUATION
+    # extractor then consumes this on the next turn.
+    extra = record.method_params.extra or {}
+    full_history = list(messages)
+    if narrative:
+        full_history.append({"role": "assistant", "content": narrative})
+    extra["messages"] = full_history
+    record.method_params.extra = extra
+
+    # Stash narrative so the classifier's record-first path skips raw-file parse.
+    record.justification = {"output_text": narrative or ""}
+
+    # Post-call cap recheck (actual billed total).
+    enforce_cost_cap(record.resource_use.cost_usd or 0.0, cap_usd=cap_usd)
     return record
 
 
@@ -659,6 +821,99 @@ def _extract_narrative_from_raw_path(raw_path: Path) -> str:
     return extract_narrative_from_mistral_raw(raw)
 
 
+def _narrative_from_record_or_raw(record: RunRecord, raw_path: Path) -> str:
+    """Pull narrative from the RunRecord if present, else parse the raw artefact.
+
+    OpenAI (and future Anthropic / Qwen) adapters populate
+    ``record.justification["output_text"]`` with the assistant narrative.
+    The Mistral adapter does not, so we fall back to re-reading the raw
+    artefact and parsing it via :func:`extract_narrative_from_mistral_raw`.
+    The dispatch path is provider-agnostic — only the data source differs.
+    """
+    just = record.justification or {}
+    if isinstance(just, dict) and just.get("output_text"):
+        return just["output_text"]
+    return _extract_narrative_from_raw_path(raw_path)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider dispatch tables (ticket 0234)
+#
+# Each adapter exposes one ``run_*_call`` with the unified signature and
+# one continuation extractor that translates its ``record.method_params.extra``
+# into the opaque ``continuation`` dict consumed on the next turn. The
+# dispatcher routes purely by these tables and never introspects the
+# continuation shape. Adding a new provider = three additions (call_fn,
+# extractor, SYSTEM_PROMPT_PASSTHROUGH policy).
+# ---------------------------------------------------------------------------
+
+
+def _extract_mistral_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """Mistral: persist agent_id across turns, refresh conversation_id."""
+    extra = record.method_params.extra or {}
+    cur = current or {}
+    agent_id = cur.get("agent_id")
+    if agent_id is None and extra.get("agent_id"):
+        agent_id = str(extra["agent_id"])
+    conv_id = extra.get("conversation_id")
+    if conv_id and agent_id:
+        return {"agent_id": agent_id, "conversation_id": conv_id}
+    return current
+
+
+def _extract_openai_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """OpenAI: chain previous_response_id from the just-returned response."""
+    extra = record.method_params.extra or {}
+    if extra.get("response_id"):
+        return {"response_id": str(extra["response_id"])}
+    return current
+
+
+def _extract_anthropic_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """Anthropic: full conversation messages list (stateless API — client resends history)."""
+    extra = record.method_params.extra or {}
+    if extra.get("messages"):
+        return {"messages": list(extra["messages"])}
+    return current
+
+
+def _extract_qwen_continuation(record: RunRecord, current: dict | None) -> dict | None:
+    """Qwen: full conversation messages list (stateless DashScope — client resends history)."""
+    extra = record.method_params.extra or {}
+    if extra.get("messages"):
+        return {"messages": list(extra["messages"])}
+    return current
+
+
+CALL_FNS = {
+    "mistral": run_mistral_call,
+    "openai": run_openai_call,
+    "anthropic": run_anthropic_call,
+    "qwen": run_qwen_call,
+}
+
+CONTINUATION_EXTRACTORS = {
+    "mistral": _extract_mistral_continuation,
+    "openai": _extract_openai_continuation,
+    "anthropic": _extract_anthropic_continuation,
+    "qwen": _extract_qwen_continuation,
+}
+
+# Should ``system_prompt`` be passed on follow-up turns (turn > 1)?
+#  - mistral / openai: no — adapter raises (Mistral) or server-side state
+#    inherits via previous_response_id (OpenAI).
+#  - anthropic / qwen: yes — both APIs are stateless on the wire; the
+#    client resends the full conversation history (including the system
+#    message) every turn.
+# Default: False (drop on follow-up).
+SYSTEM_PROMPT_PASSTHROUGH = {
+    "mistral": False,
+    "openai": False,
+    "anthropic": True,
+    "qwen": True,
+}
+
+
 def run_phase_b_multiturn(
     designed_prompt: str,
     *,
@@ -693,17 +948,6 @@ def run_phase_b_multiturn(
     ``terminal_sent``, ``agent_id`` (for caller-side cleanup), and
     ``total_classifier_cost_usd``.
     """
-    # Dispatch table: each provider registers its per-turn call shim here.
-    # Each shim accepts the same keyword-only signature (see run_mistral_call /
-    # run_openai_call) and returns a RunRecord whose method_params.extra IS
-    # the opaque continuation dict for the next turn. The dispatcher routes
-    # the dict without introspecting its contents — per-provider continuation
-    # shape varies (Mistral: {"agent_id", "conversation_id"};
-    # OpenAI: {"previous_response_id"}; 0235/0236 will add their own shapes).
-    CALL_FNS: dict[str, object] = {
-        "mistral": run_mistral_call,
-        "openai": run_openai_call,
-    }
     call_fn = CALL_FNS.get(agent)
     if call_fn is None:
         raise NotImplementedError(f"--agent {agent!r} not wired for multi-turn yet")
@@ -711,8 +955,7 @@ def run_phase_b_multiturn(
     remaining = cap_usd - initial_spent_usd
     remaining_tokens = cap_tokens
     elapsed_s = 0.0
-    continuation: dict | None = {}  # empty dict = start multi-turn
-    agent_id: str | None = None  # Mistral-only; populated for cleanup after loop
+    continuation: dict | None = {}  # empty dict = start multi-turn, keep Mistral agent alive
     terminal_sent = False
     records: list[RunRecord] = []
     verify_used = False
@@ -743,25 +986,23 @@ def run_phase_b_multiturn(
             "remaining_usd": f"{remaining:.2f}",
             "cap_usd": f"{cap_usd:.2f}",
         }
-        # A turn is a follow-up if the continuation dict is non-empty.
-        # For Mistral, the follow-up key is "agent_id" (HTTP 422 on metadata
-        # for the path-bound append endpoint — ticket 0218). For OpenAI the
-        # key is "previous_response_id". Both are truthy when continuation
-        # was set from the previous turn's record.extra.
-        is_followup_turn = bool(continuation)
-        if agent == "mistral":
-            # Mistral's path-bound append endpoint rejects body-level metadata
-            # with HTTP 422 on follow-up turns (ticket 0218).
-            if continuation and continuation.get("agent_id"):
-                extra_metadata = None
+        is_followup_turn = turn > 1
+        # Per-provider quirks on follow-up turns:
+        #  - Mistral 422s on body-level ``metadata`` against the append endpoint
+        #    (ticket 0218); OpenAI accepts it but we drop for symmetry — the
+        #    user-text status prefix already conveys the same info to the model.
+        if is_followup_turn:
+            extra_metadata = None
+        # ``system_prompt`` on follow-up: drop unless the adapter requires
+        # identical bytes every call (Anthropic, Qwen — see
+        # ``SYSTEM_PROMPT_PASSTHROUGH``).
+        turn_system_prompt = (
+            system_prompt
+            if not is_followup_turn or SYSTEM_PROMPT_PASSTHROUGH.get(agent, False)
+            else None
+        )
 
-        # System prompt is installed on turn 1 only. Follow-up turns must
-        # pass None — for Mistral the agent is already created with its
-        # description fixed (ticket 0213); for OpenAI instructions are
-        # installed on the session server-side.
-        turn_system_prompt = system_prompt if not is_followup_turn else None
-
-        record = call_fn(  # type: ignore[operator]
+        record = call_fn(
             user_text,
             cap_usd=max(remaining, 0.01),  # adapter wants positive cap
             agent_mode="phase_b_run",
@@ -788,7 +1029,7 @@ def run_phase_b_multiturn(
 
         # Classify the assistant's response. Classifier cost is harness
         # overhead, tracked separately from the SOTA agent's spend.
-        narrative = _extract_narrative_from_raw_path(paths["raw"])
+        narrative = _narrative_from_record_or_raw(record, paths["raw"])
         cls_result = dialogue_classifier.classify_report(narrative)
         total_classifier_cost_usd += cls_result.classifier_cost_usd
         paths["classification"].write_text(
@@ -817,12 +1058,16 @@ def run_phase_b_multiturn(
             encoding="utf-8",
         )
 
-        extra = record.method_params.extra or {}
-        if agent_id is None and extra.get("agent_id"):
-            agent_id = str(extra["agent_id"])
-        conv_id = extra.get("conversation_id")
-        if conv_id and agent_id:
-            continuation = {"agent_id": agent_id, "conversation_id": conv_id}
+        # Provider-specific continuation extraction (Mistral: agent_id +
+        # conversation_id; OpenAI: previous_response_id; future Anthropic /
+        # Qwen: their own shapes). Each extractor returns the opaque dict
+        # the dispatcher will pass to ``call_fn`` on the next turn. The
+        # dispatcher never introspects the continuation shape — see the
+        # return value below for the only consumer-facing field
+        # (``agent_id``) that is pulled out by canonical key.
+        new_continuation = CONTINUATION_EXTRACTORS[agent](record, continuation)
+        if new_continuation is not None:
+            continuation = new_continuation
 
         log.info(
             "Phase B turn %d (%s): spent=$%.4f remaining=$%.4f tokens_out=%s "
@@ -883,18 +1128,198 @@ def run_phase_b_multiturn(
         "total_spent_usd": cap_usd - remaining - initial_spent_usd,
         "total_tokens_used": cap_tokens - remaining_tokens,
         "terminal_sent": terminal_sent,
-        "agent_id": agent_id,
+        # Mistral exposes ``agent_id`` for caller-side conversation cleanup;
+        # other providers omit the key (None for OpenAI / Anthropic / Qwen).
+        # The dispatcher pulls it by canonical name rather than tracking it
+        # in a local variable — keeps the loop body provider-agnostic.
+        "agent_id": (continuation or {}).get("agent_id"),
         "total_classifier_cost_usd": total_classifier_cost_usd,
+    }
+
+
+def _read_turn_field(output_dir: Path, agent: str, turns: int, field: str) -> list[str]:
+    values: list[str] = []
+    for turn in range(1, turns + 1):
+        path = _turn_artefact_paths(output_dir, agent, turn)["cost"]
+        if not path.exists():
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        val = data.get(field)
+        if isinstance(val, str):
+            values.append(val)
+    return values
+
+
+def _count_markdown_table_rows(text: str) -> int:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    table_lines = [line for line in lines if line.startswith("|") and line.endswith("|")]
+    if len(table_lines) < 3:
+        return 0
+    # Header + separator + data rows.
+    return max(0, len(table_lines) - 2)
+
+
+def _estimate_inventory_rows(agent: str, phase_b: dict, output_dir: Path) -> int:
+    records = phase_b.get("records", []) or []
+    classes = _read_turn_field(output_dir, agent, phase_b.get("turns", 0), "classification")
+    for idx, cls in enumerate(classes, start=1):
+        if cls != "report":
+            continue
+        if idx > len(records):
+            continue
+        raw_path = _turn_artefact_paths(output_dir, agent, idx)["raw"]
+        narrative = _narrative_from_record_or_raw(records[idx - 1], raw_path)
+        rows = _count_markdown_table_rows(narrative)
+        if rows > 0:
+            return rows
+    return 0
+
+
+def _write_summary(output_dir: Path, per_agent: list[dict]) -> None:
+    total_cost = sum(float(item.get("total_cost_usd", 0.0)) for item in per_agent)
+    lines = [
+        "# Phase B-0 Summary",
+        "",
+        "| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |",
+        "|---|---:|---:|---:|---:|---|---:|",
+    ]
+    for item in per_agent:
+        lines.append(
+            "| {agent} | {status} | {cost:.4f} | {wall:.1f} | {turns} | {trace} | {rows} |".format(
+                agent=item["agent"],
+                status=item.get("status", "error"),
+                cost=float(item.get("total_cost_usd", 0.0)),
+                wall=float(item.get("wall_s", 0.0)),
+                turns=int(item.get("turns", 0)),
+                trace=item.get("class_trace", "n/a"),
+                rows=int(item.get("inventory_rows", 0)),
+            )
+        )
+    lines.append("")
+    lines.append(f"Total B-0 cost: ${total_cost:.4f}")
+    (output_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
+    agent_output_dir = args.output_dir / agent
+    agent_output_dir.mkdir(parents=True, exist_ok=True)
+
+    meta_prompt = assemble_meta_prompt()
+    meta_prompt_path = agent_output_dir / f"{agent}_meta_prompt.txt"
+    meta_prompt_path.write_text(meta_prompt, encoding="utf-8")
+    log.info("Meta-prompt assembled for %s (%d chars) -> %s", agent, len(meta_prompt), meta_prompt_path)
+
+    if args.dry_run:
+        return {
+            "agent": agent,
+            "status": "dry-run",
+            "total_cost_usd": 0.0,
+            "wall_s": 0.0,
+            "turns": 0,
+            "class_trace": "n/a",
+            "inventory_rows": 0,
+        }
+
+    wait_for_space(
+        f"Phase A: send meta-prompt to {agent}. Cap ${args.budget_cap_phase_a:.2f}.",
+        no_confirm=args.no_confirm,
+    )
+    phase_a_raw_path = agent_output_dir / f"{agent}_phase_a.raw.json"
+    phase_a = CALL_FNS[agent](
+        meta_prompt,
+        cap_usd=args.budget_cap_phase_a,
+        agent_mode="phase_a_design",
+        raw_output_path=phase_a_raw_path,
+        max_tokens=args.phase_a_max_tokens,
+    )
+    phase_a_path = agent_output_dir / f"{agent}_phase_a.json"
+    phase_a_path.write_text(phase_a.model_dump_json(indent=2), encoding="utf-8")
+
+    narrative_a = _narrative_from_record_or_raw(phase_a, phase_a_raw_path)
+    design = extract_phase_a_design(narrative_a)
+    design_path = agent_output_dir / f"{agent}_phase_a_design.json"
+    design_path.write_text(json.dumps(design, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    if args.stop_after_phase_a:
+        return {
+            "agent": agent,
+            "status": "phase-a-only",
+            "total_cost_usd": total_cost(phase_a),
+            "wall_s": float(phase_a.resource_use.wall_s or 0.0),
+            "turns": 0,
+            "class_trace": "n/a",
+            "inventory_rows": 0,
+        }
+
+    wait_for_space(
+        f"Phase B: multi-turn loop on {agent}. Dual cap "
+        f"{PHASE_B_TOTAL_TOKEN_CAP // 1000}K tokens + ${PHASE_B_TOTAL_BUDGET_USD:.2f}.",
+        no_confirm=args.no_confirm,
+    )
+    designed_prompt_raw = design["designed_prompt"]
+    designed_prompt = (
+        designed_prompt_raw
+        if isinstance(designed_prompt_raw, str)
+        else json.dumps(designed_prompt_raw, indent=2, ensure_ascii=False)
+    )
+    requested_max_tokens = int(
+        design.get("settings", {}).get("max_tokens") or args.phase_b_max_tokens
+    )
+    designed_system_prompt = design["system_prompt"]
+
+    phase_b = run_phase_b_multiturn(
+        designed_prompt,
+        output_dir=agent_output_dir,
+        cap_usd=PHASE_B_TOTAL_BUDGET_USD,
+        cap_tokens=PHASE_B_TOTAL_TOKEN_CAP,
+        initial_spent_usd=0.0,
+        max_tokens=requested_max_tokens,
+        agent=agent,
+        system_prompt=designed_system_prompt,
+    )
+
+    if agent == "mistral" and phase_b.get("agent_id"):
+        try:
+            adapter_mistral.cleanup_agent(phase_b["agent_id"])
+            log.info("Cleaned up Mistral agent %s", phase_b["agent_id"])
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Mistral agent cleanup failed: %s", exc)
+
+    class_trace = _read_turn_field(agent_output_dir, agent, phase_b["turns"], "classification")
+    inventory_rows = _estimate_inventory_rows(agent, phase_b, agent_output_dir)
+    total_cost_usd = total_cost(phase_a) + float(phase_b["total_spent_usd"])
+    wall_s = float(phase_a.resource_use.wall_s or 0.0) + sum(
+        float(record.resource_use.wall_s or 0.0) for record in (phase_b.get("records") or [])
+    )
+
+    status = "pass"
+    if not class_trace or "report" not in class_trace:
+        status = "fail"
+    if total_cost_usd > PHASE_B_TOTAL_BUDGET_USD + args.budget_cap_phase_a:
+        status = "fail"
+
+    return {
+        "agent": agent,
+        "status": status,
+        "total_cost_usd": total_cost_usd,
+        "wall_s": wall_s,
+        "turns": phase_b["turns"],
+        "class_trace": ",".join(class_trace) if class_trace else "n/a",
+        "inventory_rows": inventory_rows,
     }
 
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument(
-        "--agent",
+        "--agents",
+        nargs="+",
         required=True,
         choices=sorted(FAMILY_BY_AGENT),
-        help="Which SOTA agent to smoke (only 'mistral' wired in this iteration).",
+        help=(
+            "One or more SOTA agents to smoke in Phase B-0. "
+            "Example: --agents mistral qwen openai anthropic"
+        ),
     )
     p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
     p.add_argument("--no-confirm", action="store_true", help="Skip SPACE gates.")
@@ -912,121 +1337,32 @@ def main(argv: list[str] | None = None) -> int:
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
-    if args.agent != "mistral":
-        sys.exit(f"Only --agent mistral is wired in this iteration; got {args.agent!r}.")
-
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    meta_prompt = assemble_meta_prompt()
-    meta_prompt_path = args.output_dir / f"{args.agent}_meta_prompt.txt"
-    meta_prompt_path.write_text(meta_prompt, encoding="utf-8")
-    log.info("Meta-prompt assembled (%d chars) -> %s", len(meta_prompt), meta_prompt_path)
-
-    if args.dry_run:
-        log.info("--dry-run set; not calling API. Exiting.")
-        return 0
-
-    # --- Phase A: design ---
-    wait_for_space(
-        f"Phase A: send meta-prompt to {args.agent}. Cap ${args.budget_cap_phase_a:.2f}.",
-        no_confirm=args.no_confirm,
-    )
-    phase_a_raw_path = args.output_dir / f"{args.agent}_phase_a.raw.json"
-    phase_a = run_mistral_call(
-        meta_prompt,
-        cap_usd=args.budget_cap_phase_a,
-        agent_mode="phase_a_design",
-        raw_output_path=phase_a_raw_path,
-        max_tokens=args.phase_a_max_tokens,
-    )
-    phase_a_path = args.output_dir / f"{args.agent}_phase_a.json"
-    phase_a_path.write_text(phase_a.model_dump_json(indent=2), encoding="utf-8")
-    log.info(
-        "Phase A done: cost=$%.4f, wall=%ss, tokens_out=%s, web_search=%d -> %s",
-        total_cost(phase_a),
-        phase_a.resource_use.wall_s,
-        phase_a.resource_use.tokens_out,
-        len(phase_a.web_search_calls or []),
-        phase_a_path,
-    )
-
-    # Pull narrative -> JSON envelope -> designed_prompt
-    raw_a = json.loads(phase_a_raw_path.read_text(encoding="utf-8"))
-    narrative_a = extract_narrative_from_mistral_raw(raw_a)
-    design = extract_phase_a_design(narrative_a)
-    design_path = args.output_dir / f"{args.agent}_phase_a_design.json"
-    design_path.write_text(json.dumps(design, indent=2, ensure_ascii=False), encoding="utf-8")
-    dp = design.get("designed_prompt", "")
-    dp_summary = (
-        f"str/{len(dp)} chars"
-        if isinstance(dp, str)
-        else f"{type(dp).__name__}/{len(dp)} top-level keys"
-    )
-    log.info(
-        "Phase A design extracted: designed_prompt=%s, thinking=%s, max_tokens=%s -> %s",
-        dp_summary,
-        design.get("settings", {}).get("thinking"),
-        design.get("settings", {}).get("max_tokens"),
-        design_path,
-    )
-
-    if args.stop_after_phase_a:
-        log.info("--stop-after-phase-a set; exiting before Phase B.")
-        return 0
-
-    # --- Phase B: multi-turn auto-reply loop (Doc 02 + Doc 04 §2 policy) ---
-    wait_for_space(
-        f"Phase B: multi-turn loop on {args.agent}. Dual cap "
-        f"{PHASE_B_TOTAL_TOKEN_CAP // 1000}K tokens + ${PHASE_B_TOTAL_BUDGET_USD:.2f} per session "
-        f"(after Phase A's ${total_cost(phase_a):.4f}).",
-        no_confirm=args.no_confirm,
-    )
-    designed_prompt_raw = design["designed_prompt"]
-    designed_prompt = (
-        designed_prompt_raw
-        if isinstance(designed_prompt_raw, str)
-        else json.dumps(designed_prompt_raw, indent=2, ensure_ascii=False)
-    )
-    log.info(
-        "Phase B input: designed_prompt is %s, %d chars after serialisation.",
-        type(designed_prompt_raw).__name__,
-        len(designed_prompt),
-    )
-    requested_max_tokens = int(
-        design.get("settings", {}).get("max_tokens") or args.phase_b_max_tokens
-    )
-    designed_system_prompt = design["system_prompt"]
-    log.info(
-        "Phase B system prompt: str/%d chars (installed on agent at create time).",
-        len(designed_system_prompt),
-    )
-
-    phase_b = run_phase_b_multiturn(
-        designed_prompt,
-        output_dir=args.output_dir,
-        cap_usd=PHASE_B_TOTAL_BUDGET_USD,
-        cap_tokens=PHASE_B_TOTAL_TOKEN_CAP,
-        initial_spent_usd=0.0,  # Phase B has its own per-session $3 cap independent of Phase A spend
-        max_tokens=requested_max_tokens,
-        agent=args.agent,
-        system_prompt=designed_system_prompt,
-    )
-
-    if phase_b["agent_id"]:
+    per_agent: list[dict] = []
+    for agent in args.agents:
         try:
-            adapter_mistral.cleanup_agent(phase_b["agent_id"])
-            log.info("Cleaned up Mistral agent %s", phase_b["agent_id"])
-        except Exception as exc:  # noqa: BLE001 — cleanup failures should not raise
-            log.warning("Mistral agent cleanup failed: %s", exc)
+            per_agent.append(_run_one_agent(args, agent))
+        except Exception as exc:  # noqa: BLE001
+            log.error("Agent %s failed during Phase B-0 smoke: %s", agent, exc)
+            per_agent.append(
+                {
+                    "agent": agent,
+                    "status": "error",
+                    "total_cost_usd": 0.0,
+                    "wall_s": 0.0,
+                    "turns": 0,
+                    "class_trace": "n/a",
+                    "inventory_rows": 0,
+                }
+            )
 
-    log.info(
-        "SMOKE TOTAL: $%.4f (Phase A $%.4f + Phase B $%.4f over %d turns; terminal_sent=%s).",
-        total_cost(phase_a) + phase_b["total_spent_usd"],
-        total_cost(phase_a),
-        phase_b["total_spent_usd"],
-        phase_b["turns"],
-        phase_b["terminal_sent"],
-    )
+    _write_summary(args.output_dir, per_agent)
+
+    total_cost_usd = sum(float(item.get("total_cost_usd", 0.0)) for item in per_agent)
+    log.info("Phase B-0 summary written -> %s", args.output_dir / "summary.md")
+    if not args.dry_run and total_cost_usd > 10.0:
+        raise SystemExit(f"Phase B-0 total cost ${total_cost_usd:.4f} exceeds $10.00 cap.")
     return 0
 
 

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -19,6 +19,7 @@ from experiments.sota.exp2_interactive_smoke import (
     extract_narrative_from_mistral_raw,
     extract_phase_a_design,
     extract_quality_bar,
+    main,
     strip_meta_framing,
     wait_for_space,
 )
@@ -222,6 +223,23 @@ def test_extract_phase_a_design_handles_python_triple_quotes():
     assert obj["designed_prompt"] == "multi\nline\nprompt"
 
 
+def test_extract_phase_a_design_handles_literal_newlines_inside_json_strings():
+    """Mistral may emit raw newlines inside quoted values of an otherwise valid envelope."""
+    raw = (
+        '```json\n{\n'
+        '  "system_prompt": "System line 1\nSystem line 2",\n\n'
+        '  "designed_prompt": "Heading\n\nBullet one\nBullet two",\n\n'
+        '  "settings": {"thinking": true, "max_tokens": 4000},\n\n'
+        '  "rationale": "Because provenance matters."\n'
+        '}\n```'
+    )
+
+    obj = extract_phase_a_design(raw)
+
+    assert obj["system_prompt"] == "System line 1\nSystem line 2"
+    assert obj["designed_prompt"] == "Heading\n\nBullet one\nBullet two"
+
+
 def test_wait_for_space_no_confirm_returns_silently():
     """In --no-confirm mode the gate must not touch stdin."""
     wait_for_space("anything", no_confirm=True)  # should not raise / hang
@@ -240,21 +258,40 @@ def test_wait_for_space_continues_on_enter(monkeypatch):
     wait_for_space("test gate", no_confirm=False)
 
 
-def test_module_imports_no_production_adapters():
-    """The smoke calls provider APIs inline; it must not import production adapters.
+def test_main_dry_run_multiple_agents_writes_meta_and_summary(tmp_path):
+    """Ticket 0237: --agents loops and writes per-agent artefacts in dry-run mode."""
+    rc = main(
+        [
+            "--agents",
+            "mistral",
+            "openai",
+            "--dry-run",
+            "--no-confirm",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
 
-    Updated from the "mistral-only" constraint (ticket 0234): all three
-    providers added in the 0234-0236 wave call the SDK directly (like
-    review_openai in exp2_protocol_review.py) rather than routing through
-    the per-provider adapter_*.py modules. This keeps the experiment shim
-    isolated from adapter contract changes.
+    assert (tmp_path / "mistral" / "mistral_meta_prompt.txt").exists()
+    assert (tmp_path / "openai" / "openai_meta_prompt.txt").exists()
+    summary = (tmp_path / "summary.md").read_text(encoding="utf-8")
+    assert "mistral" in summary
+    assert "openai" in summary
+
+
+def test_module_imports_only_wired_adapters():
+    """The smoke imports the four wired adapters and nothing else.
+
+    Mistral (0214), OpenAI (0234), Anthropic (0235), Qwen (0236) — the
+    full optimized-arm cohort for Exp 2 protocol v3.
     """
     src = Path(__file__).parent.parent / "experiments" / "sota" / "exp2_interactive_smoke.py"
     text = src.read_text()
     assert "adapter_mistral" in text
-    # Production adapters must not be imported from the smoke shim.
-    for forbidden in ("adapter_openai_responses", "adapter_qwen_dashscope", "query_anthropic"):
-        assert forbidden not in text, f"unexpected production adapter import: {forbidden}"
+    assert "adapter_openai_responses" in text  # 0234
+    assert "query_anthropic" in text  # 0235
+    assert "adapter_qwen_dashscope" in text  # 0236
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +423,7 @@ def test_state_machine_report_then_verify_then_stop(monkeypatch, tmp_path):
 
     fake_run = _fake_run_factory(cost_per_call=0.10)
     fake_classify = _fake_classifier_factory(["report", "no_report"])
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -455,7 +492,7 @@ def test_state_machine_three_no_reports_then_terminal(monkeypatch, tmp_path):
     fake_run = _fake_run_factory(cost_per_call=0.10)
     # Four classifications consumed (one per turn) — all no_report.
     fake_classify = _fake_classifier_factory(["no_report"] * 4)
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -509,7 +546,7 @@ def test_state_machine_token_cap_overrides(monkeypatch, tmp_path):
 
     fake_run = _fake_run_factory(cost_per_call=0.01)  # cheap; dollar cap won't bind
     fake_classify = _fake_classifier_factory(["no_report"] * 10)
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -544,7 +581,7 @@ def test_state_machine_budget_overrides(monkeypatch, tmp_path):
 
     fake_run = _fake_run_factory(cost_per_call=3.0)
     fake_classify = _fake_classifier_factory(["no_report"] * 10)
-    monkeypatch.setattr(mod, "run_mistral_call", fake_run)
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
     monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
 
     result = run_phase_b_multiturn(
@@ -648,214 +685,158 @@ def test_classification_result_to_artefact_dict_uses_class_key():
 
 
 # ---------------------------------------------------------------------------
-# OpenAI Responses API multi-turn adapter (ticket 0234)
+# Ticket 0234: OpenAI Responses API adapter for multi-turn Phase B
 # ---------------------------------------------------------------------------
 
 
-from experiments.sota.exp2_interactive_smoke import run_openai_call  # noqa: E402
+def _make_fake_openai_resp(*, resp_id: str = "resp_test_001", narrative: str = "stub"):
+    """Minimal stand-in for ``openai.responses.create()`` return value.
 
+    Built to exercise :func:`adapter_openai_responses.parse_response`,
+    which is the same parser :func:`run_openai_call` uses.
+    """
+    from types import SimpleNamespace
 
-def _make_openai_mock_resp(
-    response_id: str = "resp_abc123",
-    output_tokens: int = 200,
-    reasoning_tokens: int = 50,
-    input_tokens: int = 1000,
-) -> object:
-    """Build a minimal mock response object shaped like the Responses API output."""
-    import types
+    class _Resp(SimpleNamespace):
+        def model_dump_json(self, indent: int | None = None) -> str:
+            return json.dumps({"id": resp_id, "narrative": narrative}, indent=indent)
 
-    output_tokens_details = types.SimpleNamespace(reasoning_tokens=reasoning_tokens)
-    usage = types.SimpleNamespace(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        output_tokens_details=output_tokens_details,
-    )
-    content_block = types.SimpleNamespace(type="output_text", text="Here is the inventory.")
-    message_item = types.SimpleNamespace(type="message", content=[content_block])
-
-    resp = types.SimpleNamespace(
-        id=response_id,
+    return _Resp(
+        id=resp_id,
         model="gpt-5.5",
         status="completed",
-        output=[message_item],
-        usage=usage,
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text=narrative)],
+            ),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            output_tokens_details=SimpleNamespace(reasoning_tokens=200),
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+        ),
     )
-    resp.model_dump_json = lambda **_kwargs: json.dumps({"id": response_id, "model": "gpt-5.5"})
-    return resp
 
 
 def test_run_openai_call_turn1_no_continuation(monkeypatch, tmp_path):
-    """Turn 1 (continuation=None): instructions set, web_search present, previous_response_id absent.
+    """Turn 1: instructions=system_prompt; tools includes web_search; no previous_response_id."""
+    from experiments.sota import exp2_interactive_smoke as mod
 
-    Also verifies:
-    - returned record has tokens_out and thinking_tokens populated correctly
-    - record.method_params.extra carries {"previous_response_id": resp.id}
-    """
-    import types
+    captured: dict = {}
 
-    mock_resp = _make_openai_mock_resp(
-        response_id="resp_turn1",
-        output_tokens=200,
-        reasoning_tokens=50,
-        input_tokens=1000,
-    )
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_openai_resp()
 
-    captured_kwargs: list[dict] = []
-
-    class _FakeResponses:
-        def create(self, **kwargs):
-            captured_kwargs.append(kwargs)
-            return mock_resp
-
-    class _FakeClient:
-        responses = _FakeResponses()
-
-    fake_openai_module = types.ModuleType("openai")
-    fake_openai_module.OpenAI = lambda **_: _FakeClient()  # type: ignore[attr-defined]
-
-    monkeypatch.setitem(
-        __import__(
-            "sys"
-        ).modules,  # patch sys.modules so the lazy import inside the function sees it
-        "openai",
-        fake_openai_module,
-    )
+    fake_client = type("C", (), {})()
+    fake_client.responses = type("R", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("openai.OpenAI", lambda **kw: fake_client)  # noqa: ARG005
     monkeypatch.setattr(
-        "experiments.sota.exp2_interactive_smoke._load_openai_key",
-        lambda: "test-key",
+        "aedist.adapter_openai_responses._load_openai_key", lambda: "sk-test-fixture"
     )
 
-    raw_path = tmp_path / "turn1.raw.json"
-    record = run_openai_call(
-        "Build a power plant inventory.",
-        cap_usd=5.0,
+    record = mod.run_openai_call(
+        "the prompt",
+        cap_usd=3.0,
         agent_mode="phase_b_run",
-        raw_output_path=raw_path,
-        max_tokens=8000,
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
         continuation=None,
         extra_metadata=None,
-        system_prompt="You are a research assistant.",
+        system_prompt="you are an analyst",
     )
 
-    assert len(captured_kwargs) == 1
-    kw = captured_kwargs[0]
-
-    # Turn 1 must carry instructions (system prompt installed on the session).
-    assert kw.get("instructions") == "You are a research assistant.", (
-        "instructions kwarg must carry system_prompt on turn 1"
-    )
-
-    # web_search tool must be requested.
-    assert {"type": "web_search"} in kw.get("tools", []), "web_search tool must be in the request"
-
-    # previous_response_id must NOT appear on turn 1.
-    assert "previous_response_id" not in kw, (
-        "previous_response_id must not be present on turn 1 (no continuation)"
-    )
-
-    # Token fields must be populated for dual-axis cap arithmetic.
-    assert record.resource_use.tokens_out == 200
-    assert record.resource_use.thinking_tokens == 50
-
-    # Continuation token for turn 2 lives in extra.
-    assert record.method_params.extra is not None
-    assert record.method_params.extra.get("previous_response_id") == "resp_turn1"
-
-    # Raw artefact must be written.
-    assert raw_path.exists()
+    assert captured["input"] == "the prompt"
+    assert captured["instructions"] == "you are an analyst"
+    assert {"type": "web_search"} in captured["tools"]
+    assert "previous_response_id" not in captured
+    # Cost cap accounting (Doc 02 CONTEXT > Budget): tokens_out (50) + thinking (200) = 250.
+    assert record.resource_use.tokens_out == 50
+    assert record.resource_use.thinking_tokens == 200
+    assert record.agent_mode == "phase_b_run"
+    # Raw artefact written for downstream classifier read paths.
+    assert (tmp_path / "raw.json").exists()
+    # Justification carries the narrative for the record-first classifier path.
+    assert (record.justification or {}).get("output_text") == "stub"
 
 
-def test_run_openai_call_turn2_forwards_previous_response_id(monkeypatch, tmp_path):
-    """Turn 2 (continuation carries previous_response_id): id forwarded, instructions absent."""
-    import types
+def test_run_openai_call_turn2_uses_previous_response_id(monkeypatch, tmp_path):
+    """Turn 2+: previous_response_id is forwarded; instructions NOT re-sent."""
+    from experiments.sota import exp2_interactive_smoke as mod
 
-    mock_resp = _make_openai_mock_resp(response_id="resp_turn2")
-    captured_kwargs: list[dict] = []
+    captured: dict = {}
 
-    class _FakeResponses:
-        def create(self, **kwargs):
-            captured_kwargs.append(kwargs)
-            return mock_resp
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_openai_resp(resp_id="resp_test_turn2")
 
-    class _FakeClient:
-        responses = _FakeResponses()
-
-    fake_openai_module = types.ModuleType("openai")
-    fake_openai_module.OpenAI = lambda **_: _FakeClient()  # type: ignore[attr-defined]
-
-    monkeypatch.setitem(
-        __import__("sys").modules,
-        "openai",
-        fake_openai_module,
-    )
+    fake_client = type("C", (), {})()
+    fake_client.responses = type("R", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("openai.OpenAI", lambda **kw: fake_client)  # noqa: ARG005
     monkeypatch.setattr(
-        "experiments.sota.exp2_interactive_smoke._load_openai_key",
-        lambda: "test-key",
+        "aedist.adapter_openai_responses._load_openai_key", lambda: "sk-test-fixture"
     )
 
-    raw_path = tmp_path / "turn2.raw.json"
-    record = run_openai_call(
-        "Proceed as instructed.",
-        cap_usd=5.0,
+    mod.run_openai_call(
+        "follow-up prompt",
+        cap_usd=3.0,
         agent_mode="phase_b_run",
-        raw_output_path=raw_path,
-        max_tokens=8000,
-        continuation={"previous_response_id": "resp_turn1"},
+        raw_output_path=tmp_path / "raw_turn2.json",
+        max_tokens=1000,
+        continuation={"response_id": "resp_test_turn1"},
         extra_metadata=None,
-        system_prompt=None,  # follow-up turns must pass None
+        system_prompt="you are an analyst",  # passed but should be ignored on followup
     )
 
-    assert len(captured_kwargs) == 1
-    kw = captured_kwargs[0]
-
-    # previous_response_id must be forwarded on turn 2.
-    assert kw.get("previous_response_id") == "resp_turn1", (
-        "previous_response_id must be forwarded from continuation on turn 2"
+    assert captured["previous_response_id"] == "resp_test_turn1"
+    assert "instructions" not in captured, (
+        "follow-up turn must not re-send instructions — server-side state inherits"
     )
 
-    # instructions must NOT be sent again on follow-up turns.
-    assert "instructions" not in kw, "instructions must not be re-sent on follow-up turns"
 
-    # Continuation for the next turn must carry the new response id.
-    assert record.method_params.extra is not None
-    assert record.method_params.extra.get("previous_response_id") == "resp_turn2"
+def test_state_machine_openai_dispatch_chains_response_id(monkeypatch, tmp_path):
+    """Dispatcher routes --agent openai through run_openai_call and chains response_id.
 
+    Turn-1 has empty continuation. Turn-2's call must receive
+    ``continuation={"response_id": <turn1_resp_id>}`` — proving the
+    CONTINUATION_EXTRACTORS table replaces the Mistral-specific
+    agent_id / conversation_id extraction without code branching in
+    the dispatcher body.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
 
-def test_state_machine_openai_dispatch(monkeypatch, tmp_path):
-    """CALL_FNS table routes 'openai' to run_openai_call without NotImplementedError."""
-    import experiments.sota.exp2_interactive_smoke as mod
+    call_log: list[dict] = []
 
-    captured_calls: list[dict] = []
-
-    def fake_openai_call(
+    def fake_run_openai(
         prompt,
         *,
-        cap_usd,
+        cap_usd,  # noqa: ARG001  # signature parity; cap enforced inside the real call
         agent_mode,
         raw_output_path,
-        max_tokens,
+        max_tokens,  # noqa: ARG001
         continuation=None,
         extra_metadata=None,
         system_prompt=None,
     ):
         from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
 
-        captured_calls.append(
+        call_log.append(
             {
                 "prompt": prompt,
                 "continuation": continuation,
+                "extra_metadata": extra_metadata,
                 "system_prompt": system_prompt,
             }
         )
-        raw_output_path.write_text(
-            json.dumps({"outputs": [{"type": "message.output", "content": "stub"}]})
-        )
+        raw_output_path.write_text(json.dumps({"id": f"resp_t{len(call_log)}"}))
         return RunRecord(
             method="frontier",
             method_params=MethodParams(
                 model="gpt-5.5",
                 max_tokens=100,
-                extra={"previous_response_id": f"resp_{len(captured_calls)}"},
+                extra={"response_id": f"resp_t{len(call_log)}"},
             ),
             resource_use=ResourceUse(
                 cost_usd=0.10,
@@ -867,13 +848,17 @@ def test_state_machine_openai_dispatch(monkeypatch, tmp_path):
             result_summary=ResultSummary(status="ok"),
             agent_family="openai-direct",
             agent_mode=agent_mode,
+            justification={"output_text": "stub narrative"},
         )
 
-    fake_classify = _fake_classifier_factory(["report", "no_report"])
-    monkeypatch.setattr(mod, "run_openai_call", fake_openai_call)
-    monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
+    monkeypatch.setitem(mod.CALL_FNS, "openai", fake_run_openai)
+    monkeypatch.setattr(
+        mod.dialogue_classifier,
+        "classify_report",
+        _fake_classifier_factory(["report", "no_report"]),
+    )
 
-    result = mod.run_phase_b_multiturn(
+    result = run_phase_b_multiturn(
         "the designed prompt",
         output_dir=tmp_path,
         cap_usd=10.0,
@@ -881,14 +866,477 @@ def test_state_machine_openai_dispatch(monkeypatch, tmp_path):
         initial_spent_usd=0.0,
         max_tokens=100,
         agent="openai",
-        system_prompt="system text",
+        system_prompt="designed system text",
     )
 
-    # Should complete without NotImplementedError.
-    assert result["turns"] == 2
-    assert result["terminal_sent"] is False
-    # Turn 1 receives system_prompt; turn 2 (follow-up) must not.
-    assert captured_calls[0]["system_prompt"] == "system text"
-    assert captured_calls[1]["system_prompt"] is None
-    # Turn 2 continuation must forward the response id from turn 1's record.
-    assert captured_calls[1]["continuation"] == {"previous_response_id": "resp_1"}
+    assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
+    # Turn 1: continuation is the initial empty dict — no response_id yet.
+    assert not call_log[0]["continuation"] or "response_id" not in call_log[0]["continuation"]
+    # System prompt installed on turn 1.
+    assert call_log[0]["system_prompt"] == "designed system text"
+    # Turn 2: continuation carries the turn-1 response_id.
+    assert call_log[1]["continuation"] == {"response_id": "resp_t1"}
+    # OpenAI is in SYSTEM_PROMPT_PASSTHROUGH = False group → system masked on follow-up.
+    assert call_log[1]["system_prompt"] is None
+    # Per-turn artefacts present for both turns.
+    for turn in (1, 2):
+        for suffix in (".user.txt", ".raw.json", ".record.json", ".classification.json"):
+            assert (tmp_path / f"openai_turn_{turn:02d}{suffix}").exists(), (
+                f"missing artefact openai_turn_{turn:02d}{suffix}"
+            )
+
+
+def test_dispatch_tables_share_provider_set():
+    """CALL_FNS and CONTINUATION_EXTRACTORS must cover the same providers.
+
+    Catches drift where someone adds a new provider to one table but
+    forgets the other — a partial wiring would crash at runtime with
+    a KeyError. Cheap structural invariant.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    assert set(mod.CALL_FNS) == set(mod.CONTINUATION_EXTRACTORS), (
+        f"CALL_FNS={set(mod.CALL_FNS)} but "
+        f"CONTINUATION_EXTRACTORS={set(mod.CONTINUATION_EXTRACTORS)} — "
+        "every wired provider needs both"
+    )
+    # SYSTEM_PROMPT_PASSTHROUGH may be a subset (missing entry = default False),
+    # but every key in it must be a known provider.
+    assert set(mod.SYSTEM_PROMPT_PASSTHROUGH).issubset(set(mod.CALL_FNS))
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0235: Anthropic Messages API adapter for multi-turn Phase B
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_anthropic_resp(*, narrative: str = "stub"):
+    """Minimal stand-in for ``anthropic.messages.create()`` return value."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id="msg_test_001",
+        model="claude-opus-4-6",
+        stop_reason="end_turn",
+        content=[
+            SimpleNamespace(type="text", text=narrative, citations=[]),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            server_tool_use=SimpleNamespace(web_search_requests=2),
+        ),
+    )
+
+
+def test_run_anthropic_call_turn1_sends_system_and_messages(monkeypatch, tmp_path):
+    """Turn 1: system installed, messages = [{user, prompt}], no replayed history."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_anthropic_resp()
+
+    fake_client = type("C", (), {})()
+    fake_client.messages = type("M", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("anthropic.Anthropic", lambda **kw: fake_client)  # noqa: ARG005
+    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda _: "sk-ant-test")
+
+    record = mod.run_anthropic_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    assert captured["system"] == "you are an analyst"
+    assert captured["messages"] == [{"role": "user", "content": "the prompt"}]
+    # Single web_search tool installed at turn 1 (max_uses=3 default).
+    assert any(t.get("name") == "web_search" for t in captured["tools"])
+    assert record.agent_mode == "phase_b_run"
+    # Narrative stashed for the record-first classifier path.
+    assert (record.justification or {}).get("output_text") == "stub"
+
+
+def test_run_anthropic_call_turn2_replays_full_history(monkeypatch, tmp_path):
+    """Turn 2+: messages list contains prior turns AND system is re-sent identically.
+
+    Anthropic is stateless on the wire: every call must replay the full
+    conversation history including each previous assistant reply, AND the
+    ``system`` parameter must be passed as identical bytes every turn.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_create(**payload):
+        captured.update(payload)
+        return _make_fake_anthropic_resp(narrative="turn-2 reply")
+
+    fake_client = type("C", (), {})()
+    fake_client.messages = type("M", (), {"create": staticmethod(fake_create)})()
+    monkeypatch.setattr("anthropic.Anthropic", lambda **kw: fake_client)  # noqa: ARG005
+    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda _: "sk-ant-test")
+
+    prior_history = [
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+    ]
+
+    mod.run_anthropic_call(
+        "second user message",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw_turn2.json",
+        max_tokens=1000,
+        continuation={"messages": prior_history},
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    # Full history replayed: prior 2 + new user = 3 messages.
+    assert captured["messages"] == [
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+        {"role": "user", "content": "second user message"},
+    ]
+    # System bytes identical to turn 1 (required by Anthropic).
+    assert captured["system"] == "you are an analyst"
+
+
+def test_state_machine_anthropic_dispatch_chains_messages(monkeypatch, tmp_path):
+    """Dispatcher routes --agent anthropic and appends turn-1 reply into turn-2 messages.
+
+    Two-turn trace under ``[report, no_report]``: turn-1 is the designed
+    prompt; the classifier returns "report" → VERIFY fires on turn-2.
+    On turn-2 the dispatcher must pass ``continuation["messages"]`` that
+    contains the turn-1 user message AND the turn-1 assistant reply.
+    System prompt MUST be re-sent on turn-2 (SYSTEM_PROMPT_PASSTHROUGH).
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    call_log: list[dict] = []
+
+    def fake_run_anthropic(
+        prompt,
+        *,
+        cap_usd,  # noqa: ARG001
+        agent_mode,
+        raw_output_path,
+        max_tokens,  # noqa: ARG001
+        continuation=None,
+        extra_metadata=None,
+        system_prompt=None,
+    ):
+        from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
+
+        call_log.append(
+            {
+                "prompt": prompt,
+                "continuation": continuation,
+                "extra_metadata": extra_metadata,
+                "system_prompt": system_prompt,
+            }
+        )
+        # Build the next-turn messages list: prior history (if any) + this turn.
+        history = list((continuation or {}).get("messages", []))
+        history.append({"role": "user", "content": prompt})
+        history.append({"role": "assistant", "content": f"reply-{len(call_log)}"})
+        raw_output_path.write_text(json.dumps({"id": f"msg_t{len(call_log)}"}))
+        return RunRecord(
+            method="frontier",
+            method_params=MethodParams(
+                model="claude-opus-4-6",
+                max_tokens=100,
+                extra={"run_number": 1, "messages": history},
+            ),
+            resource_use=ResourceUse(
+                cost_usd=0.10,
+                wall_s=1.0,
+                tokens_in=10,
+                tokens_out=20,
+                thinking_tokens=None,
+            ),
+            result_summary=ResultSummary(status="ok"),
+            agent_family="anthropic-direct",
+            agent_mode=agent_mode,
+            justification={"output_text": f"reply-{len(call_log)}"},
+        )
+
+    monkeypatch.setitem(mod.CALL_FNS, "anthropic", fake_run_anthropic)
+    monkeypatch.setattr(
+        mod.dialogue_classifier,
+        "classify_report",
+        _fake_classifier_factory(["report", "no_report"]),
+    )
+
+    result = run_phase_b_multiturn(
+        "the designed prompt",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="anthropic",
+        system_prompt="designed system text",
+    )
+
+    assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
+    # Turn 1: empty continuation, system installed.
+    assert not call_log[0]["continuation"] or "messages" not in call_log[0]["continuation"]
+    assert call_log[0]["system_prompt"] == "designed system text"
+    # Turn 2: messages list contains turn-1 user + turn-1 assistant.
+    msgs = (call_log[1]["continuation"] or {}).get("messages", [])
+    assert msgs[0] == {"role": "user", "content": "the designed prompt"}
+    assert msgs[1] == {"role": "assistant", "content": "reply-1"}
+    # SYSTEM_PROMPT_PASSTHROUGH=True for Anthropic — system re-sent on turn 2.
+    assert call_log[1]["system_prompt"] == "designed system text"
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0236: Qwen DashScope adapter for multi-turn Phase B
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_qwen_resp(*, narrative: str = "stub-qwen"):
+    """Minimal stand-in for ``dashscope.Generation.call()`` return value.
+
+    Mirrors the dict-shape DashScope returns: nested ``output.choices[0].message``
+    plus a top-level ``usage`` dict. Built to exercise
+    ``adapter_qwen_dashscope.parse_response``.
+    """
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "content": narrative,
+                        "reasoning_content": None,
+                    },
+                    "finish_reason": "stop",
+                },
+            ],
+            "search_info": {"search_results": []},
+        },
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "plugins": {"search": {"count": 0}},
+        },
+        "request_id": "req_test_001",
+        "status_code": 200,
+    }
+
+
+def test_run_qwen_call_turn1_injects_system(monkeypatch, tmp_path):
+    """Turn 1 Qwen call: messages = [system, user]; enable_search=True; thinking on."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_call(**payload):
+        captured.update(payload)
+        return _make_fake_qwen_resp()
+
+    monkeypatch.setattr("dashscope.Generation.call", fake_call)
+    monkeypatch.setattr("aedist.adapter_qwen_dashscope._resolve_api_key", lambda: "sk-qwen-test")
+
+    record = mod.run_qwen_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata=None,
+        system_prompt="you are an analyst",
+    )
+
+    assert captured["messages"] == [
+        {"role": "system", "content": "you are an analyst"},
+        {"role": "user", "content": "the prompt"},
+    ]
+    assert captured["enable_search"] is True
+    assert captured["enable_thinking"] is True
+    # Continuation messages (post-parse override) include system + user + assistant.
+    extra_msgs = (record.method_params.extra or {}).get("messages", [])
+    assert extra_msgs[0] == {"role": "system", "content": "you are an analyst"}
+    assert extra_msgs[1] == {"role": "user", "content": "the prompt"}
+    assert extra_msgs[2] == {"role": "assistant", "content": "stub-qwen"}
+    # Narrative reachable via the record-first classifier path.
+    assert (record.justification or {}).get("output_text") == "stub-qwen"
+
+
+def test_run_qwen_call_merges_metadata_into_existing_system(monkeypatch, tmp_path):
+    """When system_prompt AND extra_metadata are both set, exactly one system message.
+
+    Regression: an earlier implementation prepended a SECOND
+    ``{"role": "system"}`` entry when extra_metadata was set, producing
+    payload [metadata-system, real-system, user]. DashScope honours at
+    most one leading system message and would silently drop one of them.
+
+    Correct behaviour: append the [metadata] line to the existing
+    system message content, keeping a single system entry at index 0.
+    """
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_call(**payload):
+        captured.update(payload)
+        return _make_fake_qwen_resp()
+
+    monkeypatch.setattr("dashscope.Generation.call", fake_call)
+    monkeypatch.setattr("aedist.adapter_qwen_dashscope._resolve_api_key", lambda: "sk-qwen-test")
+
+    mod.run_qwen_call(
+        "the prompt",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw.json",
+        max_tokens=1000,
+        continuation=None,
+        extra_metadata={"remaining_usd": "2.50", "cap_usd": "3.00"},
+        system_prompt="you are an analyst",
+    )
+
+    # Exactly one system message at index 0.
+    system_messages = [m for m in captured["messages"] if m.get("role") == "system"]
+    assert len(system_messages) == 1, (
+        f"expected exactly 1 system message, got {len(system_messages)}: "
+        f"{[m for m in captured['messages']]}"
+    )
+    assert captured["messages"][0]["role"] == "system"
+    # Both the agent's system_prompt AND the [metadata] line must be present.
+    sys_content = captured["messages"][0]["content"]
+    assert "you are an analyst" in sys_content
+    assert "[metadata]" in sys_content
+    assert "remaining_usd=2.50" in sys_content
+
+
+def test_run_qwen_call_turn2_replays_full_history(monkeypatch, tmp_path):
+    """Turn 2+: messages list replays prior history (including system) + new user."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_call(**payload):
+        captured.update(payload)
+        return _make_fake_qwen_resp(narrative="turn-2 reply")
+
+    monkeypatch.setattr("dashscope.Generation.call", fake_call)
+    monkeypatch.setattr("aedist.adapter_qwen_dashscope._resolve_api_key", lambda: "sk-qwen-test")
+
+    prior_history = [
+        {"role": "system", "content": "you are an analyst"},
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+    ]
+
+    mod.run_qwen_call(
+        "second user message",
+        cap_usd=3.0,
+        agent_mode="phase_b_run",
+        raw_output_path=tmp_path / "raw_turn2.json",
+        max_tokens=1000,
+        continuation={"messages": prior_history},
+        extra_metadata=None,
+        system_prompt="you are an analyst",  # ignored because continuation carries it
+    )
+
+    # Full history (incl. system) + new user message sent on the wire.
+    assert captured["messages"] == [
+        {"role": "system", "content": "you are an analyst"},
+        {"role": "user", "content": "first user message"},
+        {"role": "assistant", "content": "first assistant reply"},
+        {"role": "user", "content": "second user message"},
+    ]
+
+
+def test_state_machine_qwen_dispatch_chains_messages(monkeypatch, tmp_path):
+    """Dispatcher routes --agent qwen, replays full conversation, re-sends system on turn 2."""
+    from experiments.sota import exp2_interactive_smoke as mod
+
+    call_log: list[dict] = []
+
+    def fake_run_qwen(
+        prompt,
+        *,
+        cap_usd,  # noqa: ARG001
+        agent_mode,
+        raw_output_path,
+        max_tokens,  # noqa: ARG001
+        continuation=None,
+        extra_metadata=None,
+        system_prompt=None,
+    ):
+        from aedist.schema import MethodParams, ResourceUse, ResultSummary, RunRecord
+
+        call_log.append(
+            {
+                "prompt": prompt,
+                "continuation": continuation,
+                "extra_metadata": extra_metadata,
+                "system_prompt": system_prompt,
+            }
+        )
+        # Build the full history for the next-turn continuation.
+        if continuation and continuation.get("messages"):
+            history = list(continuation["messages"])
+        else:
+            history = [{"role": "system", "content": system_prompt}] if system_prompt else []
+        history.append({"role": "user", "content": prompt})
+        history.append({"role": "assistant", "content": f"reply-{len(call_log)}"})
+        raw_output_path.write_text(json.dumps({"request_id": f"req_t{len(call_log)}"}))
+        return RunRecord(
+            method="frontier",
+            method_params=MethodParams(
+                model="qwen3-max",
+                max_tokens=100,
+                extra={"messages": history},
+            ),
+            resource_use=ResourceUse(cost_usd=0.10, wall_s=1.0, tokens_in=10, tokens_out=20),
+            result_summary=ResultSummary(status="ok"),
+            agent_family="qwen-direct",
+            agent_mode=agent_mode,
+            justification={"output_text": f"reply-{len(call_log)}"},
+        )
+
+    monkeypatch.setitem(mod.CALL_FNS, "qwen", fake_run_qwen)
+    monkeypatch.setattr(
+        mod.dialogue_classifier,
+        "classify_report",
+        _fake_classifier_factory(["report", "no_report"]),
+    )
+
+    result = run_phase_b_multiturn(
+        "the designed prompt",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="qwen",
+        system_prompt="designed system text",
+    )
+
+    assert result["turns"] == 2, f"expected 2 turns, got {result['turns']}"
+    # Turn 1: empty continuation, system installed.
+    assert not call_log[0]["continuation"] or "messages" not in call_log[0]["continuation"]
+    assert call_log[0]["system_prompt"] == "designed system text"
+    # Turn 2: full history (system + user1 + assistant1) replayed.
+    msgs = (call_log[1]["continuation"] or {}).get("messages", [])
+    assert msgs[0] == {"role": "system", "content": "designed system text"}
+    assert msgs[1] == {"role": "user", "content": "the designed prompt"}
+    assert msgs[2] == {"role": "assistant", "content": "reply-1"}
+    # SYSTEM_PROMPT_PASSTHROUGH=True for Qwen — system re-sent on turn 2.
+    assert call_log[1]["system_prompt"] == "designed system text"


### PR DESCRIPTION
PR #433 squash-merged a stale pre-0234 branch that silently reverted
1001 lines of multi-provider adapter infrastructure added by PRs #429–#431.

## What was lost (and is now restored)

- `run_anthropic_call()` — Anthropic Messages API multi-turn adapter
- `run_qwen_call()` — Qwen DashScope multi-turn adapter  
- `CALL_FNS` dict reduced from 4 providers back to 2 (mistral + openai only)
- `CONTINUATION_EXTRACTORS` dict (all 4 providers) removed entirely
- `SYSTEM_PROMPT_PASSTHROUGH` policy dict removed
- Test coverage for anthropic/qwen dispatch paths wiped

## What is preserved from #433

- AEDIST OpenAI key enforcement (`adapter_openai_responses._load_openai_key()`) — retained in both origin/main and t0237-fg

## Approach

`git checkout t0237-fg -- experiments/sota/exp2_interactive_smoke.py tests/test_exp2_interactive_smoke.py`

The t0237-fg branch has all four providers wired with AEDIST enforcement. `make check-fast` passes: 1434 tests green.

**Ticket:** tickets/0237-phase-b0-smoke-all-four.erg