### PR TITLE
feat(exp2): extend experiment2.mk to cover all four arms

### DIFF
--- a/experiments/experiment2.mk
+++ b/experiments/experiment2.mk
@@ -1,8 +1,10 @@
-# experiment2.mk — SOTA experiment runs (Arms 3 and 4)
+# experiment2.mk — SOTA experiment runs (all four arms)
 #
 # Run from the experiments/ directory:
-#   make -f experiment2.mk arm3-run02
-#   make -f experiment2.mk arm4-run02
+#   make -f experiment2.mk arm1-run01   # naive, no EP (N=5)
+#   make -f experiment2.mk arm2-run01   # optimized, no EP (N=5)
+#   make -f experiment2.mk arm3-run03   # naive + EP (N=3, start at run03)
+#   make -f experiment2.mk arm4-run02   # optimized + EP (N=3, start at run02)
 #
 # Exp 1 Qwen 3.7 top-up: modelset_exp1_baseline includes qwen/qwen3.7-max
 # (commit 8c30c78). Use main Makefile census targets (skip-existing logic):
@@ -18,8 +20,25 @@
 UV_RUN  := PYTHONPATH=.. uv run --project .. --env-file ../.env
 AGENTS  := mistral openai anthropic qwen
 EP      := evidence_packs/all18tables.yaml
+ARM1    := outputs/sota_exp3_arm1_batch1
+ARM2    := outputs/sota_exp3_arm2_batch1
 ARM3    := outputs/sota_exp3_arm3_batch1
 ARM4    := outputs/sota_exp3_arm4_batch1
+
+# ─── Arm 1: naive single-shot, no evidence pack ───────────────────────────────
+
+$(ARM1)/run%/summary.json:
+	$(UV_RUN) python sota/exp2_naive_arm.py \
+	    --agents $(AGENTS) \
+	    --output-dir $(@D)
+
+# ─── Arm 2: interactive multi-turn, no evidence pack ─────────────────────────
+
+$(ARM2)/run%/summary.json:
+	$(UV_RUN) python sota/exp2_interactive_smoke.py \
+	    --agents $(AGENTS) \
+	    --output-dir $(@D) \
+	    --no-confirm
 
 # ─── Arm 3: naive single-shot + evidence pack ─────────────────────────────────
 
@@ -42,7 +61,10 @@ $(ARM4)/run%/summary.json: $(EP)
 # .PRECIOUS prevents Make from deleting summary.json as an intermediate file
 # after building the alias target.
 
-.PRECIOUS: $(ARM3)/run%/summary.json $(ARM4)/run%/summary.json
+.PRECIOUS: $(ARM1)/run%/summary.json $(ARM2)/run%/summary.json \
+           $(ARM3)/run%/summary.json $(ARM4)/run%/summary.json
 
+arm1-%: $(ARM1)/%/summary.json ;
+arm2-%: $(ARM2)/%/summary.json ;
 arm3-%: $(ARM3)/%/summary.json ;
 arm4-%: $(ARM4)/%/summary.json ;


### PR DESCRIPTION
## Summary

- Add ARM1 (naive, no EP) and ARM2 (optimised, no EP) targets to `experiment2.mk` so the full 4-arm post-reprompt sweep can be driven from one Makefile
- ARM1/ARM2 write to `sota_exp3_arm1_batch1/` and `sota_exp3_arm2_batch1/`
- Pre-reprompt frozen data (`sota_exp2_naive_arm/`, `sota_exp2_brerun1/`) is not reused: both predate the 0278 table-first changes

## Test plan

- [ ] `make -f experiment2.mk --dry-run arm1-run01` expands correctly (no evidence-pack flag)
- [ ] `make -f experiment2.mk --dry-run arm2-run01` expands correctly (no evidence-pack flag)
- [ ] Existing arm3/arm4 targets unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)