### PR TITLE
exp3: evidence-pack assembler format + Arm 3/4 script patches

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -37,6 +37,7 @@ from pathlib import Path
 import yaml
 
 from aedist import adapter_mistral
+from aedist.harness import append_evidence_pack
 from aedist.schema import Method, MethodParams, ResourceUse, ResultSummary, RunRecord
 from experiments.sota import dialogue_classifier
 
@@ -1300,6 +1301,7 @@ def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
         if isinstance(designed_prompt_raw, str)
         else json.dumps(designed_prompt_raw, indent=2, ensure_ascii=False)
     )
+    designed_prompt = append_evidence_pack(designed_prompt, args.evidence_pack_manifest)
     requested_max_tokens = int(
         design.get("settings", {}).get("max_tokens") or args.phase_b_max_tokens
     )
@@ -1385,6 +1387,14 @@ def main(argv: list[str] | None = None) -> int:
         metavar="DIR",
         help="Load Phase A design from DIR/<agent>_run01/ instead of calling the "
         "Phase A API. Use for reps 2–N to reuse the rep-1 design.",
+    )
+    p.add_argument(
+        "--evidence-pack-manifest",
+        type=str,
+        default=None,
+        metavar="YAML",
+        help="Path to an evidence-pack manifest YAML (Arm 4). Injected into the Phase B "
+        "prompt only. Omit for Arm 2 baseline.",
     )
     args = p.parse_args(argv)
 

--- a/experiments/sota/exp2_naive_arm.py
+++ b/experiments/sota/exp2_naive_arm.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import yaml
 
+from aedist.harness import append_evidence_pack
 from experiments.sota import dialogue_classifier
 from experiments.sota.exp2_interactive_smoke import strip_meta_framing
 
@@ -281,11 +282,19 @@ def main(argv: list[str] | None = None) -> int:
         help="Replications per agent (default 1 for probe; 5 for production batch).",
     )
     p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument(
+        "--evidence-pack-manifest",
+        type=str,
+        default=None,
+        metavar="YAML",
+        help="Path to an evidence-pack manifest YAML (Arm 3). Omit for Arm 1 baseline.",
+    )
     args = p.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
     prompt = load_naive_prompt()
+    prompt = append_evidence_pack(prompt, args.evidence_pack_manifest)
     log.info("Naive prompt loaded: %d chars from %s", len(prompt), NAIVE_PROMPT_PATH)
 
     summary: list[dict] = []
@@ -318,6 +327,11 @@ def main(argv: list[str] | None = None) -> int:
                 "cost_usd": round(result["cost_usd"], 4),
                 "classifier_cost_usd": round(cls_result.classifier_cost_usd, 6),
                 "narrative_chars": len(result["narrative"]),
+                **(
+                    {"evidence_pack_manifest": args.evidence_pack_manifest}
+                    if args.evidence_pack_manifest
+                    else {}
+                ),
             }
             (args.output_dir / f"{tag}.json").write_text(
                 json.dumps(meta_record, indent=2),

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -153,7 +153,7 @@ EVIDENCE_PACK_HEADER_FIELDS = (
     "relevance",
 )
 
-EVIDENCE_PACK_SECTION_TITLE = "## Evidence Pack"
+EVIDENCE_PACK_SECTION_TITLE = "# Evidence pack"
 
 
 def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
@@ -224,13 +224,22 @@ def assemble_evidence_pack(manifest_path: Path) -> str:
         raise ValueError(f"Invalid manifest at {manifest_path}: missing source_root")
     corpus_root = _resolve_manifest_source_root(manifest_path, source_root)
 
+    items = manifest["items"]
+    manifest_lines = [
+        "These are manually curated primary sources meant to boost but not replace your own deep research.",
+        "",
+    ]
+    for index, item in enumerate(items, start=1):
+        manifest_lines.append(f"{index}. {item['source_id']} — {item.get('document_title', '')}")
+    preamble = "\n".join(manifest_lines)
+
     blocks: list[str] = []
-    for item in manifest["items"]:
+    for index, item in enumerate(items, start=1):
         source_path = corpus_root / str(item["file"])
         if not source_path.exists():
             raise FileNotFoundError(f"Evidence-pack source file not found: {source_path}")
 
-        block_lines = ["## Source Block"]
+        block_lines = [f"## Chunk {index}"]
         block_lines.extend(
             [f"{field}: {item.get(field, '')}" for field in EVIDENCE_PACK_HEADER_FIELDS]
         )
@@ -239,7 +248,7 @@ def assemble_evidence_pack(manifest_path: Path) -> str:
         block_lines.append("<<<END_SOURCE_TEXT>>>")
         blocks.append("\n".join(block_lines))
 
-    return "\n\n".join(blocks)
+    return preamble + "\n\n" + "\n\n".join(blocks)
 
 
 def _resolve_evidence_pack_manifest_path(manifest_path: str | Path) -> Path:

--- a/tests/test_evidence_pack_assembly.py
+++ b/tests/test_evidence_pack_assembly.py
@@ -32,8 +32,8 @@ def test_assemble_evidence_pack_has_stable_headers_and_expected_source_blocks() 
     """Every source block has stable headers and includes expected source_id blocks."""
     assembled = assemble_evidence_pack(MANIFEST_PATH)
 
-    # Manifest has 18 source blocks.
-    assert assembled.count("## Source Block") == 18
+    # Manifest has 18 chunks.
+    assert assembled.count("## Chunk ") == 18
 
     for field in EVIDENCE_PACK_HEADER_FIELDS:
         assert assembled.count(f"{field}:") >= 18
@@ -82,7 +82,10 @@ def test_resolve_evidence_pack_manifest_path_search_order(monkeypatch, tmp_path)
 
     assert _resolve_evidence_pack_manifest_path("local.yaml") == cwd_manifest
     assert _resolve_evidence_pack_manifest_path("repo_only.yaml") == repo_manifest
-    assert _resolve_evidence_pack_manifest_path("evidence_packs/exp_only.yaml") == experiments_manifest
+    assert (
+        _resolve_evidence_pack_manifest_path("evidence_packs/exp_only.yaml")
+        == experiments_manifest
+    )
     assert _resolve_evidence_pack_manifest_path(experiments_manifest) == experiments_manifest
 
 

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -1374,3 +1374,167 @@ def test_state_machine_qwen_dispatch_chains_messages(monkeypatch, tmp_path):
     assert msgs[2] == {"role": "assistant", "content": "reply-1"}
     # SYSTEM_PROMPT_PASSTHROUGH=True for Qwen — system re-sent on turn 2.
     assert call_log[1]["system_prompt"] == "designed system text"
+
+
+# ---------------------------------------------------------------------------
+# Regression guards — must pass before and after the --evidence-pack-manifest patch
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "experiments" / "evidence_packs" / "all18tables.yaml"
+
+FAKE_DESIGN = {
+    "designed_prompt": "Extract thermal plants from the documents.",
+    "system_prompt": "You are an energy data analyst.",
+    "settings": {"max_tokens": 4000},
+}
+
+FAKE_PHASE_B_RESULT = {
+    "turns": 2,
+    "total_spent_usd": 0.05,
+    "records": [],
+}
+
+
+@pytest.fixture()
+def phase_a_reuse_dir(tmp_path):
+    """Minimal Phase A reuse dir for mistral_run01 — skips Phase A API call."""
+    reuse = tmp_path / "phase_a_probes" / "mistral_run01"
+    reuse.mkdir(parents=True)
+    (reuse / "mistral_phase_a_design.json").write_text(json.dumps(FAKE_DESIGN), encoding="utf-8")
+    for fname in ("mistral_phase_a.json", "mistral_phase_a.raw.json"):
+        (reuse / fname).write_bytes(b"{}")
+    return tmp_path / "phase_a_probes"
+
+
+@pytest.fixture()
+def patched_phase_b(monkeypatch):
+    """Capture the prompt passed to run_phase_b_multiturn; suppress downstream reads."""
+    import experiments.sota.exp2_interactive_smoke as mod
+
+    captured: dict = {}
+
+    def fake_phase_b(prompt, **kwargs):
+        captured["prompt"] = prompt
+        return FAKE_PHASE_B_RESULT
+
+    monkeypatch.setattr(mod, "run_phase_b_multiturn", fake_phase_b)
+    monkeypatch.setattr(mod, "_read_turn_field", lambda *_a, **_k: ["report"])
+    monkeypatch.setattr(mod, "_estimate_inventory_rows", lambda *_a, **_k: 5)
+    return captured
+
+
+def test_main_dry_run_exits_zero(tmp_path):
+    from experiments.sota.exp2_interactive_smoke import main
+
+    ret = main(["--agents", "mistral", "--dry-run", "--no-confirm", "--output-dir", str(tmp_path)])
+    assert ret == 0
+
+
+def test_main_without_manifest_phase_b_gets_raw_designed_prompt(
+    phase_a_reuse_dir, patched_phase_b, tmp_path
+):
+    from experiments.sota.exp2_interactive_smoke import main
+
+    main(
+        [
+            "--agents",
+            "mistral",
+            "--reuse-phase-a-from",
+            str(phase_a_reuse_dir),
+            "--no-confirm",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    assert patched_phase_b["prompt"] == FAKE_DESIGN["designed_prompt"]
+
+
+# ---------------------------------------------------------------------------
+# TDD tests — currently FAILING; pass after the --evidence-pack-manifest patch
+# ---------------------------------------------------------------------------
+
+
+def test_main_accepts_evidence_pack_manifest_flag(phase_a_reuse_dir, patched_phase_b, tmp_path):
+    from experiments.sota.exp2_interactive_smoke import main
+
+    ret = main(
+        [
+            "--agents",
+            "mistral",
+            "--reuse-phase-a-from",
+            str(phase_a_reuse_dir),
+            "--no-confirm",
+            "--output-dir",
+            str(tmp_path),
+            "--evidence-pack-manifest",
+            str(MANIFEST_PATH),
+        ]
+    )
+    assert ret == 0
+
+
+def test_phase_b_prompt_contains_evidence_pack_when_manifest_set(
+    phase_a_reuse_dir, patched_phase_b, tmp_path
+):
+    from experiments.sota.exp2_interactive_smoke import main
+
+    main(
+        [
+            "--agents",
+            "mistral",
+            "--reuse-phase-a-from",
+            str(phase_a_reuse_dir),
+            "--no-confirm",
+            "--output-dir",
+            str(tmp_path),
+            "--evidence-pack-manifest",
+            str(MANIFEST_PATH),
+        ]
+    )
+    assert "# Evidence pack" in patched_phase_b["prompt"]
+    assert "Chunk 1" in patched_phase_b["prompt"]
+    assert FAKE_DESIGN["designed_prompt"] in patched_phase_b["prompt"]
+
+
+def test_phase_b_prompt_not_augmented_without_manifest(
+    phase_a_reuse_dir, patched_phase_b, tmp_path
+):
+    from experiments.sota.exp2_interactive_smoke import main
+
+    main(
+        [
+            "--agents",
+            "mistral",
+            "--reuse-phase-a-from",
+            str(phase_a_reuse_dir),
+            "--no-confirm",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    assert "# Evidence pack" not in patched_phase_b["prompt"]
+
+
+def test_meta_prompt_not_augmented_with_evidence_pack(
+    phase_a_reuse_dir, patched_phase_b, tmp_path
+):
+    """Phase A meta-prompt must NOT contain the evidence pack even when manifest is set."""
+    from experiments.sota.exp2_interactive_smoke import main
+
+    main(
+        [
+            "--agents",
+            "mistral",
+            "--reuse-phase-a-from",
+            str(phase_a_reuse_dir),
+            "--no-confirm",
+            "--output-dir",
+            str(tmp_path),
+            "--evidence-pack-manifest",
+            str(MANIFEST_PATH),
+        ]
+    )
+    meta_prompt_file = tmp_path / "mistral_run01" / "mistral_meta_prompt.txt"
+    assert meta_prompt_file.exists()
+    assert "# Evidence pack" not in meta_prompt_file.read_text()

--- a/tests/test_exp2_naive_arm.py
+++ b/tests/test_exp2_naive_arm.py
@@ -1,6 +1,10 @@
 import json
 import re
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 
 from experiments.sota import exp2_naive_arm
 from experiments.sota.exp2_naive_arm import _write_summary_md
@@ -52,3 +56,124 @@ def test_probe_mistral_parses_flat_string_content(monkeypatch, tmp_path):
 
     assert result["narrative"] == "stub narrative"
     assert result["cost_usd"] == 0.12
+
+
+# ---------------------------------------------------------------------------
+# Regression guards — must pass before and after the --evidence-pack-manifest patch
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "experiments" / "evidence_packs" / "all18tables.yaml"
+
+
+def _fake_result() -> dict:
+    return {
+        "narrative": "## Inventory\n| Plant | Cap |\n|---|---|\n| TestPlant | 500 MW |",
+        "cost_usd": 0.01,
+        "tokens_out": 50,
+        "wall_s": 1.0,
+        "model": "test-model-id",
+    }
+
+
+@pytest.fixture()
+def patched_probers(monkeypatch):
+    """Replace all probers with stubs; return dict mapping agent → prompt received."""
+    from experiments.sota import dialogue_classifier
+
+    captured: dict[str, str] = {}
+
+    def make_prober(name: str):
+        def prober(prompt: str, output_dir: Path) -> dict:
+            captured[name] = prompt
+            return _fake_result()
+
+        return prober
+
+    monkeypatch.setattr(
+        exp2_naive_arm, "PROBERS", {a: make_prober(a) for a in exp2_naive_arm.AGENTS}
+    )
+
+    mock_cls = MagicMock()
+    mock_cls.class_ = "report"
+    mock_cls.classifier_cost_usd = 0.0
+    monkeypatch.setattr(dialogue_classifier, "classify_report", lambda _: mock_cls)
+
+    return captured
+
+
+def test_load_naive_prompt_returns_nonempty_string():
+    prompt = exp2_naive_arm.load_naive_prompt()
+    assert isinstance(prompt, str) and len(prompt) > 100
+
+
+def test_load_naive_prompt_strips_meta_framing():
+    prompt = exp2_naive_arm.load_naive_prompt()
+    assert not prompt.startswith("This is the prompt")
+    assert not prompt.startswith("---")
+
+
+def test_main_without_manifest_passes_baseline_prompt(patched_probers, tmp_path):
+    expected = exp2_naive_arm.load_naive_prompt()
+    exp2_naive_arm.main(["--agents", "mistral", "--n", "1", "--output-dir", str(tmp_path)])
+    assert patched_probers["mistral"] == expected
+
+
+# ---------------------------------------------------------------------------
+# TDD tests — currently FAILING; pass after the --evidence-pack-manifest patch
+# ---------------------------------------------------------------------------
+
+
+def test_main_accepts_evidence_pack_manifest_flag(patched_probers, tmp_path):
+    ret = exp2_naive_arm.main(
+        [
+            "--agents",
+            "mistral",
+            "--n",
+            "1",
+            "--output-dir",
+            str(tmp_path),
+            "--evidence-pack-manifest",
+            str(MANIFEST_PATH),
+        ]
+    )
+    assert ret == 0
+
+
+def test_main_with_manifest_augments_prompt(patched_probers, tmp_path):
+    exp2_naive_arm.main(
+        [
+            "--agents",
+            "mistral",
+            "--n",
+            "1",
+            "--output-dir",
+            str(tmp_path),
+            "--evidence-pack-manifest",
+            str(MANIFEST_PATH),
+        ]
+    )
+    assert "# Evidence pack" in patched_probers["mistral"]
+    assert "Chunk 1" in patched_probers["mistral"]
+
+
+def test_main_without_manifest_prompt_not_augmented(patched_probers, tmp_path):
+    exp2_naive_arm.main(["--agents", "mistral", "--n", "1", "--output-dir", str(tmp_path)])
+    assert "# Evidence pack" not in patched_probers["mistral"]
+
+
+def test_meta_record_includes_manifest_when_set(patched_probers, tmp_path):
+    exp2_naive_arm.main(
+        [
+            "--agents",
+            "mistral",
+            "--n",
+            "1",
+            "--output-dir",
+            str(tmp_path),
+            "--evidence-pack-manifest",
+            str(MANIFEST_PATH),
+        ]
+    )
+    record = json.loads((tmp_path / "mistral.json").read_text())
+    assert record.get("evidence_pack_manifest") == str(MANIFEST_PATH)

--- a/tests/test_query_direct.py
+++ b/tests/test_query_direct.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from aedist.harness import EVIDENCE_PACK_SECTION_TITLE
 from aedist.harness import build_api_kwargs as _real_build_api_kwargs
 
 
@@ -658,7 +659,7 @@ def test_sweep_evidence_pack_injection_only_when_configured(mock_openai_cls, tmp
         "\n"
         "[sweeps.arm3]\n"
         'system_instruction = "No web search"\n'
-        "evidence_pack_manifest = \"experiments/evidence_packs/mini.yaml\"\n"
+        'evidence_pack_manifest = "experiments/evidence_packs/mini.yaml"\n'
         "\n"
         "[sweeps.arm4]\n"
         'system_instruction = "No web search"\n'
@@ -708,7 +709,7 @@ def test_sweep_evidence_pack_injection_only_when_configured(mock_openai_cls, tmp
 
     for messages, record in ((arm3_messages, arm3_record), (arm4_messages, arm4_record)):
         assert messages[1]["content"].startswith(baseline_prompt)
-        assert "## Evidence Pack" in messages[1]["content"]
+        assert EVIDENCE_PACK_SECTION_TITLE in messages[1]["content"]
         assert "source_id: demo_source" in messages[1]["content"]
         assert record["evidence_pack_manifest"] in {
             "experiments/evidence_packs/mini.yaml",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aedist.harness import (
+    EVIDENCE_PACK_SECTION_TITLE,  # used in test_evidence_pack_manifest_injected_and_persisted
+)
 from aedist.schema import JobSpec, Method
 from aedist.worker import OpenRouterWorker, PadmeWorker, Worker
 
@@ -1006,7 +1009,9 @@ def test_evidence_pack_manifest_injected_and_persisted(tmp_path: Path) -> None:
     worker = PadmeWorker(jobs_root=tmp_path / "jobs")
     patches = _harness_patches(tmp_path)
     patches["append_evidence_pack"] = MagicMock(
-        side_effect=lambda prompt, _: prompt + "\n\n## Evidence Pack\n\nsource_id: demo"
+        side_effect=lambda prompt, _: (
+            prompt + f"\n\n{EVIDENCE_PACK_SECTION_TITLE}\n\nsource_id: demo"
+        )
     )
 
     with patch.multiple("aedist.worker", **patches):
@@ -1014,7 +1019,7 @@ def test_evidence_pack_manifest_injected_and_persisted(tmp_path: Path) -> None:
 
     call_args = patches["query_model"].call_args[0]
     messages = call_args[2]
-    assert "## Evidence Pack" in messages[-1]["content"]
+    assert EVIDENCE_PACK_SECTION_TITLE in messages[-1]["content"]
     assert messages[0]["content"].startswith("List thermal plants")
 
     saved = patches["save_json"].call_args[0][1]


### PR DESCRIPTION
## Summary

- **Assembler format** (`harness.py`): evidence pack now opens with `# Evidence pack` (level-1 header), an introductory sentence explaining these are manually curated primary sources to boost but not replace the model's own research, a numbered manifest of all 18 sources, then `## Chunk N` blocks (was `## Source Block`).
- **Arm 3** (`exp2_naive_arm.py`): `--evidence-pack-manifest` flag appends the pack to the naive prompt before dispatch; field recorded in per-run JSON.
- **Arm 4** (`exp2_interactive_smoke.py`): `--evidence-pack-manifest` flag appends the pack to the Phase B designed prompt only — Phase A meta-prompt is explicitly not augmented.
- **Freeze tag** `arm1-arm2-scripts-frozen` at `2b34f91` anchors the exact scripts used for the frozen Arm 1/2 baselines.

## Test plan

- [x] `uv run pytest tests/test_evidence_pack_assembly.py` — assembler format (6 tests)
- [x] `uv run pytest tests/test_exp2_naive_arm.py` — naive arm regression + TDD (8 tests)
- [x] `uv run pytest tests/test_exp2_interactive_smoke.py` — interactive smoke regression + TDD (67 tests total)
- [x] `make check-fast` passes (1478 passed, 0 failures)

**Ticket:** tickets/0249-patch-experiment-3-runtime-to-inject-evidence-pack.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)