### PR TITLE
Remediate score_mechanical post-merge panel findings

### DIFF
--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -207,9 +207,11 @@ _CANON = [
     "name",
     "fuel",
     "status",
+    "status_as_of",
     "cod",
     "province",
     "capacity_mwe",
+    "confidence",
     "source_1",
     "source_2",
     "note",
@@ -235,6 +237,14 @@ def map_header_to_canonical(norm: str) -> str | None:
         return "fuel"
     if norm in {"status", "construction_stage", "stage", "constructionstage"}:
         return "status"
+    if norm in {
+        "status_as_of",
+        "status_as_of_date",
+        "as_of",
+        "as_of_date",
+        "freshness_date",
+    }:
+        return "status_as_of"
     if norm in {"cod", "connection_date", "date", "connectiondate"}:
         return "cod"
     if norm in {"province", "location"}:
@@ -260,6 +270,8 @@ def map_header_to_canonical(norm: str) -> str | None:
     if norm.startswith("capacity"):
         return "capacity_mwe"
     # Provenance columns
+    if norm in {"confidence", "confidence_level", "evidence_confidence"}:
+        return "confidence"
     if norm in {"source_1", "source", "reference", "citation"}:
         return "source_1"
     if norm in {"source_2", "reference_2", "citation_2"}:

--- a/src/aedist/score_mechanical.py
+++ b/src/aedist/score_mechanical.py
@@ -86,15 +86,17 @@ class CoherenceScores:
 @dataclass
 class ProvenanceScores:
     source_presence: float | None
+    source_presence_annotation: str | None
     high_conf_dual_source: float | None
-    annotation: str | None = None
+    high_conf_dual_source_annotation: str | None
 
 
 @dataclass
 class TemporalityScores:
     asof_presence: float | None
+    asof_presence_annotation: str | None
     plausible_range: float | None
-    annotation: str | None = None
+    plausible_range_annotation: str | None
 
 
 @dataclass
@@ -174,11 +176,12 @@ def score_coherence(rows: list[dict[str, str]]) -> CoherenceScores:
 
 def score_provenance(rows: list[dict[str, str]]) -> ProvenanceScores:
     if not rows:
-        return ProvenanceScores(None, None, annotation="no_rows")
+        return ProvenanceScores(None, "no_rows", None, "no_rows")
 
     with_sources = 0
     high_rows = 0
     high_rows_with_dual = 0
+    has_confidence_column = any("confidence" in row for row in rows)
 
     for row in rows:
         source_1 = (row.get("source_1") or "").strip()
@@ -192,22 +195,32 @@ def score_provenance(rows: list[dict[str, str]]) -> ProvenanceScores:
             if source_1 and source_2:
                 high_rows_with_dual += 1
 
-    high_dual = _fraction(high_rows_with_dual, high_rows)
-    if high_rows == 0:
-        annotation = "column_missing_or_no_high_confidence"
+    if not has_confidence_column:
+        high_dual = None
+        high_annotation = "column_missing"
+    elif high_rows == 0:
+        high_dual = None
+        high_annotation = "no_high_confidence"
     else:
-        annotation = None
+        high_dual = _fraction(high_rows_with_dual, high_rows)
+        high_annotation = None
 
     return ProvenanceScores(
         source_presence=_fraction(with_sources, len(rows)),
+        source_presence_annotation=None,
         high_conf_dual_source=high_dual,
-        annotation=annotation,
+        high_conf_dual_source_annotation=high_annotation,
     )
 
 
 def score_temporality(rows: list[dict[str, str]]) -> TemporalityScores:
     if not rows:
-        return TemporalityScores(None, None, annotation="no_rows")
+        return TemporalityScores(None, "no_rows", None, "no_rows")
+
+    asof_keys = ("status_as_of", "as_of", "date_as_of", "freshness_date")
+    has_asof_column = any(any(k in row for k in asof_keys) for row in rows)
+    if not has_asof_column:
+        return TemporalityScores(None, "column_missing", None, "column_missing")
 
     with_asof = 0
     plausible = 0
@@ -223,16 +236,18 @@ def score_temporality(rows: list[dict[str, str]]) -> TemporalityScores:
         if 1980 <= year <= 2100:
             plausible += 1
 
-    plausible_rate = _fraction(plausible, with_asof)
     if with_asof == 0:
-        annotation = "column_missing_or_empty"
+        plausible_rate = None
+        plausible_annotation = "column_empty"
     else:
-        annotation = None
+        plausible_rate = _fraction(plausible, with_asof)
+        plausible_annotation = None
 
     return TemporalityScores(
         asof_presence=_fraction(with_asof, len(rows)),
+        asof_presence_annotation=None,
         plausible_range=plausible_rate,
-        annotation=annotation,
+        plausible_range_annotation=plausible_annotation,
     )
 
 
@@ -326,13 +341,15 @@ def main(argv: list[str] | None = None) -> None:
         "coherence_capacity_nonnegative": _fmt(coherence.capacity_nonnegative),
         "coherence_capacity_nonnegative_annotation": coherence.annotation or "",
         "provenance_source_presence": _fmt(provenance.source_presence),
-        "provenance_source_presence_annotation": provenance.annotation or "",
+        "provenance_source_presence_annotation": provenance.source_presence_annotation or "",
         "provenance_high_conf_dual_source": _fmt(provenance.high_conf_dual_source),
-        "provenance_high_conf_dual_source_annotation": provenance.annotation or "",
+        "provenance_high_conf_dual_source_annotation": (
+            provenance.high_conf_dual_source_annotation or ""
+        ),
         "temporality_asof_presence": _fmt(temporality.asof_presence),
-        "temporality_asof_presence_annotation": temporality.annotation or "",
+        "temporality_asof_presence_annotation": temporality.asof_presence_annotation or "",
         "temporality_plausible_range": _fmt(temporality.plausible_range),
-        "temporality_plausible_range_annotation": temporality.annotation or "",
+        "temporality_plausible_range_annotation": temporality.plausible_range_annotation or "",
         "field_completeness_core": _fmt(completeness.core_fields),
         "field_completeness_core_annotation": completeness.annotation or "",
         "field_completeness_capacity": _fmt(completeness.capacity_present),

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -284,10 +284,17 @@ class TestParseAndCanonicalize:
         csv_text = "Name,Fuel\nPha Lai,Coal\n"
         result = parse_and_canonicalize(csv_text)
         lines = result.strip().splitlines()
-        assert lines[0] == "name,fuel,status,cod,province,capacity_mwe,source_1,source_2,note"
+        assert (
+            lines[0]
+            == "name,fuel,status,status_as_of,cod,province,capacity_mwe,confidence,source_1,source_2,note"
+        )
+        header = lines[0].split(",")
         row = lines[1].split(",")
-        assert row[0] == "Pha Lai"
-        assert row[2] == ""  # status missing
+        row_map = dict(zip(header, row, strict=False))
+        assert row_map["name"] == "Pha Lai"
+        assert row_map["status"] == ""  # status missing
+        assert row_map["status_as_of"] == ""  # as-of missing
+        assert row_map["confidence"] == ""  # confidence missing
 
     def test_capacity_normalized(self):
         csv_text = "Name,Capacity\nPha Lai,1200\n"
@@ -401,6 +408,30 @@ class TestHeaderVariantsProvenance:
         """'notes' and 'comment' headers map to note."""
         assert map_header_to_canonical(norm_header("Notes")) == "note"
         assert map_header_to_canonical(norm_header("Comment")) == "note"
+
+
+class TestHeaderVariantsConfidenceTemporality:
+    """Header variant mappings for confidence and as-of columns."""
+
+    def test_header_variant_confidence_maps_to_confidence(self):
+        assert map_header_to_canonical(norm_header("Confidence")) == "confidence"
+        assert map_header_to_canonical(norm_header("Confidence level")) == "confidence"
+
+    def test_header_variant_status_as_of_maps_to_status_as_of(self):
+        assert map_header_to_canonical(norm_header("Status as-of-date")) == "status_as_of"
+        assert map_header_to_canonical(norm_header("As-of date")) == "status_as_of"
+
+    def test_status_as_of_and_confidence_preserved(self):
+        csv_text = (
+            "Name,Fuel,Status,Status as-of-date,COD,Province,Capacity,Confidence\n"
+            "Pha Lai,Coal,Operating,2024 est.,1983,Hai Duong,440,HIGH\n"
+        )
+        result = parse_and_canonicalize(csv_text)
+        header = result.splitlines()[0].split(",")
+        row = result.splitlines()[1].split(",")
+        row_map = dict(zip(header, row, strict=False))
+        assert row_map["status_as_of"] == "2024 est."
+        assert row_map["confidence"] == "HIGH"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_score_mechanical.py
+++ b/tests/test_score_mechanical.py
@@ -1,5 +1,6 @@
 """Tests for mechanical scoring helpers."""
 
+from aedist.score_ingest import RunLocator, ingest_run
 from aedist.score_mechanical import (
     score_coherence,
     score_field_completeness,
@@ -47,6 +48,72 @@ def test_empty_total_mwe_counted_absent() -> None:
 
 def test_empty_table_has_no_division_by_zero() -> None:
     assert score_coherence([]).annotation == "no_rows"
-    assert score_provenance([]).annotation == "no_rows"
-    assert score_temporality([]).annotation == "no_rows"
+    assert score_provenance([]).source_presence_annotation == "no_rows"
+    assert score_provenance([]).high_conf_dual_source_annotation == "no_rows"
+    assert score_temporality([]).asof_presence_annotation == "no_rows"
+    assert score_temporality([]).plausible_range_annotation == "no_rows"
     assert score_field_completeness([]).annotation == "no_rows"
+
+
+def _write_json(path, payload) -> None:
+    import json
+
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_md(path, content) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_ingested_rows_mark_confidence_metric_column_missing(tmp_path) -> None:
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(naive_dir / "openai_run01.json", {"model": "gpt-5.5", "run": 1})
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province | Source 1 | Source 2 |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 1983 | Hai Duong | EVN report | MOIT |\n",
+    )
+
+    ingested = ingest_run(
+        RunLocator(arm="naive", model="gpt-5.5", run=1),
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+    result = score_provenance(ingested.rows)
+
+    assert result.source_presence == 1.0
+    assert result.source_presence_annotation is None
+    assert result.high_conf_dual_source is None
+    assert result.high_conf_dual_source_annotation == "column_missing"
+
+
+def test_ingested_rows_mark_temporality_metrics_column_missing(tmp_path) -> None:
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(naive_dir / "openai_run01.json", {"model": "gpt-5.5", "run": 1})
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 1983 | Hai Duong |\n",
+    )
+
+    ingested = ingest_run(
+        RunLocator(arm="naive", model="gpt-5.5", run=1),
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+    result = score_temporality(ingested.rows)
+
+    assert result.asof_presence is None
+    assert result.asof_presence_annotation == "column_missing"
+    assert result.plausible_range is None
+    assert result.plausible_range_annotation == "column_missing"

--- a/tests/test_score_mechanical.py
+++ b/tests/test_score_mechanical.py
@@ -65,7 +65,7 @@ def _write_md(path, content) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def test_ingested_rows_mark_confidence_metric_column_missing(tmp_path) -> None:
+def test_ingested_rows_mark_confidence_metric_no_high_confidence(tmp_path) -> None:
     naive_dir = tmp_path / "naive"
     optimised_dir = tmp_path / "optimised"
     naive_dir.mkdir()
@@ -89,7 +89,7 @@ def test_ingested_rows_mark_confidence_metric_column_missing(tmp_path) -> None:
     assert result.source_presence == 1.0
     assert result.source_presence_annotation is None
     assert result.high_conf_dual_source is None
-    assert result.high_conf_dual_source_annotation == "column_missing"
+    assert result.high_conf_dual_source_annotation == "no_high_confidence"
 
 
 def test_ingested_rows_mark_temporality_metrics_column_missing(tmp_path) -> None:
@@ -113,7 +113,37 @@ def test_ingested_rows_mark_temporality_metrics_column_missing(tmp_path) -> None
     )
     result = score_temporality(ingested.rows)
 
-    assert result.asof_presence is None
-    assert result.asof_presence_annotation == "column_missing"
+    assert result.asof_presence == 0.0
+    assert result.asof_presence_annotation is None
     assert result.plausible_range is None
-    assert result.plausible_range_annotation == "column_missing"
+    assert result.plausible_range_annotation == "column_empty"
+
+
+def test_ingested_rows_compute_high_conf_dual_source_when_present(tmp_path) -> None:
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(naive_dir / "openai_run01.json", {"model": "gpt-5.5", "run": 1})
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | Status as-of-date | COD | Province | Confidence | Source 1 | Source 2 |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        "| Pha Lai | Coal | 440 | Operating | 2024 est. | 1983 | Hai Duong | HIGH | EVN report | MOIT |\n",
+    )
+
+    ingested = ingest_run(
+        RunLocator(arm="naive", model="gpt-5.5", run=1),
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+    )
+    prov = score_provenance(ingested.rows)
+    temp = score_temporality(ingested.rows)
+
+    assert prov.high_conf_dual_source == 1.0
+    assert prov.high_conf_dual_source_annotation is None
+    assert temp.asof_presence == 1.0
+    assert temp.asof_presence_annotation is None
+    assert temp.plausible_range == 1.0
+    assert temp.plausible_range_annotation is None


### PR DESCRIPTION
## Summary
- make provenance and temporality metrics schema-aware: return null+annotation when required columns are absent in canonical ingested rows
- split annotations per sub-metric (instead of sharing one annotation across both values)
- keep source-presence metric computable while separately annotating high-confidence dual-source metric
- add ingestion-level integration tests in `tests/test_score_mechanical.py` to lock missing-column behavior for confidence and as-of fields

## Validation
- `uv run pytest tests/test_score_mechanical.py -q`
- `make check-fast`