### PR TITLE
fix(exp2): streaming fallback in run_anthropic_call

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -541,7 +541,7 @@ def run_anthropic_call(
     api_key = query_anthropic._load_key(query_anthropic.DEFAULT_KEY_PATH)
     client = anthropic.Anthropic(api_key=api_key)
     t0 = time.monotonic()
-    resp = client.messages.create(**payload)
+    resp = query_anthropic._call_with_retry(client, payload)
     wall = round(time.monotonic() - t0, 3)
 
     raw_output_path.write_text(


### PR DESCRIPTION
## Summary

- `run_anthropic_call()` in `exp2_interactive_smoke.py` called `client.messages.create(**payload)` directly, bypassing the streaming fallback that `query_anthropic._call_with_retry` already provides.
- With `--min-phase-b-max-tokens=32000` (above Anthropic's 21 333-token threshold for >10-min requests), the SDK raises _"Streaming is required"_ before any API call is made, causing every Phase B-0 anthropic run to fail.
- Fix: one-line swap to `query_anthropic._call_with_retry(client, payload)`.

## Test plan

- [ ] Dry-run `exp2_interactive_smoke.py --agents anthropic --dry-run` still prints payload and exits 0
- [ ] Phase B-0 smoke with `--agents anthropic --phase-b-max-tokens 32000` completes without streaming error

🤖 Generated with [Claude Code](https://claude.com/claude-code)