### PR TITLE
Add score ingestion helper for mechanical scoring

### DIFF
--- a/src/aedist/score_ingest.py
+++ b/src/aedist/score_ingest.py
@@ -1,0 +1,217 @@
+"""Run-ingestion helpers for mechanical scoring.
+
+Resolves Exp2 run outputs from `(arm, model, run)` metadata, extracts the best
+plant table from the paired markdown report, and returns canonical row dicts for
+downstream scoring.
+"""
+
+import csv
+import enum
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .extract import _extract_pipe_tables, parse_and_canonicalize, score_csv_like_block
+
+_DEFAULT_NAIVE_DIR = Path("experiments/outputs/sota_exp2_naive_arm")
+_DEFAULT_OPTIMISED_DIR = Path("experiments/outputs/sota_exp2_brerun1")
+
+
+class IngestionErrorKind(enum.Enum):
+    UNKNOWN_ARM = "unknown_arm"
+    RUN_NOT_FOUND = "run_not_found"
+    AMBIGUOUS_RUN = "ambiguous_run"
+    MISSING_MARKDOWN = "missing_markdown"
+    NO_TABLE = "no_table"
+    PARSE_FAILED = "parse_failed"
+
+
+@dataclass
+class RunLocator:
+    arm: str
+    model: str
+    run: int
+
+
+@dataclass
+class ResolvedRunPaths:
+    json_path: Path
+    markdown_path: Path
+
+
+@dataclass
+class IngestedRun:
+    locator: RunLocator
+    json_path: Path
+    markdown_path: Path
+    rows: list[dict[str, str]]
+
+
+@dataclass
+class ParityDiagnostic:
+    locator: RunLocator
+    expected_rows: int
+    observed_rows: int
+    matches: bool
+    message: str
+
+
+class IngestionError(RuntimeError):
+    def __init__(self, kind: IngestionErrorKind, locator: RunLocator, detail: str):
+        self.kind = kind
+        self.locator = locator
+        self.detail = detail
+        super().__init__(f"{kind.value}: {detail}")
+
+
+def _arm_dir(arm: str, naive_dir: Path, optimised_dir: Path) -> Path:
+    if arm == "naive":
+        return naive_dir
+    if arm == "optimised":
+        return optimised_dir
+    raise IngestionError(
+        IngestionErrorKind.UNKNOWN_ARM,
+        RunLocator(arm=arm, model="", run=0),
+        f"unknown arm '{arm}'",
+    )
+
+
+def resolve_run_paths(
+    locator: RunLocator,
+    *,
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+) -> ResolvedRunPaths:
+    arm_dir = _arm_dir(locator.arm, naive_dir, optimised_dir)
+    pattern = f"*_run{locator.run:02d}.json"
+    matches: list[Path] = []
+    for json_path in sorted(arm_dir.glob(pattern)):
+        meta = json.loads(json_path.read_text(encoding="utf-8"))
+        if meta.get("model") == locator.model:
+            matches.append(json_path)
+
+    if not matches:
+        raise IngestionError(
+            IngestionErrorKind.RUN_NOT_FOUND,
+            locator,
+            f"no {locator.arm} run found for model={locator.model!r} run={locator.run}",
+        )
+    if len(matches) > 1:
+        raise IngestionError(
+            IngestionErrorKind.AMBIGUOUS_RUN,
+            locator,
+            f"multiple run files matched: {[path.name for path in matches]}",
+        )
+
+    json_path = matches[0]
+    markdown_path = json_path.with_suffix(".md")
+    if not markdown_path.exists():
+        raise IngestionError(
+            IngestionErrorKind.MISSING_MARKDOWN,
+            locator,
+            f"missing markdown report {markdown_path.name}",
+        )
+    return ResolvedRunPaths(json_path=json_path, markdown_path=markdown_path)
+
+
+def ingest_run(
+    locator: RunLocator,
+    *,
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+) -> IngestedRun:
+    resolved = resolve_run_paths(locator, naive_dir=naive_dir, optimised_dir=optimised_dir)
+    text = resolved.markdown_path.read_text(encoding="utf-8", errors="replace")
+    candidates = _extract_pipe_tables(text)
+    if not candidates:
+        raise IngestionError(
+            IngestionErrorKind.NO_TABLE,
+            locator,
+            f"no markdown pipe tables found in {resolved.markdown_path.name}",
+        )
+
+    best = max(candidates, key=score_csv_like_block)
+    try:
+        canonical_csv = parse_and_canonicalize(best)
+    except Exception as exc:
+        raise IngestionError(
+            IngestionErrorKind.PARSE_FAILED,
+            locator,
+            f"failed to canonicalize {resolved.markdown_path.name}: {exc}",
+        ) from exc
+
+    rows = list(csv.DictReader(io.StringIO(canonical_csv)))
+    return IngestedRun(
+        locator=locator,
+        json_path=resolved.json_path,
+        markdown_path=resolved.markdown_path,
+        rows=rows,
+    )
+
+
+def check_inventory_row_parity(
+    locator: RunLocator,
+    expected_rows: int,
+    *,
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+) -> ParityDiagnostic:
+    ingested = ingest_run(locator, naive_dir=naive_dir, optimised_dir=optimised_dir)
+    observed_rows = len(ingested.rows)
+    matches = observed_rows == expected_rows
+    if matches:
+        message = (
+            f"row parity OK for {locator.arm}/{locator.model}/run{locator.run:02d}: "
+            f"expected={expected_rows} observed={observed_rows}"
+        )
+    else:
+        message = (
+            f"row parity mismatch for {locator.arm}/{locator.model}/run{locator.run:02d}: "
+            f"expected={expected_rows} observed={observed_rows}"
+        )
+    return ParityDiagnostic(
+        locator=locator,
+        expected_rows=expected_rows,
+        observed_rows=observed_rows,
+        matches=matches,
+        message=message,
+    )
+
+
+def check_inventory_row_parity_row(
+    row: dict[str, str],
+    *,
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+) -> ParityDiagnostic:
+    locator = RunLocator(
+        arm=row["arm"],
+        model=row["model"],
+        run=int(row["run"]),
+    )
+    expected_rows = int(row["inventory_rows"])
+    return check_inventory_row_parity(
+        locator,
+        expected_rows,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+
+
+def check_inventory_row_parity_csv(
+    csv_path: Path,
+    *,
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+) -> list[ParityDiagnostic]:
+    with csv_path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        return [
+            check_inventory_row_parity_row(
+                row,
+                naive_dir=naive_dir,
+                optimised_dir=optimised_dir,
+            )
+            for row in reader
+        ]

--- a/src/aedist/score_ingest.py
+++ b/src/aedist/score_ingest.py
@@ -23,8 +23,10 @@ class IngestionErrorKind(enum.Enum):
     RUN_NOT_FOUND = "run_not_found"
     AMBIGUOUS_RUN = "ambiguous_run"
     MISSING_MARKDOWN = "missing_markdown"
+    INVALID_ENCODING = "invalid_encoding"
     NO_TABLE = "no_table"
     PARSE_FAILED = "parse_failed"
+    INVALID_PARITY_ROW = "invalid_parity_row"
 
 
 @dataclass
@@ -122,7 +124,14 @@ def ingest_run(
     optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
 ) -> IngestedRun:
     resolved = resolve_run_paths(locator, naive_dir=naive_dir, optimised_dir=optimised_dir)
-    text = resolved.markdown_path.read_text(encoding="utf-8", errors="replace")
+    try:
+        text = resolved.markdown_path.read_text(encoding="utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise IngestionError(
+            IngestionErrorKind.INVALID_ENCODING,
+            locator,
+            f"invalid UTF-8 in markdown report {resolved.markdown_path.name}",
+        ) from exc
     candidates = _extract_pipe_tables(text)
     if not candidates:
         raise IngestionError(
@@ -185,17 +194,60 @@ def check_inventory_row_parity_row(
     naive_dir: Path = _DEFAULT_NAIVE_DIR,
     optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
 ) -> ParityDiagnostic:
+    required = {"arm", "model", "run", "inventory_rows"}
+    missing = sorted(k for k in required if not row.get(k))
+    if missing:
+        raise IngestionError(
+            IngestionErrorKind.INVALID_PARITY_ROW,
+            RunLocator(arm=row.get("arm", ""), model=row.get("model", ""), run=0),
+            f"missing required parity fields: {missing}",
+        )
+
+    run_raw = row["run"].strip()
+    expected_raw = row["inventory_rows"].strip()
+    try:
+        run = int(run_raw)
+    except ValueError as exc:
+        raise IngestionError(
+            IngestionErrorKind.INVALID_PARITY_ROW,
+            RunLocator(arm=row["arm"], model=row["model"], run=0),
+            f"invalid run value {run_raw!r}; expected integer",
+        ) from exc
+
+    try:
+        expected_rows = int(expected_raw)
+    except ValueError as exc:
+        raise IngestionError(
+            IngestionErrorKind.INVALID_PARITY_ROW,
+            RunLocator(arm=row["arm"], model=row["model"], run=run),
+            f"invalid inventory_rows value {expected_raw!r}; expected integer",
+        ) from exc
+
     locator = RunLocator(
         arm=row["arm"],
         model=row["model"],
-        run=int(row["run"]),
+        run=run,
     )
-    expected_rows = int(row["inventory_rows"])
     return check_inventory_row_parity(
         locator,
         expected_rows,
         naive_dir=naive_dir,
         optimised_dir=optimised_dir,
+    )
+
+
+def _diagnostic_from_error(err: IngestionError) -> ParityDiagnostic:
+    locator = err.locator
+    return ParityDiagnostic(
+        locator=RunLocator(
+            arm=locator.arm or "<invalid>",
+            model=locator.model or "<invalid>",
+            run=locator.run,
+        ),
+        expected_rows=0,
+        observed_rows=0,
+        matches=False,
+        message=f"{err.kind.value}: {err.detail}",
     )
 
 
@@ -205,13 +257,18 @@ def check_inventory_row_parity_csv(
     naive_dir: Path = _DEFAULT_NAIVE_DIR,
     optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
 ) -> list[ParityDiagnostic]:
+    diagnostics: list[ParityDiagnostic] = []
     with csv_path.open(newline="", encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
-        return [
-            check_inventory_row_parity_row(
-                row,
-                naive_dir=naive_dir,
-                optimised_dir=optimised_dir,
-            )
-            for row in reader
-        ]
+        for row in reader:
+            try:
+                diagnostics.append(
+                    check_inventory_row_parity_row(
+                        row,
+                        naive_dir=naive_dir,
+                        optimised_dir=optimised_dir,
+                    )
+                )
+            except IngestionError as err:
+                diagnostics.append(_diagnostic_from_error(err))
+    return diagnostics

--- a/tests/test_score_ingest.py
+++ b/tests/test_score_ingest.py
@@ -1,0 +1,185 @@
+"""Tests for aedist.score_ingest."""
+
+import csv
+import json
+
+import pytest
+
+from aedist.score_ingest import (
+    IngestionError,
+    IngestionErrorKind,
+    RunLocator,
+    check_inventory_row_parity,
+    check_inventory_row_parity_csv,
+    ingest_run,
+)
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_md(path, content):
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_csv(path, fieldnames, rows):
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_ingest_run_extracts_sectioned_table(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(
+        naive_dir / "openai_run01.json",
+        {"model": "gpt-5.5", "run": 1},
+    )
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "### Coal operating\n\n"
+        "| Name | Fuel | Total MWe | Status | COD | Province | Notes |\n"
+        "| --- | --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 1983 | Hai Duong | Legacy |\n"
+        "| Uong Bi | Coal | 630 | Operating | 2009/2013 | Quang Ninh | Expansion only |\n\n"
+        "| Fuel | Capacity |\n"
+        "| --- | --- |\n"
+        "| Coal | 1070 |\n",
+    )
+
+    ingested = ingest_run(
+        RunLocator(arm="naive", model="gpt-5.5", run=1),
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+
+    assert len(ingested.rows) == 2
+    assert ingested.rows[0]["name"] == "Pha Lai"
+    assert ingested.rows[0]["capacity_mwe"] == "440.0"
+    assert ingested.rows[1]["name"] == "Uong Bi"
+    assert ingested.rows[1]["capacity_mwe"] == "630.0"
+
+
+def test_ingest_run_missing_path_returns_typed_error(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    with pytest.raises(IngestionError) as excinfo:
+        ingest_run(
+            RunLocator(arm="naive", model="gpt-5.5", run=99),
+            naive_dir=naive_dir,
+            optimised_dir=optimised_dir,
+        )
+
+    assert excinfo.value.kind is IngestionErrorKind.RUN_NOT_FOUND
+
+
+def test_check_inventory_row_parity_for_naive_and_optimised_runs(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(
+        naive_dir / "openai_run01.json",
+        {"model": "gpt-5.5", "run": 1},
+    )
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 1983 | Hai Duong |\n"
+        "| Uong Bi | Coal | 630 | Operating | 2002 | Quang Ninh |\n",
+    )
+
+    _write_json(
+        optimised_dir / "anthropic_run03.json",
+        {"model": "claude-opus-4-6", "run": 3},
+    )
+    _write_md(
+        optimised_dir / "anthropic_run03.md",
+        "| Name | Fuel | Total MW | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| Vinh Tan 1 | Coal | 1240 | Operating | 2018 | Binh Thuan |\n"
+        "| Duyen Hai 1 | Coal | 1245 | Operating | 2015 | Tra Vinh |\n"
+        "| Song Hau 1 | Coal | 1200 | Operating | 2022 | Hau Giang |\n",
+    )
+
+    naive_diag = check_inventory_row_parity(
+        RunLocator(arm="naive", model="gpt-5.5", run=1),
+        expected_rows=2,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+    optimised_diag = check_inventory_row_parity(
+        RunLocator(arm="optimised", model="claude-opus-4-6", run=3),
+        expected_rows=3,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+
+    assert naive_diag.matches is True
+    assert naive_diag.observed_rows == 2
+    assert "expected=2 observed=2" in naive_diag.message
+    assert optimised_diag.matches is True
+    assert optimised_diag.observed_rows == 3
+    assert "expected=3 observed=3" in optimised_diag.message
+
+
+def test_check_inventory_row_parity_csv_reads_runs_csv(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(naive_dir / "openai_run01.json", {"model": "gpt-5.5", "run": 1})
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 1983 | Hai Duong |\n",
+    )
+
+    _write_json(
+        optimised_dir / "anthropic_run03.json",
+        {"model": "claude-opus-4-6", "run": 3},
+    )
+    _write_md(
+        optimised_dir / "anthropic_run03.md",
+        "| Name | Fuel | Total MW | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| Vinh Tan 1 | Coal | 1240 | Operating | 2018 | Binh Thuan |\n"
+        "| Duyen Hai 1 | Coal | 1245 | Operating | 2015 | Tra Vinh |\n",
+    )
+
+    runs_csv = tmp_path / "tab_exp2_arms_runs.csv"
+    _write_csv(
+        runs_csv,
+        ["arm", "model", "run", "inventory_rows"],
+        [
+            {"arm": "naive", "model": "gpt-5.5", "run": 1, "inventory_rows": 1},
+            {
+                "arm": "optimised",
+                "model": "claude-opus-4-6",
+                "run": 3,
+                "inventory_rows": 2,
+            },
+        ],
+    )
+
+    diagnostics = check_inventory_row_parity_csv(
+        runs_csv,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+
+    assert len(diagnostics) == 2
+    assert diagnostics[0].matches is True
+    assert diagnostics[1].matches is True

--- a/tests/test_score_ingest.py
+++ b/tests/test_score_ingest.py
@@ -79,6 +79,27 @@ def test_ingest_run_missing_path_returns_typed_error(tmp_path):
         )
 
     assert excinfo.value.kind is IngestionErrorKind.RUN_NOT_FOUND
+    assert excinfo.value.locator.model == "gpt-5.5"
+    assert "gpt-5.5" in excinfo.value.detail
+
+
+def test_ingest_run_invalid_utf8_returns_typed_error(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(naive_dir / "openai_run01.json", {"model": "gpt-5.5", "run": 1})
+    (naive_dir / "openai_run01.md").write_bytes(b"\xff\xfe\xfa")
+
+    with pytest.raises(IngestionError) as excinfo:
+        ingest_run(
+            RunLocator(arm="naive", model="gpt-5.5", run=1),
+            naive_dir=naive_dir,
+            optimised_dir=optimised_dir,
+        )
+
+    assert excinfo.value.kind is IngestionErrorKind.INVALID_ENCODING
 
 
 def test_check_inventory_row_parity_for_naive_and_optimised_runs(tmp_path):
@@ -182,4 +203,40 @@ def test_check_inventory_row_parity_csv_reads_runs_csv(tmp_path):
 
     assert len(diagnostics) == 2
     assert diagnostics[0].matches is True
+    assert diagnostics[1].matches is True
+
+
+def test_check_inventory_row_parity_csv_keeps_processing_on_invalid_row(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(naive_dir / "openai_run01.json", {"model": "gpt-5.5", "run": 1})
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 1983 | Hai Duong |\n",
+    )
+
+    runs_csv = tmp_path / "tab_exp2_arms_runs.csv"
+    _write_csv(
+        runs_csv,
+        ["arm", "model", "run", "inventory_rows"],
+        [
+            {"arm": "naive", "model": "gpt-5.5", "run": "bad", "inventory_rows": 1},
+            {"arm": "naive", "model": "gpt-5.5", "run": 1, "inventory_rows": 1},
+        ],
+    )
+
+    diagnostics = check_inventory_row_parity_csv(
+        runs_csv,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+
+    assert len(diagnostics) == 2
+    assert diagnostics[0].matches is False
+    assert diagnostics[0].message.startswith("invalid_parity_row")
     assert diagnostics[1].matches is True

--- a/tickets/0275-score-mechanical-ingestion-and-parity.erg
+++ b/tickets/0275-score-mechanical-ingestion-and-parity.erg
@@ -9,6 +9,8 @@ Blocked-by: 0277
 2026-05-24T11:22Z HDMX-coding-agent created
 2026-05-24T13:20Z HDMX-coding-agent updated from 0272 execution finding: sampled parity mismatch confirmed on openai_run01 (naive 79 vs 118, optimised 83 vs 122). Likely cause is inventory_rows counting all markdown pipe-table rows including summary tables while scorer extraction targets the main plant table.
 2026-05-24T13:36Z HDMX-coding-agent narrowed scope: inventory_rows producer bug is split into 0277. This ticket stays ingestion/parity only and is blocked until upstream row-count semantics are fixed.
+2026-05-24T15:18Z HDMX-coding-agent execute pass: added `src/aedist/score_ingest.py` to resolve `(arm, model, run)` to canonical markdown rows with typed ingestion errors and CSV-facing parity diagnostics.
+2026-05-24T15:22Z HDMX-coding-agent validation pass: `uv run pytest tests/test_score_ingest.py` and `make check-fast` succeeded.
 
 --- body ---
 ## Context
@@ -46,7 +48,7 @@ Upstream row-count semantics are handled by 0277. This ticket starts only once
 
 ## Exit criteria
 
-- [ ] Ingestion helper module committed with parser reuse (no duplicate parser implementation)
-- [ ] Parity diagnostics implemented and tested
-- [ ] Ingestion tests pass
-- [ ] `make check-fast` passes
+- [x] Ingestion helper module committed with parser reuse (no duplicate parser implementation)
+- [x] Parity diagnostics implemented and tested
+- [x] Ingestion tests pass
+- [x] `make check-fast` passes


### PR DESCRIPTION
**Ticket:** tickets/0275-score-mechanical-ingestion-and-parity.erg

## Summary
- add `aedist.score_ingest` to resolve Exp2 run outputs from `(arm, model, run)` and ingest canonical rows from the paired markdown report
- return typed ingestion errors instead of silent path fallbacks when a run cannot be resolved or parsed
- add explicit parity diagnostics, including a CSV-facing wrapper for `tab_exp2_arms_runs.csv` rows

## Validation
- uv run pytest tests/test_score_ingest.py
- make check-fast