### PR TITLE
exp3(0250): floor Phase B max_tokens to prevent truncated reports

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -1315,8 +1315,9 @@ def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
         else json.dumps(designed_prompt_raw, indent=2, ensure_ascii=False)
     )
     designed_prompt = append_evidence_pack(designed_prompt, args.evidence_pack_manifest)
-    requested_max_tokens = int(
-        design.get("settings", {}).get("max_tokens") or args.phase_b_max_tokens
+    requested_max_tokens = max(
+        int(design.get("settings", {}).get("max_tokens") or args.phase_b_max_tokens),
+        args.min_phase_b_max_tokens,
     )
     designed_system_prompt = design["system_prompt"]
 
@@ -1381,6 +1382,13 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--budget-cap-phase-b", type=float, default=15.0)
     p.add_argument("--phase-a-max-tokens", type=int, default=8000)
     p.add_argument("--phase-b-max-tokens", type=int, default=12000)
+    p.add_argument(
+        "--min-phase-b-max-tokens",
+        type=int,
+        default=16000,
+        help="Floor applied to Phase A's designed max_tokens for Phase B turns. "
+        "Prevents low Phase A estimates from truncating multi-turn outputs.",
+    )
     p.add_argument(
         "--stop-after-phase-a",
         action="store_true",

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -1610,3 +1610,19 @@ def test_meta_prompt_not_augmented_with_evidence_pack(
     meta_prompt_file = tmp_path / "mistral_run01" / "mistral_meta_prompt.txt"
     assert meta_prompt_file.exists()
     assert "# Evidence pack" not in meta_prompt_file.read_text()
+
+
+def test_min_phase_b_max_tokens_flag_present():
+    """--min-phase-b-max-tokens must be wired in argparse with a default of 16000."""
+    src = open("experiments/sota/exp2_interactive_smoke.py", encoding="utf-8").read()
+    assert "--min-phase-b-max-tokens" in src
+    assert "default=16000" in src
+
+
+def test_min_phase_b_max_tokens_floor_applied():
+    """Floor must be enforced with max(), not an if-guard, in _run_one_agent."""
+    src = open("experiments/sota/exp2_interactive_smoke.py", encoding="utf-8").read()
+    # The floor is applied via max(designed, args.min_phase_b_max_tokens)
+    assert "args.min_phase_b_max_tokens" in src
+    # Must use max(), not a conditional assignment
+    assert "max(\n        int(design.get" in src or "= max(" in src


### PR DESCRIPTION
## Summary

- Smoke data showed Mistral returns `finish_reason=stop` even when hitting the `max_tokens` cap — turns 3–4 in both Arm 4 smoke runs hit exactly 4000 tokens (Phase A's designed value), truncating the final report
- Add `--min-phase-b-max-tokens` (default 16000) applied as `max(designed, floor)` over Phase A's designed value, matching Arm 3's `PROBE_MAX_TOKENS`
- Two source-inspection tests verify the flag is wired and the `max()` floor pattern is present

## Test plan

- [x] `make check-fast` passes (1511 passed)
- [x] New tests `test_min_phase_b_max_tokens_flag_present` and `test_min_phase_b_max_tokens_floor_applied` pass

**Ticket:** tickets/0250-run-experiment-3-four-arm-sweep.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)