### PR TITLE
tickets: close 0249 and 0202, unblock 0200 and 0250

### DIFF
--- a/tickets/0200-case-study-tailored-solution-spec-and-run.erg
+++ b/tickets/0200-case-study-tailored-solution-spec-and-run.erg
@@ -2,12 +2,12 @@
 Title: Case study — §5 tailored solution: spec and demonstration (time permitting)
 Created: 2026-05-21
 Author: claude
-Blocked-by: 0202
 
 --- log ---
 2026-05-21T12:25Z claude created — replacement for closed 0153 (Exp 3 leg)
 2026-05-21T13:55Z claude note retitled "Experiment 3 → Case study" and added Blocked-by 0202 per design dialogue 2026-05-21: talk narrative is "three experiments and a case study (if we get to it in time)". Exp 3 is now 0202 (reconstruction-from-verified-bibliography sweep, §3 territory); this ticket remains the §5 stateful production demonstration, downgraded to time-permitting case-study status. Architecturally convergent with 0202 (shared state object, shared verified bibliography, shared starting state) but a separate ticket per Reading 1. File renamed 0200-exp3-... → 0200-case-study-... .
 
+2026-05-23T20:11Z HDMX-coding-agent note blocker 0202 closed — Blocked-by removed.
 --- body ---
 
 ## Context

--- a/tickets/0250-run-experiment-3-four-arm-sweep.erg
+++ b/tickets/0250-run-experiment-3-four-arm-sweep.erg
@@ -2,11 +2,11 @@
 Title: Run Experiment 3 intervention arms
 Created: 2026-05-23
 Author: Copilot
-Blocked-by: 0249
 
 --- log ---
 2026-05-23T16:02Z Copilot created
 
+2026-05-23T20:11Z HDMX-coding-agent note blocker 0249 closed — Blocked-by removed.
 --- body ---
 ## Context
 The Experiment 3 protocol is drafted and the implementation path is split into an assembler prerequisite and a runtime patch. This ticket covers the actual Experiment 3 runs after the codebase patch lands. Arms 1 and 2 are reused as existing baselines; they are not rerun.

--- a/tickets/closed/0202-exp3-reconstruction-from-verified-bibliography.erg
+++ b/tickets/closed/0202-exp3-reconstruction-from-verified-bibliography.erg
@@ -2,6 +2,7 @@
 Title: Experiment 3 — reconstruction from verified bibliography (5 strategies × 5 models)
 Created: 2026-05-21
 Author: claude
+Closed: superseded — Exp 3 redesigned as Arms 3/4; live ticket 0250
 
 --- log ---
 2026-05-21T13:30Z claude created — replaces the §3 regimes-ladder portion of closed 0153; supersedes 0135
@@ -11,6 +12,7 @@ Author: claude
 2026-05-21T17:00Z HDMX-coding-agent note imported the two artefacts into main as tests/fixtures/exp3_source_mistral_report.md and tests/fixtures/exp3_source_mistral_citations.json — durable on main, no dependency on rebuild-exp2-smoke branch for 0202 to start
 2026-05-21T18:00Z HDMX-coding-agent note clarification — 120 citation entries → 42 unique URLs (Mistral repeats URLs across cited passages). Document store for reconstruction itself is already on main at data/rag_corpus/ (18 primary-source markdown files); the bibliography is just the candidate URL list to classify
 
+2026-05-23T20:11Z HDMX-coding-agent closed — superseded — Exp 3 redesigned as Arms 3/4; live ticket 0250
 --- body ---
 
 ## Context

--- a/tickets/closed/0249-patch-experiment-3-runtime-to-inject-evidence-pack.erg
+++ b/tickets/closed/0249-patch-experiment-3-runtime-to-inject-evidence-pack.erg
@@ -2,13 +2,14 @@
 Title: Patch Experiment 3 runtime to inject evidence pack
 Created: 2026-05-23
 Author: Copilot
-Blocked-by: 0248
+Closed: autoclosed — PR #468
 
 --- log ---
 2026-05-23T16:02Z Copilot created
 2026-05-23T16:05Z Copilot note Patch should use a shared helper with a no-op default; baseline arms stay unchanged and arms 3/4 opt in through config.
 2026-05-23T16:06Z Copilot note The authoritative output record format is the shared RunRecord/measurements.jsonl path; any extra evidence-pack metadata must be additive.
 
+2026-05-23T20:11Z HDMX-coding-agent closed — autoclosed — PR #468
 --- body ---
 ## Context
 The evidence-pack assembler is its own prerequisite. This ticket is the codebase patch that threads the assembled pack into the Experiment 3 runtime so the intervention arms can use it.


### PR DESCRIPTION
## Summary

Ticket housekeeping following PR #468 merge:

- `0249`: closed, moved to `tickets/closed/`, stale `Blocked-by: 0248` removed
- `0202`: closed as superseded (Exp 3 redesigned as Arms 3/4), moved to `tickets/closed/`
- `0200`: stale `Blocked-by: 0202` removed (0202 now closed)
- `0250`: stale `Blocked-by: 0249` removed (unblocked — ready for Arm 3/4 runs)

These changes were committed on the PR branch during the #468 cycle but weren't captured in the squash commit. Housekeeping-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)