### PR TITLE
adopt(exp3): mark protocol ADOPTED, fix H1/H2 thresholds, update MASTERPLAN

### DIFF
--- a/MASTERPLAN.md
+++ b/MASTERPLAN.md
@@ -192,6 +192,11 @@ Deliverable: slides (French, Beamer) in `slides/`. Consumes current state (censu
 - Slides synced to the v0 pipeline design (fusion reframe, fragment taxonomy, incrementality, master + sidecar, 3-tier verification, 4-category HITL memory, agents anchored on data-model concerns).
 - Technical report carries warning boxes in Ch. 3 RAG intro, Ch. 6 Architecture proposée, and `inputs/verification_methods.tex`. Full rewrite tracked in tickets 0098 (Ch. 6 + Ch. 3 reframe) and 0099 (verification_methods.tex). Both blocked by 0097 (source-grounding Phase 1 results feed the rewrites).
 
+**Experiment structure (2026-05-23):** Three experiments feed the talk evidence.
+- **Experiment 1** — memory ceiling: 16 models × 5 reps, no retrieval (done).
+- **Experiment 2** — SOTA multi-turn: naive arm (Arm 1) and optimized arm (Arm 2), 4 subjects × 5 reps each (done).
+- **Experiment 3** — evidence-pack intervention: 4-arm design reusing Exp 2 arms as frozen baselines; Arms 3/4 inject a fixed 18-source prompt-side evidence pack; protocol at `docs/protocol-experiment-3.md` (adopted 2026-05-23). Any local-vs-cloud comparison is a separate future experiment.
+
 ### Presentation (done)
 
 Present the methods benchmark pilot.

--- a/docs/protocol-experiment-3.md
+++ b/docs/protocol-experiment-3.md
@@ -1,7 +1,8 @@
 ---
 title: Protocol for Experiment 3
 date: 2026-05-23
-status: DRAFT
+status: ADOPTED
+adopted: 2026-05-23
 ---
 
 # Protocol for Experiment 3
@@ -40,17 +41,17 @@ The study compares Arm 3 vs Arm 1 and Arm 4 vs Arm 2. Arms 1 and 2 are the basel
 
 On the first baseline protocol surface, Arm 3 yields higher row-level F1 than Arm 1.
 
-- Supported: paired mean $\Delta F1 \ge 0.05$ and one-sided paired permutation test $p < 0.05$
+- Supported: paired mean $\Delta F1 \ge 0.05$
 - Falsified: paired mean $\Delta F1 \le 0$
-- Inconclusive: positive improvement below $0.05$, or $p \ge 0.05$
+- Inconclusive: positive improvement below $0.05$
 
 ### H2 — Evidence pack improves baseline surface B
 
 On the second baseline protocol surface, Arm 4 yields higher row-level F1 than Arm 2.
 
-- Supported: paired mean $\Delta F1 \ge 0.05$ and one-sided paired permutation test $p < 0.05$
+- Supported: paired mean $\Delta F1 \ge 0.05$
 - Falsified: paired mean $\Delta F1 \le 0$
-- Inconclusive: positive improvement below $0.05$, or $p \ge 0.05$
+- Inconclusive: positive improvement below $0.05$
 
 ### H3 — Evidence-pack outputs remain auditable
 
@@ -140,8 +141,6 @@ For each subject system:
 2. Compute the mean F1 over repeated runs in Arm 3.
 3. Compute the paired difference $\Delta F1 = F1_{A3} - F1_{A1}$.
 
-Test the paired mean difference with a one-sided paired permutation test.
-
 ### H2 test
 
 For each subject system:
@@ -149,8 +148,6 @@ For each subject system:
 1. Compute the mean F1 over repeated runs in Arm 2.
 2. Compute the mean F1 over repeated runs in Arm 4.
 3. Compute the paired difference $\Delta F1 = F1_{A4} - F1_{A2}$.
-
-Test the paired mean difference with a one-sided paired permutation test.
 
 ### H3 audit
 


### PR DESCRIPTION
## Summary

- `docs/protocol-experiment-3.md`: status DRAFT → ADOPTED (2026-05-23); H1 and H2 drop the p-value arm — a paired permutation test on n=4 subjects has minimum attainable p = 0.0625, making p < 0.05 unreachable. Effect-size-only thresholds (ΔF1 ≥ 0.05) are used instead.
- `MASTERPLAN.md`: adds three-experiment summary under Econom'IA 2026; explicitly records that local-vs-cloud comparison is a separate future experiment.

**Ticket:** tickets/0250-run-experiment-3-four-arm-sweep.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)