### PR TITLE
fix(make): check-fast now excludes integration and slow markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,12 @@ MEASUREMENTS := measurements.jsonl
 GEN          := report/inputs/generated
 SLIDE_GEN    := slides/inputs/generated
 
-.PHONY: test lint check-fast check census census-summary show-prompts
+.PHONY: test test-fast lint check-fast check census census-summary show-prompts
 
 # --- Tests --------------------------------------------------------------------
+
+test-fast:
+	uv run pytest -m "not integration and not slow"
 
 test:
 	uv run pytest
@@ -20,7 +23,7 @@ lint:
 	uv run ruff check src/ tests/ scripts/
 	uv run python scripts/check_ticket_structure.py
 
-check-fast: test lint
+check-fast: test-fast lint
 
 check: test lint
 

--- a/tickets/closed/0252-check-fast-excludes-slow-integration-markers.erg
+++ b/tickets/closed/0252-check-fast-excludes-slow-integration-markers.erg
@@ -2,10 +2,12 @@
 Title: Fix make check-fast to exclude slow/integration markers
 Created: 2026-05-23
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #467
 
 --- log ---
 2026-05-23T18:05Z HDMX-coding-agent created
 
+2026-05-23T19:08Z HDMX-coding-agent closed — autoclosed — PR #467
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add `test-fast` target: `uv run pytest -m "not integration and not slow"`
- Wire `check-fast` to `test-fast lint` instead of `test lint`
- `make check` unchanged — still runs the full 1467-test suite

Result: `make check-fast` completes in ~17 s (was timing out at 60 s+).

**Ticket:** tickets/0252-check-fast-excludes-slow-integration-markers.erg

## Test plan

- [x] `make check-fast` runs in ~17 s locally (1460 passed, 5 deselected)
- [x] `make check-fast` lint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)