### PR TITLE
Exp2: migrate to JSON mart canonical flow with parity gate

### DIFF
--- a/docs/scoring-contract.md
+++ b/docs/scoring-contract.md
@@ -226,4 +226,48 @@ All other metrics are scoreable on Exp1 outputs (the remaining fields are
 
 ## Mart schema section
 
-*(To be appended by ticket 0283 — Exp2 mart schema contract.)*
+The Exp2 mart is a JSONL contract for analysis-time records. It is intentionally
+smaller and more structured than the raw run artifacts: it carries stable
+identifiers, nested summaries, and immutable artifact pointers, but it does not
+carry verbatim chat payloads.
+
+### Record kinds
+
+- `run` records summarize one Exp2 run and point to the run JSON artifact.
+- `probe` records summarize one turn/probe slice and point to the probe file.
+- `score` records carry the mechanical-score payload for one run and point to
+	the source run artifact.
+
+### Versioning
+
+- `mart_schema = "exp2_mart"`
+- `mart_schema_version = 1`
+
+Any change that adds, removes, or renames mart fields must bump the schema
+version and ship a new validator model.
+
+### Artifact pointers
+
+Each pointer field is a repo-relative path plus a SHA-256 digest of the target
+file. The schema rejects absolute paths and upward traversal.
+
+- `result_file`
+- `parsed_table_file`
+- `probe_file`
+
+### Nested summaries
+
+Mart records use grouped JSON summaries rather than a flat CSV-shaped record.
+That keeps the mart readable for downstream code while leaving flattening to the
+CSV view layer introduced in later tickets.
+
+- Run records carry `run_summary`.
+- Probe records carry `probe_summary`.
+- Score records carry `score_summary`, grouped into accuracy, coherence,
+	provenance, temporality, and field-completeness sections.
+
+### Forbidden payloads
+
+The mart schema uses strict field checking and must reject any verbatim chat
+payload keys such as `raw_payload`, `messages`, `content`, or `thinking`.
+Only structured summaries, hashes, and artifact pointers are allowed.

--- a/report/exp2-analysis.mk
+++ b/report/exp2-analysis.mk
@@ -3,6 +3,9 @@
 #   make -f report/exp2-analysis.mk exp2-analysis-report
 
 GEN := report/inputs/generated
+MART_JSONL := $(GEN)/exp2_mart.jsonl
+OLD_STAGE := $(GEN)/exp2-old-path
+MART_STAGE := $(GEN)/exp2-mart-path
 
 NAIVE_DIR    := experiments/outputs/sota_exp2_naive_arm
 OPTIMISED_DIR := experiments/outputs/sota_exp2_brerun1
@@ -14,18 +17,80 @@ OPTIMISED_MDS  := $(wildcard $(OPTIMISED_DIR)/*.md)
 PROBE_RAWS     := $(wildcard $(OPTIMISED_DIR)/probes/*/*.raw.json)
 PROBE_CLSF     := $(wildcard $(OPTIMISED_DIR)/probes/*/*.classification.json)
 
-# --- Intermediate: flat per-run CSV ------------------------------------------
+# --- Canonical mart and mart-derived views ---------------------------------
 
-$(GEN)/tab_exp2_arms_runs.csv: $(NAIVE_JSONS) $(NAIVE_MDS) $(OPTIMISED_JSONS)
+$(MART_JSONL): $(NAIVE_JSONS) $(NAIVE_MDS) $(OPTIMISED_JSONS) $(OPTIMISED_MDS) \
+        experiments/derived/sota_cross_eval.csv $(PROBE_RAWS) $(PROBE_CLSF)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart \
+	    --naive-dir $(NAIVE_DIR) \
+	    --optimised-dir $(OPTIMISED_DIR) \
+	    --cross-eval-csv experiments/derived/sota_cross_eval.csv \
+	    --output $@ \
+	    --repo-root .
+
+$(GEN)/tab_exp2_arms_runs_view.csv $(GEN)/tab_exp2_bib_quality_view.csv \
+$(GEN)/exp2_turn_trajectory_view.csv $(GEN)/sota_cross_eval_view.csv: $(MART_JSONL)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart_views \
+	    --mart-jsonl $(MART_JSONL) \
+	    --output-dir $(GEN) \
+	    --repo-root .
+
+# --- Dual-run parity staging -------------------------------------------------
+
+$(OLD_STAGE)/tab_exp2_arms_runs.csv: $(NAIVE_JSONS) $(NAIVE_MDS) $(OPTIMISED_JSONS)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_exp2_arms_runs \
 	    --naive-dir $(NAIVE_DIR) \
 	    --optimised-dir $(OPTIMISED_DIR) \
 	    --output $@
 
+$(OLD_STAGE)/tab_exp2_bib_quality.csv: $(NAIVE_MDS) $(OPTIMISED_MDS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.extract_exp2_bib \
+	    --naive-dir $(NAIVE_DIR) \
+	    --optimised-dir $(OPTIMISED_DIR) \
+	    --output $@
+
+$(OLD_STAGE)/exp2_turn_trajectory.csv: $(PROBE_RAWS) $(PROBE_CLSF)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.export_exp2_turn_trajectory_csv \
+	    --probes-dir $(OPTIMISED_DIR)/probes \
+	    --output $@
+
+$(OLD_STAGE)/sota_cross_eval.csv: experiments/derived/sota_cross_eval.csv
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+$(MART_STAGE)/tab_exp2_arms_runs_view.csv $(MART_STAGE)/tab_exp2_bib_quality_view.csv \
+$(MART_STAGE)/exp2_turn_trajectory_view.csv $(MART_STAGE)/sota_cross_eval_view.csv: $(MART_JSONL)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart_views \
+	    --mart-jsonl $(MART_JSONL) \
+	    --output-dir $(MART_STAGE) \
+	    --repo-root .
+
+exp2-old-path: \
+	$(OLD_STAGE)/tab_exp2_arms_runs.csv \
+	$(OLD_STAGE)/tab_exp2_bib_quality.csv \
+	$(OLD_STAGE)/exp2_turn_trajectory.csv \
+	$(OLD_STAGE)/sota_cross_eval.csv
+
+exp2-mart-path: \
+	$(MART_STAGE)/tab_exp2_arms_runs_view.csv \
+	$(MART_STAGE)/tab_exp2_bib_quality_view.csv \
+	$(MART_STAGE)/exp2_turn_trajectory_view.csv \
+	$(MART_STAGE)/sota_cross_eval_view.csv
+
+check-mart-parity: exp2-old-path exp2-mart-path
+	uv run python -m aedist.check_exp2_mart_parity \
+	    --left-dir $(OLD_STAGE) \
+	    --right-dir $(MART_STAGE)
+
 # --- Table: per-model summary (reads from CSV) --------------------------------
 
-$(GEN)/tab_exp2_arms.tex: $(GEN)/tab_exp2_arms_runs.csv
+$(GEN)/tab_exp2_arms.tex: $(GEN)/tab_exp2_arms_runs_view.csv
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_exp2_arms \
 	    --input $< \
@@ -35,7 +100,7 @@ $(GEN)/tab_exp2_arms.tex: $(GEN)/tab_exp2_arms_runs.csv
 
 # --- Figure: three-panel comparison (reads from CSV) -------------------------
 
-$(GEN)/fig_exp2_arms_comparison.pdf: $(GEN)/tab_exp2_arms_runs.csv
+$(GEN)/fig_exp2_arms_comparison.pdf: $(GEN)/tab_exp2_arms_runs_view.csv
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_arms_comparison \
 	    --input $< \
@@ -43,24 +108,17 @@ $(GEN)/fig_exp2_arms_comparison.pdf: $(GEN)/tab_exp2_arms_runs.csv
 
 # --- Figure: turn-by-turn trajectory for Arm 2 (reads from probes/) ---------
 
-$(GEN)/fig_exp2_turn_trajectory.pdf: $(PROBE_RAWS) $(PROBE_CLSF)
+$(GEN)/fig_exp2_turn_trajectory.pdf: $(GEN)/exp2_turn_trajectory_view.csv
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_turn_trajectory \
-	    --probes-dir $(OPTIMISED_DIR)/probes \
+	    --input $< \
 	    --output $@
 
 # --- Bibliography quality CSV (reads markdown outputs) ----------------------
 
-$(GEN)/tab_exp2_bib_quality.csv: $(NAIVE_MDS) $(OPTIMISED_MDS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.extract_exp2_bib \
-	    --naive-dir $(NAIVE_DIR) \
-	    --optimised-dir $(OPTIMISED_DIR) \
-	    --output $@
-
 # --- Bibliography quality LaTeX table (reads from CSV) ----------------------
 
-$(GEN)/tab_exp2_bib_quality.tex: $(GEN)/tab_exp2_bib_quality.csv
+$(GEN)/tab_exp2_bib_quality.tex: $(GEN)/tab_exp2_bib_quality_view.csv
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_exp2_bib_quality \
 	    --input $< \
@@ -68,7 +126,7 @@ $(GEN)/tab_exp2_bib_quality.tex: $(GEN)/tab_exp2_bib_quality.csv
 
 # --- Figure: coverage vs. certainty scatter (reads from bib quality CSV) -----
 
-$(GEN)/fig_exp2_coverage_certainty.pdf: $(GEN)/tab_exp2_bib_quality.csv
+$(GEN)/fig_exp2_coverage_certainty.pdf: $(GEN)/tab_exp2_bib_quality_view.csv
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_coverage_certainty \
 	    --input $< \
@@ -76,7 +134,7 @@ $(GEN)/fig_exp2_coverage_certainty.pdf: $(GEN)/tab_exp2_bib_quality.csv
 
 # --- Figure: five-axis quality spider from cross-eval scores -----------------
 
-$(GEN)/fig_quality_spider.pdf: experiments/derived/sota_cross_eval.csv experiments/quality_spider_config.yaml
+$(GEN)/fig_quality_spider.pdf: $(GEN)/sota_cross_eval_view.csv experiments/quality_spider_config.yaml
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_quality_spider \
 	    --input $< \
@@ -147,11 +205,11 @@ $(GEN)/tab_exp2_outline_hypothesis_status.tex:
 .PHONY: exp2-analysis-report
 
 exp2-analysis-report: \
-	$(GEN)/tab_exp2_arms_runs.csv \
+	$(GEN)/tab_exp2_arms_runs_view.csv \
 	$(GEN)/tab_exp2_arms.tex \
 	$(GEN)/fig_exp2_arms_comparison.pdf \
 	$(GEN)/fig_exp2_turn_trajectory.pdf \
-	$(GEN)/tab_exp2_bib_quality.csv \
+	$(GEN)/tab_exp2_bib_quality_view.csv \
 	$(GEN)/tab_exp2_bib_quality.tex \
 	$(GEN)/fig_exp2_coverage_certainty.pdf \
 	$(GEN)/fig_quality_spider.pdf \

--- a/src/aedist/build_exp2_mart.py
+++ b/src/aedist/build_exp2_mart.py
@@ -1,0 +1,354 @@
+"""Build the Exp2 mart JSONL artifact from immutable run outputs."""
+
+import argparse
+import csv
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+
+from .exp2_mart import (
+    AccuracyMetrics,
+    ArtifactPointer,
+    CoherenceMetrics,
+    Exp2ProbeMartRecord,
+    Exp2RunMartRecord,
+    Exp2ScoreMartRecord,
+    FieldCompletenessMetrics,
+    MetricValue,
+    ProbeSummary,
+    ProvenanceMetrics,
+    RunSummary,
+    ScoreSummary,
+    TemporalityMetrics,
+)
+from .extract import count_best_table_rows
+from .score_ingest import IngestionError, IngestionErrorKind, RunLocator, ingest_run
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_NAIVE_DIR = Path("experiments/outputs/sota_exp2_naive_arm")
+_DEFAULT_OPTIMISED_DIR = Path("experiments/outputs/sota_exp2_brerun1")
+_DEFAULT_CROSS_EVAL = Path("experiments/derived/sota_cross_eval.csv")
+_DEFAULT_OUTPUT = Path("report/inputs/generated/exp2_mart.jsonl")
+_RUN_RE = re.compile(r"^([a-z]+)_run(\d+)\.json$")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _pointer(path: Path, repo_root: Path) -> ArtifactPointer:
+    relative_path = path.relative_to(repo_root)
+    return ArtifactPointer(path=relative_path.as_posix(), sha256=_sha256(path))
+
+
+def _record_id(arm: str, model: str, run: int, suffix: str = "") -> str:
+    safe_model = model.replace("/", "_")
+    base = f"exp2/{arm}/{safe_model}/run{run:02d}"
+    return f"{base}/{suffix}" if suffix else base
+
+
+def _metric(value: str | None, annotation: str | None) -> MetricValue:
+    token = (value or "").strip()
+    parsed = float(token) if token else None
+    return MetricValue(value=parsed, annotation=(annotation or "").strip())
+
+
+def _score_summary(row: dict[str, str]) -> ScoreSummary:
+    return ScoreSummary(
+        n_rows=int(row["n_rows"]),
+        accuracy=AccuracyMetrics(
+            coverage=_metric(row.get("accuracy_coverage"), row.get("accuracy_coverage_annotation")),
+            precision=_metric(row.get("accuracy_precision"), row.get("accuracy_precision_annotation")),
+            f1=_metric(row.get("accuracy_f1"), row.get("accuracy_f1_annotation")),
+            fuel=_metric(row.get("accuracy_fuel"), row.get("accuracy_fuel_annotation")),
+            status=_metric(row.get("accuracy_status"), row.get("accuracy_status_annotation")),
+            province=_metric(row.get("accuracy_province"), row.get("accuracy_province_annotation")),
+        ),
+        coherence=CoherenceMetrics(
+            vocab_adherence=_metric(
+                row.get("coherence_vocab_adherence"), row.get("coherence_vocab_adherence_annotation")
+            ),
+            status_vocab_adherence=_metric(
+                row.get("coherence_status_vocab_adherence", row.get("coherence_capacity_nonnegative")),
+                row.get(
+                    "coherence_status_vocab_adherence_annotation",
+                    row.get("coherence_capacity_nonnegative_annotation"),
+                ),
+            ),
+        ),
+        provenance=ProvenanceMetrics(
+            source_presence=_metric(
+                row.get("provenance_source_presence"), row.get("provenance_source_presence_annotation")
+            ),
+            high_conf_dual_source=_metric(
+                row.get("provenance_high_conf_dual_source"),
+                row.get("provenance_high_conf_dual_source_annotation"),
+            ),
+        ),
+        temporality=TemporalityMetrics(
+            asof_presence=_metric(row.get("temporality_asof_presence"), row.get("temporality_asof_presence_annotation")),
+            plausible_range=_metric(
+                row.get("temporality_plausible_range"), row.get("temporality_plausible_range_annotation")
+            ),
+        ),
+        field_completeness=FieldCompletenessMetrics(
+            core=_metric(row.get("field_completeness_core"), row.get("field_completeness_core_annotation")),
+            capacity=_metric(
+                row.get("field_completeness_capacity"), row.get("field_completeness_capacity_annotation")
+            ),
+        ),
+    )
+
+
+def _load_score_rows(
+    csv_path: Path,
+) -> tuple[
+    dict[tuple[str, str, int], dict[str, str]],
+    dict[tuple[str, int], list[dict[str, str]]],
+    dict[tuple[str, str, int], list[dict[str, str]]],
+]:
+    rows: dict[tuple[str, str, int], dict[str, str]] = {}
+    rows_by_arm_run: dict[tuple[str, int], list[dict[str, str]]] = {}
+    rows_by_arm_agent_run: dict[tuple[str, str, int], list[dict[str, str]]] = {}
+
+    def infer_agent(model: str) -> str | None:
+        token = model.lower()
+        if "claude" in token or "anthropic" in token:
+            return "anthropic"
+        if "gpt" in token or "openai" in token:
+            return "openai"
+        if "mistral" in token:
+            return "mistral"
+        if "qwen" in token:
+            return "qwen"
+        return None
+
+    with csv_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            key = (row["arm"], row["model"], int(row["run"]))
+            rows[key] = row
+            rows_by_arm_run.setdefault((row["arm"], int(row["run"])), []).append(row)
+            agent = infer_agent(row["model"])
+            if agent is not None:
+                rows_by_arm_agent_run.setdefault((row["arm"], agent, int(row["run"])), []).append(row)
+    return rows, rows_by_arm_run, rows_by_arm_agent_run
+
+
+def _resolve_score_row(
+    arm: str,
+    agent: str,
+    model: str,
+    run: int,
+    score_rows: dict[tuple[str, str, int], dict[str, str]],
+    rows_by_arm_agent_run: dict[tuple[str, str, int], list[dict[str, str]]],
+) -> dict[str, str] | None:
+    exact = score_rows.get((arm, model, run))
+    if exact is not None:
+        return exact
+
+    by_agent = rows_by_arm_agent_run.get((arm, agent, run), [])
+    if len(by_agent) == 1:
+        return by_agent[0]
+    return None
+
+
+def _build_run_records(
+    arm_dir: Path,
+    arm: str,
+    *,
+    repo_root: Path,
+    naive_dir: Path,
+    optimised_dir: Path,
+) -> list[Exp2RunMartRecord]:
+    records: list[Exp2RunMartRecord] = []
+    for json_path in sorted(arm_dir.glob("*.json")):
+        match = _RUN_RE.match(json_path.name)
+        if not match:
+            continue
+        agent, run_raw = match.groups()
+        run = int(run_raw)
+        meta = json.loads(json_path.read_text(encoding="utf-8"))
+        locator = RunLocator(arm=arm, model=meta.get("model", ""), run=run)
+        md_path = json_path.with_suffix(".md")
+        md_text = md_path.read_text(encoding="utf-8", errors="replace")
+        legacy_n_rows = count_best_table_rows(md_text)
+
+        try:
+            ingest_run(locator, naive_dir=naive_dir, optimised_dir=optimised_dir)
+        except IngestionError as exc:
+            # Some runs have empty or non-canonical markdown tables.
+            # Fall back to the legacy row counter used by tabulate_exp2_arms_runs.
+            if exc.kind in {IngestionErrorKind.NO_TABLE, IngestionErrorKind.PARSE_FAILED}:
+                pass
+            else:
+                raise
+
+        records.append(
+            Exp2RunMartRecord(
+                record_id=_record_id(arm, meta.get("model", agent), run),
+                arm=arm,
+                model=meta.get("model", ""),
+                run=run,
+                prompt_version=meta.get("prompt_version"),
+                run_summary=RunSummary(
+                    n_rows=legacy_n_rows,
+                    classification=meta.get("classification"),
+                    turns=meta.get("turns", 1 if arm == "naive" else None),
+                    tokens_out=meta.get("tokens_out"),
+                    wall_s=meta.get("wall_s"),
+                    cost_usd=meta.get("cost_usd", meta.get("total_cost_usd")),
+                    classifier_cost_usd=meta.get("classifier_cost_usd"),
+                    narrative_chars=meta.get("narrative_chars"),
+                ),
+                result_file=_pointer(json_path, repo_root),
+                parsed_table_file=_pointer(md_path, repo_root),
+            )
+        )
+    return records
+
+
+def _build_probe_records(
+    arm_dir: Path,
+    arm: str,
+    *,
+    repo_root: Path,
+) -> list[Exp2ProbeMartRecord]:
+    records: list[Exp2ProbeMartRecord] = []
+    probes_dir = arm_dir / "probes"
+    if not probes_dir.exists():
+        return records
+
+    for run_dir in sorted(p for p in probes_dir.iterdir() if p.is_dir()):
+        match = re.match(r"^([a-z]+)_run(\d+)$", run_dir.name)
+        if not match:
+            continue
+        agent, run_raw = match.groups()
+        run = int(run_raw)
+        run_json_path = arm_dir / f"{agent}_run{run:02d}.json"
+        if not run_json_path.exists():
+            continue
+        meta = json.loads(run_json_path.read_text(encoding="utf-8"))
+
+        for raw_path in sorted(run_dir.glob(f"{agent}_turn_*.raw.json")):
+            turn_match = re.search(r"_turn_(\d+)\.raw\.json$", raw_path.name)
+            if turn_match is None:
+                continue
+            turn = int(turn_match.group(1))
+            cls_path = raw_path.with_name(raw_path.name.replace(".raw.json", ".classification.json"))
+            probe_label = None
+            if cls_path.exists():
+                cls_payload = json.loads(cls_path.read_text(encoding="utf-8"))
+                probe_label = cls_payload.get("class")
+
+            records.append(
+                Exp2ProbeMartRecord(
+                    record_id=_record_id(arm, meta.get("model", agent), run, f"turn{turn:02d}"),
+                    parent_record_id=_record_id(arm, meta.get("model", agent), run),
+                    arm=arm,
+                    model=meta.get("model", ""),
+                    run=run,
+                    prompt_version=meta.get("prompt_version"),
+                    probe_summary=ProbeSummary(turn=turn, probe_label=probe_label),
+                    probe_file=_pointer(raw_path, repo_root),
+                )
+            )
+
+    return records
+
+
+def build_exp2_mart(
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+    cross_eval_csv: Path = _DEFAULT_CROSS_EVAL,
+    repo_root: Path | None = None,
+) -> list[Exp2RunMartRecord | Exp2ScoreMartRecord]:
+    repo_root = repo_root or Path.cwd()
+    score_rows, _rows_by_arm_run, rows_by_arm_agent_run = _load_score_rows(cross_eval_csv)
+    records: list[Exp2RunMartRecord | Exp2ScoreMartRecord] = []
+
+    for arm, arm_dir in (("naive", naive_dir), ("optimised", optimised_dir)):
+        for run_record in _build_run_records(
+            arm_dir,
+            arm,
+            repo_root=repo_root,
+            naive_dir=naive_dir,
+            optimised_dir=optimised_dir,
+        ):
+            records.append(run_record)
+            agent = Path(run_record.result_file.path).name.split("_run", 1)[0]
+            score_row = _resolve_score_row(
+                run_record.arm,
+                agent,
+                run_record.model,
+                run_record.run,
+                score_rows,
+                rows_by_arm_agent_run,
+            )
+            if score_row is None:
+                continue
+            records.append(
+                Exp2ScoreMartRecord(
+                    record_id=_record_id(run_record.arm, run_record.model, run_record.run, "score"),
+                    parent_record_id=run_record.record_id,
+                    arm=run_record.arm,
+                    model=run_record.model,
+                    run=run_record.run,
+                    prompt_version=score_row.get("prompt_version") or run_record.prompt_version,
+                    score_summary=_score_summary(score_row),
+                    result_file=run_record.result_file,
+                    parsed_table_file=run_record.parsed_table_file,
+                )
+            )
+        records.extend(_build_probe_records(arm_dir, arm, repo_root=repo_root))
+
+    records.sort(key=lambda record: (record.arm, record.model, record.run, record.record_kind))
+    return records
+
+
+def write_exp2_mart(
+    output: Path,
+    naive_dir: Path = _DEFAULT_NAIVE_DIR,
+    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
+    cross_eval_csv: Path = _DEFAULT_CROSS_EVAL,
+    repo_root: Path | None = None,
+) -> list[Exp2RunMartRecord | Exp2ScoreMartRecord]:
+    records = build_exp2_mart(
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=cross_eval_csv,
+        repo_root=repo_root,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(record.model_dump_json())
+            handle.write("\n")
+    return records
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Build the Exp2 mart JSONL artifact")
+    parser.add_argument("--output", default=str(_DEFAULT_OUTPUT))
+    parser.add_argument("--naive-dir", default=str(_DEFAULT_NAIVE_DIR))
+    parser.add_argument("--optimised-dir", default=str(_DEFAULT_OPTIMISED_DIR))
+    parser.add_argument("--cross-eval-csv", default=str(_DEFAULT_CROSS_EVAL))
+    parser.add_argument("--repo-root", default=str(Path.cwd()))
+    args = parser.parse_args(argv)
+
+    records = write_exp2_mart(
+        Path(args.output),
+        naive_dir=Path(args.naive_dir),
+        optimised_dir=Path(args.optimised_dir),
+        cross_eval_csv=Path(args.cross_eval_csv),
+        repo_root=Path(args.repo_root),
+    )
+    log.info("Wrote %d mart records to %s", len(records), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/build_exp2_mart_views.py
+++ b/src/aedist/build_exp2_mart_views.py
@@ -1,0 +1,324 @@
+"""Build CSV views from the Exp2 mart JSONL artifact."""
+
+import argparse
+import csv
+import json
+import logging
+import re
+from pathlib import Path
+
+from .extract_exp2_bib import parse_md
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_OUTPUT_DIR = Path("report/inputs/generated")
+
+_ARMS_RUNS_FIELDS = [
+    "arm",
+    "agent",
+    "model",
+    "run",
+    "classification",
+    "narrative_chars",
+    "inventory_rows",
+    "cost_usd",
+    "wall_s",
+    "turns",
+]
+
+_BIB_FIELDS = [
+    "agent",
+    "arm",
+    "run",
+    "n_rows",
+    "src1_empty",
+    "src1_notfound",
+    "src1_present",
+    "src1_valid",
+    "src1_primary",
+    "src2_empty",
+    "src2_notfound",
+    "src2_present",
+    "src2_valid",
+    "src2_primary",
+    "notes_empty",
+    "notes_notfound",
+    "notes_present",
+    "bib_entries",
+    "bib_valid",
+    "bib_primary",
+    "citation_style",
+]
+
+_TURN_FIELDS = ["agent", "arm", "run", "turn", "rows", "cls"]
+
+_SCORE_VIEW_FIELDS = [
+    "arm",
+    "model",
+    "run",
+    "prompt_version",
+    "n_rows",
+    "accuracy_coverage",
+    "accuracy_coverage_annotation",
+    "accuracy_precision",
+    "accuracy_precision_annotation",
+    "accuracy_f1",
+    "accuracy_f1_annotation",
+    "accuracy_fuel",
+    "accuracy_fuel_annotation",
+    "accuracy_status",
+    "accuracy_status_annotation",
+    "accuracy_province",
+    "accuracy_province_annotation",
+    "coherence_vocab_adherence",
+    "coherence_vocab_adherence_annotation",
+    "coherence_capacity_nonnegative",
+    "coherence_capacity_nonnegative_annotation",
+    "provenance_source_presence",
+    "provenance_source_presence_annotation",
+    "provenance_high_conf_dual_source",
+    "provenance_high_conf_dual_source_annotation",
+    "temporality_asof_presence",
+    "temporality_asof_presence_annotation",
+    "temporality_plausible_range",
+    "temporality_plausible_range_annotation",
+    "field_completeness_core",
+    "field_completeness_core_annotation",
+    "field_completeness_capacity",
+    "field_completeness_capacity_annotation",
+]
+
+
+def _load_mart_records(mart_path: Path) -> list[dict]:
+    records = []
+    for line in mart_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        records.append(json.loads(line))
+    return records
+
+
+def _fmt(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.4f}"
+
+
+def _agent_from_artifact_path(path: str) -> str:
+    artifact = Path(path)
+    for token in (artifact.name, artifact.parent.name):
+        match = re.match(r"^([a-z]+)_run\d+", token)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _record_key(record: dict) -> tuple[str, str, int]:
+    return (record["arm"], record["model"], int(record["run"]))
+
+
+def _read_pointer(repo_root: Path, pointer: dict[str, str]) -> Path:
+    return repo_root / pointer["path"]
+
+
+def _extract_text(raw: dict) -> str:
+    if "content" in raw and isinstance(raw["content"], list):
+        return " ".join(block.get("text", "") for block in raw["content"] if block.get("type") == "text")
+    if isinstance(raw.get("output"), dict) and "choices" in raw["output"]:
+        return raw["output"]["choices"][0]["message"].get("content", "")
+    if isinstance(raw.get("output"), list):
+        parts = []
+        for item in raw["output"]:
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            parts.extend(
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "output_text"
+            )
+        return " ".join(part for part in parts if part)
+    if isinstance(raw.get("outputs"), list):
+        for item in reversed(raw["outputs"]):
+            if item.get("type") == "message.output":
+                content = item.get("content", "")
+                if isinstance(content, list):
+                    return " ".join(block.get("text", "") for block in content if isinstance(block, dict))
+                return str(content)
+    return ""
+
+
+def _count_rows_from_probe(repo_root: Path, probe_pointer: dict[str, str]) -> int:
+    raw_path = _read_pointer(repo_root, probe_pointer)
+    text = _extract_text(json.loads(raw_path.read_text(encoding="utf-8")))
+    from .extract import count_best_table_rows
+
+    return count_best_table_rows(text)
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_exp2_mart_views(mart_path: Path, repo_root: Path | None = None) -> dict[str, list[dict]]:
+    repo_root = repo_root or Path.cwd()
+    records = _load_mart_records(mart_path)
+
+    runs = [record for record in records if record.get("record_kind") == "run"]
+    probes = [record for record in records if record.get("record_kind") == "probe"]
+    scores = [record for record in records if record.get("record_kind") == "score"]
+
+    run_rows: list[dict] = []
+    bib_rows: list[dict] = []
+    turn_rows: list[dict] = []
+
+    for record in runs:
+        agent = _agent_from_artifact_path(record["result_file"]["path"])
+        run_rows.append(
+            {
+                "arm": record["arm"],
+                "agent": agent,
+                "model": record["model"],
+                "run": record["run"],
+                "classification": record["run_summary"].get("classification", ""),
+                "narrative_chars": record["run_summary"].get("narrative_chars", 0),
+                "inventory_rows": record["run_summary"].get("n_rows", 0),
+                "cost_usd": record["run_summary"].get("cost_usd", 0.0),
+                "wall_s": record["run_summary"].get("wall_s", 0.0),
+                "turns": record["run_summary"].get("turns", 1),
+            }
+        )
+
+        bib_metrics = parse_md(_read_pointer(repo_root, record["parsed_table_file"]))
+        bib_rows.append({"agent": agent, "arm": record["arm"], "run": record["run"], **bib_metrics})
+
+    for record in probes:
+        agent = _agent_from_artifact_path(record["probe_file"]["path"])
+        turn_rows.append(
+            {
+                "agent": agent,
+                "arm": record["arm"],
+                "run": record["run"],
+                "turn": record["probe_summary"]["turn"],
+                "rows": _count_rows_from_probe(repo_root, record["probe_file"]),
+                "cls": record["probe_summary"].get("probe_label") or "no_report",
+            }
+        )
+
+    score_rows: list[dict] = []
+    for record in scores:
+        summary = record["score_summary"]
+        score_rows.append(
+            {
+                "arm": record["arm"],
+                "model": record["model"],
+                "run": str(record["run"]),
+                "prompt_version": record.get("prompt_version", ""),
+                "n_rows": str(summary["n_rows"]),
+                "accuracy_coverage": _fmt(summary["accuracy"]["coverage"].get("value")),
+                "accuracy_coverage_annotation": summary["accuracy"]["coverage"].get("annotation", ""),
+                "accuracy_precision": _fmt(summary["accuracy"]["precision"].get("value")),
+                "accuracy_precision_annotation": summary["accuracy"]["precision"].get("annotation", ""),
+                "accuracy_f1": _fmt(summary["accuracy"]["f1"].get("value")),
+                "accuracy_f1_annotation": summary["accuracy"]["f1"].get("annotation", ""),
+                "accuracy_fuel": _fmt(summary["accuracy"]["fuel"].get("value")),
+                "accuracy_fuel_annotation": summary["accuracy"]["fuel"].get("annotation", ""),
+                "accuracy_status": _fmt(summary["accuracy"]["status"].get("value")),
+                "accuracy_status_annotation": summary["accuracy"]["status"].get("annotation", ""),
+                "accuracy_province": _fmt(summary["accuracy"]["province"].get("value")),
+                "accuracy_province_annotation": summary["accuracy"]["province"].get("annotation", ""),
+                "coherence_vocab_adherence": _fmt(summary["coherence"]["vocab_adherence"].get("value")),
+                "coherence_vocab_adherence_annotation": summary["coherence"]["vocab_adherence"].get(
+                    "annotation", ""
+                ),
+                "coherence_capacity_nonnegative": _fmt(
+                    summary["coherence"]["status_vocab_adherence"].get("value")
+                ),
+                "coherence_capacity_nonnegative_annotation": summary["coherence"][
+                    "status_vocab_adherence"
+                ].get("annotation", ""),
+                "provenance_source_presence": _fmt(summary["provenance"]["source_presence"].get("value")),
+                "provenance_source_presence_annotation": summary["provenance"]["source_presence"].get(
+                    "annotation", ""
+                ),
+                "provenance_high_conf_dual_source": _fmt(
+                    summary["provenance"]["high_conf_dual_source"].get("value")
+                ),
+                "provenance_high_conf_dual_source_annotation": summary["provenance"][
+                    "high_conf_dual_source"
+                ].get("annotation", ""),
+                "temporality_asof_presence": _fmt(summary["temporality"]["asof_presence"].get("value")),
+                "temporality_asof_presence_annotation": summary["temporality"]["asof_presence"].get(
+                    "annotation", ""
+                ),
+                "temporality_plausible_range": _fmt(summary["temporality"]["plausible_range"].get("value")),
+                "temporality_plausible_range_annotation": summary["temporality"]["plausible_range"].get(
+                    "annotation", ""
+                ),
+                "field_completeness_core": _fmt(summary["field_completeness"]["core"].get("value")),
+                "field_completeness_core_annotation": summary["field_completeness"]["core"].get(
+                    "annotation", ""
+                ),
+                "field_completeness_capacity": _fmt(summary["field_completeness"]["capacity"].get("value")),
+                "field_completeness_capacity_annotation": summary["field_completeness"]["capacity"].get(
+                    "annotation", ""
+                ),
+            }
+        )
+
+    run_rows.sort(key=lambda row: (row["arm"], row["agent"], row["run"]))
+    bib_rows.sort(key=lambda row: (row["arm"], row["agent"], row["run"]))
+    turn_rows.sort(key=lambda row: (row["arm"], row["agent"], row["run"], row["turn"]))
+    score_rows.sort(key=lambda row: (row["arm"], row["model"], int(row["run"])))
+
+    return {
+        "tab_exp2_arms_runs_view.csv": run_rows,
+        "tab_exp2_bib_quality_view.csv": bib_rows,
+        "exp2_turn_trajectory_view.csv": turn_rows,
+        "sota_cross_eval_view.csv": score_rows,
+    }
+
+
+def write_exp2_mart_views(mart_path: Path, output_dir: Path, repo_root: Path | None = None) -> dict[str, Path]:
+    views = build_exp2_mart_views(mart_path, repo_root=repo_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    outputs = {
+        "tab_exp2_arms_runs_view.csv": output_dir / "tab_exp2_arms_runs_view.csv",
+        "tab_exp2_bib_quality_view.csv": output_dir / "tab_exp2_bib_quality_view.csv",
+        "exp2_turn_trajectory_view.csv": output_dir / "exp2_turn_trajectory_view.csv",
+        "sota_cross_eval_view.csv": output_dir / "sota_cross_eval_view.csv",
+    }
+
+    for filename, path in outputs.items():
+        rows = views[filename]
+        fieldnames = _ARMS_RUNS_FIELDS if filename == "tab_exp2_arms_runs_view.csv" else (
+            _BIB_FIELDS if filename == "tab_exp2_bib_quality_view.csv" else (
+                _TURN_FIELDS if filename == "exp2_turn_trajectory_view.csv" else _SCORE_VIEW_FIELDS
+            )
+        )
+        _write_csv(path, fieldnames, rows)
+        log.info("Wrote %d rows to %s", len(rows), path)
+    return outputs
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Build CSV views from the Exp2 mart JSONL")
+    parser.add_argument("--mart-jsonl", required=True)
+    parser.add_argument("--output-dir", default=str(_DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--repo-root", default=str(Path.cwd()))
+    args = parser.parse_args(argv)
+
+    write_exp2_mart_views(
+        Path(args.mart_jsonl),
+        Path(args.output_dir),
+        repo_root=Path(args.repo_root),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/check_exp2_mart_parity.py
+++ b/src/aedist/check_exp2_mart_parity.py
@@ -1,0 +1,133 @@
+"""Compare legacy Exp2 CSV intermediates against mart-derived views.
+
+Tolerance policy:
+- row counts must match exactly
+- column sets must match exactly
+- numeric cells compare within max($1e-3$, $0.001 x max(1, |a|, |b|))
+- non-numeric cells compare exactly after trimming whitespace
+"""
+
+import argparse
+import csv
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ParityResult:
+    name: str
+    ok: bool
+    message: str
+
+
+def _load_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _as_float(text: str) -> float | None:
+    value = text.strip()
+    if value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _compare_cells(left: str, right: str) -> bool:
+    left_value = _as_float(left)
+    right_value = _as_float(right)
+    if left_value is None or right_value is None:
+        return left.strip() == right.strip()
+    scale = max(1.0, abs(left_value), abs(right_value))
+    return abs(left_value - right_value) <= max(1e-3, 1e-3 * scale)
+
+
+def _compare_csvs(left: Path, right: Path, key_fields: list[str], name: str) -> ParityResult:
+    left_rows = _load_csv(left)
+    right_rows = _load_csv(right)
+
+    if len(left_rows) != len(right_rows):
+        return ParityResult(name, False, f"row-count mismatch: {len(left_rows)} != {len(right_rows)}")
+
+    if not left_rows and not right_rows:
+        return ParityResult(name, True, "empty")
+
+    left_fields = set(left_rows[0].keys())
+    right_fields = set(right_rows[0].keys())
+    if left_fields != right_fields:
+        return ParityResult(name, False, f"column-set mismatch: {sorted(left_fields)} != {sorted(right_fields)}")
+
+    left_rows = sorted(left_rows, key=lambda row: tuple(row[field] for field in key_fields))
+    right_rows = sorted(right_rows, key=lambda row: tuple(row[field] for field in key_fields))
+
+    for index, (left_row, right_row) in enumerate(zip(left_rows, right_rows, strict=True), start=1):
+        for field in left_fields:
+            if not _compare_cells(left_row[field], right_row[field]):
+                return ParityResult(
+                    name,
+                    False,
+                    f"mismatch at row {index} field {field!r}: {left_row[field]!r} != {right_row[field]!r}",
+                )
+
+    return ParityResult(name, True, "ok")
+
+
+def check_parity(left_dir: Path, right_dir: Path) -> list[ParityResult]:
+    specs = [
+        ("tab_exp2_arms_runs", "tab_exp2_arms_runs.csv", "tab_exp2_arms_runs_view.csv", ["agent", "arm", "model", "run"]),
+        (
+            "tab_exp2_bib_quality",
+            "tab_exp2_bib_quality.csv",
+            "tab_exp2_bib_quality_view.csv",
+            ["agent", "arm", "run"],
+        ),
+        (
+            "exp2_turn_trajectory",
+            "exp2_turn_trajectory.csv",
+            "exp2_turn_trajectory_view.csv",
+            ["agent", "arm", "run", "turn"],
+        ),
+        (
+            "sota_cross_eval",
+            "sota_cross_eval.csv",
+            "sota_cross_eval_view.csv",
+            ["arm", "model", "run"],
+        ),
+    ]
+
+    results: list[ParityResult] = []
+    for name, left_name, right_name, key_fields in specs:
+        left_path = left_dir / left_name
+        right_path = right_dir / right_name
+        if not left_path.exists():
+            results.append(ParityResult(name, False, f"missing left file: {left_path}"))
+            continue
+        if not right_path.exists():
+            results.append(ParityResult(name, False, f"missing right file: {right_path}"))
+            continue
+        results.append(_compare_csvs(left_path, right_path, key_fields, name))
+    return results
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Compare legacy Exp2 CSV intermediates against mart views")
+    parser.add_argument("--left-dir", required=True, help="Directory with legacy CSV intermediates")
+    parser.add_argument("--right-dir", required=True, help="Directory with mart-derived view CSVs")
+    args = parser.parse_args(argv)
+
+    results = check_parity(Path(args.left_dir), Path(args.right_dir))
+    failures = [result for result in results if not result.ok]
+    for result in results:
+        log.info("%s: %s", result.name, result.message)
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/exp2_mart.py
+++ b/src/aedist/exp2_mart.py
@@ -1,0 +1,164 @@
+"""Canonical JSON schema for the Exp2 mart.
+
+The mart stores structured analysis records and immutable artifact pointers.
+It deliberately rejects verbatim chat payload fields.
+"""
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_MART_SCHEMA_NAME = "exp2_mart"
+_MART_SCHEMA_VERSION = 1
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class ArtifactPointer(BaseModel):
+    """Pointer to an immutable artifact in the repository."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(..., min_length=1, description="Repo-relative artifact path.")
+    sha256: str = Field(..., pattern=_SHA256_PATTERN, description="SHA-256 digest.")
+
+    @model_validator(mode="after")
+    def _validate_path(self) -> "ArtifactPointer":
+        candidate = Path(self.path)
+        if candidate.is_absolute():
+            raise ValueError("artifact paths must be repo-relative")
+        if ".." in candidate.parts:
+            raise ValueError("artifact paths must not traverse upward")
+        return self
+
+
+class MetricValue(BaseModel):
+    """A metric value with its annotation code."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: float | None = Field(default=None, ge=0.0, le=1.0)
+    annotation: str = ""
+
+
+class AccuracyMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    coverage: MetricValue = Field(default_factory=MetricValue)
+    precision: MetricValue = Field(default_factory=MetricValue)
+    f1: MetricValue = Field(default_factory=MetricValue)
+    fuel: MetricValue = Field(default_factory=MetricValue)
+    status: MetricValue = Field(default_factory=MetricValue)
+    province: MetricValue = Field(default_factory=MetricValue)
+
+
+class CoherenceMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    vocab_adherence: MetricValue = Field(default_factory=MetricValue)
+    status_vocab_adherence: MetricValue = Field(default_factory=MetricValue)
+
+
+class ProvenanceMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_presence: MetricValue = Field(default_factory=MetricValue)
+    high_conf_dual_source: MetricValue = Field(default_factory=MetricValue)
+
+
+class TemporalityMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asof_presence: MetricValue = Field(default_factory=MetricValue)
+    plausible_range: MetricValue = Field(default_factory=MetricValue)
+
+
+class FieldCompletenessMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    core: MetricValue = Field(default_factory=MetricValue)
+    capacity: MetricValue = Field(default_factory=MetricValue)
+
+
+class ScoreSummary(BaseModel):
+    """Grouped mechanical-score payload matching the scorer contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_rows: int = Field(..., ge=0)
+    accuracy: AccuracyMetrics = Field(default_factory=AccuracyMetrics)
+    coherence: CoherenceMetrics = Field(default_factory=CoherenceMetrics)
+    provenance: ProvenanceMetrics = Field(default_factory=ProvenanceMetrics)
+    temporality: TemporalityMetrics = Field(default_factory=TemporalityMetrics)
+    field_completeness: FieldCompletenessMetrics = Field(default_factory=FieldCompletenessMetrics)
+
+
+class RunSummary(BaseModel):
+    """Run-level summary for one Exp2 output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_rows: int = Field(..., ge=0)
+    classification: str | None = Field(default=None)
+    turns: int | None = Field(default=None, ge=0)
+    tokens_out: int | None = Field(default=None, ge=0)
+    wall_s: float | None = Field(default=None, ge=0)
+    cost_usd: float | None = Field(default=None, ge=0)
+    classifier_cost_usd: float | None = Field(default=None, ge=0)
+    narrative_chars: int | None = Field(default=None, ge=0)
+
+
+class ProbeSummary(BaseModel):
+    """Turn/probe-level summary for one Exp2 probe artifact."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    turn: int = Field(..., ge=1)
+    probe_label: str | None = Field(default=None)
+    rows: int | None = Field(default=None, ge=0)
+
+
+class Exp2MartBase(BaseModel):
+    """Common mart fields shared by all Exp2 record types."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mart_schema: Literal["exp2_mart"] = _MART_SCHEMA_NAME
+    mart_schema_version: Literal[1] = _MART_SCHEMA_VERSION
+    record_kind: Literal["run", "probe", "score"]
+    record_id: str = Field(..., min_length=1)
+    parent_record_id: str | None = Field(default=None)
+    arm: Literal["naive", "optimised"]
+    model: str = Field(..., min_length=1)
+    run: int = Field(..., ge=1)
+    prompt_version: str | None = Field(default=None)
+    result_file: ArtifactPointer | None = Field(default=None)
+    parsed_table_file: ArtifactPointer | None = Field(default=None)
+    probe_file: ArtifactPointer | None = Field(default=None)
+
+
+class Exp2RunMartRecord(Exp2MartBase):
+    """Run-level mart record."""
+
+    record_kind: Literal["run"] = "run"
+    run_summary: RunSummary
+    result_file: ArtifactPointer
+
+
+class Exp2ProbeMartRecord(Exp2MartBase):
+    """Turn/probe-level mart record."""
+
+    record_kind: Literal["probe"] = "probe"
+    probe_summary: ProbeSummary
+    probe_file: ArtifactPointer
+
+
+class Exp2ScoreMartRecord(Exp2MartBase):
+    """Mechanical score mart record."""
+
+    record_kind: Literal["score"] = "score"
+    score_summary: ScoreSummary
+    result_file: ArtifactPointer
+
+
+Exp2MartRecord = Exp2RunMartRecord | Exp2ProbeMartRecord | Exp2ScoreMartRecord

--- a/src/aedist/export_exp2_turn_trajectory_csv.py
+++ b/src/aedist/export_exp2_turn_trajectory_csv.py
@@ -1,0 +1,59 @@
+"""Export the legacy Exp2 turn-trajectory CSV from raw probe artifacts."""
+
+import argparse
+import csv
+import logging
+from pathlib import Path
+
+from .plot_exp2_turn_trajectory import load_run_turns
+
+log = logging.getLogger(__name__)
+
+_FIELDS = ["agent", "arm", "run", "turn", "rows", "cls"]
+_AGENTS = ["anthropic", "mistral", "openai", "qwen"]
+
+
+def build_turn_trajectory_csv(probes_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    for agent in _AGENTS:
+        for run in range(1, 6):
+            rows.extend(
+                [
+                    {
+                        "agent": agent,
+                        "arm": "optimised",
+                        "run": run,
+                        "turn": turn["turn"],
+                        "rows": turn["rows"],
+                        "cls": turn["cls"],
+                    }
+                    for turn in load_run_turns(probes_dir, agent, run)
+                ]
+            )
+    rows.sort(key=lambda row: (row["agent"], row["run"], row["turn"]))
+    return rows
+
+
+def write_turn_trajectory_csv(probes_dir: Path, output: Path) -> list[dict]:
+    rows = build_turn_trajectory_csv(probes_dir)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    return rows
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Export the legacy Exp2 turn trajectory CSV")
+    parser.add_argument("--probes-dir", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+
+    rows = write_turn_trajectory_csv(Path(args.probes_dir), Path(args.output))
+    log.info("Wrote %d rows to %s", len(rows), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aedist/plot_exp2_turn_trajectory.py
+++ b/src/aedist/plot_exp2_turn_trajectory.py
@@ -4,17 +4,17 @@ Four panels, one per agent, sharing a common y-axis scale.  Each panel shows
 N=5 runs as connected lines.  Filled dots = turn classified 'report'; open
 circles = 'no_report'.  Colors from the model-family palette.
 
-Data source: probes/ subdirectory of the optimised arm output directory.
-Each run has per-turn raw API responses (*.raw.json) and classifier verdicts
-(*.classification.json).
+Data source: the mart-derived `exp2_turn_trajectory_view.csv` view.
+The legacy probes/ reader remains available for backward-compatible tests.
 
 Usage:
-    python -m aedist.plot_exp2_turn_trajectory \\
-        --probes-dir experiments/outputs/sota_exp2_brerun1/probes \\
+    python -m aedist.plot_exp2_turn_trajectory \
+        --input report/inputs/generated/exp2_turn_trajectory_view.csv \
         --output report/inputs/generated/fig_exp2_turn_trajectory.pdf
 """
 
 import argparse
+import csv
 import json
 import logging
 from pathlib import Path
@@ -93,6 +93,95 @@ def load_run_turns(probes_dir: Path, agent: str, run: int) -> list[dict]:
         text = _extract_text(json.loads(raw_path.read_text(encoding="utf-8")))
         result.append({"turn": turn_num, "rows": _count_table_rows(text), "cls": cls})
     return result
+
+
+def _load_view_turns(view_csv: Path) -> list[dict]:
+    with view_csv.open(newline="", encoding="utf-8") as fh:
+        return [
+            {
+                "agent": row["agent"],
+                "arm": row["arm"],
+                "run": int(row["run"]),
+                "turn": int(row["turn"]),
+                "rows": int(row["rows"]),
+                "cls": row["cls"],
+            }
+            for row in csv.DictReader(fh)
+        ]
+
+
+def make_figure_from_view(rows: list[dict], output: Path) -> None:
+    import matplotlib.patches as mpatches
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(1, 4, figsize=(10, 3.2), sharey=True)
+
+    for ax, agent in zip(axes, _AGENT_ORDER, strict=True):
+        color = model_family_color(_AGENT_MODEL[agent])
+        for run in range(1, 6):
+            turns = [r for r in rows if r["agent"] == agent and r["run"] == run]
+            if not turns:
+                continue
+            xs = [t["turn"] for t in turns]
+            ys = [t["rows"] for t in turns]
+            ax.plot(xs, ys, color=color, linewidth=0.8, alpha=0.45, zorder=2)
+            for t in turns:
+                if t["cls"] == "report":
+                    ax.scatter([t["turn"]], [t["rows"]], color=color, s=24, zorder=3, linewidths=0)
+                else:
+                    ax.scatter(
+                        [t["turn"]],
+                        [t["rows"]],
+                        facecolors="none",
+                        edgecolors=color,
+                        s=24,
+                        zorder=3,
+                        linewidths=1.1,
+                    )
+
+        ax.set_title(_AGENT_LABELS[agent], fontsize=8, loc="left")
+        ax.set_xlabel("Turn", fontsize=7.5)
+        ax.set_xticks([1, 2, 3, 4])
+        ax.tick_params(labelsize=7.5)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.set_ylim(bottom=0)
+
+    axes[0].set_ylabel("Inventory rows", fontsize=8)
+    for ax in axes[1:]:
+        ax.tick_params(left=False)
+
+    legend_handles = [
+        mpatches.Patch(color=COLOR_NEUTRAL, label="● report"),
+        plt.Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor="none",
+            markeredgecolor=COLOR_NEUTRAL,
+            markersize=6,
+            label="○ no_report",
+        ),
+    ]
+    fig.legend(
+        handles=legend_handles,
+        loc="lower center",
+        ncol=2,
+        fontsize=8,
+        frameon=False,
+        bbox_to_anchor=(0.5, -0.06),
+    )
+    fig.suptitle(
+        "Arm 2 (optimised) — inventory rows per turn, N=5 runs per agent",
+        fontsize=9,
+        y=1.01,
+    )
+    fig.tight_layout()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    log.info("Wrote %s", output)
 
 
 def make_figure(probes_dir: Path, output: Path) -> None:
@@ -179,10 +268,15 @@ def make_figure(probes_dir: Path, output: Path) -> None:
 def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     parser = argparse.ArgumentParser(description="Exp2 Arm 2 turn-trajectory figure")
-    parser.add_argument("--probes-dir", required=True, help="Path to probes/ directory")
+    parser.add_argument("--input", default="report/inputs/generated/exp2_turn_trajectory_view.csv")
+    parser.add_argument("--probes-dir", default=None, help="Legacy probes/ directory input")
     parser.add_argument("--output", required=True, help="Path to write PDF figure")
     args = parser.parse_args(argv)
-    make_figure(Path(args.probes_dir), Path(args.output))
+
+    if args.probes_dir:
+        make_figure(Path(args.probes_dir), Path(args.output))
+    else:
+        make_figure_from_view(_load_view_turns(Path(args.input)), Path(args.output))
 
 
 if __name__ == "__main__":

--- a/src/aedist/tabulate_exp2_bib_quality.py
+++ b/src/aedist/tabulate_exp2_bib_quality.py
@@ -2,7 +2,7 @@
 
 Usage:
     python -m aedist.tabulate_exp2_bib_quality \
-        --input report/inputs/generated/tab_exp2_bib_quality.csv \
+        --input report/inputs/generated/tab_exp2_bib_quality_view.csv \
         --output report/inputs/generated/tab_exp2_bib_quality.tex
 
 Reads the flat per-run CSV produced by extract_exp2_bib and generates a
@@ -17,7 +17,7 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_INPUT = Path("report/inputs/generated/tab_exp2_bib_quality.csv")
+_DEFAULT_INPUT = Path("report/inputs/generated/tab_exp2_bib_quality_view.csv")
 
 _AGENT_DISPLAY = {
     "anthropic": "Claude",

--- a/tests/test_build_exp2_mart.py
+++ b/tests/test_build_exp2_mart.py
@@ -1,0 +1,315 @@
+"""Tests for the Exp2 mart builder."""
+
+import json
+
+from aedist.build_exp2_mart import build_exp2_mart, write_exp2_mart
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_md(path, content):
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_cross_eval_csv(path, rows):
+    import csv
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _score_row(arm, model, run):
+    return {
+        "arm": arm,
+        "model": model,
+        "run": str(run),
+        "prompt_version": "exp2",
+        "n_rows": "1",
+        "accuracy_coverage": "0.5000",
+        "accuracy_coverage_annotation": "",
+        "accuracy_precision": "1.0000",
+        "accuracy_precision_annotation": "",
+        "accuracy_f1": "0.6667",
+        "accuracy_f1_annotation": "",
+        "accuracy_fuel": "1.0000",
+        "accuracy_fuel_annotation": "",
+        "accuracy_status": "1.0000",
+        "accuracy_status_annotation": "",
+        "accuracy_province": "1.0000",
+        "accuracy_province_annotation": "",
+        "coherence_vocab_adherence": "1.0000",
+        "coherence_vocab_adherence_annotation": "",
+        "coherence_status_vocab_adherence": "1.0000",
+        "coherence_status_vocab_adherence_annotation": "",
+        "provenance_source_presence": "1.0000",
+        "provenance_source_presence_annotation": "",
+        "provenance_high_conf_dual_source": "1.0000",
+        "provenance_high_conf_dual_source_annotation": "",
+        "temporality_asof_presence": "1.0000",
+        "temporality_asof_presence_annotation": "",
+        "temporality_plausible_range": "1.0000",
+        "temporality_plausible_range_annotation": "",
+        "field_completeness_core": "1.0000",
+        "field_completeness_core_annotation": "",
+        "field_completeness_capacity": "1.0000",
+        "field_completeness_capacity_annotation": "",
+    }
+
+
+def test_build_exp2_mart_ignores_raw_payload_files(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(
+        naive_dir / "anthropic_run01.json",
+        {"model": "claude-opus-4-6", "run": 1, "classification": "report", "narrative_chars": 4},
+    )
+    _write_md(
+        naive_dir / "anthropic_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| A | Coal | 1 | Operating | 1983 | HN |\n",
+    )
+    _write_json(
+        optimised_dir / "anthropic_run01.json",
+        {
+            "model": "claude-opus-4-6",
+            "run": 1,
+            "arm": "optimised",
+            "classification": "report",
+            "turns": 3,
+            "narrative_chars": 8,
+            "total_cost_usd": 1.0,
+        },
+    )
+    _write_md(
+        optimised_dir / "anthropic_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| B | Gas | 2 | Operating | 1984 | HN |\n",
+    )
+    (naive_dir / "anthropic_run01.raw.json").write_text("{not: valid json}", encoding="utf-8")
+
+    for run_dir, turn_cls in ((naive_dir, "report"), (optimised_dir, "report")):
+        probe_dir = run_dir / "probes" / "anthropic_run01"
+        probe_dir.mkdir(parents=True)
+        (probe_dir / "anthropic_turn_01.raw.json").write_text("{not: valid json}", encoding="utf-8")
+        _write_json(
+            probe_dir / "anthropic_turn_01.classification.json",
+            {"class": turn_cls},
+        )
+
+    _write_cross_eval_csv(
+        tmp_path / "sota_cross_eval.csv",
+        [
+            _score_row("naive", "claude-opus-4-6", 1),
+            _score_row("optimised", "claude-opus-4-6", 1),
+        ],
+    )
+
+    records = build_exp2_mart(
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=tmp_path / "sota_cross_eval.csv",
+        repo_root=tmp_path,
+    )
+
+    assert len(records) == 6
+    run_record = next(record for record in records if record.record_kind == "run" and record.arm == "naive")
+    probe_record = next(record for record in records if record.record_kind == "probe" and record.arm == "naive")
+    score_record = next(record for record in records if record.record_kind == "score" and record.arm == "naive")
+    assert run_record.run_summary.n_rows == 1
+    assert probe_record.probe_summary.turn == 1
+    assert score_record.score_summary.accuracy.coverage.value == 0.5
+
+
+def test_write_exp2_mart_writes_jsonl(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    for arm_dir, arm_name in ((naive_dir, "naive"), (optimised_dir, "optimised")):
+        _write_json(
+            arm_dir / "anthropic_run01.json",
+            {
+                "model": "claude-opus-4-6",
+                "run": 1,
+                "arm": arm_name,
+                "classification": "report",
+                "turns": 1 if arm_name == "naive" else 3,
+                "narrative_chars": 4,
+                "cost_usd": 0.1,
+            },
+        )
+        _write_md(
+            arm_dir / "anthropic_run01.md",
+            "| Name | Fuel | Capacity | Status | COD | Province |\n"
+            "| --- | --- | --- | --- | --- | --- |\n"
+            "| A | Coal | 1 | Operating | 1983 | HN |\n",
+        )
+        probe_dir = arm_dir / "probes" / "anthropic_run01"
+        probe_dir.mkdir(parents=True)
+        _write_json(probe_dir / "anthropic_turn_01.classification.json", {"class": "report"})
+        _write_json(probe_dir / "anthropic_turn_01.raw.json", {"content": [{"type": "text", "text": "| A | 1 |\n"}]})
+
+    _write_cross_eval_csv(
+        tmp_path / "sota_cross_eval.csv",
+        [
+            _score_row("naive", "claude-opus-4-6", 1),
+            _score_row("optimised", "claude-opus-4-6", 1),
+        ],
+    )
+
+    output = tmp_path / "exp2_mart.jsonl"
+    records = write_exp2_mart(
+        output,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=tmp_path / "sota_cross_eval.csv",
+        repo_root=tmp_path,
+    )
+
+    lines = output.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == len(records)
+    assert any('"record_kind":"score"' in line for line in lines)
+    assert any('"record_kind":"probe"' in line for line in lines)
+
+
+def test_build_exp2_mart_handles_no_report_empty_markdown(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(
+        naive_dir / "mistral_run02.json",
+        {
+            "model": "mistral-large-2512",
+            "run": 2,
+            "classification": "no_report",
+            "narrative_chars": 0,
+            "cost_usd": 0.1,
+        },
+    )
+    (naive_dir / "mistral_run02.md").write_text("", encoding="utf-8")
+
+    _write_json(
+        optimised_dir / "mistral_run02.json",
+        {
+            "model": "mistral-large-2512",
+            "run": 2,
+            "arm": "optimised",
+            "classification": "no_report",
+            "turns": 2,
+            "narrative_chars": 0,
+            "total_cost_usd": 0.2,
+        },
+    )
+    (optimised_dir / "mistral_run02.md").write_text("", encoding="utf-8")
+
+    _write_cross_eval_csv(
+        tmp_path / "sota_cross_eval.csv",
+        [
+            _score_row("naive", "mistral-large-2512", 2),
+            _score_row("optimised", "mistral-large-2512", 2),
+        ],
+    )
+
+    records = build_exp2_mart(
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=tmp_path / "sota_cross_eval.csv",
+        repo_root=tmp_path,
+    )
+
+    naive_run = next(
+        record
+        for record in records
+        if record.record_kind == "run" and record.arm == "naive" and record.model == "mistral-large-2512"
+    )
+    assert naive_run.run_summary.classification == "no_report"
+    assert naive_run.run_summary.n_rows == 0
+
+
+def test_build_exp2_mart_matches_score_row_with_model_drift(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(
+        naive_dir / "anthropic_run01.json",
+        {
+            "model": "claude-opus-4-6",
+            "run": 1,
+            "classification": "report",
+            "narrative_chars": 4,
+        },
+    )
+    _write_md(
+        naive_dir / "anthropic_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| A | Coal | 1 | Operating | 1983 | HN |\n",
+    )
+
+    _write_cross_eval_csv(
+        tmp_path / "sota_cross_eval.csv",
+        [_score_row("naive", "claude-opus-4-6-20250514", 1)],
+    )
+
+    records = build_exp2_mart(
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=tmp_path / "sota_cross_eval.csv",
+        repo_root=tmp_path,
+    )
+
+    score_record = next(record for record in records if record.record_kind == "score")
+    assert score_record.model == "claude-opus-4-6"
+    assert score_record.score_summary.n_rows == 1
+
+
+def test_build_exp2_mart_allows_missing_score_rows(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    _write_json(
+        naive_dir / "openai_run01.json",
+        {
+            "model": "gpt-5.5",
+            "run": 1,
+            "classification": "report",
+            "narrative_chars": 4,
+        },
+    )
+    _write_md(
+        naive_dir / "openai_run01.md",
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| A | Coal | 1 | Operating | 1983 | HN |\n",
+    )
+
+    _write_cross_eval_csv(
+        tmp_path / "sota_cross_eval.csv",
+        [_score_row("naive", "some-other-model", 99)],
+    )
+
+    records = build_exp2_mart(
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=tmp_path / "sota_cross_eval.csv",
+        repo_root=tmp_path,
+    )
+
+    assert any(record.record_kind == "run" for record in records)
+    assert not any(record.record_kind == "score" for record in records)

--- a/tests/test_build_exp2_mart_views.py
+++ b/tests/test_build_exp2_mart_views.py
@@ -1,0 +1,139 @@
+"""Tests for mart-derived Exp2 CSV views."""
+
+import csv
+import json
+
+from aedist.build_exp2_mart import write_exp2_mart
+from aedist.build_exp2_mart_views import write_exp2_mart_views
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_md(path, content):
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_cross_eval_csv(path, rows):
+    import csv
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _score_row(arm):
+    return {
+        "arm": arm,
+        "model": "claude-opus-4-6",
+        "run": "1",
+        "prompt_version": "exp2",
+        "n_rows": "1",
+        "accuracy_coverage": "0.5000",
+        "accuracy_coverage_annotation": "",
+        "accuracy_precision": "1.0000",
+        "accuracy_precision_annotation": "",
+        "accuracy_f1": "0.6667",
+        "accuracy_f1_annotation": "",
+        "accuracy_fuel": "1.0000",
+        "accuracy_fuel_annotation": "",
+        "accuracy_status": "1.0000",
+        "accuracy_status_annotation": "",
+        "accuracy_province": "1.0000",
+        "accuracy_province_annotation": "",
+        "coherence_vocab_adherence": "1.0000",
+        "coherence_vocab_adherence_annotation": "",
+        "coherence_status_vocab_adherence": "1.0000",
+        "coherence_status_vocab_adherence_annotation": "",
+        "provenance_source_presence": "1.0000",
+        "provenance_source_presence_annotation": "",
+        "provenance_high_conf_dual_source": "1.0000",
+        "provenance_high_conf_dual_source_annotation": "",
+        "temporality_asof_presence": "1.0000",
+        "temporality_asof_presence_annotation": "",
+        "temporality_plausible_range": "1.0000",
+        "temporality_plausible_range_annotation": "",
+        "field_completeness_core": "1.0000",
+        "field_completeness_core_annotation": "",
+        "field_completeness_capacity": "1.0000",
+        "field_completeness_capacity_annotation": "",
+    }
+
+
+def _mart_fixture(tmp_path):
+    naive_dir = tmp_path / "naive"
+    optimised_dir = tmp_path / "optimised"
+    naive_dir.mkdir()
+    optimised_dir.mkdir()
+
+    for arm_dir, arm_name, turns in ((naive_dir, "naive", 1), (optimised_dir, "optimised", 2)):
+        _write_json(
+            arm_dir / "anthropic_run01.json",
+            {
+                "model": "claude-opus-4-6",
+                "run": 1,
+                "arm": arm_name,
+                "classification": "report",
+                "turns": turns,
+                "narrative_chars": 4,
+                "cost_usd": 0.1,
+            },
+        )
+        _write_md(
+            arm_dir / "anthropic_run01.md",
+            "| Name | Fuel | Capacity | Status | COD | Province | Source 1 | Source 2 | Notes |\n"
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+            "| A | Coal | 1 | Operating | 1983 | HN | EVN report | Reuters | note |\n"
+            "## Bibliography\n"
+            "1. **EVN report**\n"
+            "2. **Reuters article**\n",
+        )
+        probe_dir = arm_dir / "probes" / "anthropic_run01"
+        probe_dir.mkdir(parents=True)
+        _write_json(
+            probe_dir / "anthropic_turn_01.raw.json",
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "| Name | Cap |\n| --- | --- |\n| A | 1 |\n",
+                    }
+                ]
+            },
+        )
+        _write_json(probe_dir / "anthropic_turn_01.classification.json", {"class": "report"})
+
+    cross_eval_csv = tmp_path / "sota_cross_eval.csv"
+    _write_cross_eval_csv(cross_eval_csv, [_score_row("naive"), _score_row("optimised")])
+    mart_path = tmp_path / "exp2_mart.jsonl"
+    write_exp2_mart(
+        mart_path,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=cross_eval_csv,
+        repo_root=tmp_path,
+    )
+    return mart_path
+
+
+def test_write_exp2_mart_views(tmp_path):
+    mart_path = _mart_fixture(tmp_path)
+    output_dir = tmp_path / "generated"
+
+    outputs = write_exp2_mart_views(mart_path, output_dir, repo_root=tmp_path)
+
+    arms_rows = list(csv.DictReader(outputs["tab_exp2_arms_runs_view.csv"].open(encoding="utf-8")))
+    bib_rows = list(csv.DictReader(outputs["tab_exp2_bib_quality_view.csv"].open(encoding="utf-8")))
+    turn_rows = list(csv.DictReader(outputs["exp2_turn_trajectory_view.csv"].open(encoding="utf-8")))
+    score_rows = list(csv.DictReader(outputs["sota_cross_eval_view.csv"].open(encoding="utf-8")))
+
+    assert len(arms_rows) == 2
+    assert arms_rows[0]["inventory_rows"] == "1"
+    assert len(bib_rows) == 2
+    assert bib_rows[0]["src1_present"] == "1"
+    assert len(turn_rows) == 2
+    assert turn_rows[0]["rows"] == "1"
+    assert len(score_rows) == 2
+    assert score_rows[0]["accuracy_coverage"] == "0.5000"

--- a/tests/test_check_exp2_mart_parity.py
+++ b/tests/test_check_exp2_mart_parity.py
@@ -1,0 +1,195 @@
+"""Tests for the Exp2 mart parity checker."""
+
+import csv
+
+from aedist.check_exp2_mart_parity import check_parity
+
+
+def _write_csv(path, fieldnames, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_check_parity_passes_for_matching_views(tmp_path):
+    old_dir = tmp_path / "old"
+    mart_dir = tmp_path / "mart"
+
+    _write_csv(
+        old_dir / "tab_exp2_arms_runs.csv",
+        ["arm", "agent", "model", "run", "classification", "narrative_chars", "inventory_rows", "cost_usd", "wall_s", "turns"],
+        [
+            {
+                "arm": "naive",
+                "agent": "anthropic",
+                "model": "claude-opus-4-6",
+                "run": "1",
+                "classification": "report",
+                "narrative_chars": "10",
+                "inventory_rows": "1",
+                "cost_usd": "0.10",
+                "wall_s": "1.0",
+                "turns": "1",
+            }
+        ],
+    )
+    _write_csv(
+        mart_dir / "tab_exp2_arms_runs_view.csv",
+        ["arm", "agent", "model", "run", "classification", "narrative_chars", "inventory_rows", "cost_usd", "wall_s", "turns"],
+        [
+            {
+                "arm": "naive",
+                "agent": "anthropic",
+                "model": "claude-opus-4-6",
+                "run": "1",
+                "classification": "report",
+                "narrative_chars": "10",
+                "inventory_rows": "1",
+                "cost_usd": "0.1005",
+                "wall_s": "1.0",
+                "turns": "1",
+            }
+        ],
+    )
+
+    bib_fields = [
+        "agent",
+        "arm",
+        "run",
+        "n_rows",
+        "src1_empty",
+        "src1_notfound",
+        "src1_present",
+        "src1_valid",
+        "src1_primary",
+        "src2_empty",
+        "src2_notfound",
+        "src2_present",
+        "src2_valid",
+        "src2_primary",
+        "notes_empty",
+        "notes_notfound",
+        "notes_present",
+        "bib_entries",
+        "bib_valid",
+        "bib_primary",
+        "citation_style",
+    ]
+    bib_row = {
+        "agent": "anthropic",
+        "arm": "naive",
+        "run": "1",
+        "n_rows": "1",
+        "src1_empty": "0",
+        "src1_notfound": "0",
+        "src1_present": "1",
+        "src1_valid": "1",
+        "src1_primary": "1",
+        "src2_empty": "0",
+        "src2_notfound": "0",
+        "src2_present": "1",
+        "src2_valid": "1",
+        "src2_primary": "0",
+        "notes_empty": "0",
+        "notes_notfound": "0",
+        "notes_present": "1",
+        "bib_entries": "2",
+        "bib_valid": "",
+        "bib_primary": "1",
+        "citation_style": "inline-ref",
+    }
+    _write_csv(old_dir / "tab_exp2_bib_quality.csv", bib_fields, [bib_row])
+    _write_csv(mart_dir / "tab_exp2_bib_quality_view.csv", bib_fields, [bib_row])
+
+    turn_fields = ["agent", "arm", "run", "turn", "rows", "cls"]
+    _write_csv(
+        old_dir / "exp2_turn_trajectory.csv",
+        turn_fields,
+        [{"agent": "anthropic", "arm": "optimised", "run": "1", "turn": "1", "rows": "1", "cls": "report"}],
+    )
+    _write_csv(
+        mart_dir / "exp2_turn_trajectory_view.csv",
+        turn_fields,
+        [{"agent": "anthropic", "arm": "optimised", "run": "1", "turn": "1", "rows": "1", "cls": "report"}],
+    )
+
+    score_fields = [
+        "arm",
+        "model",
+        "run",
+        "prompt_version",
+        "n_rows",
+        "accuracy_coverage",
+        "accuracy_coverage_annotation",
+        "accuracy_precision",
+        "accuracy_precision_annotation",
+        "accuracy_f1",
+        "accuracy_f1_annotation",
+        "accuracy_fuel",
+        "accuracy_fuel_annotation",
+        "accuracy_status",
+        "accuracy_status_annotation",
+        "accuracy_province",
+        "accuracy_province_annotation",
+        "coherence_vocab_adherence",
+        "coherence_vocab_adherence_annotation",
+        "coherence_status_vocab_adherence",
+        "coherence_status_vocab_adherence_annotation",
+        "provenance_source_presence",
+        "provenance_source_presence_annotation",
+        "provenance_high_conf_dual_source",
+        "provenance_high_conf_dual_source_annotation",
+        "temporality_asof_presence",
+        "temporality_asof_presence_annotation",
+        "temporality_plausible_range",
+        "temporality_plausible_range_annotation",
+        "field_completeness_core",
+        "field_completeness_core_annotation",
+        "field_completeness_capacity",
+        "field_completeness_capacity_annotation",
+    ]
+    score_row = {
+        "arm": "naive",
+        "model": "claude-opus-4-6",
+        "run": "1",
+        "prompt_version": "exp2",
+        "n_rows": "1",
+        "accuracy_coverage": "0.5000",
+        "accuracy_coverage_annotation": "",
+        "accuracy_precision": "1.0000",
+        "accuracy_precision_annotation": "",
+        "accuracy_f1": "0.6667",
+        "accuracy_f1_annotation": "",
+        "accuracy_fuel": "1.0000",
+        "accuracy_fuel_annotation": "",
+        "accuracy_status": "1.0000",
+        "accuracy_status_annotation": "",
+        "accuracy_province": "1.0000",
+        "accuracy_province_annotation": "",
+        "coherence_vocab_adherence": "1.0000",
+        "coherence_vocab_adherence_annotation": "",
+        "coherence_status_vocab_adherence": "1.0000",
+        "coherence_status_vocab_adherence_annotation": "",
+        "provenance_source_presence": "1.0000",
+        "provenance_source_presence_annotation": "",
+        "provenance_high_conf_dual_source": "1.0000",
+        "provenance_high_conf_dual_source_annotation": "",
+        "temporality_asof_presence": "1.0000",
+        "temporality_asof_presence_annotation": "",
+        "temporality_plausible_range": "1.0000",
+        "temporality_plausible_range_annotation": "",
+        "field_completeness_core": "1.0000",
+        "field_completeness_core_annotation": "",
+        "field_completeness_capacity": "1.0000",
+        "field_completeness_capacity_annotation": "",
+    }
+    _write_csv(old_dir / "sota_cross_eval.csv", score_fields, [score_row])
+    score_row_mart = dict(score_row)
+    score_row_mart["accuracy_coverage"] = "0.5005"
+    _write_csv(mart_dir / "sota_cross_eval_view.csv", score_fields, [score_row_mart])
+
+    results = check_parity(old_dir, mart_dir)
+
+    assert all(result.ok for result in results)

--- a/tests/test_exp2_mart.py
+++ b/tests/test_exp2_mart.py
@@ -1,0 +1,110 @@
+"""Tests for the Exp2 mart schema."""
+
+from pydantic import ValidationError
+
+from aedist.exp2_mart import (
+    ArtifactPointer,
+    Exp2ProbeMartRecord,
+    Exp2RunMartRecord,
+    Exp2ScoreMartRecord,
+)
+
+
+def _pointer(path: str) -> ArtifactPointer:
+    return ArtifactPointer(path=path, sha256="a" * 64)
+
+
+def test_artifact_pointer_rejects_absolute_paths() -> None:
+    try:
+        ArtifactPointer(path="/tmp/exp2.json", sha256="a" * 64)
+    except ValidationError as exc:
+        assert "repo-relative" in str(exc)
+    else:
+        raise AssertionError("absolute paths must be rejected")
+
+
+def test_run_record_carries_mart_version_and_result_pointer() -> None:
+    record = Exp2RunMartRecord(
+        record_id="exp2-naive/anthropic/01",
+        arm="naive",
+        model="claude-opus-4-6",
+        run=1,
+        prompt_version="exp2-naive",
+        run_summary={
+            "n_rows": 79,
+            "classification": "report",
+            "turns": 1,
+            "tokens_out": 25522,
+            "wall_s": 437.2,
+            "cost_usd": 1.1551,
+            "classifier_cost_usd": 0.002334,
+            "narrative_chars": 50471,
+        },
+        result_file=_pointer("experiments/outputs/sota_exp2_naive_arm/anthropic_run01.json"),
+    )
+
+    assert record.mart_schema == "exp2_mart"
+    assert record.mart_schema_version == 1
+    assert record.record_kind == "run"
+    assert record.run_summary.classification == "report"
+    assert record.result_file.path.endswith("anthropic_run01.json")
+
+
+def test_probe_record_requires_probe_pointer() -> None:
+    record = Exp2ProbeMartRecord(
+        record_id="exp2-naive/anthropic/01/turn-01",
+        parent_record_id="exp2-naive/anthropic/01",
+        arm="naive",
+        model="claude-opus-4-6",
+        run=1,
+        probe_summary={"turn": 1, "probe_label": "report", "rows": 42},
+        probe_file=_pointer("experiments/outputs/sota_exp2_naive_arm/probes/turn01.md"),
+    )
+
+    assert record.record_kind == "probe"
+    assert record.parent_record_id == "exp2-naive/anthropic/01"
+    assert record.probe_summary.turn == 1
+    assert record.probe_file.path.endswith("turn01.md")
+
+
+def test_score_record_rejects_verbatim_chat_payload_fields() -> None:
+    try:
+        Exp2ScoreMartRecord(
+            record_id="exp2-naive/anthropic/01/score",
+            arm="naive",
+            model="claude-opus-4-6",
+            run=1,
+            score_summary={
+                "n_rows": 79,
+                "accuracy": {
+                    "coverage": {"value": 0.4847, "annotation": ""},
+                    "precision": {"value": 1.0, "annotation": ""},
+                    "f1": {"value": 0.6529, "annotation": ""},
+                    "fuel": {"value": 0.5063, "annotation": ""},
+                    "status": {"value": 0.5316, "annotation": ""},
+                    "province": {"value": 0.8101, "annotation": ""},
+                },
+                "coherence": {
+                    "vocab_adherence": {"value": 0.6456, "annotation": ""},
+                    "status_vocab_adherence": {"value": 1.0, "annotation": ""},
+                },
+                "provenance": {
+                    "source_presence": {"value": 1.0, "annotation": ""},
+                    "high_conf_dual_source": {"value": 1.0, "annotation": ""},
+                },
+                "temporality": {
+                    "asof_presence": {"value": 1.0, "annotation": ""},
+                    "plausible_range": {"value": 1.0, "annotation": ""},
+                },
+                "field_completeness": {
+                    "core": {"value": 1.0, "annotation": ""},
+                    "capacity": {"value": 1.0, "annotation": ""},
+                },
+            },
+            result_file=_pointer("experiments/outputs/sota_exp2_naive_arm/anthropic_run01.json"),
+            raw_payload={"content": "verbatim chat text"},
+        )
+    except ValidationError as exc:
+        assert "raw_payload" in str(exc)
+    else:
+        raise AssertionError("verbatim payload fields must be rejected")


### PR DESCRIPTION
## Summary
- introduce a strict Exp2 mart schema and canonical JSONL artifact (`exp2_mart.jsonl`)
- add mart builder + mart-to-view exporters so downstream tables/figures keep consuming CSV views without changing contracts
- wire report build to produce dual outputs (`exp2-old-path` and `exp2-mart-path`) and enforce `check-mart-parity`
- update Exp2 consumers (`plot_exp2_turn_trajectory`, bib quality tabulation defaults) to read mart views
- document mart contract and add focused tests for schema, builder, views, and parity checker

## Why this shape
- keeps mart as the scientific source of truth in JSON while preserving legacy compatibility at the view layer
- parity gate ensures migration does not regress row counts, columns, or values in existing report outputs

## Validation
- `make check-fast`
- `make -f report/exp2-analysis.mk check-mart-parity`

**Ticket:** tickets/0282-exp2-mart-migration-parent-tracker.erg