### PR TITLE
chore: healthcheck fixes — STATE.md cleanup + ticket 0252

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-05-23T16:30Z
+Last updated: 2026-05-23T18:05Z
 
 ## North star
 
@@ -32,9 +32,7 @@ Milestones in order:
 
 ## Backlog (post-conference)
 
-1. **Tooling** — 0203/0204 raid follow-ups still open.
-2. **Scaling-curve diagnosis** — direct_complete F1=0 on 3 capable models; likely parser failure on structured-document output.
-3. **Registry / figures infrastructure** — 0156→0160.
+1. **Scaling-curve diagnosis** — direct_complete F1=0 on 3 capable models; likely parser failure on structured-document output.
 
 ## Suspended / deferred
 

--- a/tickets/0252-check-fast-excludes-slow-integration-markers.erg
+++ b/tickets/0252-check-fast-excludes-slow-integration-markers.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: Fix make check-fast to exclude slow/integration markers
+Created: 2026-05-23
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-23T18:05Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`make check-fast` is defined as `test lint` with no marker filtering.
+1467 tests are collected, including `@pytest.mark.integration` (subprocess/sleep)
+and `@pytest.mark.slow` (network/real-data) tests.
+The project rule requires check-fast to complete in < 30 s, but the suite
+times out at 60 s in the healthcheck probe and likely takes much longer.
+
+## Root cause
+
+`Makefile` `check-fast` target runs bare `uv run pytest` (via `test`),
+which collects all 1467 tests. The markers are registered in `pyproject.toml`
+but not applied as excludes in the fast target.
+
+## Exit criteria
+
+- [ ] `make check-fast` runs in < 30 s on a warm machine
+- [ ] `make check-fast` excludes `integration` and `slow` markers
+- [ ] `make check` continues to run the full suite (no change)
+- [ ] `make check-fast` passes in CI (ticket/STATE-only diffs bypass CI, so verify locally)
+
+## Proposed fix
+
+In `Makefile`, split the `test` target or add a `test-fast` target:
+
+```makefile
+test-fast:
+	uv run pytest -m "not integration and not slow"
+
+test:
+	uv run pytest
+
+check-fast: test-fast lint
+
+check: test lint
+```


### PR DESCRIPTION
## Summary

- Remove stale backlog entries from STATE.md: tickets 0203, 0204, 0156, 0160 are all closed
- Open ticket 0252: `make check-fast` runs all 1467 tests with no marker filtering — suite exceeds 60 s; fix is `-m "not integration and not slow"`

## Test plan

- [ ] STATE.md backlog section no longer references closed tickets
- [ ] Ticket 0252 file present at `tickets/0252-check-fast-excludes-slow-integration-markers.erg`
- [ ] CI passes (ticket/STATE-only diff, skips lint/tests via path-filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)