### PR TITLE
tickets: 0278–0281 reprompt bundle, extractor hardening, Phase A manifest, provenance scorer

### DIFF
--- a/tickets/0250-run-experiment-3-four-arm-sweep.erg
+++ b/tickets/0250-run-experiment-3-four-arm-sweep.erg
@@ -2,11 +2,13 @@
 Title: Run Experiment 3 intervention arms
 Created: 2026-05-23
 Author: Copilot
+Blocked-by: 0278
 
 --- log ---
 2026-05-23T16:02Z Copilot created
 
 2026-05-23T20:11Z HDMX-coding-agent note blocker 0249 closed — Blocked-by removed.
+2026-05-24T16:00Z HDMX-coding-agent note added Blocked-by 0278 (reprompt bundle: table-first, single-table, no summary tables, max_tokens 64K); 0278 is itself blocked on 0279+0280
 --- body ---
 ## Context
 The Experiment 3 protocol is drafted and the implementation path is split into an assembler prerequisite and a runtime patch. This ticket covers the actual Experiment 3 runs after the codebase patch lands. Arms 1 and 2 are reused as existing baselines; they are not rerun.

--- a/tickets/0278-reprompt-exp2-exp3-quality-bundle.erg
+++ b/tickets/0278-reprompt-exp2-exp3-quality-bundle.erg
@@ -1,0 +1,77 @@
+%erg 0.1
+Title: Reprompt bundle — table order, single table, no summary tables, max_tokens 64K
+Created: 2026-05-24
+Author: haduong
+Blocked-by: 0279
+Blocked-by: 0280
+
+--- log ---
+2026-05-24T14:30Z haduong created
+
+--- body ---
+## Context
+
+Four concrete protocol fixes identified before next arm3/arm4 run batch.
+All touch prompt files and/or harness constants. Must land before 0250 proceeds.
+
+## Changes
+
+### 1. Table-first output ordering (both prompts)
+
+Current format order in `protocol_07_naive_prompt.md` and `protocol_02_metaprompt.md`:
+  sector overview → per-plant narratives → structured table → summary tables → bibliography
+
+With max_tokens binding (4/5 Anthropic arm1 corrected runs hit 32K), the table
+arrives late and gets truncated. Reorder to:
+  structured table → condensed per-plant notes → bibliography
+
+The primary measurement artifact is always complete even in a truncated run.
+
+### 2. Single-table enforcement (both prompts)
+
+Current column spec lists "Fuel (Coal / Domestic gas / Imported LNG)" which models
+read as an invitation to produce three sub-tables by fuel. Add one explicit line:
+
+  > Produce ONE unified table. Do not split by fuel, status, or any other dimension.
+
+The fixed extractor (0279) handles remaining fragmentation, but the prompt should
+not invite it.
+
+### 3. Remove summary-tables ask (both prompts)
+
+Remove: "statistical summary tables (capacity by fuel × status; top 15 provinces;
+timeline of additions by period and fuel; data-quality summary by confidence level
+and fuel)"
+
+Rationale: summary tables were intended as a coherence-forcing mechanism but
+(a) the token budget is better spent on plant rows, (b) runs truncated before
+the summary section had no coherence enforcement at all, (c) the extractor had
+to be hardened (#492) because of them. The coherence test will be applied
+post-hoc by the mechanical scorer (0276).
+
+### 4. max_tokens bump: 32K → 64K for Anthropic
+
+In `exp2_naive_arm.py`: `ANTHROPIC_MAX_TOKENS = 32_000` → `64_000`.
+In `exp2_interactive_smoke.py`: update the corresponding floor/default constant.
+
+Streaming is already required at 32K, so no API path change needed.
+Cost impact: ~doubles per run ($1.15–$1.37 → ~$2.30), ~$11.50 for 5 runs.
+Justification: 4/5 corrected arm1 runs were truncated at 32K; reference dataset
+is 163 plants; corrected runs yielded 19–51 plants (best table). More tokens
+directly improve recall.
+
+## Files to change
+
+- `experiments/sota/protocol_07_naive_prompt.md`
+- `experiments/sota/protocol_02_metaprompt.md`
+- `experiments/sota/exp2_naive_arm.py` (ANTHROPIC_MAX_TOKENS constant)
+- `experiments/sota/exp2_interactive_smoke.py` (max_tokens floor/default)
+
+## Exit criteria
+
+- [ ] `protocol_07_naive_prompt.md` updated: table first, single-table instruction,
+      summary tables removed
+- [ ] `protocol_02_metaprompt.md` updated: same structural changes + Phase A note
+      that evidence pack manifest follows in the meta-prompt body (see 0280)
+- [ ] `ANTHROPIC_MAX_TOKENS = 64_000` in `exp2_naive_arm.py`
+- [ ] `make check-fast` passes

--- a/tickets/0279-harden-extractor-fragmented-tables.erg
+++ b/tickets/0279-harden-extractor-fragmented-tables.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Harden extractor for fragmented plant tables
+Created: 2026-05-24
+Author: haduong
+
+--- log ---
+2026-05-24T14:30Z haduong created
+
+--- body ---
+## Context
+
+`count_best_table_rows` in `src/aedist/extract.py` (introduced in #492) selects
+the single largest markdown table as the plant table. When a model emits three
+sub-tables (coal / gas / LNG), only the largest (typically coal) is counted.
+Run01 result: extractor reports 46 rows vs ~109 actual plant rows across all
+three fuel sub-tables.
+
+This is the extractor side of the single-table problem. Ticket 0278 adds a
+prompt instruction to discourage fragmentation; this ticket ensures the extractor
+handles it robustly even when the model ignores the instruction.
+
+## Design
+
+Fragmentation detection heuristic: if two or more tables within 20 lines of each
+other share the same number of columns AND have compatible headers (≥2 columns
+with identical normalised names — e.g., "Name", "Province", "MWe", "Status"),
+treat them as fragments of one logical table and merge before row-counting.
+
+The merge is additive: concatenate data rows, deduplicate by normalised Vietnamese
+name (case-insensitive, strip diacritics). Header and separator rows are not
+duplicated.
+
+## Scope
+
+- Modify `count_best_table_rows` (or extract a `merge_fragmented_tables` helper
+  it calls) in `src/aedist/extract.py`.
+- Add regression tests in `tests/test_extract.py`:
+  - Input: markdown with 3 consecutive compatible tables (coal/gas/LNG split).
+    Expected: merged row count = sum of data rows across all three.
+  - Input: markdown with unrelated tables (different column counts).
+    Expected: largest table only, no merge.
+- Verify on `experiments/outputs/sota_exp2_naive_arm/anthropic_run01.md`:
+  corrected extractor count ≥ 80 rows (vs current 46).
+
+## Exit criteria
+
+- [ ] `merge_fragmented_tables` or equivalent logic in `extract.py`
+- [ ] Both regression tests pass
+- [ ] Spot-check on anthropic_run01.md: count ≥ 80
+- [ ] `make check-fast` passes

--- a/tickets/0280-manifest-in-phase-a.erg
+++ b/tickets/0280-manifest-in-phase-a.erg
@@ -1,0 +1,55 @@
+%erg 0.1
+Title: Pass evidence pack manifest to Phase A meta-prompt
+Created: 2026-05-24
+Author: haduong
+
+--- log ---
+2026-05-24T14:30Z haduong created
+
+--- body ---
+## Context
+
+In Arms 3/4 (with evidence pack), Phase A currently runs without any knowledge
+of the evidence pack. The agent designs a retrieval strategy as if it were Arm 2
+(no evidence), and the evidence pack is grafted onto the designed prompt after
+Phase A returns. This means the protocol design step is blind to what data is
+actually available.
+
+Passing the manifest (a small YAML list of available evidence items) in Phase A
+lets the agent write a strategy that actually exploits the pack: e.g., "I will
+start from the GEM tracker entry for each plant, then cross-check against the
+EVN load dispatch reports."
+
+## Design
+
+The manifest YAML is small (~1K chars). It should appear in `protocol_02_metaprompt.md`
+as a filled-in section (e.g., "## Available evidence pack\n<manifest content>")
+when an evidence pack is active.
+
+Option A — inline in prompt file: `assemble_meta_prompt()` accepts an optional
+`manifest_path` and injects the YAML block.
+Option B — passed as a separate section appended by `assemble_meta_prompt()`.
+
+Prefer option A (single function signature change, testable).
+
+## Changes
+
+1. `assemble_meta_prompt(manifest_path: Path | None = None)` in
+   `exp2_interactive_smoke.py`: if manifest_path is provided, append a
+   "## Available evidence pack" section with the YAML contents after the
+   budget announcement.
+
+2. Call site (main loop): pass `args.evidence_pack_manifest` to
+   `assemble_meta_prompt()` when provided.
+
+3. `protocol_02_metaprompt.md`: add a placeholder section near the end:
+   "## Available evidence pack (injected at runtime when --evidence-pack-manifest
+   is provided)". This makes the injection visible when reading the template.
+
+## Exit criteria
+
+- [ ] `assemble_meta_prompt(manifest_path)` implemented and called correctly
+- [ ] Dry-run with `--no-confirm` prints manifest content in the meta-prompt
+      for arm4 invocation
+- [ ] No change to arm2 behaviour (manifest_path=None path unchanged)
+- [ ] `make check-fast` passes

--- a/tickets/0281-provenance-spot-check-scorer.erg
+++ b/tickets/0281-provenance-spot-check-scorer.erg
@@ -1,0 +1,59 @@
+%erg 0.1
+Title: Automated provenance spot-check — verify N=10 source URLs per run
+Created: 2026-05-24
+Author: haduong
+Blocked-by: 0276
+
+--- log ---
+2026-05-24T14:30Z haduong created
+
+--- body ---
+## Context
+
+The four quality dimensions announced in the protocol (accuracy, coherence,
+provenance, temporality) are evaluated post-hoc. Only accuracy is currently
+measured by the mechanical scorer (0276) via row-level F1 against the 163-plant
+reference. Provenance is the paper's differentiating claim — "agents can produce
+verifiable tables" — but goes unmeasured.
+
+This ticket adds an automated spot-check: for each run, sample N=10 matched
+plant rows at random and verify whether Source 1 is (a) a real URL that resolves
+and (b) a page whose text content actually mentions the plant by name and
+(plausibly) the claimed capacity. Output: a provenance score 0–10 per run.
+
+## Design
+
+Input: one run's `.md` file + the matched plant rows from `sota_cross_eval.csv`
+(produced by 0276 — hence the blocker).
+
+Algorithm:
+1. For each sampled matched row, extract Source 1 URL from the markdown table.
+2. HTTP GET the URL (10s timeout, single retry). Record: resolved / unresolved /
+   fabricated (URL syntactically valid but 404/domain-not-found).
+3. If resolved, search page text for the plant's Vietnamese or English name
+   (case-insensitive). If found and capacity within ±10% of claimed value: PASS.
+4. Emit per-row result (pass/fail/unresolved) and aggregate provenance_score = n_pass / 10.
+
+Output columns added to `sota_cross_eval.csv` (or a companion
+`sota_provenance_sample.csv`):
+  run_id, sampled_rows (JSON list of plant names), n_resolved, n_name_found,
+  n_capacity_match, provenance_score
+
+## Scope limits
+
+- Only Source 1, not Source 2 (keep it simple).
+- N=10 per run (not exhaustive — this is a spot-check, not a full citation audit).
+- No JavaScript rendering (plain HTTP GET only). Dynamic pages score as unresolved.
+- Capacity check is fuzzy ±10%, not exact.
+
+## Why block on 0276
+
+Needs `sota_cross_eval.csv` with matched plant rows to know which rows to sample
+(unmatched rows have no reference to check against).
+
+## Exit criteria
+
+- [ ] `score_provenance.py` or equivalent module implemented with the algorithm above
+- [ ] Output columns defined and documented in `docs/scoring-contract.md`
+- [ ] Smoke test on ≥1 run from `sota_exp2_naive_arm/`
+- [ ] `make check-fast` passes (HTTP calls mocked in tests)


### PR DESCRIPTION
Tickets only — no source code changes.

- **0278** (blocked on 0279+0280): reprompt bundle — table-first order, single-table enforcement, remove summary tables, `ANTHROPIC_MAX_TOKENS` 32K→64K
- **0279**: harden extractor for fragmented tables (`merge_fragmented_tables` in `extract.py`)
- **0280**: pass evidence pack manifest to `assemble_meta_prompt` in Phase A
- **0281** (blocked on 0276): automated provenance spot-check scorer
- **0250**: added `Blocked-by: 0278` — Exp3 arms 3/4 must not run until reprompt lands

Dependency chain:
```
0250 (run Exp3) ← 0278 ← 0279, 0280
0281 ← 0276
```