### PR TITLE
tickets: add 0243 (classifier boundary) and 0244 (openai 429 retry)

### DIFF
--- a/tickets/0243-dialogue-classifier-boundary-false-labels.erg
+++ b/tickets/0243-dialogue-classifier-boundary-false-labels.erg
@@ -1,0 +1,60 @@
+%erg 0.1
+Title: Dialogue classifier false labels at boundary turns (verify + candidate-universe)
+Created: 2026-05-23
+Author: claude
+
+--- log ---
+2026-05-23T13:35Z claude created — root-cause investigation of Phase B "null-content glitch" revealed two classifier accuracy failures
+
+--- body ---
+## Context
+
+During Exp 2 Phase B N=5 batch, two runs were manually aborted and
+retried after the dialogue classifier (nvidia/nemotron-nano-9b-v2)
+returned incorrect labels on specific turn types. Both were initially
+misdiagnosed as "null content glitches". Root cause investigation
+(2026-05-23) shows they are classifier false negatives/positives.
+
+### Case 1 — False negative on verify turn (Mistral rep 2)
+
+- Turn 1 (designed_prompt): Mistral produced a substantial candidate
+  universe + partial inventory with tables. Classifier: `report` ✓
+- Turn 2 (verify): Mistral produced an 18,700-char polished inventory
+  with 26 table rows. `extract_narrative_from_mistral_raw` correctly
+  extracted the full text. Classifier: `no_report` ✗
+
+Evidence: `/tmp/mistral_run02_failed_rep2/mistral_turn_02.raw.json`
+(18,700-char content, 26 markdown table rows).
+
+### Case 2 — False positive on designed_prompt turn (OpenAI rep 3)
+
+- Turn 1 (designed_prompt): OpenAI produced a 12,482-char candidate
+  universe. Model explicitly wrote "I will **not** produce the final
+  inventory yet." Classifier: `report` ✗
+- Turn 2 (verify): sent prematurely; model correctly said it could not
+  verify a non-existent inventory. Classifier: `no_report` ✓
+
+Evidence: `/tmp/openai_run03_failed_rep3/openai_turn_01.record.json`
+(output_text starts "Turn 1 — Candidate universe + source map progress
+note … I will not produce the final inventory yet").
+
+## Hypotheses
+
+The boundary cases where the classifier fails:
+
+1. **Verify turn response**: formatted as "corrected/verified inventory"
+   with tables — classifier may not distinguish this from a partial-
+   progress response because it lacks the explicit framing it expects.
+
+2. **Candidate-universe designed_prompt turn**: contains many markdown
+   tables (plant candidates) but explicitly says it is not the final
+   inventory — classifier may key on table presence alone.
+
+## Exit criteria
+
+- [ ] Audit classifier prompt and few-shot examples for these two failure modes
+- [ ] Add at least 2 boundary examples to the classifier test suite:
+  - A verify-turn polished inventory → expected `report`
+  - A candidate-universe turn with explicit "not final" language → expected `no_report`
+- [ ] Re-run the failed artefacts through the updated classifier and confirm correct labels
+- [ ] `make check` passes

--- a/tickets/0244-adapter-openai-429-retry.erg
+++ b/tickets/0244-adapter-openai-429-retry.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Add 429 / transient-failure retry to adapter_openai_responses
+Created: 2026-05-23
+Author: claude
+
+--- log ---
+2026-05-23T13:35Z claude created — gap found during Phase B post-mortem: Mistral (PR #399) and Qwen have retry; OpenAI does not
+
+--- body ---
+## Context
+
+The three SOTA adapters have uneven retry coverage:
+
+| Adapter | 429 retry | Transient retry | Where |
+|---------|-----------|-----------------|-------|
+| `adapter_mistral.py` | ✓ (PR #399) | ✓ exponential backoff | `_request_with_retry` |
+| `adapter_qwen_dashscope.py` | ✓ | ✓ | `_call_with_retry` |
+| `adapter_openai_responses.py` | ✗ | ✗ | — |
+
+Ticket 0242 listed "429-retry added to OpenAI and Qwen adapters" as an
+exit criterion, but OpenAI was not implemented. No 429 errors occurred
+during the N=5 batch because 1-agent-per-process parallelism means no
+same-provider contention, but the gap remains for future runs with higher
+concurrency or provider-side rate limits.
+
+## What to implement
+
+Mirror the Mistral retry policy in `adapter_openai_responses.py`:
+
+- Max 3 retries, exponential backoff 1s / 2s / 4s ± 10% jitter
+- Retry on: 429 (rate limit), 5xx transient, connection timeout
+- Do NOT retry on: 4xx (except 429) — these are request-shape bugs
+- Log each retry attempt with URL and reason
+
+The OpenAI Responses API uses `openai.OpenAI().responses.create(...)`.
+The SDK raises `openai.RateLimitError` (429) and
+`openai.APIStatusError` (5xx). Wrap the `client.responses.create` call.
+
+## Reference
+
+- `src/aedist/adapter_mistral.py` lines ~295–382 — retry implementation to mirror
+- `src/aedist/adapter_qwen_dashscope.py` lines ~57–74 — Qwen variant
+- `src/aedist/adapter_openai_responses.py` — target file
+
+## Exit criteria
+
+- [ ] `_call_with_retry` wrapper added to `adapter_openai_responses.py`
+- [ ] Retries on `openai.RateLimitError` and 5xx `openai.APIStatusError`
+- [ ] Unit test: monkeypatched client raises 429 twice then succeeds → 1 result returned, 2 retries logged
+- [ ] `make check` passes


### PR DESCRIPTION
Adds two tickets surfaced by Phase B post-mortem root-cause analysis.