### PR TITLE
refactor(prompts): unify Exp1/Exp2 prompt schema — GEM vocab, shared protocol_07, no framing

### DIFF
--- a/experiments/experiments.toml
+++ b/experiments/experiments.toml
@@ -505,7 +505,7 @@ output = "outputs/rag_cited"
 # (inventory, scenarios, skill), 1 run each, high max_tokens
 [sweeps.sweep_direct_complete]
 mode = "single"
-prompt = "prompts/prompt_complete.txt"
+prompt = "sota/protocol_07_naive_prompt.md"
 models = "models.yaml"
 model_set = "modelset_frontier_10labs"
 repeat = 1

--- a/experiments/prompts/modules/5_table.txt
+++ b/experiments/prompts/modules/5_table.txt
@@ -8,7 +8,7 @@ Where:
 - Fuel: Coal / Domestic gas / Imported LNG
 - Technology (coal): Subcritical / Supercritical / USC
 - Technology (gas): CCGT / OCGT
-- Status: Approved / Planned / Operational / Under construction / Suspended / Cancelled / Retired
+- Status: Announced / Pre-permit / Permitted / Construction / Operating / Shelved / Cancelled / Retired
 - Total MWe: Include units > 30MWe.
 - COD: Actual or expected commercial operation date
 - Sources: specify where in the document, include URL

--- a/experiments/prompts/modules/A_Statistics.txt
+++ b/experiments/prompts/modules/A_Statistics.txt
@@ -1,7 +1,7 @@
 ## Statistical Summary Tables
 
 Produce these cross-tabulations from your inventory:
-a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operational/Under construction/Approved/Planned columns), with row and column totals
+a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operating/Construction/Permitted/Announced columns), with row and column totals
 b) **Top provinces**: The 15 provinces with highest total thermal capacity (all statuses combined), showing breakdown by fuel
 c) **Timeline of additions**: Capacity entering service by period — pre-2005, 2005–2010, 2011–2015, 2016–2020, 2021–2025, 2026–2030, post-2030 — by fuel type
 d) **Data quality summary**: Count of plants by confidence level (High/Medium/Low) and fuel type

--- a/experiments/prompts/prompt_complete.txt
+++ b/experiments/prompts/prompt_complete.txt
@@ -32,7 +32,7 @@ Where:
 - Fuel: Coal / Domestic gas / Imported LNG
 - Technology (coal): Subcritical / Supercritical / USC
 - Technology (gas): CCGT / OCGT
-- Status: Approved / Planned / Operational / Under construction / Suspended / Cancelled / Retired
+- Status: Announced / Pre-permit / Permitted / Construction / Operating / Shelved / Cancelled / Retired
 - Total MWe: Include units > 30MWe.
 - COD: Actual or expected commercial operation date
 - Sources: specify where in the document, include URL
@@ -54,7 +54,7 @@ For each source provide:
 ## Statistical Summary Tables
 
 Produce these cross-tabulations from your inventory:
-a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operational/Under construction/Approved/Planned columns), with row and column totals
+a) **Capacity by fuel × status**: Total MWe in each cell (Coal/Gas/LNG rows × Operating/Construction/Permitted/Announced columns), with row and column totals
 b) **Top provinces**: The 15 provinces with highest total thermal capacity (all statuses combined), showing breakdown by fuel
 c) **Timeline of additions**: Capacity entering service by period — pre-2005, 2005–2010, 2011–2015, 2016–2020, 2021–2025, 2026–2030, post-2030 — by fuel type
 d) **Data quality summary**: Count of plants by confidence level (High/Medium/Low) and fuel type

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -106,36 +106,14 @@ def extract_quality_bar(manuscript_text: str) -> str:
     return manuscript_text[start:end].strip()
 
 
-_FRAMING_SEPARATOR = "\n---\n"
-
-
-def strip_meta_framing(text: str) -> str:
-    """Drop the meta-framing prefix from a protocol prompt file.
-
-    Convention used in `protocol_02_metaprompt.md` and `protocol_07_naive_prompt.md`:
-    the file opens with a single framing line ("This is the prompt sent to ...,
-    verbatim. ...") followed by `---` and then the actual prompt content.
-    The framing line is FOR THE REVIEWER, not the agent. The script must
-    strip it before sending the bytes to the model.
-
-    If no `\\n---\\n` separator is present, the input is returned unchanged.
-    """
-    if _FRAMING_SEPARATOR in text:
-        _, _, content = text.partition(_FRAMING_SEPARATOR)
-        return content.lstrip("\n")
-    return text
-
-
 def assemble_meta_prompt(metaprompt_path: Path = METAPROMPT_PATH) -> str:
-    """Return the Phase A meta-prompt verbatim from disk, framing stripped.
+    """Return the Phase A meta-prompt verbatim from disk.
 
     The canonical text lives at ``experiments/sota/protocol_02_metaprompt.md``
     (Doc 02 of the protocol set). The harness reads it as-is at run time;
-    edits to Doc 02 propagate without code change. The opening framing line
-    ("This is the prompt sent to the agents, verbatim.") is removed before
-    dispatch (see :func:`strip_meta_framing`).
+    edits to Doc 02 propagate without code change.
     """
-    return strip_meta_framing(metaprompt_path.read_text(encoding="utf-8"))
+    return metaprompt_path.read_text(encoding="utf-8")
 
 
 def load_model_meta(agent: str) -> dict:

--- a/experiments/sota/exp2_naive_arm.py
+++ b/experiments/sota/exp2_naive_arm.py
@@ -7,9 +7,8 @@ The contrast with the optimized arm (Phase A meta-prompt + multi-turn
 state machine) isolates the protocol's contribution.
 
 Doc 07 (`experiments/sota/protocol_07_naive_prompt.md`) is the user-side
-prompt — Doc 02's GOAL + QUALITY DIMENSIONS + FORMAT sections, with the
-Phase A/B scaffolding language minimally adapted. The file's opening
-meta-framing line is stripped by `strip_meta_framing` before dispatch.
+prompt — identical output spec to Doc 02's Phase B, without the Phase A
+self-design scaffolding.
 
 Each response is classified via the dialogue classifier (Nemotron).
 Outcome categories per session:
@@ -32,7 +31,6 @@ import yaml
 
 from aedist.harness import append_evidence_pack
 from experiments.sota import dialogue_classifier
-from experiments.sota.exp2_interactive_smoke import strip_meta_framing
 
 log = logging.getLogger(__name__)
 
@@ -52,8 +50,8 @@ ANTHROPIC_CAP_USD = 6.00  # input alone costs ~$1.7; 64K output adds ~$1.6
 
 
 def load_naive_prompt(path: Path = NAIVE_PROMPT_PATH) -> str:
-    """Read Doc 07 from disk, strip the meta-framing line, return the prompt."""
-    return strip_meta_framing(path.read_text(encoding="utf-8"))
+    """Read Doc 07 from disk and return the prompt."""
+    return path.read_text(encoding="utf-8")
 
 
 def _write_summary_md(output_dir: Path, summary: list[dict]) -> Path:

--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -1,7 +1,3 @@
-This is the prompt sent to the agents, verbatim.
-
----
-
 # ROLE
 
 You are a state-of-the-art AI assistant being evaluated as a subject in a structured statistical-inventory experiment. The conversation runs in two phases: this turn (Phase A) is for designing how you want to work; subsequent turns (Phase B) execute that design as a multi-turn conversation with budget caps.

--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -16,7 +16,7 @@ In Phase B you will produce a single Markdown document: a complete, primary-sour
 - per-asset or per-project explanatory notes: for each asset that warrants it (major, disputed, ambiguous, or historically important), a concise sourced note covering development history, notable issues, and confidence-qualified attributes. Straightforward operational assets need no note.
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
-All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled and pre-FID projects are in scope if they have appeared in formal planning cycles.
+All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled projects are in scope if they have appeared in formal planning cycles.
 
 When uncertain, mark confidence LOW and explain why in the Notes field. Never fabricate sources or URLs; write "URL not verified" if you cannot locate the exact handle. Include known plants even without a primary source rather than omitting them (see source-quality rules).
 

--- a/experiments/sota/protocol_02_metaprompt.md
+++ b/experiments/sota/protocol_02_metaprompt.md
@@ -16,7 +16,7 @@ In Phase B you will produce a single Markdown document: a complete, primary-sour
 - per-asset or per-project explanatory notes: for each asset that warrants it (major, disputed, ambiguous, or historically important), a concise sourced note covering development history, notable issues, and confidence-qualified attributes. Straightforward operational assets need no note.
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
-All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled projects are in scope if they have appeared in formal planning cycles.
+Scope includes all thermal assets > 30 MWe at any stage of the lifecycle, including shelved or cancelled projects.
 
 When uncertain, mark confidence LOW and explain why in the Notes field. Never fabricate sources or URLs; write "URL not verified" if you cannot locate the exact handle. Include known plants even without a primary source rather than omitting them (see source-quality rules).
 

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -10,6 +10,8 @@ Scope includes all thermal assets > 30 MWe at any stage of the lifecycle, includ
 
 When uncertain, mark confidence LOW and explain why in the Notes field. Never fabricate sources or URLs; write "URL not verified" if you cannot locate the exact handle. Include known plants even without a primary source rather than omitting them.
 
+Output format: Markdown.
+
 # QUALITY DIMENSIONS
 
 Your output is judged on four axes:

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -31,3 +31,62 @@ shortlist of well-known assets.
 # FORMAT
 
 Output format: Markdown.
+
+# CONTEXT
+
+## Source quality management
+
+Two distinct epistemic roles — do not conflate them:
+- Discovery & characterization: parametric knowledge and web search, including tertiary sources, MAY be used to generate leads, locate assets, and form initial hypotheses about attributes.
+- Justification in the final inventory: a claim can be justified ONLY by an admissible independently consulted source that actually supports it.
+
+Admissible primary sources: official government documents; regulator-aggregated official data; operator filings/press releases.
+
+Admissible secondary sources: international-institution reports; bylined trade press; industry trackers and data brokers that expose the primary they cite.
+
+Not admissible sources:
+- Tertiary compilations (encyclopedias, Wikipedia/Wikidata/DBpedia, mirrors, aggregators re-syndicating without independent verification).
+- Any deposited dataset that does NOT expose, per value, the primary source it draws from — a DOI or repository deposit does not by itself confer admissibility.
+
+Local-language sources are preferred but not required; when used, include the original-language title plus an English translation in brackets.
+
+If a lead surfaces only via an inadmissible source, trace to its original source and cite that; if none is found, record Source = "not found", confidence LOW. In the table mention the inadmissible source in Notes, not in Sources.
+
+## Calibrated confidence vocabulary
+
+Each row in the inventory table carries a confidence level based on evidence and agreement:
+-  HIGH   = >=2 INDEPENDENT concordant sources, at least one is primary
+-  MEDIUM = 1 primary source, OR a sourced aggregator citing a verifiable primary
+-  LOW    = secondary only / inferred / unresolved conflict / not found
+
+Independence check (run BEFORE judging agreement):
+-  Trace each source to its origin; merge sources sharing one origin into ONE.
+-  Sources re-syndicating Wikipedia/Wikidata are NOT independent and NOT admissible.
+-  Filling both Source columns does not by itself confer HIGH; independence is required
+
+Hard ceilings (override the above):
+- Commercial operator self-reported not confirmed by an official source: cap claim at MEDIUM.
+- Status attested only by a source older than 24 months and unconfirmed since: cap status at MEDIUM (LOW if older than 48 months). Freshness is measured on the publication date of the most recent admissible source attesting the status — NOT on the older Status as-of-date.
+- "Source = not found" rows: LOW by construction.
+
+Explanatory notes must state the confidence level for the row-level existence/status claim and may additionally qualify one or two disputed attributes (capacity, status, fuel, COD, owner/operator, or location). Per qualified claim, state: value, confidence level, evidence type (primary/secondary), and sources. When sources disagree, investigate for transcription errors, time-based changes, and unit/translation issues; follow the higher-tier source if unresolved, and add a note in the Notes cell.
+
+## Asset-row and status rules
+
+Each row corresponds to one asset record. The DEFAULT unit is the plant / unit-group, not the power center: when a site co-locates several plants with distinct capacity, COD, owner/developer, fuel, status, or financing (BOT/IPP) arrangements, each one is its own row. Aggregate to center-level in a single row ONLY when detailed evidence is unavailable; in that case mark the row ambiguous and explain the aggregation in Notes. Conversely, do not split a single plant into multiple rows when the only difference is individual generating units sharing one commissioning, owner, and status — record these as Units × MW on one row.
+
+Status definitions (use these exact terms, aligned with Global Energy Monitor vocabulary):
+- Announced: described in government plans or corporate filings; no permits sought, no land acquired.
+- Pre-permit: environmental and regulatory approvals being sought; no permits issued yet.
+- Permitted: all required government approvals received; construction not yet started.
+- Construction: site preparation or EPC execution underway.
+- Operating: formally commissioned.
+- Shelved: previously active or advancing but progress halted without formal cancellation.
+- Cancelled: formally cancelled or replaced by another project.
+- Retired: permanently closed or decommissioned.
+
+Capacity rule:
+Record nameplate electrical capacity in MWe when available. If sources do not distinguish gross vs net, record the stated MW value and note "gross/net unspecified". Do not mix thermal MW, boiler capacity, steam output, or investment package capacity with electrical MWe. For Units × MW, make arithmetic consistent with Total MWe or explain discrepancies in Notes.
+
+Explanatory notes discipline:
+The table comes first. Per-asset notes follow the table and are selective: write one only for assets that are major, disputed, ambiguous, or historically important. For straightforward operational assets a compact Notes cell in the table is sufficient; do not repeat it as a separate note.

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -26,10 +26,6 @@ Your output is judged on four axes:
 We prefer a comprehensive inventory with uncertainty clearly expressed over a
 shortlist of well-known assets.
 
-# FORMAT
-
-Output format: Markdown.
-
 # CONTEXT
 
 ## Source quality management

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -4,12 +4,10 @@ This is the prompt sent to the naive-arm agents, verbatim. Single user message, 
 
 # GOAL
 
-Produce a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30 MWe), structured as follows:
+Produce a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30 MWe). Begin the document directly with the inventory table — no title, no preamble, no overview section. Structure it as follows:
 
-- a sector overview (electricity mix, policy framework, key institutional actors, current challenges)
-- a concise sourced per-plant narrative for each plant (development history, notable issues, including key plant attributes, possibly confidence-qualified)
-- the requested structured power-plants table with columns: Name (Vietnamese), Name (English), Province, Fuel (Coal / Domestic gas / Imported LNG), Technology (Subcritical / Supercritical / USC for coal; CCGT / OCGT for gas), Units × MW, Total MWe, Status, Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes
-- statistical summary tables (capacity by fuel × status; top 15 provinces; timeline of additions by period and fuel; data-quality summary by confidence level and fuel)
+- the plant inventory: **exactly one pipe table**, never split into sub-tables by status, fuel, province, or any other dimension. Columns in this exact order: Name (Vietnamese), Name (English), Province, Fuel (Coal / Domestic gas / Imported LNG), Technology (Subcritical / Supercritical / USC for coal; CCGT / OCGT for gas), Units × MW, Total MWe, Status, Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes. Do not add statistical summary, cross-tabulation, or any other pipe tables; fold aggregate statistics into prose.
+- per-asset or per-project explanatory notes: for each asset that warrants it (major, disputed, ambiguous, or historically important), a concise sourced note covering development history, notable issues, and confidence-qualified attributes. Straightforward operational assets need no note.
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
 Scope includes all thermal assets > 30 MWe at any stage of the lifecycle, including shelved or cancelled projects.

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -12,7 +12,7 @@ Produce a complete, primary-sourced reference inventory of Vietnam's past, prese
 - statistical summary tables (capacity by fuel × status; top 15 provinces; timeline of additions by period and fuel; data-quality summary by confidence level and fuel)
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
-All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled projects are in scope if they have appeared in formal planning cycles.
+Scope includes all thermal assets > 30 MWe at any stage of the lifecycle, including shelved or cancelled projects.
 
 When uncertain, mark confidence LOW and explain why in the Notes field. Never fabricate sources or URLs; write "URL not verified" if you cannot locate the exact handle. Include known plants even without a primary source rather than omitting them.
 

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -12,7 +12,7 @@ Produce a complete, primary-sourced reference inventory of Vietnam's past, prese
 - statistical summary tables (capacity by fuel × status; top 15 provinces; timeline of additions by period and fuel; data-quality summary by confidence level and fuel)
 - an annotated bibliography of every source cited (full citation; URL when available; original-language title plus English translation for non-English sources; summary annotation of what was drawn from each)
 
-All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled and pre-FID projects are in scope if they have appeared in formal planning cycles.
+All plants > 30 MWe are in scope regardless of grid connection (grid, micro-grid, off-grid) or cogeneration (electricity-only, CHP, industrial captive). Capacity is the only inclusion gate. Cancelled projects are in scope if they have appeared in formal planning cycles.
 
 When uncertain, mark confidence LOW and explain why in the Notes field. Never fabricate sources or URLs; write "URL not verified" if you cannot locate the exact handle. Include known plants even without a primary source rather than omitting them.
 

--- a/experiments/sota/protocol_07_naive_prompt.md
+++ b/experiments/sota/protocol_07_naive_prompt.md
@@ -1,7 +1,3 @@
-This is the prompt sent to the naive-arm agents, verbatim. Single user message, no system prompt, no protocol scaffolding.
-
----
-
 # GOAL
 
 Produce a complete, primary-sourced reference inventory of Vietnam's past, present and future thermal generation assets (> 30 MWe). Begin the document directly with the inventory table — no title, no preamble, no overview section. Structure it as follows:

--- a/src/aedist/query_direct.py
+++ b/src/aedist/query_direct.py
@@ -6,14 +6,14 @@ and temperature=0 for deterministic, exhaustive output.
 
 Usage:
     uv run python -m aedist.query_direct \
-        --prompt prompts/prompt_complete.txt \
+        --prompt sota/protocol_07_naive_prompt.md \
         --models models_frontier.yaml \
         --output outputs/direct_complete/ \
         --budget-usd 20
 
     # Single model:
     uv run python -m aedist.query_direct \
-        --prompt prompts/prompt_complete.txt \
+        --prompt sota/protocol_07_naive_prompt.md \
         --models models_frontier.yaml \
         --output outputs/direct_complete/ \
         --model anthropic/claude-opus-4.6

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -21,33 +21,14 @@ from experiments.sota.exp2_interactive_smoke import (
     extract_phase_a_design,
     extract_quality_bar,
     main,
-    strip_meta_framing,
     wait_for_space,
 )
 
 
-def test_strip_meta_framing_drops_prefix_and_separator():
-    """The framing line + `---` separator is stripped; content survives intact."""
-    text = "This is the prompt sent to the agents, verbatim.\n\n---\n\n# ROLE\n\nBody content.\n"
-    stripped = strip_meta_framing(text)
-    assert stripped.startswith("# ROLE"), f"unexpected leading content: {stripped[:40]!r}"
-    assert "This is the prompt sent" not in stripped
-    assert "Body content." in stripped
-
-
-def test_strip_meta_framing_idempotent_on_unframed_input():
-    """Files without a framing separator are returned unchanged."""
-    text = "# ROLE\n\nBody.\n"
-    assert strip_meta_framing(text) == text
-
-
-def test_assemble_meta_prompt_strips_framing():
-    """assemble_meta_prompt() must NOT include the framing line in the dispatched bytes."""
+def test_assemble_meta_prompt_starts_with_role():
+    """assemble_meta_prompt() must begin directly with content, no framing line."""
     prompt = assemble_meta_prompt()
-    assert not prompt.startswith("This is the prompt"), (
-        "framing line leaked into dispatched meta-prompt"
-    )
-    assert "# ROLE" in prompt or "# GOAL" in prompt, "meta-prompt content missing"
+    assert prompt.startswith("# ROLE"), f"unexpected leading content: {prompt[:40]!r}"
 
 
 def test_metaprompt_file_exists():
@@ -76,16 +57,12 @@ def test_extract_quality_bar_raises_on_missing_markers():
         extract_quality_bar("no markers here")
 
 
-def test_assemble_meta_prompt_is_doc_02_content_post_framing():
-    """The assembled meta-prompt is Doc 02's content after the framing strip.
-
-    Single source of truth: edits to Doc 02 propagate to the dispatched
-    bytes (modulo the meta-framing line stripped by strip_meta_framing).
-    """
+def test_assemble_meta_prompt_is_doc_02_verbatim():
+    """assemble_meta_prompt() must return Doc 02 verbatim — no in-code template."""
     assembled = assemble_meta_prompt()
     on_disk = METAPROMPT_PATH.read_text(encoding="utf-8")
-    assert assembled == strip_meta_framing(on_disk), (
-        "assemble_meta_prompt() must return Doc 02 minus the framing line — "
+    assert assembled == on_disk, (
+        "assemble_meta_prompt() must return Doc 02 verbatim — "
         "any in-code template would create a second source of truth"
     )
 
@@ -1508,7 +1485,9 @@ def test_estimate_inventory_rows_ignores_summary_tables(monkeypatch, tmp_path):
     import experiments.sota.exp2_interactive_smoke as mod
 
     monkeypatch.setattr(mod, "_read_turn_field", lambda *_a, **_k: ["report"])
-    monkeypatch.setattr(mod, "_turn_artefact_paths", lambda *_a, **_k: {"raw": tmp_path / "missing"})
+    monkeypatch.setattr(
+        mod, "_turn_artefact_paths", lambda *_a, **_k: {"raw": tmp_path / "missing"}
+    )
     monkeypatch.setattr(
         mod,
         "_narrative_from_record_or_raw",


### PR DESCRIPTION
## Summary

- **GEM vocabulary alignment**: replace legacy status terms (`Approved / Planned / Operational / Under construction / Suspended`) with GEM canonical terms (`Announced / Pre-permit / Permitted / Construction / Operating / Shelved / Cancelled / Retired`) in `prompt_complete.txt`, `protocol_07_naive_prompt.md`, `protocol_02_metaprompt.md`, and the prompt modules
- **Scope clause simplified**: verbose 3-sentence scope block replaced with one line: *"Scope includes all thermal assets > 30 MWe at any stage of the lifecycle, including shelved or cancelled projects."*
- **protocol_07 structurally aligned with protocol_02**: table-first, exactly one pipe table, selective per-asset notes, annotated bibliography — sector overview and stat summary tables removed. Full CONTEXT block (source quality management, calibrated confidence vocabulary, asset-row and status rules) ported verbatim from the metaprompt.
- **Framing lines removed**: both protocol files previously opened with a reviewer-facing sentence + `---` separator; these are deleted. `strip_meta_framing()` and `_FRAMING_SEPARATOR` deleted from `exp2_interactive_smoke.py`; runners now read files verbatim.
- **Exp 1 repointed to protocol_07**: `sweep_direct_complete` now uses `sota/protocol_07_naive_prompt.md`. Exp 1 and Exp 2 Arm 1 share the same prompt; the only experimental variable between them is web access.
- **Modules synced**: `5_table.txt` and `A_Statistics.txt` updated to match `prompt_complete.txt`; `test_modules_match_prompt_complete` passes.

## Test plan
- [x] `pytest tests/test_exp2_interactive_smoke.py` — 62 passed
- [x] `pytest tests/test_modules_match_prompt_complete.py` — 1 passed
- [x] `strip_meta_framing` deletion verified: no remaining references in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)