### PR TITLE
fix(experiment2.mk): PYTHONPATH=.. for experiments.sota imports

### DIFF
--- a/experiments/experiment2.mk
+++ b/experiments/experiment2.mk
@@ -15,7 +15,7 @@
 #   mkdir -p outputs/sota_exp3_arm4_batch1/run01
 #   echo '[]' > outputs/sota_exp3_arm4_batch1/run01/summary.json
 
-UV_RUN  := uv run --project .. --env-file ../.env
+UV_RUN  := PYTHONPATH=.. uv run --project .. --env-file ../.env
 AGENTS  := mistral openai anthropic qwen
 EP      := evidence_packs/all18tables.yaml
 ARM3    := outputs/sota_exp3_arm3_batch1


### PR DESCRIPTION
`uv run --project ..` sets up the venv but does not add the repo root to
`sys.path`. Scripts under `experiments/sota/` import `from experiments.sota
import …` which requires the repo root on `PYTHONPATH`.

**Fix:** prepend `PYTHONPATH=..` to `UV_RUN` in `experiment2.mk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)