### PR TITLE
exp3(0249): inject evidence pack into intervention runtime paths

### DIFF
--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -235,6 +235,7 @@ def _backfill_resource_use(record: RunRecord, json_path: Path) -> None:
     # without re-reading raw JSON.
     for key in (
         "system_instruction",
+        "evidence_pack_manifest",
         "reasoning_effort",
         "seed",
         "provider_order",

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -153,6 +153,8 @@ EVIDENCE_PACK_HEADER_FIELDS = (
     "relevance",
 )
 
+EVIDENCE_PACK_SECTION_TITLE = "## Evidence Pack"
+
 
 def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
     """Assemble a prompt from the always-pair plus named optional modules.
@@ -238,6 +240,44 @@ def assemble_evidence_pack(manifest_path: Path) -> str:
         blocks.append("\n".join(block_lines))
 
     return "\n\n".join(blocks)
+
+
+def _resolve_evidence_pack_manifest_path(manifest_path: str | Path) -> Path:
+    """Resolve a manifest path from cwd/repo-relative conventions.
+
+    Runtime callers invoke from both repo root and experiments/ subdirs.
+    This resolver accepts any of:
+    - absolute path
+    - repo-relative path (e.g. experiments/evidence_packs/all18tables.yaml)
+    - experiments-relative path (e.g. evidence_packs/all18tables.yaml)
+    """
+    candidate = Path(manifest_path)
+    if candidate.is_absolute():
+        return candidate
+
+    repo_root = Path(__file__).resolve().parents[2]
+    search_paths = [
+        Path.cwd() / candidate,
+        repo_root / candidate,
+        repo_root / "experiments" / candidate,
+    ]
+    for path in search_paths:
+        if path.exists():
+            return path
+    # Preserve deterministic error paths while still returning a sensible default.
+    return search_paths[0]
+
+
+def append_evidence_pack(prompt: str, manifest_path: str | Path | None) -> str:
+    """Append a rendered evidence pack to a prompt when configured.
+
+    Returns the original prompt byte-identically when ``manifest_path`` is not set.
+    """
+    if not manifest_path:
+        return prompt
+    resolved_manifest = _resolve_evidence_pack_manifest_path(manifest_path)
+    evidence_pack = assemble_evidence_pack(resolved_manifest)
+    return f"{prompt}\n\n{EVIDENCE_PACK_SECTION_TITLE}\n\n{evidence_pack}"
 
 
 def build_messages(user_text: str, system_instruction: str | None) -> list[dict]:

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -28,6 +28,7 @@ import openai
 
 from .harness import (
     BudgetTracker,
+    append_evidence_pack,
     assemble_prompt,
     build_api_kwargs,
     build_messages,
@@ -113,6 +114,14 @@ def main():
         default=None,
         help="System message prepended to every API call (overrides --sweep value).",
     )
+    parser.add_argument(
+        "--evidence-pack-manifest",
+        default=None,
+        help=(
+            "Optional evidence-pack manifest YAML path. "
+            "When set, append the assembled evidence pack to the prompt."
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -133,6 +142,7 @@ def main():
     output_dir = Path(args.output)
 
     system_instruction = args.system_instruction
+    evidence_pack_manifest = args.evidence_pack_manifest
     if args.model_set:
         experiments = load_experiments(args.experiments)
         set_ids = experiments["sets"][args.model_set]["model_ids"]
@@ -140,10 +150,17 @@ def main():
         if args.sweep and system_instruction is None:
             sweep_section = experiments.get("sweeps", {}).get(args.sweep, {})
             system_instruction = sweep_section.get("system_instruction")
+        if args.sweep and evidence_pack_manifest is None:
+            sweep_section = experiments.get("sweeps", {}).get(args.sweep, {})
+            evidence_pack_manifest = sweep_section.get("evidence_pack_manifest")
     elif args.sweep and system_instruction is None:
         experiments = load_experiments(args.experiments)
         sweep_section = experiments.get("sweeps", {}).get(args.sweep, {})
         system_instruction = sweep_section.get("system_instruction")
+        if evidence_pack_manifest is None:
+            evidence_pack_manifest = sweep_section.get("evidence_pack_manifest")
+
+    prompt = append_evidence_pack(prompt, evidence_pack_manifest)
 
     if args.model:
         models = [m for m in models if m["name"] == args.model]
@@ -285,6 +302,8 @@ def main():
                 }
                 if system_instruction:
                     record["system_instruction"] = system_instruction
+                if evidence_pack_manifest:
+                    record["evidence_pack_manifest"] = evidence_pack_manifest
                 if model.get("reasoning_effort"):
                     record["reasoning_effort"] = model["reasoning_effort"]
                 save_json(filepath, record)

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -431,6 +431,11 @@ class JobSpec(BaseModel):
         "Per-sweep, not per-model — different regimes (RAG, livesearch) carry "
         "different system instructions in their own sweeps.",
     )
+    evidence_pack_manifest: str | None = Field(
+        default=None,
+        description="Optional path to evidence-pack manifest YAML. "
+        "When set, the runtime appends the assembled evidence pack to the prompt.",
+    )
     output_dir: str = Field(..., description="Output directory for results.")
     timeout_seconds: int = Field(default=600, ge=0)
     estimated_duration: float | None = Field(

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from .harness import (
     BudgetTracker,
+    append_evidence_pack,
     assemble_prompt,
     build_api_kwargs,
     build_messages,
@@ -187,6 +188,7 @@ class Worker:
             prompt = assemble_prompt(modules_dir, job.prompt_modules)
         else:
             prompt = Path(job.prompt).read_text().strip()
+        prompt = append_evidence_pack(prompt, job.evidence_pack_manifest)
         models = load_models(job.models_file)
         output_dir = Path(job.output_dir)
 
@@ -421,6 +423,8 @@ class Worker:
         extra: dict = {"prompt": prompt}
         if system_instruction:
             extra["system_instruction"] = system_instruction
+        if job.evidence_pack_manifest:
+            extra["evidence_pack_manifest"] = job.evidence_pack_manifest
         return self._query_and_save(
             client,
             model_id,
@@ -710,8 +714,13 @@ class Worker:
         method_params = MethodParams(model=job.model_filter or "unknown")
         if ablation_pv is not None:
             method_params.prompt_version = ablation_pv
+        extra: dict[str, bool | str] = {}
         if job.no_think:
-            method_params.extra = {"no_think": True}
+            extra["no_think"] = True
+        if job.evidence_pack_manifest:
+            extra["evidence_pack_manifest"] = job.evidence_pack_manifest
+        if extra:
+            method_params.extra = extra
         record = RunRecord(
             method=emitted_method,
             method_params=method_params,

--- a/tests/test_evidence_pack_assembly.py
+++ b/tests/test_evidence_pack_assembly.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from aedist.harness import EVIDENCE_PACK_HEADER_FIELDS, assemble_evidence_pack
+from aedist.harness import (
+    EVIDENCE_PACK_HEADER_FIELDS,
+    EVIDENCE_PACK_SECTION_TITLE,
+    append_evidence_pack,
+    assemble_evidence_pack,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = REPO_ROOT / "experiments" / "evidence_packs" / "all18tables.yaml"
@@ -34,3 +39,18 @@ def test_assemble_evidence_pack_has_stable_headers_and_expected_source_blocks() 
     assert "source_id: evn_ar_2010_2011_capacities" in assembled
     assert "source_id: pdp8_annex2_table3" in assembled
     assert "source_id: study_e542_pl9_5a" in assembled
+
+
+def test_append_evidence_pack_noop_when_manifest_unset() -> None:
+    """Prompt is unchanged when no evidence-pack manifest is configured."""
+    prompt = "Baseline prompt text"
+    assert append_evidence_pack(prompt, None) == prompt
+
+
+def test_append_evidence_pack_adds_section_when_manifest_set() -> None:
+    """Evidence-pack manifest appends a dedicated section to the baseline prompt."""
+    prompt = "Baseline prompt text"
+    combined = append_evidence_pack(prompt, MANIFEST_PATH)
+    assert combined.startswith(prompt)
+    assert EVIDENCE_PACK_SECTION_TITLE in combined
+    assert "source_id: evn_ar_2010_2011_capacities" in combined

--- a/tests/test_jobspec.py
+++ b/tests/test_jobspec.py
@@ -225,6 +225,10 @@ class TestJobSpecForbidExtras:
         j = _make_jobspec(web_search=True)
         assert j.web_search is True
 
+    def test_evidence_pack_manifest_field(self):
+        j = _make_jobspec(evidence_pack_manifest="experiments/evidence_packs/all18tables.yaml")
+        assert j.evidence_pack_manifest == "experiments/evidence_packs/all18tables.yaml"
+
     def test_round_trip_new_fields(self):
         original = _make_jobspec(
             seed=42,
@@ -232,6 +236,7 @@ class TestJobSpecForbidExtras:
             num_ctx=16384,
             max_tokens=8192,
             web_search=True,
+            evidence_pack_manifest="experiments/evidence_packs/all18tables.yaml",
         )
         restored = JobSpec.from_yaml(original.to_yaml())
         assert restored == original
@@ -302,6 +307,18 @@ class TestJobSpecSweepRemap:
         assert j.mode == Method.SINGLE
         assert j.seed == 42
         assert j.max_tokens == 32768
+
+    def test_evidence_pack_manifest_from_toml_section(self):
+        section = {
+            "mode": "single",
+            "prompt": "p.txt",
+            "models": "models.yaml",
+            "repeat": 1,
+            "output": "outputs/test",
+            "evidence_pack_manifest": "experiments/evidence_packs/all18tables.yaml",
+        }
+        j = JobSpec.from_toml_section(section)
+        assert j.evidence_pack_manifest == "experiments/evidence_packs/all18tables.yaml"
 
 
 class TestLeaseInfo:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -239,6 +239,7 @@ def test_fanout_forwards_all_jobspec_fields(tmp_path: Path):
         f"num_ctx: 65536\n"
         f"temperature: 0.5\n"
         f"system_instruction: 'no web search'\n"
+        f"evidence_pack_manifest: experiments/evidence_packs/all18tables.yaml\n"
         f"output: outputs/test\n"
     )
     jobs_root = tmp_path / "jobs"
@@ -267,6 +268,7 @@ def test_fanout_forwards_all_jobspec_fields(tmp_path: Path):
     assert child.no_think is True
     assert child.provider_order == ["DeepSeek", "Alibaba"]
     assert child.num_ctx == 65536
+    assert child.evidence_pack_manifest == "experiments/evidence_packs/all18tables.yaml"
 
 
 def test_idempotency_across_dirs(tmp_path: Path):

--- a/tests/test_query_direct.py
+++ b/tests/test_query_direct.py
@@ -614,3 +614,102 @@ def test_sweep_propagates_system_instruction_to_messages(mock_openai_cls, tmp_pa
     assert len(json_files) == 1
     record = json.loads(json_files[0].read_text())
     assert record["system_instruction"] == sentinel
+
+
+@patch("aedist.harness.OpenAI")
+def test_sweep_evidence_pack_injection_only_when_configured(mock_openai_cls, tmp_path):
+    """Baseline sweep keeps prompt unchanged; intervention sweep appends evidence pack."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_mock_response()
+    mock_openai_cls.return_value = mock_client
+
+    models_path = _minimal_models_yaml(tmp_path)
+    prompt_path = _prompt_file(tmp_path)
+    output_arm1 = tmp_path / "out-arm1"
+    output_arm3 = tmp_path / "out-arm3"
+
+    corpus_dir = tmp_path / "data" / "rag_corpus"
+    corpus_dir.mkdir(parents=True)
+    (corpus_dir / "source.md").write_text("Installed capacity table")
+    manifest_path = tmp_path / "experiments" / "evidence_packs" / "mini.yaml"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        "source_root: data/rag_corpus\n"
+        "items:\n"
+        "  - source_id: demo_source\n"
+        "    file: source.md\n"
+        "    document_title: Demo\n"
+        "    section_title: Capacity\n"
+        "    source_type: primary\n"
+        "    relevance: baseline check\n"
+    )
+
+    experiments_path = tmp_path / "experiments.toml"
+    experiments_path.write_text(
+        "[sweeps.arm1]\n"
+        'system_instruction = "No web search"\n'
+        "\n"
+        "[sweeps.arm3]\n"
+        'system_instruction = "No web search"\n'
+        f'evidence_pack_manifest = "{manifest_path}"\n'
+    )
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query_direct",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_arm1),
+                "--sweep",
+                "arm1",
+                "--experiments",
+                str(experiments_path),
+            ],
+        ):
+            from aedist.query_direct import main
+
+            main()
+
+    arm1_call = mock_client.chat.completions.create.call_args
+    arm1_messages = arm1_call.kwargs.get("messages") or arm1_call[1].get("messages")
+    assert arm1_messages[1]["content"] == "List power plants."
+    arm1_record = json.loads(next(output_arm1.rglob("*.json")).read_text())
+    assert "evidence_pack_manifest" not in arm1_record
+
+    mock_client.chat.completions.create.reset_mock()
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "query_direct",
+                "--prompt",
+                str(prompt_path),
+                "--models",
+                str(models_path),
+                "--output",
+                str(output_arm3),
+                "--sweep",
+                "arm3",
+                "--experiments",
+                str(experiments_path),
+            ],
+        ):
+            from aedist.query_direct import main
+
+            main()
+
+    arm3_call = mock_client.chat.completions.create.call_args
+    arm3_messages = arm3_call.kwargs.get("messages") or arm3_call[1].get("messages")
+    assert "## Evidence Pack" in arm3_messages[1]["content"]
+    assert "source_id: demo_source" in arm3_messages[1]["content"]
+
+    arm3_record = json.loads(next(output_arm3.rglob("*.json")).read_text())
+    assert arm3_record["evidence_pack_manifest"] == str(manifest_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -383,6 +383,7 @@ def _harness_patches(tmp_path):
     return {
         "make_client": MagicMock(return_value=MagicMock()),
         "load_models": MagicMock(return_value=[{"name": "qwen3:8b"}]),
+        "append_evidence_pack": MagicMock(side_effect=lambda prompt, _: prompt),
         "query_model": MagicMock(return_value=_canned_single_result()),
         "compute_cost": MagicMock(return_value=0.0),
         "model_metadata": MagicMock(return_value={}),
@@ -978,11 +979,46 @@ def test_system_instruction_round_trip_in_execute(tmp_path: Path) -> None:
     messages = call_args[2]
     assert messages[0] == {"role": "system", "content": "Do not search the web."}
     assert messages[1]["role"] == "user"
-    assert messages[1]["content"] == "List thermal plants"
 
     # (b) save_json record carries system_instruction so evaluate.py can backfill
     saved = patches["save_json"].call_args[0][1]
     assert saved["system_instruction"] == "Do not search the web."
+
+
+def test_evidence_pack_manifest_injected_and_persisted(tmp_path: Path) -> None:
+    """JobSpec evidence_pack_manifest appends prompt content and is saved in raw output."""
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("List thermal plants")
+
+    job = JobSpec(
+        job_id="evpack-test",
+        priority=50,
+        mode=Method.SINGLE,
+        prompt=str(prompt_file),
+        models_file="models.yaml",
+        model_filter="qwen3:8b",
+        output_dir=str(tmp_path / "out"),
+        repeat=1,
+        budget_usd=1.0,
+        evidence_pack_manifest="experiments/evidence_packs/all18tables.yaml",
+    )
+
+    worker = PadmeWorker(jobs_root=tmp_path / "jobs")
+    patches = _harness_patches(tmp_path)
+    patches["append_evidence_pack"] = MagicMock(
+        side_effect=lambda prompt, _: prompt + "\n\n## Evidence Pack\n\nsource_id: demo"
+    )
+
+    with patch.multiple("aedist.worker", **patches):
+        worker.execute(job)
+
+    call_args = patches["query_model"].call_args[0]
+    messages = call_args[2]
+    assert "## Evidence Pack" in messages[-1]["content"]
+    assert messages[0]["content"].startswith("List thermal plants")
+
+    saved = patches["save_json"].call_args[0][1]
+    assert saved["evidence_pack_manifest"] == "experiments/evidence_packs/all18tables.yaml"
 
 
 def test_reasoning_effort_surfaced_in_record(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add shared prompt helper to append assembled evidence packs only when configured
- thread optional evidence_pack_manifest through JobSpec, worker dispatch, and query_direct sweep/CLI paths
- persist additive evidence_pack_manifest metadata in raw records and evaluate backfill
- add tests proving baseline no-op vs intervention injection and propagation through manager/worker

## Validation
- make check-fast

**Ticket:** tickets/0249-patch-experiment-3-runtime-to-inject-evidence-pack.erg