### PR TITLE
exp3: fix evidence-pack smoke gaps

### DIFF
--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -264,8 +264,8 @@ def _resolve_evidence_pack_manifest_path(manifest_path: str | Path) -> Path:
     for path in search_paths:
         if path.exists():
             return path
-    # Preserve deterministic error paths while still returning a sensible default.
-    return search_paths[0]
+    searched = ", ".join(str(path) for path in search_paths)
+    raise FileNotFoundError(f"Evidence-pack manifest not found. Searched: {searched}")
 
 
 def append_evidence_pack(prompt: str, manifest_path: str | Path | None) -> str:

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -147,16 +147,17 @@ def main():
         experiments = load_experiments(args.experiments)
         set_ids = experiments["sets"][args.model_set]["model_ids"]
         models = select_models(models, set_ids)
-        if args.sweep and system_instruction is None:
+        if args.sweep and (system_instruction is None or evidence_pack_manifest is None):
             sweep_section = experiments.get("sweeps", {}).get(args.sweep, {})
+        if args.sweep and system_instruction is None:
             system_instruction = sweep_section.get("system_instruction")
         if args.sweep and evidence_pack_manifest is None:
-            sweep_section = experiments.get("sweeps", {}).get(args.sweep, {})
             evidence_pack_manifest = sweep_section.get("evidence_pack_manifest")
-    elif args.sweep and system_instruction is None:
+    elif args.sweep and (system_instruction is None or evidence_pack_manifest is None):
         experiments = load_experiments(args.experiments)
         sweep_section = experiments.get("sweeps", {}).get(args.sweep, {})
-        system_instruction = sweep_section.get("system_instruction")
+        if system_instruction is None:
+            system_instruction = sweep_section.get("system_instruction")
         if evidence_pack_manifest is None:
             evidence_pack_manifest = sweep_section.get("evidence_pack_manifest")
 

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -399,6 +399,8 @@ class Worker:
         }
         if model_entry.get("reasoning_effort"):
             record["reasoning_effort"] = model_entry["reasoning_effort"]
+        if job and job.evidence_pack_manifest and job.mode not in (Method.MULTITURN,):
+            record["evidence_pack_manifest"] = job.evidence_pack_manifest
         if extra_fields:
             record.update(extra_fields)
         save_json(filepath, record)
@@ -528,6 +530,11 @@ class Worker:
                 "date": date.today().isoformat(),
                 "temperature": (api_kwargs or {}).get("temperature"),
                 "model_metadata": model_metadata(model_entry),
+                **(
+                    {"evidence_pack_manifest": job.evidence_pack_manifest}
+                    if job.evidence_pack_manifest
+                    else {}
+                ),
                 **conv,
             },
         )

--- a/tests/test_evidence_pack_assembly.py
+++ b/tests/test_evidence_pack_assembly.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
+import pytest
+
 from aedist.harness import (
     EVIDENCE_PACK_HEADER_FIELDS,
     EVIDENCE_PACK_SECTION_TITLE,
+    _resolve_evidence_pack_manifest_path,
     append_evidence_pack,
     assemble_evidence_pack,
 )
@@ -54,3 +57,45 @@ def test_append_evidence_pack_adds_section_when_manifest_set() -> None:
     assert combined.startswith(prompt)
     assert EVIDENCE_PACK_SECTION_TITLE in combined
     assert "source_id: evn_ar_2010_2011_capacities" in combined
+
+
+def test_resolve_evidence_pack_manifest_path_search_order(monkeypatch, tmp_path) -> None:
+    """Manifest resolution should accept cwd-relative, repo-relative, and experiments-relative paths."""
+    fake_repo = tmp_path / "repo"
+    fake_source = fake_repo / "src" / "aedist"
+    fake_source.mkdir(parents=True)
+    fake_harness = fake_source / "harness.py"
+    fake_harness.touch()
+    monkeypatch.setattr("aedist.harness.__file__", str(fake_harness))
+
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    cwd_manifest = cwd / "local.yaml"
+    cwd_manifest.write_text("cwd")
+    repo_manifest = fake_repo / "repo_only.yaml"
+    repo_manifest.write_text("repo")
+    experiments_manifest = fake_repo / "experiments" / "evidence_packs" / "exp_only.yaml"
+    experiments_manifest.parent.mkdir(parents=True)
+    experiments_manifest.write_text("experiments")
+
+    assert _resolve_evidence_pack_manifest_path("local.yaml") == cwd_manifest
+    assert _resolve_evidence_pack_manifest_path("repo_only.yaml") == repo_manifest
+    assert _resolve_evidence_pack_manifest_path("evidence_packs/exp_only.yaml") == experiments_manifest
+    assert _resolve_evidence_pack_manifest_path(experiments_manifest) == experiments_manifest
+
+
+def test_resolve_evidence_pack_manifest_path_missing(monkeypatch, tmp_path) -> None:
+    """Missing manifests should raise a clear FileNotFoundError listing searched paths."""
+    fake_repo = tmp_path / "repo"
+    fake_source = fake_repo / "src" / "aedist"
+    fake_source.mkdir(parents=True)
+    fake_harness = fake_source / "harness.py"
+    fake_harness.touch()
+    monkeypatch.setattr("aedist.harness.__file__", str(fake_harness))
+
+    (tmp_path / "cwd").mkdir()
+    monkeypatch.chdir(tmp_path / "cwd")
+    with pytest.raises(FileNotFoundError, match="Evidence-pack manifest not found"):
+        _resolve_evidence_pack_manifest_path("missing.yaml")

--- a/tests/test_query_direct.py
+++ b/tests/test_query_direct.py
@@ -618,15 +618,19 @@ def test_sweep_propagates_system_instruction_to_messages(mock_openai_cls, tmp_pa
 
 @patch("aedist.harness.OpenAI")
 def test_sweep_evidence_pack_injection_only_when_configured(mock_openai_cls, tmp_path):
-    """Baseline sweep keeps prompt unchanged; intervention sweep appends evidence pack."""
+    """All four arms should keep baseline prompts unchanged for Arms 1/2 and append the pack for Arms 3/4."""
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = _make_mock_response()
     mock_openai_cls.return_value = mock_client
 
+    from pytest import MonkeyPatch
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.chdir(tmp_path)
+
     models_path = _minimal_models_yaml(tmp_path)
     prompt_path = _prompt_file(tmp_path)
-    output_arm1 = tmp_path / "out-arm1"
-    output_arm3 = tmp_path / "out-arm3"
+    outputs = {arm: tmp_path / f"out-arm{arm}" for arm in range(1, 5)}
 
     corpus_dir = tmp_path / "data" / "rag_corpus"
     corpus_dir.mkdir(parents=True)
@@ -649,67 +653,66 @@ def test_sweep_evidence_pack_injection_only_when_configured(mock_openai_cls, tmp
         "[sweeps.arm1]\n"
         'system_instruction = "No web search"\n'
         "\n"
+        "[sweeps.arm2]\n"
+        'system_instruction = "No web search"\n'
+        "\n"
         "[sweeps.arm3]\n"
+        'system_instruction = "No web search"\n'
+        "evidence_pack_manifest = \"experiments/evidence_packs/mini.yaml\"\n"
+        "\n"
+        "[sweeps.arm4]\n"
         'system_instruction = "No web search"\n'
         f'evidence_pack_manifest = "{manifest_path}"\n'
     )
 
-    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(
-            sys,
-            "argv",
-            [
-                "query_direct",
-                "--prompt",
-                str(prompt_path),
-                "--models",
-                str(models_path),
-                "--output",
-                str(output_arm1),
-                "--sweep",
-                "arm1",
-                "--experiments",
-                str(experiments_path),
-            ],
-        ):
-            from aedist.query_direct import main
+    def run_sweep(sweep_name: str, output_dir: Path) -> tuple[list[dict], dict]:
+        mock_client.chat.completions.create.reset_mock()
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "query_direct",
+                    "--prompt",
+                    str(prompt_path),
+                    "--models",
+                    str(models_path),
+                    "--output",
+                    str(output_dir),
+                    "--sweep",
+                    sweep_name,
+                    "--experiments",
+                    str(experiments_path),
+                ],
+            ):
+                from aedist.query_direct import main
 
-            main()
+                main()
 
-    arm1_call = mock_client.chat.completions.create.call_args
-    arm1_messages = arm1_call.kwargs.get("messages") or arm1_call[1].get("messages")
-    assert arm1_messages[1]["content"] == "List power plants."
-    arm1_record = json.loads(next(output_arm1.rglob("*.json")).read_text())
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs.get("messages") or call_args[1].get("messages")
+        record = json.loads(next(output_dir.rglob("*.json")).read_text())
+        return messages, record
+
+    arm1_messages, arm1_record = run_sweep("arm1", outputs[1])
+    arm2_messages, arm2_record = run_sweep("arm2", outputs[2])
+    arm3_messages, arm3_record = run_sweep("arm3", outputs[3])
+    arm4_messages, arm4_record = run_sweep("arm4", outputs[4])
+
+    baseline_prompt = "List power plants."
+    assert arm1_messages[1]["content"] == baseline_prompt
+    assert arm2_messages[1]["content"] == baseline_prompt
+    assert arm1_messages[1]["content"] == arm2_messages[1]["content"]
     assert "evidence_pack_manifest" not in arm1_record
+    assert "evidence_pack_manifest" not in arm2_record
 
-    mock_client.chat.completions.create.reset_mock()
+    for messages, record in ((arm3_messages, arm3_record), (arm4_messages, arm4_record)):
+        assert messages[1]["content"].startswith(baseline_prompt)
+        assert "## Evidence Pack" in messages[1]["content"]
+        assert "source_id: demo_source" in messages[1]["content"]
+        assert record["evidence_pack_manifest"] in {
+            "experiments/evidence_packs/mini.yaml",
+            str(manifest_path),
+        }
 
-    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "fake-key"}):
-        with patch.object(
-            sys,
-            "argv",
-            [
-                "query_direct",
-                "--prompt",
-                str(prompt_path),
-                "--models",
-                str(models_path),
-                "--output",
-                str(output_arm3),
-                "--sweep",
-                "arm3",
-                "--experiments",
-                str(experiments_path),
-            ],
-        ):
-            from aedist.query_direct import main
-
-            main()
-
-    arm3_call = mock_client.chat.completions.create.call_args
-    arm3_messages = arm3_call.kwargs.get("messages") or arm3_call[1].get("messages")
-    assert "## Evidence Pack" in arm3_messages[1]["content"]
-    assert "source_id: demo_source" in arm3_messages[1]["content"]
-
-    arm3_record = json.loads(next(output_arm3.rglob("*.json")).read_text())
-    assert arm3_record["evidence_pack_manifest"] == str(manifest_path)
+    monkeypatch.undo()


### PR DESCRIPTION
## Summary
- make evidence-pack manifest resolution fail loudly with searched paths
- preserve `evidence_pack_manifest` in worker raw outputs across query modes
- expand the Experiment 3 smoke-style tests to cover arms 1-4

## Validation
- `make check-fast`

**Ticket:** tickets/0251-patch-experiment-3-review-gaps.erg