### PR TITLE
tickets: decompose 0270 mechanical scoring into staged child tickets

### DIFF
--- a/tickets/0270-implement-score-mechanical.erg
+++ b/tickets/0270-implement-score-mechanical.erg
@@ -1,101 +1,45 @@
 %erg 0.1
-Title: Implement score_mechanical.py — 12-metric automatic scoring across 5 axes
+Title: Parent tracker — mechanical scoring pipeline (contract, ingestion, scorer)
 Created: 2026-05-24
 Author: HDMX-coding-agent
+Blocked-by: 0272
+Blocked-by: 0274
+Blocked-by: 0275
+Blocked-by: 0276
 
 --- log ---
 2026-05-24T09:30Z HDMX-coding-agent created
+2026-05-24T11:20Z HDMX-coding-agent scope split: converted this composite ticket into a parent tracker and opened child tickets 0274/0275/0276 for staged delivery.
 
 --- body ---
 ## Context
 
-Ticket 0171 specifies LLM-as-judge scoring of quality dimensions. This ticket
-implements the mechanical layer: 12 automatic metrics across 5 axes that require
-no LLM call. They serve as direct measurement or as priors injected into a judge
-prompt later.
+Original ticket 0270 bundled three risk domains in one change:
+1. Scientific validity/interpretation contract (what a score means when prompts omit fields)
+2. Data ingestion and parser/path robustness (markdown extraction, run-file resolution, row-count parity)
+3. Scoring implementation and output materialization
 
-Axes and metrics (all fractions reported as n_events / n_total_rows):
+To de-risk execution and reduce rework, this ticket now tracks the sequence only.
+Implementation is delivered by child tickets.
 
-**Accuracy** (reference-dependent):
-- `acc_tp`, `acc_fp`, `acc_fn`, `acc_f1` (derived from existing `evaluate.py`)
+## Child tickets
 
-**Coherence** (reference-free):
-- `coh_no_duplicate_frac` — n_unique_plant_names / n_total_rows; 1.0 = no duplicates
-- `coh_vocab_adherent_frac` — fraction of rows where Fuel×Technology pair is in the
-  allowed set (Coal→{Subcritical/Supercritical/USC}, Gas→{CCGT/OCGT}) AND Status is
-  in the 7-value vocabulary. Two checks computed separately, displayed as one index.
-- `coh_high_conf_dual_sourced_frac` — among Confidence=HIGH rows, fraction that also
-  have Source 1 AND Source 2 present. Null when Confidence column absent.
+- `0274` — define scoring contract + nullability/annotation policy and lock CSV schema
+- `0275` — ingestion and row extraction robustness (parser reuse, run-path resolution, parity tests)
+- `0276` — implement `score_mechanical.py` scoring core + CLI + smoke artifact
 
-**Provenance** (reference-free):
-- `prov_dual_source_frac` — rows with Source 1 AND Source 2 both non-empty
-- `prov_primary_s1_frac` — rows where Source 1 classified as primary via
-  `classify_source_by_text()` from `verify.py`
+## Required execution order
 
-**Temporality** (reference-free):
-- `temp_asof_present_frac` — Status as-of-date field non-empty
-- `temp_asof_plausible_frac` — Status as-of-date parses as a date in [1980, 2026]
-  (Vietnam thermal history starts with 1980s Soviet-era plants)
-
-**Field completeness / PyPSA-readiness** (reference-free):
-- `fc_capacity_present_frac` — Total MWe non-null and > 0
-- `fc_cod_plausible_frac` — COD field parses as a year in [1954, 2050]
-- `fc_province_present_frac` — Province field non-empty
-
-## Relevant files
-
-- `src/aedist/score_mechanical.py` — new module (primary deliverable)
-- `src/aedist/score_provenance.py` — reuse `classify_source_by_text()`
-- `src/aedist/evaluate.py` — reuse `load_plants_csv()` and plant-matching logic
-- `experiments/derived/sota_cross_eval.csv` — output destination
-
-## Actions
-
-1. Implement `src/aedist/score_mechanical.py` with 5 scoring functions returning
-   typed dataclasses. Signature:
-   ```python
-   score_accuracy(rows, ref_path: Path | None) -> AccuracyScores
-   score_coherence(rows) -> CoherenceScores
-   score_provenance(rows) -> ProvenanceScores
-   score_temporality(rows) -> TemporalityScores
-   score_field_completeness(rows) -> FieldCompletenessScores
-   ```
-   Where `rows` is `list[dict]` with column-name keys.
-
-2. **Parser**: for Exp 2/3 markdown outputs, check what markdown-table parser
-   already exists in the codebase (`extract_*.py`, `evaluate.py`) before writing
-   a new one. Reuse; do not duplicate.
-
-3. CLI entry point: reads an output file (CSV or markdown with table), runs all
-   5 scoring functions, writes one row to `sota_cross_eval.csv`.
-
-4. Output CSV schema:
-   ```
-   model, run, arm,
-   acc_tp, acc_fp, acc_fn, acc_f1,
-   coh_no_duplicate, coh_no_duplicate_frac,
-   coh_vocab_adherent, coh_vocab_adherent_frac,
-   coh_high_conf_dual_sourced, coh_high_conf_dual_sourced_frac,
-   prov_dual_source, prov_dual_source_frac,
-   prov_primary_s1, prov_primary_s1_frac,
-   temp_asof_present, temp_asof_present_frac,
-   temp_asof_plausible, temp_asof_plausible_frac,
-   fc_capacity_present, fc_capacity_present_frac,
-   fc_cod_plausible, fc_cod_plausible_frac,
-   fc_province_present, fc_province_present_frac
-   ```
-
-## Test
-
-`tests/test_score_mechanical.py`:
-- Row with Fuel=Coal, Technology=CCGT → `coh_vocab_adherent_frac` < 1.0
-- Row Confidence=HIGH, Source 2 empty → `coh_high_conf_dual_sourced_frac` < 1.0
-- Status-as-of="1979" → fails plausible range; "1980" → passes
-- Total MWe="" → `fc_capacity_present_frac` counts as absent
-- Empty table → all fractions = 0.0, no ZeroDivisionError
+1. `0272` verifies articulation and upstream assumptions.
+2. `0274` locks interpretation contract and schema.
+3. `0275` ensures parser/path/row denominators are reliable.
+4. `0276` implements scoring logic against those locked interfaces.
 
 ## Exit criteria
 
-- [ ] `score_mechanical.py` exists with all 5 functions and CLI entry point
-- [ ] `sota_cross_eval.csv` generated for at least one Exp 2 run as smoke check
-- [ ] `make check-fast` passes
+- [ ] Ticket `0272` merged
+- [ ] Ticket `0274` merged
+- [ ] Ticket `0275` merged
+- [ ] Ticket `0276` merged
+- [ ] `experiments/derived/sota_cross_eval.csv` generated for at least one Exp2 run via the new scorer path
+- [ ] `make check-fast` passes on the integration branch that closes this tracker

--- a/tickets/0271-spider-plot-quality-scores.erg
+++ b/tickets/0271-spider-plot-quality-scores.erg
@@ -3,14 +3,17 @@ Title: Spider plot — visualize 5-axis quality scores per model/arm, modelset-c
 Created: 2026-05-24
 Author: HDMX-coding-agent
 Blocked-by: 0270
+Blocked-by: 0276
 
 --- log ---
 2026-05-24T09:30Z HDMX-coding-agent created
+2026-05-24T11:24Z HDMX-coding-agent dependency note: scorer pipeline split into 0274/0275/0276; this ticket waits on 0276 artifact readiness.
 
 --- body ---
 ## Context
 
-Ticket 0270 produces `sota_cross_eval.csv` with 12 mechanical scores per run.
+Ticket 0270 parent tracker (implemented by child 0276 after 0274/0275) produces
+`sota_cross_eval.csv` with 12 mechanical scores per run.
 This ticket renders those scores as a radar/spider chart — one polygon per model
 or arm — so quality profiles are visually comparable across experiments and modelsets.
 

--- a/tickets/0274-lock-mechanical-scoring-contract.erg
+++ b/tickets/0274-lock-mechanical-scoring-contract.erg
@@ -1,0 +1,47 @@
+%erg 0.1
+Title: Lock mechanical scoring contract — schema, nullability, and annotation policy
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0272
+
+--- log ---
+2026-05-24T11:22Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Before implementing any scorer, lock the interpretation contract so metrics are
+scientifically valid and not confounded by prompt articulation gaps.
+
+Ticket 0272 identifies where prompts ask fields explicitly, imply them, or omit
+them. This ticket turns that analysis into a machine-enforceable scoring policy.
+
+## Deliverables
+
+1. Contract doc: `docs/scoring-contract.md` defining, for each metric:
+   - required columns
+   - numerator/denominator definition
+   - when metric is null (not 0)
+   - annotation code when null (e.g., `prompt_not_asked`, `column_missing`, `parse_failed`)
+
+2. Lock output schema for `experiments/derived/sota_cross_eval.csv`:
+   - include `prompt_version`
+   - include per-metric value and per-metric annotation fields where needed
+   - deterministic column order documented in the contract
+
+3. Test fixture policy in `tests/test_score_mechanical_contract.py`:
+   - missing Confidence column -> high-confidence dual-source metric is null + annotated
+   - missing Status as-of-date -> temporality as-of metrics null + annotated
+   - present column but empty values -> metric computes with denominator semantics from contract
+
+## Non-goals
+
+- No parser extraction work.
+- No scoring algorithm implementation beyond minimal helpers required to enforce contract.
+
+## Exit criteria
+
+- [ ] `docs/scoring-contract.md` committed
+- [ ] CSV schema (including `prompt_version`) locked and documented
+- [ ] Contract tests pass
+- [ ] `make check-fast` passes

--- a/tickets/0275-score-mechanical-ingestion-and-parity.erg
+++ b/tickets/0275-score-mechanical-ingestion-and-parity.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: Mechanical scoring ingestion — parser reuse, run-path resolution, and row-count parity
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0274
+
+--- log ---
+2026-05-24T11:22Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Scoring quality metrics is only meaningful if extracted rows and run metadata are
+stable and reproducible. This ticket isolates ingestion correctness from scoring.
+
+## Actions
+
+1. Implement a reusable ingestion helper module (e.g. `src/aedist/score_ingest.py`) that:
+   - resolves run output paths from known run metadata (arm/model/run)
+   - reuses existing markdown-table extraction from `extract.py`/`evaluate.py`
+   - normalizes extracted row dicts into one canonical header map used by scorer
+
+2. Add parity checks against `tab_exp2_arms_runs.csv`:
+   - for sample runs in each arm, parsed row count equals inventory_rows when comparable
+   - mismatch is surfaced as explicit diagnostic (not silent fallback)
+
+3. Add tests `tests/test_score_ingest.py`:
+   - markdown file with sectioned table still extracts rows correctly
+   - unknown/missing run path returns a typed ingestion error
+   - sample parity test for one naive and one optimised run fixture
+
+4. Optional throughput note:
+   - if re-parse cost is non-trivial, document and optionally emit extracted rows cache path
+
+## Non-goals
+
+- No axis metric formulas.
+- No final cross-eval CSV writer.
+
+## Exit criteria
+
+- [ ] Ingestion helper module committed with parser reuse (no duplicate parser implementation)
+- [ ] Parity diagnostics implemented and tested
+- [ ] Ingestion tests pass
+- [ ] `make check-fast` passes

--- a/tickets/0276-implement-score-mechanical-core-and-cli.erg
+++ b/tickets/0276-implement-score-mechanical-core-and-cli.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: Implement score_mechanical core and CLI over locked contract and ingestion
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0275
+
+--- log ---
+2026-05-24T11:22Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+With contract (0274) and ingestion (0275) locked, implement scoring functions and
+CSV emission with minimal ambiguity.
+
+## Actions
+
+1. Implement `src/aedist/score_mechanical.py` with 5 scoring functions:
+   - `score_accuracy(rows, ref_path: Path | None) -> AccuracyScores`
+   - `score_coherence(rows) -> CoherenceScores`
+   - `score_provenance(rows) -> ProvenanceScores`
+   - `score_temporality(rows) -> TemporalityScores`
+   - `score_field_completeness(rows) -> FieldCompletenessScores`
+
+2. Reuse existing utilities where applicable:
+   - `evaluate.py` for accuracy / reference matching primitives
+   - `verify.classify_source_by_text()` for primary source classification
+
+3. CLI entry point:
+   - consumes canonical rows from ingestion helper
+   - applies contract nullability/annotation policy
+   - appends one row to `experiments/derived/sota_cross_eval.csv`
+
+4. Add tests `tests/test_score_mechanical.py`:
+   - coal+CCGT mismatch lowers vocab adherence
+   - HIGH confidence with missing Source 2 lowers dual-source metric
+   - as-of 1979 fails plausible range while 1980 passes
+   - empty Total MWe counted absent
+   - empty table does not divide by zero
+
+5. Smoke:
+   - score at least one Exp2 run and commit/refresh `experiments/derived/sota_cross_eval.csv`
+
+## Exit criteria
+
+- [ ] `score_mechanical.py` implemented with all 5 scorers + CLI
+- [ ] Unit tests for scorer pass
+- [ ] smoke row written to `sota_cross_eval.csv`
+- [ ] `make check-fast` passes


### PR DESCRIPTION
## Summary\n- convert 0270 from composite implementation ticket into parent tracker\n- add child tickets 0274 (contract), 0275 (ingestion/parity), 0276 (scorer core+CLI)\n- update 0271 to note dependency on 0276 artifact readiness\n\n## Why\n0270 mixed three failure domains (validity contract, parser/path robustness, scorer logic), which increased rollout and review risk. This split establishes a safer execution order: 0272 -> 0274 -> 0275 -> 0276 -> 0271.\n\n## Scope\nTicket/spec changes only. No production code or data artifacts modified.\n\n**Ticket:** tickets/0270-implement-score-mechanical.erg