### PR TITLE
fix(scorer): harden LP matcher, temporality, coherence; align meta-prompt vocab

### DIFF
--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -12,9 +12,8 @@ In Phase A — this turn — you design your own approach. You will return a JSO
 
 In Phase B you will produce a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30 MWe), structured as follows:
 
-- a sector overview (electricity mix, policy framework, key institutional actors, current challenges)
-- a concise sourced per-plant narrative for each plant (development history, notable issues, including key plant attributes, possibly confidence-qualified)
 - the plant inventory: **exactly one pipe table**, never split into sub-tables by status, fuel, province, or any other dimension. Columns in this exact order: Name (Vietnamese), Name (English), Province, Fuel (Coal / Domestic gas / Imported LNG), Technology (Subcritical / Supercritical / USC for coal; CCGT / OCGT for gas), Units × MW, Total MWe, Status, Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes. Do not add statistical summary, cross-tabulation, or any other pipe tables; fold aggregate statistics into prose.
+- per-asset or per-project explanatory notes: for each asset that warrants it (major, disputed, ambiguous, or historically important), a concise sourced note covering development history, notable issues, and confidence-qualified attributes. Straightforward operational assets need no note.
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
 All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled and pre-FID projects are in scope if they have appeared in formal planning cycles.
@@ -133,5 +132,5 @@ Status definitions (use these exact terms in the Status column):
 Capacity rule:
 Record nameplate electrical capacity in MWe when available. If sources do not distinguish gross vs net, record the stated MW value and note "gross/net unspecified". Do not mix thermal MW, boiler capacity, steam output, or investment package capacity with electrical MWe. For Units × MW, make arithmetic consistent with Total MWe or explain discrepancies in Notes.
 
-Narrative discipline:
-Prioritise the structured table. Provide full per-plant narratives only for major, disputed, ambiguous, or historically important assets. For straightforward operational assets, a compact Notes entry is sufficient.
+Explanatory notes discipline:
+The table comes first. Per-asset notes follow the table and are selective: write one only for assets that are major, disputed, ambiguous, or historically important. For straightforward operational assets a compact Notes cell in the table is sufficient; do not repeat it as a separate note.

--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -8,9 +8,9 @@ You are a state-of-the-art AI assistant being evaluated as a subject in a struct
 
 # GOAL
 
-In Phase A — this turn — you design your own approach. You will return a JSON envelope containing a `system_prompt` to install on yourself at agent-create time, a `designed_prompt` to receive as the first user message of Phase B, runtime `settings`, and a short `rationale`. You have full freedom over what those four fields contain. The designed Phase B prompt should be operational, not philosophical: it should define search strategy, source hierarchy, table schema, confidence rules, budget discipline, and stopping criteria.
+In Phase A — this turn — you design your own approach. You will return a JSON envelope containing a `system_prompt` to install on yourself at agent-create time, a `designed_prompt` to receive as the first user message of Phase B, runtime `settings`, and a short `rationale`. Your freedom covers search strategy, source hierarchy, confidence rules, budget discipline, and stopping criteria — the Phase B deliverable schema and structure are fixed by this prompt. The designed Phase B prompt must be operational, not philosophical.
 
-In Phase B you will produce a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30 MWe), structured as follows:
+In Phase B you will produce a single Markdown document: a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30 MWe). Begin the document directly with the inventory table — no title, no preamble, no overview section. Structure it as follows:
 
 - the plant inventory: **exactly one pipe table**, never split into sub-tables by status, fuel, province, or any other dimension. Columns in this exact order: Name (Vietnamese), Name (English), Province, Fuel (Coal / Domestic gas / Imported LNG), Technology (Subcritical / Supercritical / USC for coal; CCGT / OCGT for gas), Units × MW, Total MWe, Status, Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes. Do not add statistical summary, cross-tabulation, or any other pipe tables; fold aggregate statistics into prose.
 - per-asset or per-project explanatory notes: for each asset that warrants it (major, disputed, ambiguous, or historically important), a concise sourced note covering development history, notable issues, and confidence-qualified attributes. Straightforward operational assets need no note.
@@ -19,8 +19,6 @@ In Phase B you will produce a complete, primary-sourced reference inventory of V
 All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled and pre-FID projects are in scope if they have appeared in formal planning cycles.
 
 When uncertain, mark confidence LOW and explain why in the Notes field. Never fabricate sources or URLs; write "URL not verified" if you cannot locate the exact handle. Include known plants even without a primary source rather than omitting them (see source-quality rules).
-
-The Phase B deliverable is a single Markdown document.
 
 # QUALITY DIMENSIONS
 
@@ -62,13 +60,13 @@ Phase B has a two-dimensional budget per session:
 - **50,000 tokens** of model generation: visible output + internal thinking / reasoning tokens, summed across all your turns in that session.
 - **$3.00 dollar guard**: everything the provider bills (tokens at all rates + per-call web_search fees + connector tokens at connector rates).
 
-Whichever cap reaches 20% of its initial value first triggers a terminal reply. The classifier cost (a small overhead the harness pays to route the conversation) is not deducted from your budget.
+Whichever cap reaches 20% of its initial value first triggers a terminal reply.
 
 Web search input/output, connector tokens, and document-fetch payload do not count toward the 50,000-token cap — those are retrieval payload, not your generation. They do count toward the $3 dollar guard.
 
 Phase A (this turn) has a separate $1 ceiling. Across one Phase A and five Phase B sessions per subject, the total per-subject budget is ≤ $16.
 
-If budget becomes tight, preserve recall, provenance, and uncertainty notes; compress overview, narratives, and bibliography annotations.
+If budget becomes tight, preserve recall, provenance, and uncertainty notes; compress per-asset notes and bibliography annotations.
 
 ## Planning headroom
 
@@ -98,7 +96,7 @@ If a lead surfaces only via an inadmissible source, trace to its original source
 
 ## Calibrated confidence vocabulary
 
-The statistical table assigns a confidence level to each row based on evidence and agreement:
+Each row in the inventory table carries a confidence level based on evidence and agreement:
 -  HIGH   = >=2 INDEPENDENT concordant sources, at least one is primary
 -  MEDIUM = 1 primary source, OR a sourced aggregator citing a verifiable primary
 -  LOW    = secondary only / inferred / unresolved conflict / not found
@@ -113,7 +111,7 @@ Hard ceilings (override the above):
 - Status attested only by a source older than 24 months and unconfirmed since: cap status at MEDIUM (LOW if older than 48 months). Freshness is measured on the publication date of the most recent admissible source attesting the status — NOT on the older Status as-of-date.
 - "Source = not found" rows: LOW by construction.
 
-The detailed inventory must assign a confidence level to the row-level existence/status claim and may additionally qualify one or two disputed attributes among capacity, status, fuel, COD, owner/operator, or location. Per claim, expose: value — level — [evidence axis / agreement axis] — sources. Doing more would likely exceed the resources allowed. When sources disagree on a value, investigate for material errors (transcription, translation, technical issues), for genuine changes over time, and for other likely causes. If still unresolved, follow the higher-tier source. Discuss the resolution in the detailed inventory, include a note in the statistical table.
+Explanatory notes must state the confidence level for the row-level existence/status claim and may additionally qualify one or two disputed attributes (capacity, status, fuel, COD, owner/operator, or location). Per qualified claim, state: value, confidence level, evidence type (primary/secondary), and sources. When sources disagree, investigate for transcription errors, time-based changes, and unit/translation issues; follow the higher-tier source if unresolved, and add a note in the Notes cell.
 
 ## Asset-row and status rules
 
@@ -122,8 +120,8 @@ Each row corresponds to one asset record. The DEFAULT unit is the plant / unit-g
 Status definitions (use these exact terms in the Status column):
 - Operating: commissioned or reported in service.
 - Under construction: physical construction or EPC execution has begun.
-- Pre-FID: investment decision pending; project has appeared in formal plans or PDP cycles but construction has not started.
-- Approved: formally approved or permitted but pre-FID and construction not confirmed.
+- Approved: government approval or formal permit granted; Final Investment Decision (FID) may still be pending; construction not started.
+- Pre-FID: listed in formal plans or PDP cycles; not yet formally approved; construction not started.
 - Planned: proposed or listed in a planning cycle, but not yet approved or materially committed.
 - Suspended: previously active, approved, or under construction but halted without formal cancellation.
 - Cancelled: formally cancelled, removed, or replaced by another project.

--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -14,8 +14,7 @@ In Phase B you will produce a complete, primary-sourced reference inventory of V
 
 - a sector overview (electricity mix, policy framework, key institutional actors, current challenges)
 - a concise sourced per-plant narrative for each plant (development history, notable issues, including key plant attributes, possibly confidence-qualified)
-- the requested structured power-plants table with columns: Name (Vietnamese), Name (English), Province, Fuel (Coal / Domestic gas / Imported LNG), Technology (Subcritical / Supercritical / USC for coal; CCGT / OCGT for gas), Units × MW, Total MWe, Status, Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes
-- statistical summary tables (capacity by fuel × status; top 15 provinces; timeline of additions by period and fuel; data-quality summary by confidence level and fuel)
+- the plant inventory: **exactly one pipe table**, never split into sub-tables by status, fuel, province, or any other dimension. Columns in this exact order: Name (Vietnamese), Name (English), Province, Fuel (Coal / Domestic gas / Imported LNG), Technology (Subcritical / Supercritical / USC for coal; CCGT / OCGT for gas), Units × MW, Total MWe, Status, Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes. Do not add statistical summary, cross-tabulation, or any other pipe tables; fold aggregate statistics into prose.
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
 All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled and pre-FID projects are in scope if they have appeared in formal planning cycles.
@@ -121,10 +120,11 @@ The detailed inventory must assign a confidence level to the row-level existence
 
 Each row corresponds to one asset record. The DEFAULT unit is the plant / unit-group, not the power center: when a site co-locates several plants with distinct capacity, COD, owner/developer, fuel, status, or financing (BOT/IPP) arrangements, each one is its own row. Aggregate to center-level in a single row ONLY when detailed evidence is unavailable; in that case mark the row ambiguous and explain the aggregation in Notes. Conversely, do not split a single plant into multiple rows when the only difference is individual generating units sharing one commissioning, owner, and status — record these as Units × MW on one row.
 
-Status definitions:
-- Operational: commissioned or reported in service.
+Status definitions (use these exact terms in the Status column):
+- Operating: commissioned or reported in service.
 - Under construction: physical construction or EPC execution has begun.
-- Approved: formally approved, permitted, or included in a binding plan, but construction is not confirmed.
+- Pre-FID: investment decision pending; project has appeared in formal plans or PDP cycles but construction has not started.
+- Approved: formally approved or permitted but pre-FID and construction not confirmed.
 - Planned: proposed or listed in a planning cycle, but not yet approved or materially committed.
 - Suspended: previously active, approved, or under construction but halted without formal cancellation.
 - Cancelled: formally cancelled, removed, or replaced by another project.

--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -117,15 +117,15 @@ Explanatory notes must state the confidence level for the row-level existence/st
 
 Each row corresponds to one asset record. The DEFAULT unit is the plant / unit-group, not the power center: when a site co-locates several plants with distinct capacity, COD, owner/developer, fuel, status, or financing (BOT/IPP) arrangements, each one is its own row. Aggregate to center-level in a single row ONLY when detailed evidence is unavailable; in that case mark the row ambiguous and explain the aggregation in Notes. Conversely, do not split a single plant into multiple rows when the only difference is individual generating units sharing one commissioning, owner, and status — record these as Units × MW on one row.
 
-Status definitions (use these exact terms in the Status column):
-- Operating: commissioned or reported in service.
-- Under construction: physical construction or EPC execution has begun.
-- Approved: government approval or formal permit granted; Final Investment Decision (FID) may still be pending; construction not started.
-- Pre-FID: listed in formal plans or PDP cycles; not yet formally approved; construction not started.
-- Planned: proposed or listed in a planning cycle, but not yet approved or materially committed.
-- Suspended: previously active, approved, or under construction but halted without formal cancellation.
-- Cancelled: formally cancelled, removed, or replaced by another project.
-- Retired: previously operational but permanently closed or decommissioned.
+Status definitions (use these exact terms, aligned with Global Energy Monitor vocabulary):
+- Announced: described in government plans or corporate filings; no permits sought, no land acquired.
+- Pre-permit: environmental and regulatory approvals being sought; no permits issued yet.
+- Permitted: all required government approvals received; construction not yet started.
+- Construction: site preparation or EPC execution underway.
+- Operating: formally commissioned.
+- Shelved: previously active or advancing but progress halted without formal cancellation.
+- Cancelled: formally cancelled or replaced by another project.
+- Retired: permanently closed or decommissioned.
 
 Capacity rule:
 Record nameplate electrical capacity in MWe when available. If sources do not distinguish gross vs net, record the stated MW value and note "gross/net unspecified". Do not mix thermal MW, boiler capacity, steam output, or investment package capacity with electrical MWe. For Units × MW, make arithmetic consistent with Total MWe or explain discrepancies in Notes.

--- a/src/aedist/matching/lp.py
+++ b/src/aedist/matching/lp.py
@@ -103,12 +103,18 @@ def _handle_empty(df1: pd.DataFrame, df2: pd.DataFrame) -> pd.DataFrame | None:
     return None
 
 
+def _extract_digit_tokens(name: str) -> frozenset[str]:
+    """Return the set of standalone digit tokens in a name_clean string."""
+    return frozenset(tok for tok in name.split() if tok.isdigit())
+
+
 def _compute_costs(
     df1: pd.DataFrame,
     df2: pd.DataFrame,
     similarity_threshold: int,
     mismatch_penalty: float,
     capacity_weight: float,
+    dummy_cost: float = DEFAULT_DUMMY_COST,
 ) -> dict[tuple[int, int], float]:
     """
     Compute the matching cost for each potential pairing between records of df1 and df2.
@@ -123,21 +129,35 @@ def _compute_costs(
           1 if the fuzzy similarity score (using fuzz.partial_ratio) meets or exceeds similarity_threshold;
           mismatch_penalty otherwise.
 
+    Unit-number veto: if both names contain digit tokens and those sets differ (e.g. "1" vs "2"),
+    the cost is set to 2*dummy_cost+1, making it cheaper for the LP to leave both records
+    unmatched than to accept a cross-unit false positive.
+
     Args:
         df1 (pd.DataFrame): First DataFrame with plant records.
         df2 (pd.DataFrame): Second DataFrame with plant records.
         similarity_threshold (int): Threshold for fuzzy matching.
         mismatch_penalty (float): Penalty applied when fuzzy matching fails.
         capacity_weight (float): Weight coefficient for the capacity difference component.
+        dummy_cost (float): Cost for leaving a record unmatched (used to calibrate veto cost).
 
     Returns:
         dict[tuple[int, int], float]: A mapping from (i, j) indices to computed matching cost.
     """
+    veto_cost = 2 * dummy_cost + 1
     costs: dict[tuple[int, int], float] = {}
     for i in df1.index:
         for j in df2.index:
             name1 = str(df1.loc[i, "name_clean"])
             name2 = str(df2.loc[j, "name_clean"])
+
+            # Unit-number veto: different trailing unit numbers must not match.
+            digits1 = _extract_digit_tokens(name1)
+            digits2 = _extract_digit_tokens(name2)
+            if digits1 and digits2 and digits1 != digits2:
+                costs[(i, j)] = veto_cost
+                continue
+
             cap1 = df1.loc[i, "capacity_clean"]
             cap2 = df2.loc[j, "capacity_clean"]
             if cap1 is None or cap2 is None or math.isnan(cap1) or math.isnan(cap2):
@@ -404,7 +424,9 @@ def reconcile(df1: pd.DataFrame, df2: pd.DataFrame, **kwargs: object) -> pd.Data
     if empty_result is not None:
         return empty_result
 
-    costs = _compute_costs(df1, df2, similarity_threshold, mismatch_penalty, capacity_weight)
+    costs = _compute_costs(
+        df1, df2, similarity_threshold, mismatch_penalty, capacity_weight, dummy_cost
+    )
     prob, x_vars, u_vars, v_vars = _setup_lp(df1, df2, costs, dummy_cost)
 
     # Warm start: set initial values from greedy pre-alignment

--- a/src/aedist/matching/phased.py
+++ b/src/aedist/matching/phased.py
@@ -5,12 +5,24 @@
 
 """Module for reconciling power plant data using fuzzy and exact matching."""
 
+from functools import partial
 from typing import Any
 
 import pandas as pd
 from rapidfuzz import fuzz, process
 
 from aedist.matching.result_row import build_result_row
+
+
+def _digit_compatible(name1: str, name2: str) -> bool:
+    """Return True if two name_clean strings are compatible for matching.
+
+    Two names are incompatible when both carry digit tokens (unit numbers) that differ,
+    e.g. "na duong 1" vs "na duong 2".
+    """
+    d1 = frozenset(tok for tok in name1.split() if tok.isdigit())
+    d2 = frozenset(tok for tok in name2.split() if tok.isdigit())
+    return not (d1 and d2 and d1 != d2)
 
 
 def find_exact_match(
@@ -32,8 +44,13 @@ def find_exact_match(
     """
     if "name_clean" not in row1 or "capacity_clean" not in row1:
         raise ValueError("row1 is missing required columns 'name_clean' and/or 'capacity_clean'.")
-    if "name_clean" not in unmatched_group2.columns or "capacity_clean" not in unmatched_group2.columns:
-        raise ValueError("unmatched_group2 is missing required columns 'name_clean' and/or 'capacity_clean'.")
+    if (
+        "name_clean" not in unmatched_group2.columns
+        or "capacity_clean" not in unmatched_group2.columns
+    ):
+        raise ValueError(
+            "unmatched_group2 is missing required columns 'name_clean' and/or 'capacity_clean'."
+        )
 
     exact_matches = unmatched_group2[
         (unmatched_group2["name_clean"] == row1["name_clean"])
@@ -138,8 +155,13 @@ def reconcile(group1: pd.DataFrame, group2: pd.DataFrame, **kwargs) -> pd.DataFr
     # ----------------------------------------------------------------------
     group1_drop_indexes = []
     for idx1, row1 in unmatched_group1.iterrows():
-        row2, match_idx2, fuzzy_score = find_fuzzy_match(
-            row1, unmatched_group2, similarity_threshold
+        # Unit-number guard: only consider candidates with compatible digit tokens.
+        mask = unmatched_group2["name_clean"].apply(partial(_digit_compatible, row1["name_clean"]))
+        candidates = unmatched_group2.loc[mask]
+        row2, match_idx2, fuzzy_score = (
+            find_fuzzy_match(row1, candidates, similarity_threshold)
+            if not candidates.empty
+            else (None, None, None)
         )
         if row2 is not None:
             capacity_difference = abs(row1["capacity_clean"] - row2["capacity_clean"])
@@ -147,11 +169,15 @@ def reconcile(group1: pd.DataFrame, group2: pd.DataFrame, **kwargs) -> pd.DataFr
                 status = "Matched (Fuzzy) (Diff)"
             else:
                 status = "Matched (Fuzzy)"
-            reconciled_rows.append(build_result_row(row1, row2, status, similarity_score=fuzzy_score))
+            reconciled_rows.append(
+                build_result_row(row1, row2, status, similarity_score=fuzzy_score)
+            )
             group1_drop_indexes.append(idx1)
             unmatched_group2.drop(index=match_idx2, inplace=True)
         else:
-            reconciled_rows.append(build_result_row(row1, None, "Only in file1", similarity_score=None))
+            reconciled_rows.append(
+                build_result_row(row1, None, "Only in file1", similarity_score=None)
+            )
 
     unmatched_group1.drop(index=group1_drop_indexes, inplace=True)
     unmatched_group1.reset_index(drop=True, inplace=True)
@@ -161,6 +187,8 @@ def reconcile(group1: pd.DataFrame, group2: pd.DataFrame, **kwargs) -> pd.DataFr
     # Phase 3: Rows remaining in group2 (Only in file2)
     # ----------------------------------------------------------------------
     for _, row2 in unmatched_group2.iterrows():
-        reconciled_rows.append(build_result_row(None, row2, "Only in file2", similarity_score=None))
+        reconciled_rows.append(
+            build_result_row(None, row2, "Only in file2", similarity_score=None)
+        )
 
     return pd.DataFrame(reconciled_rows)

--- a/src/aedist/score_mechanical.py
+++ b/src/aedist/score_mechanical.py
@@ -36,12 +36,15 @@ _ALLOWED_FUELS = {
 
 _ALLOWED_STATUSES = {
     "operating",
+    "operational",  # legacy synonym
     "under construction",
-    "cancelled",
-    "planned",
-    "decommissioned",
     "pre-fid",
+    "approved",
+    "planned",
+    "suspended",
+    "cancelled",
     "commissioning",
+    "decommissioned",
     "retired",
 }
 

--- a/src/aedist/score_mechanical.py
+++ b/src/aedist/score_mechanical.py
@@ -35,17 +35,24 @@ _ALLOWED_FUELS = {
 }
 
 _ALLOWED_STATUSES = {
+    # GEM canonical terms
+    "announced",
+    "pre-permit",
+    "pre-permit development",
+    "permitted",
+    "construction",
     "operating",
-    "operational",  # legacy synonym
+    "shelved",
+    "cancelled",
+    "retired",
+    # Accepted synonyms
+    "operational",
     "under construction",
-    "pre-fid",
     "approved",
     "planned",
     "suspended",
-    "cancelled",
     "commissioning",
     "decommissioned",
-    "retired",
 }
 
 _CSV_COLUMNS = [

--- a/src/aedist/score_mechanical.py
+++ b/src/aedist/score_mechanical.py
@@ -34,6 +34,17 @@ _ALLOWED_FUELS = {
     "unknown",
 }
 
+_ALLOWED_STATUSES = {
+    "operating",
+    "under construction",
+    "cancelled",
+    "planned",
+    "decommissioned",
+    "pre-fid",
+    "commissioning",
+    "retired",
+}
+
 _CSV_COLUMNS = [
     "arm",
     "model",
@@ -54,8 +65,8 @@ _CSV_COLUMNS = [
     "accuracy_province_annotation",
     "coherence_vocab_adherence",
     "coherence_vocab_adherence_annotation",
-    "coherence_capacity_nonnegative",
-    "coherence_capacity_nonnegative_annotation",
+    "coherence_status_vocab_adherence",
+    "coherence_status_vocab_adherence_annotation",
     "provenance_source_presence",
     "provenance_source_presence_annotation",
     "provenance_high_conf_dual_source",
@@ -85,7 +96,7 @@ class AccuracyScores:
 @dataclass
 class CoherenceScores:
     vocab_adherence: float | None
-    capacity_nonnegative: float | None
+    status_vocab_adherence: float | None
     annotation: str | None = None
 
 
@@ -164,20 +175,20 @@ def score_coherence(rows: list[dict[str, str]]) -> CoherenceScores:
     if not rows:
         return CoherenceScores(None, None, annotation="no_rows")
 
-    valid_vocab = 0
-    nonnegative = 0
+    valid_fuel = 0
+    valid_status = 0
     for row in rows:
         fuel = (row.get("fuel") or "").strip().lower()
         if fuel in _ALLOWED_FUELS:
-            valid_vocab += 1
+            valid_fuel += 1
 
-        cap = _as_float(_first_nonempty(row, _CAPACITY_KEYS))
-        if cap is not None and cap >= 0:
-            nonnegative += 1
+        status = (row.get("status") or "").strip().lower()
+        if status in _ALLOWED_STATUSES:
+            valid_status += 1
 
     return CoherenceScores(
-        vocab_adherence=_fraction(valid_vocab, len(rows)),
-        capacity_nonnegative=_fraction(nonnegative, len(rows)),
+        vocab_adherence=_fraction(valid_fuel, len(rows)),
+        status_vocab_adherence=_fraction(valid_status, len(rows)),
         annotation=None,
     )
 
@@ -232,6 +243,7 @@ def score_temporality(rows: list[dict[str, str]]) -> TemporalityScores:
 
     with_asof = 0
     plausible = 0
+    years_found: list[int] = []
     for row in rows:
         cell = _pick_asof_cell(row)
         if not cell:
@@ -241,12 +253,17 @@ def score_temporality(rows: list[dict[str, str]]) -> TemporalityScores:
         if not match:
             continue
         year = int(match.group(1))
+        years_found.append(year)
         if 1980 <= year <= 2100:
             plausible += 1
 
     if with_asof == 0:
         plausible_rate = None
         plausible_annotation = "column_empty"
+    elif len(years_found) >= 2 and len(set(years_found)) == 1:
+        # All cells carry the same year — likely the run date stamped on every row.
+        plausible_rate = 0.0
+        plausible_annotation = "all_identical"
     else:
         plausible_rate = _fraction(plausible, with_asof)
         plausible_annotation = None
@@ -350,8 +367,8 @@ def main(argv: list[str] | None = None) -> None:
         "accuracy_province_annotation": accuracy.annotation or "",
         "coherence_vocab_adherence": _fmt(coherence.vocab_adherence),
         "coherence_vocab_adherence_annotation": coherence.annotation or "",
-        "coherence_capacity_nonnegative": _fmt(coherence.capacity_nonnegative),
-        "coherence_capacity_nonnegative_annotation": coherence.annotation or "",
+        "coherence_status_vocab_adherence": _fmt(coherence.status_vocab_adherence),
+        "coherence_status_vocab_adherence_annotation": coherence.annotation or "",
         "provenance_source_presence": _fmt(provenance.source_presence),
         "provenance_source_presence_annotation": provenance.source_presence_annotation or "",
         "provenance_high_conf_dual_source": _fmt(provenance.high_conf_dual_source),

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -10,14 +10,11 @@ def reconcile(request):
     module = importlib.import_module(f"aedist.matching.{request.param}")
     return module.reconcile
 
+
 def test_exact_match(reconcile):
     """Test when group1 and group2 contain exactly matching rows."""
-    group1 = pd.DataFrame([
-        {"name": "Plant A", "name_clean": "plant a", "capacity_clean": 50}
-    ])
-    group2 = pd.DataFrame([
-        {"name": "Plant A", "name_clean": "plant a", "capacity_clean": 50}
-    ])
+    group1 = pd.DataFrame([{"name": "Plant A", "name_clean": "plant a", "capacity_clean": 50}])
+    group2 = pd.DataFrame([{"name": "Plant A", "name_clean": "plant a", "capacity_clean": 50}])
 
     result = reconcile(group1, group2)
 
@@ -29,11 +26,10 @@ def test_exact_match(reconcile):
     assert row["capacity_file2"] == 50
     assert row["capacity_difference"] == 0
 
+
 def test_only_in_file1(reconcile):
     """Test when group2 is empty, so all group1 capacity is unmatched."""
-    group1 = pd.DataFrame([
-        {"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}
-    ])
+    group1 = pd.DataFrame([{"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}])
     group2 = pd.DataFrame(columns=["name", "name_clean", "capacity_clean"])
 
     result = reconcile(group1, group2)
@@ -45,12 +41,11 @@ def test_only_in_file1(reconcile):
     assert row["capacity_file1"] == 100
     assert row["name_file2"] is None
 
+
 def test_only_in_file2(reconcile):
     """Test when group1 is empty, so all group2 capacity is unmatched."""
     group1 = pd.DataFrame(columns=["name", "name_clean", "capacity_clean"])
-    group2 = pd.DataFrame([
-        {"name": "Plant B", "name_clean": "plant b", "capacity_clean": 80}
-    ])
+    group2 = pd.DataFrame([{"name": "Plant B", "name_clean": "plant b", "capacity_clean": 80}])
 
     result = reconcile(group1, group2)
 
@@ -61,21 +56,22 @@ def test_only_in_file2(reconcile):
     assert row["capacity_file2"] == 80
     assert row["name_file1"] is None
 
+
 def test_fuzzy_match_name(reconcile):
     """
     Test fuzzy matching with names that differ slightly but have capacities
     within the allowed tolerance.
     """
-    group1 = pd.DataFrame([
-        {"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}
-    ])
-    group2 = pd.DataFrame([
-        {
-            "name": "Plant A Incorporated",
-            "name_clean": "plant a incorporated",
-            "capacity_clean": 100,
-        }
-    ])
+    group1 = pd.DataFrame([{"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}])
+    group2 = pd.DataFrame(
+        [
+            {
+                "name": "Plant A Incorporated",
+                "name_clean": "plant a incorporated",
+                "capacity_clean": 100,
+            }
+        ]
+    )
 
     result = reconcile(group1, group2)
 
@@ -83,21 +79,22 @@ def test_fuzzy_match_name(reconcile):
     row = result.iloc[0]
     assert row["status"] == "Matched (Fuzzy)"
 
+
 def test_fuzzy_match_within_tolerance(reconcile):
     """
     Test fuzzy matching with names that differ slightly but have capacities
     within the allowed tolerance.
     """
-    group1 = pd.DataFrame([
-        {"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}
-    ])
-    group2 = pd.DataFrame([
-        {
-            "name": "Plant A Incorporated",
-            "name_clean": "plant a incorporated",
-            "capacity_clean": 145,
-        }
-    ])
+    group1 = pd.DataFrame([{"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}])
+    group2 = pd.DataFrame(
+        [
+            {
+                "name": "Plant A Incorporated",
+                "name_clean": "plant a incorporated",
+                "capacity_clean": 145,
+            }
+        ]
+    )
 
     result = reconcile(group1, group2, capacity_tolerance=50)
 
@@ -107,21 +104,22 @@ def test_fuzzy_match_within_tolerance(reconcile):
     assert row["capacity_file1"] == 100
     assert row["capacity_file2"] == 145
 
+
 def test_fuzzy_match_outside_tolerance(reconcile):
     """
     Test fuzzy matching with names that differ slightly but have capacities
     outside of the allowed tolerance.
     """
-    group1 = pd.DataFrame([
-        {"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}
-    ])
-    group2 = pd.DataFrame([
-        {
-            "name": "Plant A Incorporated",
-            "name_clean": "plant a incorporated",
-            "capacity_clean": 145,
-        }
-    ])
+    group1 = pd.DataFrame([{"name": "Plant A", "name_clean": "plant a", "capacity_clean": 100}])
+    group2 = pd.DataFrame(
+        [
+            {
+                "name": "Plant A Incorporated",
+                "name_clean": "plant a incorporated",
+                "capacity_clean": 145,
+            }
+        ]
+    )
 
     result = reconcile(group1, group2, capacity_tolerance=0)
 
@@ -130,6 +128,7 @@ def test_fuzzy_match_outside_tolerance(reconcile):
     assert row["status"] == "Matched (Fuzzy) (Diff)"
     assert row["capacity_file1"] == 100
     assert row["capacity_file2"] == 145
+
 
 def test_main_example(reconcile):
     """
@@ -143,7 +142,11 @@ def test_main_example(reconcile):
         {"name": "Plant B", "name_clean": "plant b", "capacity_clean": 200},
     ]
     data2 = [
-        {"name": "Plant A Incorporated", "name_clean": "plant a incorporated", "capacity_clean": 105},
+        {
+            "name": "Plant A Incorporated",
+            "name_clean": "plant a incorporated",
+            "capacity_clean": 105,
+        },
         {"name": "Plant B", "name_clean": "plant b", "capacity_clean": 200},
     ]
     file1_df = pd.DataFrame(data1)
@@ -170,6 +173,39 @@ def test_main_example(reconcile):
     # For Plant B: capacity difference = 200 - 200 = 0 (exact match)
     assert row_b["capacity_difference"] == 0
     assert row_b["status"] == "Matched"
+
+
+def test_unit_number_veto(reconcile):
+    """Plants with differing trailing unit numbers must not be matched."""
+    group1 = pd.DataFrame(
+        [{"name": "Na Duong 1", "name_clean": "na duong 1", "capacity_clean": 110}]
+    )
+    group2 = pd.DataFrame(
+        [{"name": "Na Duong 2", "name_clean": "na duong 2", "capacity_clean": 110}]
+    )
+    result = reconcile(group1, group2)
+    assert len(result) == 2
+    assert set(result["status"].tolist()) == {"Only in file1", "Only in file2"}
+
+
+def test_same_unit_number_still_matches(reconcile):
+    """Plants with the same trailing unit number and similar names should match."""
+    group1 = pd.DataFrame(
+        [{"name": "Na Duong 1", "name_clean": "na duong 1", "capacity_clean": 110}]
+    )
+    group2 = pd.DataFrame(
+        [
+            {
+                "name": "Nhiet Dien Na Duong 1",
+                "name_clean": "nhiet dien na duong 1",
+                "capacity_clean": 110,
+            }
+        ]
+    )
+    result = reconcile(group1, group2)
+    assert len(result) == 1
+    assert result.iloc[0]["status"] in {"Matched", "Matched (Fuzzy)"}
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_score_mechanical.py
+++ b/tests/test_score_mechanical.py
@@ -18,6 +18,15 @@ def test_coal_and_ccgt_lowers_vocab_adherence() -> None:
     assert result.vocab_adherence == 0.5
 
 
+def test_status_vocab_adherence_rejects_noncanonical() -> None:
+    rows = [
+        {"name": "A", "fuel": "coal", "status": "Operating"},
+        {"name": "B", "fuel": "coal", "status": "Under Constr."},
+    ]
+    result = score_coherence(rows)
+    assert result.status_vocab_adherence == 0.5
+
+
 def test_high_confidence_missing_source2_lowers_dual_source_metric() -> None:
     rows = [
         {
@@ -38,6 +47,17 @@ def test_temporality_1979_fails_and_1980_passes_plausible_range() -> None:
     ]
     result = score_temporality(rows)
     assert result.plausible_range == 0.5
+
+
+def test_temporality_all_identical_years_scores_zero() -> None:
+    rows = [
+        {"name": "A", "status_as_of": "as-of 2025"},
+        {"name": "B", "status_as_of": "2025"},
+        {"name": "C", "status_as_of": "checked 2025"},
+    ]
+    result = score_temporality(rows)
+    assert result.plausible_range == 0.0
+    assert result.plausible_range_annotation == "all_identical"
 
 
 def test_empty_total_mwe_counted_absent() -> None:


### PR DESCRIPTION
## Summary

- **LP matcher false positives**: unit-number veto in both phased and LP matchers prevents Na Duong 1 ↔ Na Duong 2 cross-matches; veto cost set to `2 * dummy_cost + 1` so LP never prefers a vetoed match over leaving both unmatched
- **Temporality metric**: `all_identical` annotation fires when ≥2 rows share the same year, scoring 0.0 instead of trivially 1.0 when models stamp the run date on every row
- **Coherence metric**: replaced trivially-passing `capacity_nonnegative` with `status_vocab_adherence` (varies meaningfully across models)
- **Status vocabulary alignment**: `_ALLOWED_STATUSES` expanded with GEM canonical terms; meta-prompt status definitions rewritten to match GEM (Announced / Pre-permit / Permitted / Construction / Operating / Shelved / Cancelled / Retired)
- **Meta-prompt rewrites**: table-first structure, single-table constraint, no-preamble instruction, scoped Phase A freedom, stale "statistical table" references fixed, Pre-FID dropped, classifier-cost note removed

## Test plan

- [ ] `pytest tests/test_score_mechanical.py tests/test_matching.py` — 28 passed
- [ ] `make check-fast` passes
- [ ] Road-test scorer on existing outputs: `uv run python -m aedist.score_mechanical --arm naive --model anthropic --run 1`

**Ticket:** tickets/0171-exp2-cross-eval.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)