### PR TITLE
tickets: close 0218 (substantially resolved), spin 0247 for adapter self-guard

### DIFF
--- a/tickets/0218-adapter-mistral-followup-metadata-dropped.erg
+++ b/tickets/0218-adapter-mistral-followup-metadata-dropped.erg
@@ -2,11 +2,13 @@
 Title: adapter_mistral follow-up turn likely drops `extra_metadata` silently
 Created: 2026-05-21
 Author: claude
+Closed: substantially resolved: 422 (not silent-drop) confirmed; caller-guard landed (exp2_interactive_smoke.py:999-1000 sets extra_metadata=None on follow-ups); OpenAI/Anthropic/Qwen continuation audited; policy in exp2_protocol_spec.md:75. Residual adapter self-guard tracked in 0247.
 
 --- log ---
 2026-05-21T16:45Z claude created — known limitation flagged by 0211 raid agent in PR #398
 2026-05-21T16:50Z claude note empirical resolution: HTTP 422 (NOT silent drop). Re-smoke after PR #398 sent extra_metadata on the follow-up; Mistral 422'd the body. Harness-side workaround landed in the same commit (skip extra_metadata on follow-up turns); ticket scope unchanged (the adapter still attaches metadata defensively — it should learn to skip on follow-ups too).
 
+2026-05-23T13:51Z HDMX-coding-agent closed — substantially resolved: 422 (not silent-drop) confirmed; caller-guard landed (exp2_interactive_smoke.py:999-1000 sets extra_metadata=None on follow-ups); OpenAI/Anthropic/Qwen continuation audited; policy in exp2_protocol_spec.md:75. Residual adapter self-guard tracked in 0247.
 --- body ---
 
 ## Context

--- a/tickets/0247-adapter-mistral-self-guard-metadata-followup.erg
+++ b/tickets/0247-adapter-mistral-self-guard-metadata-followup.erg
@@ -1,0 +1,59 @@
+%erg 0.1
+Title: adapter_mistral: self-guard against metadata on follow-up turns
+Created: 2026-05-23
+Author: claude
+Tag: deferred
+
+--- log ---
+2026-05-23T00:00Z claude created — residual from 0218; caller-guard exists, adapter still attaches metadata on follow-up (footgun)
+
+--- body ---
+## Context
+
+Spun off from 0218 (closed substantially-resolved). The Mistral
+follow-up 422 on body-level `metadata` is empirically confirmed and
+fully mitigated **at the caller**: `experiments/sota/exp2_interactive_smoke.py:999-1000`
+sets `extra_metadata = None` on every turn > 1.
+
+The **adapter itself is not hardened**. `adapter_mistral.py:605`
+unconditionally calls `_attach_metadata(conv_body)` on the follow-up
+branch. Any future caller that forgets the `None` guard will hit a
+runtime 422 — and this adapter's own docstring cites a "history of
+HTTP 422 silent-accept incidents." This is belt-and-suspenders, not
+a live bug (Exp 2 already ran clean, uniform treatment across arms).
+
+## Relevant files
+
+- `src/aedist/adapter_mistral.py` — `is_followup` branch (~:588-608),
+  `_attach_metadata` (~:581), the unconditional call at ~:605
+- `src/aedist/adapter_mistral.py:491` — docstring still says metadata
+  "may not support it"; should state the confirmed follow-up 422
+- `experiments/sota/exp2_protocol_spec.md:75` — policy stated
+  conditionally; could enumerate per-provider metadata degradation
+
+## Actions
+
+1. On the Mistral follow-up branch, either skip `_attach_metadata`
+   entirely, or adopt the Qwen-style prepend (a machine-parseable
+   `[metadata]` line inside the user message text) so the structured
+   budget signal survives turn 2+. Prefer the prepend — it preserves
+   the 0207 policy intent rather than dropping the signal.
+2. Unit-test the follow-up metadata path (currently untested — the
+   only `extra_metadata` test, `test_exp2_interactive_smoke.py:1242`,
+   exercises the Qwen turn-1 path).
+3. Tighten the adapter docstring (:491) to state the confirmed 422,
+   not "may not support it".
+
+## Out of scope
+
+- Re-architecting `extra_metadata` into a typed cross-provider surface
+  (still out of scope, as in 0218).
+
+## Exit criteria
+
+- [ ] Mistral follow-up branch no longer sends a 422-triggering
+      `metadata` body key; budget signal preserved via prepend OR
+      explicitly dropped with a documented rationale.
+- [ ] Unit test covers the Mistral follow-up metadata path.
+- [ ] Adapter docstring (:491) states the confirmed follow-up 422.
+- [ ] `make check` passes.


### PR DESCRIPTION
Outcome of exploring **ticket 0218** doneness/importance/urgency during the 2026-05-23 staleness audit.

**Verdict:** 0218 ("Mistral silently drops `extra_metadata` on follow-up turns") is substantially resolved — its premise is empirically inverted and the practical risk is already mitigated. Closed here; the one real residual is spun off as **0247** (tagged `deferred`).

### Why 0218 closes
- **Premise inverted:** Mistral **422s** (not silent-drop) on body-level `metadata` against the append endpoint — confirmed in the live 0185 smoke.
- **Caller-guard already landed:** `experiments/sota/exp2_interactive_smoke.py:999-1000` sets `extra_metadata = None` on every turn > 1, so the 422 never fires in production. Exp 2 Phase B ran with **uniform treatment across all four arms** (metadata on turn 1, chat-text status every turn) — no confound.
- **Audit done (criterion 3):** OpenAI accepts metadata on continuation (dropped for symmetry), Anthropic 400-rejects (dropped silently), Qwen uses the system-message fallback — all documented in code.
- **Policy (criterion 4):** stated conditionally at `experiments/sota/exp2_protocol_spec.md:75`.

### What 0247 tracks (residual, post-conference)
`adapter_mistral.py:605` still attaches `metadata` on the follow-up branch unconditionally — a footgun for any future caller that forgets the `None` guard (the adapter's own docstring cites a "history of HTTP 422 silent-accept incidents"). 0247: self-guard the adapter (prefer Qwen-style prepend so the 0207 budget signal survives turn 2+), unit-test the follow-up path, tighten the docstring. Nothing on the 2026-05-27 slides critical path depends on it.

**Ticket:** tickets/0218-adapter-mistral-followup-metadata-dropped.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)