### PR TITLE
ci: skip lint/tests on ticket/STATE-only diffs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,16 +4,46 @@ on:
     branches: [main]
   pull_request:
 jobs:
+  # Decide whether the diff touches anything that lint/tests care about.
+  # `chore` is true ONLY when *every* changed file is a ticket or STATE.md
+  # (predicate-quantifier: every). Anything else — code, configs, docs, a
+  # mixed diff, or an empty/errored output — leaves it != 'true', so the
+  # heavy steps below run. Fail-safe: ambiguity always runs full CI.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      chore: ${{ steps.filter.outputs.chore }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            chore:
+              - 'tickets/**'
+              - 'STATE.md'
   lint:
+    needs: changes
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
-      - run: uv run ruff check src/ tests/
+      - if: needs.changes.outputs.chore != 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.chore != 'true'
+        uses: astral-sh/setup-uv@v4
+      - if: needs.changes.outputs.chore != 'true'
+        run: uv run ruff check src/ tests/
   tests:
+    needs: changes
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
-      - run: uv sync --group dev
-      - run: uv run pytest -q
+      - if: needs.changes.outputs.chore != 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.chore != 'true'
+        uses: astral-sh/setup-uv@v4
+      - if: needs.changes.outputs.chore != 'true'
+        run: uv sync --group dev
+      - if: needs.changes.outputs.chore != 'true'
+        run: uv run pytest -q


### PR DESCRIPTION
## Summary

Chore PRs (ticket archival, STATE refresh) ran the full ~40s `lint`+`tests` suite despite touching zero code — and since `main` is protection-gated, every chore must go through a PR. Pure latency on a path the agent loop hits constantly.

This adds a `changes` job (dorny/paths-filter, `predicate-quantifier: every`): the `chore` output is true only when **every** changed file is under `tickets/` or is `STATE.md`. `lint`/`tests` still run as jobs (so the required check names always report), but their steps are gated on `chore != 'true'` and skip in seconds on chore-only diffs.

**Fail-safe by construction:** positive globs only (no untested negation), gate is `!= 'true'` — so a mixed diff, a code change, or an empty/errored filter output all run the full suite. The bypass fires only on a definitive chore-only signal.

This PR itself touches `.github/workflows/` (not a chore path), so it correctly runs the full suite.

## Test plan

- [x] YAML parses; jobs = `changes`, `lint`, `tests`; gates wired
- [x] Full CI runs on this PR (CI-config change → not bypassed)
- [ ] Verified post-merge: the next ticket-/STATE-only PR shows `lint`/`tests` green in seconds

_No ticket — direct request; implements the long-noted chore-bypass._

🤖 Generated with [Claude Code](https://claude.com/claude-code)