### PR TITLE
fix(exp3): arm3/4 launch fixes — streaming fallback, per-agent tokens, qwen3.7-max, budget wire

### DIFF
--- a/experiments/models.yaml
+++ b/experiments/models.yaml
@@ -55,24 +55,22 @@
 # dispatcher to select the right adapter (adapter_qwen_dashscope.py).
 # International endpoint pricing verified 2026-05-20. Mainland routing
 # is out of scope; per-search fee is ~$0.00057 mainland vs $0.010 intl.
-- name: "qwen3-max-2026-01-23"
+- name: "qwen3.7-max-2026-05-20"
   family: qwen-direct
   route: dashscope
   base_url: "https://dashscope-intl.aliyuncs.com/api/v1"
-  model_id: "qwen3-max-2026-01-23"
-  display_name: "Qwen3 Max (DashScope direct, thinking + web_search)"
+  model_id: "qwen3.7-max-2026-05-20"
+  display_name: "Qwen3.7 Max (DashScope direct, web_search)"
   provider: Alibaba
   country: CN
   architecture: moe
   context_window: 262144
-  price_per_mtok_in: 1.2
-  price_per_mtok_out: 6.0
-  price_per_mtok_reasoning: 6.0
+  price_per_mtok_in: 2.5
+  price_per_mtok_out: 7.5
   price_per_web_search_call_usd: 0.010
   size_class: frontier
   license: commercial
   web_search: true
-  reasoning_effort: "default"
 
 - name: "anthropic/claude-opus-4.6"
   route: openrouter

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -1305,7 +1305,7 @@ def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
 
     wait_for_space(
         f"Phase B: multi-turn loop on {agent}. Dual cap "
-        f"{PHASE_B_TOTAL_TOKEN_CAP // 1000}K tokens + ${PHASE_B_TOTAL_BUDGET_USD:.2f}.",
+        f"{PHASE_B_TOTAL_TOKEN_CAP // 1000}K tokens + ${args.budget_cap_phase_b:.2f}.",
         no_confirm=args.no_confirm,
     )
     designed_prompt_raw = design["designed_prompt"]
@@ -1324,7 +1324,7 @@ def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
     phase_b = run_phase_b_multiturn(
         designed_prompt,
         output_dir=agent_output_dir,
-        cap_usd=PHASE_B_TOTAL_BUDGET_USD,
+        cap_usd=args.budget_cap_phase_b,
         cap_tokens=PHASE_B_TOTAL_TOKEN_CAP,
         initial_spent_usd=0.0,
         max_tokens=requested_max_tokens,
@@ -1349,7 +1349,7 @@ def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
     status = "pass"
     if not class_trace or "report" not in class_trace:
         status = "fail"
-    if total_cost_usd > PHASE_B_TOTAL_BUDGET_USD + args.budget_cap_phase_a:
+    if total_cost_usd > args.budget_cap_phase_b + args.budget_cap_phase_a:
         status = "fail"
 
     return {

--- a/experiments/sota/exp2_naive_arm.py
+++ b/experiments/sota/exp2_naive_arm.py
@@ -45,7 +45,7 @@ AGENTS = ("mistral", "qwen", "openai", "anthropic")
 PROBE_MAX_TOKENS = 16_000       # mistral baseline
 OPENAI_MAX_TOKENS = 32_000      # gpt-5.5 truncated at 16K
 QWEN_MAX_TOKENS = 32_000        # qwen3.7-max (thinking disabled)
-ANTHROPIC_MAX_TOKENS = 64_000   # opus thinking + web search eat headroom before text
+ANTHROPIC_MAX_TOKENS = 32_000   # 64K triggers SDK streaming requirement; 32K fits ~9 min
 QWEN_CALL_TIMEOUT = 600         # 160K+ char prompt with evidence pack is slow
 PROBE_CAP_USD = 3.00
 ANTHROPIC_CAP_USD = 6.00        # input alone costs ~$1.7; 64K output adds ~$1.6
@@ -191,6 +191,7 @@ def probe_qwen(prompt: str, output_dir: Path) -> dict:
                 break
     dashscope.api_key = api_key
     dashscope.base_http_api_url = "https://dashscope-intl.aliyuncs.com/api/v1"
+    dashscope.request_timeout = QWEN_CALL_TIMEOUT
     t0 = time.monotonic()
     resp = dashscope.Generation.call(
         model=meta.get("model_id"),
@@ -199,7 +200,6 @@ def probe_qwen(prompt: str, output_dir: Path) -> dict:
         max_tokens=QWEN_MAX_TOKENS,
         enable_thinking=False,
         enable_search=True,  # the whole point of the probe
-        call_timeout=QWEN_CALL_TIMEOUT,
     )
     wall_s = round(time.monotonic() - t0, 2)
     narrative = ""

--- a/experiments/sota/exp2_naive_arm.py
+++ b/experiments/sota/exp2_naive_arm.py
@@ -42,8 +42,13 @@ MODELS_YAML = REPO_ROOT / "experiments" / "models.yaml"
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "experiments" / "outputs" / "sota_exp2_naive_arm"
 
 AGENTS = ("mistral", "qwen", "openai", "anthropic")
-PROBE_MAX_TOKENS = 16_000
+PROBE_MAX_TOKENS = 16_000       # mistral baseline
+OPENAI_MAX_TOKENS = 32_000      # gpt-5.5 truncated at 16K
+QWEN_MAX_TOKENS = 32_000        # qwen3.7-max (thinking disabled)
+ANTHROPIC_MAX_TOKENS = 64_000   # opus thinking + web search eat headroom before text
+QWEN_CALL_TIMEOUT = 600         # 160K+ char prompt with evidence pack is slow
 PROBE_CAP_USD = 3.00
+ANTHROPIC_CAP_USD = 6.00        # input alone costs ~$1.7; 64K output adds ~$1.6
 
 
 def load_naive_prompt(path: Path = NAIVE_PROMPT_PATH) -> str:
@@ -144,7 +149,7 @@ def probe_openai(prompt: str, output_dir: Path) -> dict:
         input=prompt,
         tools=[{"type": "web_search"}],
         reasoning={"effort": "low"},  # web_search rejects 'minimal'
-        max_output_tokens=PROBE_MAX_TOKENS,
+        max_output_tokens=OPENAI_MAX_TOKENS,
     )
     wall_s = round(time.monotonic() - t0, 2)
     narrative = ""
@@ -191,9 +196,10 @@ def probe_qwen(prompt: str, output_dir: Path) -> dict:
         model=meta.get("model_id"),
         messages=[{"role": "user", "content": prompt}],
         result_format="message",
-        max_tokens=PROBE_MAX_TOKENS,
+        max_tokens=QWEN_MAX_TOKENS,
         enable_thinking=False,
         enable_search=True,  # the whole point of the probe
+        call_timeout=QWEN_CALL_TIMEOUT,
     )
     wall_s = round(time.monotonic() - t0, 2)
     narrative = ""
@@ -225,7 +231,7 @@ def probe_anthropic(prompt: str, output_dir: Path) -> dict:
     payload = query_anthropic.assemble_request(
         prompt,
         model=meta.get("model_id"),
-        max_tokens=PROBE_MAX_TOKENS,
+        max_tokens=ANTHROPIC_MAX_TOKENS,
     )
     t0 = time.monotonic()
     result = query_anthropic.dispatch(
@@ -235,7 +241,7 @@ def probe_anthropic(prompt: str, output_dir: Path) -> dict:
         output_dir=output_dir,
         run=1,
         agent_mode="naive_probe",
-        cap_usd=PROBE_CAP_USD,
+        cap_usd=ANTHROPIC_CAP_USD,
     )
     wall_s = round(time.monotonic() - t0, 2)
     record = result.get("run_record")

--- a/src/aedist/query_anthropic.py
+++ b/src/aedist/query_anthropic.py
@@ -403,7 +403,15 @@ def _call_with_retry(client: Any, payload: dict) -> Any:
     last_exc: Exception | None = None
     for attempt in range(_MAX_RETRIES + 1):
         try:
-            return client.messages.create(**payload)
+            try:
+                return client.messages.create(**payload)
+            except anthropic.APIStatusError as stream_exc:
+                # SDK raises when max_tokens would exceed the 10-min non-streaming limit.
+                if "Streaming is required" not in str(stream_exc):
+                    raise
+                log.info("Falling back to streaming (max_tokens too large for non-streaming)")
+                with client.messages.stream(**payload) as stream:
+                    return stream.get_final_message()
         except anthropic.RateLimitError as exc:
             last_exc = exc
             if attempt < _MAX_RETRIES:

--- a/src/aedist/query_anthropic.py
+++ b/src/aedist/query_anthropic.py
@@ -405,8 +405,9 @@ def _call_with_retry(client: Any, payload: dict) -> Any:
         try:
             try:
                 return client.messages.create(**payload)
-            except anthropic.APIStatusError as stream_exc:
-                # SDK raises when max_tokens would exceed the 10-min non-streaming limit.
+            except (anthropic.APIStatusError, ValueError) as stream_exc:
+                # SDK raises ValueError (client-side) or APIStatusError when max_tokens > 21333
+                # (expected_time = 3600 * max_tokens / 128_000 > 600s triggers streaming requirement).
                 if "Streaming is required" not in str(stream_exc):
                     raise
                 log.info("Falling back to streaming (max_tokens too large for non-streaming)")


### PR DESCRIPTION
## Summary

- **Per-agent max_tokens**: mistral 16K, openai/qwen/anthropic 32K (was single 16K cap — caused openai truncation and anthropic stop_reason=max_tokens)
- **Anthropic streaming fallback**: the SDK raises `ValueError` (client-side, before any HTTP call) when `expected_time = 3600 * max_tokens / 128_000 > 600s` (i.e. max_tokens > 21333). Previous catch only handled `APIStatusError`. Fixed to `except (anthropic.APIStatusError, ValueError)`.
- **DashScope timeout**: set `dashscope.request_timeout = QWEN_CALL_TIMEOUT` (600s) globally before the call; the `call_timeout` kwarg is silently ignored by the SDK.
- **Budget cap wire-up**: `--budget-cap-phase-b` CLI arg was declared but not wired to `run_phase_b_multiturn` — arm 4 anthropic was failing at $2.99 despite `--budget-cap-phase-b 6.0`.
- **Qwen3.7-max model**: adds `qwen3.7-max-2026-05-20` in `qwen-direct` family (DashScope international, $2.5/$7.5 per Mtok, web_search enabled).
- **OpenRouter entry**: adds `qwen/qwen3.7-max` for OpenRouter routing.

## Arm 3/4 N=1 gate results

| Arm | Agent | Status | Notes |
|-----|-------|--------|-------|
| 3 (naive + evidence) | mistral | report ✓ | 32K chars, $0.05 |
| 3 | openai | report ✓ | 47K chars, $0.44 |
| 3 | anthropic | report ✓ | 45K chars, $2.47, 534s streaming |
| 3 | qwen | pending | qwen3.7-max running now |
| 4 (multiturn + evidence) | mistral | pass ✓ | 60 rows |
| 4 | openai | pass ✓ | 171 rows |
| 4 | anthropic | pass ✓ | 143 rows, $4.03, 3 turns |
| 4 | qwen | pass ✓ | 26 rows |

## Test plan

- [x] Arm 3: mistral, openai, anthropic produce `report`
- [x] Arm 4: all 4 agents produce `pass` with row counts
- [ ] Arm 3 qwen: qwen3.7-max with 600s DashScope timeout (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)