### PR TITLE
fix(exp3): persist full conversation history in run_phase_b_multiturn

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -968,6 +968,13 @@ def run_phase_b_multiturn(
     encouragement_count = 0
     total_classifier_cost_usd = 0.0
     turn = 1
+    # Client-side conversation log — agent-agnostic. Stateful APIs (Mistral,
+    # OpenAI) do not resend history on each call, so this is the only locally
+    # persisted copy of the full exchange. Updated and saved after every turn.
+    conversation_history: list[dict] = []
+    if system_prompt:
+        conversation_history.append({"role": "system", "content": system_prompt})
+    conversation_path = output_dir / f"{agent}_conversation.json"
     last_slot = "designed_prompt"
     pending_reply = ""  # populated after each turn's classification
 
@@ -1036,6 +1043,12 @@ def run_phase_b_multiturn(
         # Classify the assistant's response. Classifier cost is harness
         # overhead, tracked separately from the SOTA agent's spend.
         narrative = _narrative_from_record_or_raw(record, paths["raw"])
+        conversation_history.append({"role": "user", "content": user_text})
+        conversation_history.append({"role": "assistant", "content": narrative})
+        conversation_path.write_text(
+            json.dumps({"messages": conversation_history}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
         cls_result = dialogue_classifier.classify_report(narrative)
         total_classifier_cost_usd += cls_result.classifier_cost_usd
         paths["classification"].write_text(

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -561,6 +561,78 @@ def test_state_machine_three_no_reports_then_terminal(monkeypatch, tmp_path):
             assert (tmp_path / f"mistral_turn_{turn:02d}{suffix}").exists()
 
 
+def test_conversation_json_persisted_after_run(monkeypatch, tmp_path):
+    """run_phase_b_multiturn must write {agent}_conversation.json with the full exchange.
+
+    Covers the showstopper gap for stateful APIs (Mistral, OpenAI): unlike
+    Anthropic/Qwen which resend the full history every call, stateful providers
+    only carry agent_id/conversation_id in their continuation — the conversation
+    is server-side only.  The client-side conversation_history ensures the
+    complete dialogue is persisted locally regardless of provider.
+    """
+    import experiments.sota.exp2_interactive_smoke as mod
+
+    fake_run = _fake_run_factory(cost_per_call=0.10)
+    fake_classify = _fake_classifier_factory(["no_report", "report", "no_report"])
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
+    monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
+
+    run_phase_b_multiturn(
+        "the designed prompt",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="mistral",
+        system_prompt="you are an analyst",
+    )
+
+    conv_path = tmp_path / "mistral_conversation.json"
+    assert conv_path.exists(), "mistral_conversation.json must be written"
+    conv = json.loads(conv_path.read_text())
+    messages = conv["messages"]
+    # System prompt is first.
+    assert messages[0] == {"role": "system", "content": "you are an analyst"}
+    # Alternating user / assistant pairs follow.
+    roles = [m["role"] for m in messages[1:]]
+    assert roles == ["user", "assistant"] * ((len(messages) - 1) // 2), (
+        f"expected alternating user/assistant, got {roles}"
+    )
+    # Turn-1 user message is the designed prompt.
+    assert messages[1]["content"] == "the designed prompt"
+    # Every assistant message is non-empty.
+    for m in messages:
+        if m["role"] == "assistant":
+            assert m["content"], "assistant message must be non-empty"
+
+
+def test_conversation_json_written_without_system_prompt(monkeypatch, tmp_path):
+    """conversation.json is correct when no system_prompt is passed."""
+    import experiments.sota.exp2_interactive_smoke as mod
+
+    fake_run = _fake_run_factory(cost_per_call=0.10)
+    fake_classify = _fake_classifier_factory(["report", "no_report"])
+    monkeypatch.setitem(mod.CALL_FNS, "mistral", fake_run)
+    monkeypatch.setattr(mod.dialogue_classifier, "classify_report", fake_classify)
+
+    run_phase_b_multiturn(
+        "user prompt only",
+        output_dir=tmp_path,
+        cap_usd=10.0,
+        cap_tokens=100_000,
+        initial_spent_usd=0.0,
+        max_tokens=100,
+        agent="mistral",
+    )
+
+    conv = json.loads((tmp_path / "mistral_conversation.json").read_text())
+    messages = conv["messages"]
+    # No system prompt — first message is the user turn.
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "user prompt only"
+
+
 def test_state_machine_token_cap_overrides(monkeypatch, tmp_path):
     """Token cap below 20 % → TERMINAL on next turn regardless of class.
 


### PR DESCRIPTION
## Summary

Stateful APIs (Mistral, OpenAI) only carry `agent_id`/`conversation_id` in their continuation dict — the conversation history lives server-side only. After agent cleanup, if the provider purges the conversation, the dialogue is irretrievable except from the individual turn files (user.txt + raw.json per turn).

This adds a **client-side `conversation_history` list** that accumulates every user/assistant exchange regardless of provider. Written as `{agent}_conversation.json` after each turn (so partial runs on crash are also captured). Symmetric with Anthropic/Qwen which already resend the full history every call.

## Test plan

- [ ] `test_conversation_json_persisted_after_run` — system_prompt + 3 turns, checks message structure
- [ ] `test_conversation_json_written_without_system_prompt` — no-system-prompt case
- [ ] Full `make check-fast` (1496 passed before PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)