### PR TITLE
fix(exp1): replace qwen3-max-thinking with qwen3.7-max in modelset_ablation_journal

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -155,9 +155,9 @@ model_ids = [
 # Journal tier — v2 (ticket 0175): 16 models × 5 reps = 80 runs.
 # Organised around three language families (EN/FR/ZH) with multiple labs per
 # family. All four SOTA Wave-2 agents (Opus 4.7, GPT-5.5, Mistral Large 2512,
-# Qwen 3 Max) are included so Experiment 2's "deep research vs parametric"
+# Qwen 3.7 Max) are included so Experiment 2's "deep research vs parametric"
 # claim can be tested within-model. No -thinking variants in the parametric
-# baseline; reasoning-configurable models (gpt-oss-*, qwen3-max) declare
+# baseline; reasoning-configurable models (gpt-oss-*, qwen3.7-max) declare
 # reasoning_effort="minimal" in models.yaml.
 [sets.modelset_ablation_journal]
 model_ids = [
@@ -178,7 +178,7 @@ model_ids = [
     "qwen/qwen3.6-35b-a3b",
     "qwen/qwen3.5-flash-02-23",
     "qwen/qwen3.6-plus",
-    "qwen/qwen3-max-thinking",
+    "qwen/qwen3.7-max",
     # ZH — DeepSeek
     "deepseek/deepseek-v4-pro",
     "deepseek/deepseek-v4-flash:free",

--- a/experiments/models.yaml
+++ b/experiments/models.yaml
@@ -1148,6 +1148,22 @@
   web_search: false
   reasoning_effort: "minimal"
 
+- name: "qwen/qwen3.7-max"
+  route: openrouter
+  base_url: "https://openrouter.ai/api/v1"
+  model_id: "qwen/qwen3.7-max"
+  display_name: "Qwen 3.7 Max"
+  provider: Alibaba
+  country: CN
+  architecture: moe
+  context_window: 262144
+  price_per_mtok_in: 2.5
+  price_per_mtok_out: 7.5
+  size_class: frontier
+  license: commercial
+  web_search: false
+  reasoning_effort: "minimal"
+
 - name: "qwen/qwen3.6-max-preview"
   route: openrouter
   base_url: "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary

- Replaces `qwen/qwen3-max-thinking` with `qwen/qwen3.7-max` in `modelset_ablation_journal` (Exp 1 parametric ceiling panel)
- Adds `qwen/qwen3.7-max` OpenRouter entry to `models.yaml` (price $2.5/$7.5 per Mtok, `reasoning_effort: minimal`)
- The thinking variant was inconsistent with the parametric baseline design ("no -thinking variants in the parametric baseline")
- `modelset_exp1_baseline` (frozen replica for reproducibility) is unchanged

## Next steps (not in this PR)

5 fresh `qwen3.7-max` reps to run via `sweep_ablation_p1_direct_base` — the old `qwen3-max-thinking` reps will not be pooled with the new cohort.

Also applies to Exp 3 Arms 1/2: the `qwen-direct` family already points to `qwen3.7-max-2026-05-20` via PR #483.

**Ticket:** none (config-only change, no ticket required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)