### PR TITLE
tickets: add Exp2 mart migration bundle 0282-0287

### DIFF
--- a/tickets/0282-exp2-mart-migration-parent-tracker.erg
+++ b/tickets/0282-exp2-mart-migration-parent-tracker.erg
@@ -1,0 +1,42 @@
+%erg 0.1
+Title: Parent tracker - Exp2 analysis mart migration (schema, builder, views, consumers)
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0283
+Blocked-by: 0284
+Blocked-by: 0285
+Blocked-by: 0286
+Blocked-by: 0287
+
+--- log ---
+2026-05-24T14:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Exp2 analysis outputs currently read from a mix of intermediates and raw probe
+artifacts. We want a single canonical data mart for analysis flow, without
+embedding verbatim chat text.
+
+This tracker coordinates a staged migration:
+1. Define schema contract
+2. Build canonical mart
+3. Emit consumer CSV views
+4. Migrate figures/tables
+5. Dual-run parity gate before cutover
+
+## Child tickets
+
+- `0283` - Define Exp2 mart schema contract (Pydantic + docs)
+- `0284` - Build `exp2_mart.jsonl` from immutable artifacts
+- `0285` - Materialize CSV views from mart for consumer scripts
+- `0286` - Migrate Exp2 figures/tables to mart views
+- `0287` - Add dual-run parity gate and cutover checks
+
+## Exit criteria
+
+- [ ] Tickets `0283`, `0284`, `0285`, `0286`, `0287` merged
+- [ ] Canonical mart contains no verbatim chat payloads
+- [ ] All Exp2 figures/tables read mart-derived views (not raw probes)
+- [ ] Dual-run parity checks pass
+- [ ] `make check-fast` passes on integration branch

--- a/tickets/0283-define-exp2-mart-schema-contract.erg
+++ b/tickets/0283-define-exp2-mart-schema-contract.erg
@@ -1,0 +1,37 @@
+%erg 0.1
+Title: Define Exp2 mart schema contract (Pydantic + docs)
+Created: 2026-05-24
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-24T14:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Before migration, lock a typed contract for a canonical Exp2 mart. The mart
+must carry stable IDs, metric fields, nullability annotations, and immutable
+artifact pointers. It must not store verbatim chat text.
+
+## Deliverables
+
+1. New schema module (Pydantic) for mart records, for example:
+   - run-level records
+   - turn/probe-level records
+   - mechanical score records
+2. Explicit schema versioning field(s)
+3. Pointer fields to immutable artifacts (`result_file`, `parsed_table_file`,
+   `probe_file`) plus hash fields
+4. Contract doc describing required/optional fields and annotation semantics
+
+## Non-goals
+
+- No consumer migration
+- No Makefile cutover
+
+## Exit criteria
+
+- [ ] Schema module committed with validation tests
+- [ ] Contract doc committed
+- [ ] Schema explicitly bans verbatim chat payload fields
+- [ ] `make check-fast` passes

--- a/tickets/0284-build-exp2-mart-jsonl-from-immutable-artifacts.erg
+++ b/tickets/0284-build-exp2-mart-jsonl-from-immutable-artifacts.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Build exp2_mart.jsonl from immutable artifacts
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0283
+
+--- log ---
+2026-05-24T14:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Implement a mart builder that reads immutable Exp2 outputs and emits one
+canonical JSONL artifact validated against the schema from 0283.
+
+## Deliverables
+
+1. Builder script/module producing `report/inputs/generated/exp2_mart.jsonl`
+2. Record-level hash and pointer enrichment
+3. Validation failure on schema mismatch
+4. Tests with fixture outputs proving no verbatim chat payload appears in mart
+
+## Non-goals
+
+- No figure/table migration yet
+
+## Exit criteria
+
+- [ ] Builder writes validated mart JSONL
+- [ ] Mart includes artifact pointers and hashes
+- [ ] Negative test confirms verbatim chat fields are rejected/absent
+- [ ] `make check-fast` passes

--- a/tickets/0285-materialize-exp2-csv-views-from-mart.erg
+++ b/tickets/0285-materialize-exp2-csv-views-from-mart.erg
@@ -1,0 +1,34 @@
+%erg 0.1
+Title: Materialize Exp2 CSV views from mart
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0284
+
+--- log ---
+2026-05-24T14:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Existing figure/table scripts mostly consume CSV. Keep that ergonomics by
+emitting mart-derived CSV views as build artifacts.
+
+## Deliverables
+
+1. View generator(s) that read `exp2_mart.jsonl` and write CSV views, e.g.:
+   - `tab_exp2_arms_runs_view.csv`
+   - `tab_exp2_bib_quality_view.csv`
+   - `exp2_turn_trajectory_view.csv`
+   - `sota_cross_eval_view.csv`
+2. Deterministic column order and null encoding rules
+3. Tests for row-count and key-field parity with source mart slices
+
+## Non-goals
+
+- No consumer cutover yet
+
+## Exit criteria
+
+- [ ] All required CSV views generated from mart
+- [ ] View tests pass
+- [ ] `make check-fast` passes

--- a/tickets/0286-migrate-exp2-figures-and-tables-to-mart-views.erg
+++ b/tickets/0286-migrate-exp2-figures-and-tables-to-mart-views.erg
@@ -1,0 +1,28 @@
+%erg 0.1
+Title: Migrate Exp2 figures/tables to mart-derived views
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0285
+
+--- log ---
+2026-05-24T14:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Switch Exp2 consumer scripts from ad-hoc/raw inputs to mart-derived CSV views.
+This consolidates analysis flow while preserving existing outputs.
+
+## Deliverables
+
+1. Update Exp2 table/figure scripts and Makefile deps to read mart views
+2. Remove direct probe/raw dependencies where replaced by views
+3. Keep output filenames unchanged unless required
+4. Add migration tests asserting script behavior on view inputs
+
+## Exit criteria
+
+- [ ] Exp2 tables read mart views
+- [ ] Exp2 figures read mart views
+- [ ] No direct raw-probe read path remains for migrated consumers
+- [ ] `make check-fast` passes

--- a/tickets/0287-add-dual-run-parity-gate-for-mart-cutover.erg
+++ b/tickets/0287-add-dual-run-parity-gate-for-mart-cutover.erg
@@ -1,0 +1,28 @@
+%erg 0.1
+Title: Add dual-run parity gate for mart cutover
+Created: 2026-05-24
+Author: HDMX-coding-agent
+Blocked-by: 0286
+
+--- log ---
+2026-05-24T14:55Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Before fully trusting the mart flow, run old and new analysis paths side by
+side and gate cutover on parity thresholds.
+
+## Deliverables
+
+1. Dual-run target(s) in Makefile for old-path vs mart-path outputs
+2. Parity checker for key tables/figures or their numeric intermediates
+3. Explicit tolerance policy (exact match where expected, tolerance where needed)
+4. CI/local gate target failing on parity regressions
+
+## Exit criteria
+
+- [ ] Dual-run pipeline target exists
+- [ ] Parity check target exists and is documented
+- [ ] Parity checks pass on current baseline
+- [ ] `make check-fast` passes


### PR DESCRIPTION
## Summary
- add parent tracker `0282` for Exp2 analysis mart migration
- add child ticket chain `0283` through `0287` for schema, mart builder, CSV views, consumer migration, and parity gate
- keep scope explicit: no verbatim chat in mart, immutable artifact pointers + hashes

## Files
- tickets/0282-exp2-mart-migration-parent-tracker.erg
- tickets/0283-define-exp2-mart-schema-contract.erg
- tickets/0284-build-exp2-mart-jsonl-from-immutable-artifacts.erg
- tickets/0285-materialize-exp2-csv-views-from-mart.erg
- tickets/0286-migrate-exp2-figures-and-tables-to-mart-views.erg
- tickets/0287-add-dual-run-parity-gate-for-mart-cutover.erg