### PR TITLE
tickets: add 0292 ex post extractor, 0293 ref-count score, 0294 web-search metrics

### DIFF
--- a/tickets/0292-expost-extractor-unified-dataflow.erg
+++ b/tickets/0292-expost-extractor-unified-dataflow.erg
@@ -3,8 +3,11 @@ Title: Ex post extractor for EXP3 outputs with unified data flow and source hand
 Created: 2026-05-25
 Author: HDMX-coding-agent
 
+Supersedes: 0291
+
 --- log ---
 2026-05-25T00:00Z HDMX-coding-agent created
+2026-05-25T12:00Z HDMX-coding-agent add exp2_phase_b0_consolidate.py adaptation requirement (user request); note supersession of 0291; extraction side of 0290 delegated here
 
 --- body ---
 ## Context
@@ -28,6 +31,9 @@ its data flow with arms 2 and 4.
 - [ ] Remove extractor responsibilities from `experiments/sota/exp2_naive_arm.py`.
 - [ ] Unify data flow conventions with arm2/arm4 artifacts (conversation/turn/raw
       schemas and derived outputs).
+- [ ] Adapt `experiments/sota/exp2_phase_b0_consolidate.py` to the new run{N}/
+      directory layout (currently expects flat layout; must walk run01/, run02/
+      etc. and discover per-run raw files rather than assuming flat filenames).
 - [ ] Consolidate split tables into a single canonical inventory table.
 - [ ] Strip all non-table preambles from derived report outputs.
 - [ ] Map Mistral `tool_reference` citations into Source columns (Source 1/2)
@@ -39,3 +45,13 @@ its data flow with arms 2 and 4.
 - [ ] Canonical derived outputs are reproducible from raw artifacts only.
 - [ ] No scoring component depends on legacy inline extractor behavior.
 - [ ] Integration test covers split-table consolidation + citation mapping.
+- [ ] `exp2_phase_b0_consolidate.py` (or its replacement) correctly walks the
+      new run{N}/ layout and produces the same aggregated output as before.
+
+## Coordination
+
+- **0291** (Separate raw from derived): superseded — the snapshot commit in
+  branch `t0291-results-cleanstack-nomd` closes Action 1; this ticket closes
+  Action 2. Close 0291 when the branch merges.
+- **0290** (Anthropic table fragmentation): extraction side (sub-table
+  concatenation) tracked here. Prompt-engineering actions remain in 0290.

--- a/tickets/0292-expost-extractor-unified-dataflow.erg
+++ b/tickets/0292-expost-extractor-unified-dataflow.erg
@@ -48,10 +48,22 @@ its data flow with arms 2 and 4.
 - [ ] `exp2_phase_b0_consolidate.py` (or its replacement) correctly walks the
       new run{N}/ layout and produces the same aggregated output as before.
 
-## Coordination
+## Prompt-engineering actions (absorbed from 0290)
 
-- **0291** (Separate raw from derived): superseded — the snapshot commit in
-  branch `t0291-results-cleanstack-nomd` closes Action 1; this ticket closes
-  Action 2. Close 0291 when the branch merges.
-- **0290** (Anthropic table fragmentation): extraction side (sub-table
-  concatenation) tracked here. Prompt-engineering actions remain in 0290.
+The same table-fragmentation problem requires both extraction fixes (above) and
+prompt-level constraints:
+
+1. **Prescribe the exact table header** in the Phase A meta-prompt: instruct
+   the Phase A designer to begin the Plant Inventory Table section with a
+   specific header row, e.g. `| Plant name | Fuel | Capacity (MWe) | Status |
+   As-of date | Confidence | Source 1 | Source 2 |`. Hard constraint, not a
+   suggestion.
+2. **Add a table-unity reminder to `VERIFY_REPLY`**: append a sentence
+   instructing the agent to consolidate all sub-tables into one master table
+   before returning the corrected inventory.
+3. **Consider adding to `TERMINAL_REPLY`**: if the agent has not yet produced
+   a unified table, explicitly ask for consolidation as the final act.
+
+Additional exit criterion (arm4 anthropic smoke run):
+- [ ] Re-run produces ≤ 2 table headers in the final output turn and
+      `inventory_rows` ≥ 40.

--- a/tickets/0293-anchor-score-reference-count.erg
+++ b/tickets/0293-anchor-score-reference-count.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Consider alternate anchoring score using reference count
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Current anchoring/provenance checks focus on presence/quality of sources, but an
+additional lightweight signal may be informative: number of references cited.
+
+## Question
+
+Evaluate whether "reference count" should be added as a complementary anchoring
+indicator (not a standalone quality score).
+
+## Scope
+
+- [ ] Define candidate metrics:
+      total references, unique references, references per table row,
+      references per 1k output tokens.
+- [ ] Test sensitivity to citation inflation (spam references without grounding).
+- [ ] Evaluate relationship with existing provenance pass/fail outcomes.
+- [ ] Recommend whether/how to integrate in reporting.
+
+## Exit criteria
+
+- [ ] One-page note with recommendation and caveats.
+- [ ] If retained, add explicit formula and anti-gaming guardrails.

--- a/tickets/0294-imagine-extract-web-search-metrics.erg
+++ b/tickets/0294-imagine-extract-web-search-metrics.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: Imagine post-processing extraction of web-search and pages-consulted counts
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T00:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Provider raw payloads contain tool-use traces, but we do not yet have a unified
+post-processing metric for:
+- number of web searches performed,
+- number of pages consulted/resolved.
+
+## Goal
+
+Design (Imagine phase) a robust post-processing extraction method that works
+across providers and arm formats.
+
+## Questions to answer
+
+- [ ] What are provider-specific fields for web-search calls and returned URLs?
+- [ ] How to normalize into a common schema: `n_web_search_calls`,
+      `n_pages_returned`, `n_unique_domains`, `n_unique_urls`?
+- [ ] How to handle partial traces, retries, and missing/embedded tool records?
+- [ ] Should counts be per-turn, per-run, and per-final-report simultaneously?
+
+## Deliverable
+
+- [ ] Design note with schema proposal and extraction pseudocode.
+- [ ] Validation plan on EXP3 arm1/2/3/4 samples.


### PR DESCRIPTION
Open three tickets for planned EXP3 analysis work:
- **0293**: alternate anchoring score using reference count
- **0294**: post-processing extraction of web-search and pages-consulted counts
- **0292**: ex post extractor redesign (absorbs 0290 prompt-engineering actions, supersedes 0291)

No code changes.