### PR TITLE
chore: ledger alignement post-postrun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ attic/
 # These are extracted from raw JSON during post-processing, not primary data
 experiments/outputs/sota_exp3_*/**/*.md
 !experiments/outputs/sota_exp3_*/**/README.md
+!experiments/outputs/sota_exp3_*/**/summary_*.md
 
 # Evaluation reconciliation artifacts (generated)
 reconciliation_*.csv

--- a/experiments/outputs/README.md
+++ b/experiments/outputs/README.md
@@ -17,5 +17,7 @@ Files are named `{model}[-runN].json` with extracted `.csv` and `.eval.json`.
 
 Derived analyses live in `../derived/`, qualitative experiments in `../qualitative/`.
 
+Exp3 provenance and ledger policy is documented in `sota_exp3_DERIVATION_NOTICE.md`.
+
 Results are evaluated by `make rebuild-measurements`, which extracts CSVs
 from the JSON and scores them against `data/reference/vietnam_thermal_v1.csv`.

--- a/experiments/outputs/sota_exp3_DERIVATION_NOTICE.md
+++ b/experiments/outputs/sota_exp3_DERIVATION_NOTICE.md
@@ -1,10 +1,13 @@
-# EXP3 Snapshot (Raw/JSON Only)
+# EXP3 Snapshot (Raw, JSON, and Derived Ledgers)
 
 Date: 2026-05-25
 
-This commit intentionally snapshots EXP3 outputs as raw provider payloads and JSON metadata only.
+This notice defines the provenance policy for EXP3 artifacts under `sota_exp3_*`.
 
 Rules:
-- No EXP3 `.md` artifacts are included at snapshot step 1.
-- Canonical evidence for provenance/scoring is in raw provider payloads and JSON files.
-- Narrative markdown must be regenerated ex post from raw payloads via a dedicated extractor.
+- Canonical evidence for provenance/scoring is in raw provider payloads and raw prompts.
+- Runtime JSON metadata (for example `*_phase_a.json`, `*_turn_*.record.json`) is derived from raw payloads and is kept for reproducibility.
+- Run ledger `summary.json` is derived and represents the latest run state for that run directory.
+- Timestamped `summary_*.md` files are derived append-only audit snapshots and must be kept in git.
+- `summary_*.md` snapshots are not canonical scientific evidence, but are required for audit recovery when `summary.json` is overwritten by reruns.
+- Narrative markdown reports can be regenerated ex post from raw payloads via a dedicated extractor.

--- a/experiments/outputs/sota_exp3_arm1_batch1/run01/summary_20260524T2115Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm1_batch1/run01/summary_20260524T2115Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.2679 | 210.5 | 79565 |
+| openai | 1 | gpt-5.5 | report | 0.2787 | 172.3 | 56130 |
+| anthropic | 1 | claude-opus-4-6 | report | 2.0890 | 1220.0 | 45742 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.0567 | 88.4 | 23471 |
+
+Total cost: $2.6923

--- a/experiments/outputs/sota_exp3_arm1_batch1/run02/summary_20260524T2140Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm1_batch1/run02/summary_20260524T2140Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.1624 | 148.3 | 52318 |
+| openai | 1 | gpt-5.5 | report | 0.2664 | 172.1 | 53943 |
+| anthropic | 1 | claude-opus-4-6 | report | 1.8781 | 1027.6 | 48575 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.0613 | 139.4 | 25521 |
+
+Total cost: $2.3682

--- a/experiments/outputs/sota_exp3_arm1_batch1/run03/summary_20260524T2207Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm1_batch1/run03/summary_20260524T2207Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.2689 | 235.6 | 76061 |
+| openai | 1 | gpt-5.5 | report | 0.2559 | 165.1 | 60074 |
+| anthropic | 1 | claude-opus-4-6 | report | 2.0270 | 1098.5 | 41744 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.0524 | 74.6 | 22764 |
+
+Total cost: $2.6042

--- a/experiments/outputs/sota_exp3_arm1_batch1/run04/summary_20260524T2233Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm1_batch1/run04/summary_20260524T2233Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.2890 | 193.9 | 62784 |
+| openai | 1 | gpt-5.5 | report | 0.2577 | 157.7 | 58681 |
+| anthropic | 1 | claude-opus-4-6 | report | 1.9556 | 1048.4 | 36544 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.0585 | 100.7 | 22406 |
+
+Total cost: $2.5608

--- a/experiments/outputs/sota_exp3_arm1_batch1/run05/summary_20260524T2303Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm1_batch1/run05/summary_20260524T2303Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.2502 | 309.1 | 78026 |
+| openai | 1 | gpt-5.5 | report | 0.3047 | 190.1 | 69762 |
+| anthropic | 1 | claude-opus-4-6 | report | 2.1352 | 1217.0 | 36123 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.0522 | 81.8 | 21060 |
+
+Total cost: $2.7423

--- a/experiments/outputs/sota_exp3_arm2_batch1/run01/summary_20260524T2117Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm2_batch1/run01/summary_20260524T2117Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.2383 | 1251.0 | 2 | report,report | 32 |
+| openai | pass | 0.7410 | 310.9 | 3 | no_report,report,report | 79 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.2445 | 178.0 | 3 | no_report,report,report | 34 |
+
+Total B-0 cost: $1.2238

--- a/experiments/outputs/sota_exp3_arm2_batch1/run02/summary_20260524T2129Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm2_batch1/run02/summary_20260524T2129Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.1906 | 220.8 | 2 | report,report | 39 |
+| openai | pass | 0.5585 | 292.5 | 2 | report,report | 96 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.1917 | 132.9 | 3 | no_report,report,report | 28 |
+
+Total B-0 cost: $0.9408

--- a/experiments/outputs/sota_exp3_arm2_batch1/run03/summary_20260524T2150Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm2_batch1/run03/summary_20260524T2150Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.2166 | 694.5 | 2 | report,report | 58 |
+| openai | pass | 0.7343 | 304.0 | 2 | report,report | 86 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.2028 | 141.6 | 2 | report,report | 25 |
+
+Total B-0 cost: $1.1538

--- a/experiments/outputs/sota_exp3_arm2_batch1/run04/summary_20260524T2204Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm2_batch1/run04/summary_20260524T2204Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.2518 | 289.3 | 2 | report,report | 52 |
+| openai | pass | 0.6281 | 312.9 | 2 | report,report | 85 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.2198 | 171.4 | 3 | no_report,report,report | 25 |
+
+Total B-0 cost: $1.0997

--- a/experiments/outputs/sota_exp3_arm2_batch1/run05/summary_20260524T2219Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm2_batch1/run05/summary_20260524T2219Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.2480 | 300.1 | 2 | report,report | 44 |
+| openai | pass | 0.7392 | 368.0 | 3 | no_report,report,report | 88 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.1709 | 125.0 | 3 | no_report,report,report | 15 |
+
+Total B-0 cost: $1.1582

--- a/experiments/outputs/sota_exp3_arm3_batch1/run01/summary_20260523T2202Z_mistral_openai_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm3_batch1/run01/summary_20260523T2202Z_mistral_openai_anthropic.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.0522 | 169.1 | 31949 |
+| openai | 1 | gpt-5.5 | report | 0.4396 | 163.9 | 46754 |
+| anthropic | 1 | claude-opus-4-6 | no_report | 2.1213 | 289.3 | 0 |
+| qwen | 1 | error | error | 0 | 0 | 0 |
+
+Total cost: $2.6131

--- a/experiments/outputs/sota_exp3_arm3_batch1/run03/summary_20260524T2108Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm3_batch1/run03/summary_20260524T2108Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.0625 | 274.5 | 74865 |
+| openai | 1 | gpt-5.5 | report | 0.4970 | 210.7 | 59407 |
+| anthropic | 1 | claude-opus-4-6 | report | 2.8500 | 678.4 | 43917 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.2957 | 70.0 | 32881 |
+
+Total cost: $3.7052

--- a/experiments/outputs/sota_exp3_arm3_batch1/run04/summary_20260524T2128Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm3_batch1/run04/summary_20260524T2128Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.0623 | 262.0 | 100967 |
+| openai | 1 | gpt-5.5 | report | 0.4945 | 199.3 | 59006 |
+| anthropic | 1 | claude-opus-4-6 | report | 2.8404 | 656.6 | 51145 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.2802 | 59.0 | 26618 |
+
+Total cost: $3.6774

--- a/experiments/outputs/sota_exp3_arm3_batch1/run05/summary_20260524T2150Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm3_batch1/run05/summary_20260524T2150Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Naive Arm Summary
+
+| Agent | Run | Model | Classification | Cost USD | Wall s | Narrative chars |
+|---|---:|---|---|---:|---:|---:|
+| mistral | 1 | mistral-large-2512 | report | 0.0608 | 273.5 | 75476 |
+| openai | 1 | gpt-5.5 | report | 0.4570 | 182.8 | 53957 |
+| anthropic | 1 | claude-opus-4-6 | report | 2.8750 | 746.5 | 48777 |
+| qwen | 1 | qwen3.7-max-2026-05-20 | report | 0.2858 | 89.1 | 31064 |
+
+Total cost: $3.6786

--- a/experiments/outputs/sota_exp3_arm4_batch1/run02/summary.json
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run02/summary.json
@@ -1,5 +1,23 @@
 [
   {
+    "agent": "mistral",
+    "status": "pass",
+    "total_cost_usd": 0.3761,
+    "wall_s": 543.0,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 97
+  },
+  {
+    "agent": "openai",
+    "status": "pass",
+    "total_cost_usd": 1.1042,
+    "wall_s": 366.1,
+    "turns": 3,
+    "class_trace": "no_report,report,report",
+    "inventory_rows": 110
+  },
+  {
     "agent": "anthropic",
     "status": "pass",
     "total_cost_usd": 3.2201049999999984,
@@ -7,5 +25,14 @@
     "turns": 2,
     "class_trace": "report,report",
     "inventory_rows": 35
+  },
+  {
+    "agent": "qwen",
+    "status": "pass",
+    "total_cost_usd": 0.8794,
+    "wall_s": 226.3,
+    "turns": 3,
+    "class_trace": "no_report,report,report",
+    "inventory_rows": 0
   }
 ]

--- a/experiments/outputs/sota_exp3_arm4_batch1/run02/summary_20260524T2107Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run02/summary_20260524T2107Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.3761 | 543.0 | 2 | report,report | 97 |
+| openai | pass | 1.1042 | 366.1 | 3 | no_report,report,report | 110 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.8794 | 226.3 | 3 | no_report,report,report | 0 |
+
+Total B-0 cost: $2.3598

--- a/experiments/outputs/sota_exp3_arm4_batch1/run02/summary_20260525T0342Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run02/summary_20260525T0342Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+
+Total B-0 cost: $0.0000

--- a/experiments/outputs/sota_exp3_arm4_batch1/run02/summary_20260525T0355Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run02/summary_20260525T0355Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | pass | 3.2201 | 643.1 | 2 | report,report | 35 |
+
+Total B-0 cost: $3.2201

--- a/experiments/outputs/sota_exp3_arm4_batch1/run03/summary.json
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run03/summary.json
@@ -1,5 +1,23 @@
 [
   {
+    "agent": "mistral",
+    "status": "pass",
+    "total_cost_usd": 0.1294,
+    "wall_s": 500.6,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 69
+  },
+  {
+    "agent": "openai",
+    "status": "pass",
+    "total_cost_usd": 0.9319,
+    "wall_s": 286.8,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 109
+  },
+  {
     "agent": "anthropic",
     "status": "pass",
     "total_cost_usd": 4.036069999999999,
@@ -7,5 +25,14 @@
     "turns": 3,
     "class_trace": "no_report,report,report",
     "inventory_rows": 88
+  },
+  {
+    "agent": "qwen",
+    "status": "pass",
+    "total_cost_usd": 0.8443,
+    "wall_s": 179.5,
+    "turns": 3,
+    "class_trace": "no_report,report,report",
+    "inventory_rows": 36
   }
 ]

--- a/experiments/outputs/sota_exp3_arm4_batch1/run03/summary_20260524T2125Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run03/summary_20260524T2125Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.1294 | 500.6 | 2 | report,report | 69 |
+| openai | pass | 0.9319 | 286.8 | 2 | report,report | 109 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.8443 | 179.5 | 3 | no_report,report,report | 36 |
+
+Total B-0 cost: $1.9056

--- a/experiments/outputs/sota_exp3_arm4_batch1/run03/summary_20260525T0342Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run03/summary_20260525T0342Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+
+Total B-0 cost: $0.0000

--- a/experiments/outputs/sota_exp3_arm4_batch1/run03/summary_20260525T0409Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run03/summary_20260525T0409Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | pass | 4.0361 | 781.1 | 3 | no_report,report,report | 88 |
+
+Total B-0 cost: $4.0361

--- a/experiments/outputs/sota_exp3_arm4_batch1/run04/summary.json
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run04/summary.json
@@ -1,5 +1,23 @@
 [
   {
+    "agent": "mistral",
+    "status": "pass",
+    "total_cost_usd": 0.3588,
+    "wall_s": 383.0,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 62
+  },
+  {
+    "agent": "openai",
+    "status": "pass",
+    "total_cost_usd": 1.015,
+    "wall_s": 287.0,
+    "turns": 3,
+    "class_trace": "no_report,report,report",
+    "inventory_rows": 106
+  },
+  {
     "agent": "anthropic",
     "status": "pass",
     "total_cost_usd": 5.363949999999999,
@@ -7,5 +25,14 @@
     "turns": 4,
     "class_trace": "no_report,no_report,report,no_report",
     "inventory_rows": 62
+  },
+  {
+    "agent": "qwen",
+    "status": "pass",
+    "total_cost_usd": 0.6824,
+    "wall_s": 201.9,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 77
   }
 ]

--- a/experiments/outputs/sota_exp3_arm4_batch1/run04/summary_20260524T2141Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run04/summary_20260524T2141Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.3588 | 383.0 | 2 | report,report | 62 |
+| openai | pass | 1.0150 | 287.0 | 3 | no_report,report,report | 106 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.6824 | 201.9 | 2 | report,report | 77 |
+
+Total B-0 cost: $2.0562

--- a/experiments/outputs/sota_exp3_arm4_batch1/run04/summary_20260525T0342Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run04/summary_20260525T0342Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+
+Total B-0 cost: $0.0000

--- a/experiments/outputs/sota_exp3_arm4_batch1/run04/summary_20260525T0424Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run04/summary_20260525T0424Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | pass | 5.3639 | 879.3 | 4 | no_report,no_report,report,no_report | 62 |
+
+Total B-0 cost: $5.3639

--- a/experiments/outputs/sota_exp3_arm4_batch1/run05/summary.json
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run05/summary.json
@@ -1,5 +1,23 @@
 [
   {
+    "agent": "mistral",
+    "status": "pass",
+    "total_cost_usd": 0.1265,
+    "wall_s": 421.4,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 98
+  },
+  {
+    "agent": "openai",
+    "status": "pass",
+    "total_cost_usd": 1.8057,
+    "wall_s": 643.1,
+    "turns": 4,
+    "class_trace": "no_report,no_report,report,report",
+    "inventory_rows": 127
+  },
+  {
     "agent": "anthropic",
     "status": "pass",
     "total_cost_usd": 4.431205,
@@ -7,5 +25,14 @@
     "turns": 4,
     "class_trace": "no_report,no_report,report,report",
     "inventory_rows": 119
+  },
+  {
+    "agent": "qwen",
+    "status": "pass",
+    "total_cost_usd": 0.6813,
+    "wall_s": 369.3,
+    "turns": 2,
+    "class_trace": "report,report",
+    "inventory_rows": 50
   }
 ]

--- a/experiments/outputs/sota_exp3_arm4_batch1/run05/summary_20260525T0325Z_mistral_openai_anthropic_qwen.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run05/summary_20260525T0325Z_mistral_openai_anthropic_qwen.md
@@ -1,0 +1,10 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| mistral | pass | 0.1265 | 421.4 | 2 | report,report | 98 |
+| openai | pass | 1.8057 | 643.1 | 4 | no_report,no_report,report,report | 127 |
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+| qwen | pass | 0.6813 | 369.3 | 2 | report,report | 50 |
+
+Total B-0 cost: $2.6135

--- a/experiments/outputs/sota_exp3_arm4_batch1/run05/summary_20260525T0342Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run05/summary_20260525T0342Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | error | 0.0000 | 0.0 | 0 | n/a | 0 |
+
+Total B-0 cost: $0.0000

--- a/experiments/outputs/sota_exp3_arm4_batch1/run05/summary_20260525T0437Z_anthropic.md
+++ b/experiments/outputs/sota_exp3_arm4_batch1/run05/summary_20260525T0437Z_anthropic.md
@@ -1,0 +1,7 @@
+# Phase B-0 Summary
+
+| Agent | Status | Cost USD | Wall s | Turns | Class Trace | Inventory Rows |
+|---|---:|---:|---:|---:|---|---:|
+| anthropic | pass | 4.4312 | 760.9 | 4 | no_report,no_report,report,report | 119 |
+
+Total B-0 cost: $4.4312

--- a/tickets/0295-rerun-exp3-arm2-anthropic-with-credit-precheck.erg
+++ b/tickets/0295-rerun-exp3-arm2-anthropic-with-credit-precheck.erg
@@ -1,0 +1,36 @@
+%erg 0.1
+Title: Rerun exp3 arm2 anthropic with credit precheck
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T00:00Z HDMX-coding-agent created
+2026-05-25T00:00Z HDMX-coding-agent note opened after exp3 rerun audit showed arm2 anthropic status=error with turns=0 across run01-run05.
+
+--- body ---
+## Context
+
+Exp3 arm2 (`experiments/outputs/sota_exp3_arm2_batch1`) shows Anthropic failures
+for all five runs with `status = error`, `turns = 0`, `wall_s = 0`, and
+`total_cost_usd = 0`.
+
+The interactive runner records these as generic errors when agent execution
+raises before Phase B turns are captured, so we need a clean rerun lane focused
+on Anthropic with explicit budget/credit checks before launch.
+
+## Scope
+
+- Prepare Anthropic-only reruns for arm2 run01-run05.
+- Verify Anthropic/OpenRouter credit availability before reruns.
+- Preserve existing artifacts; write rerun outputs with clear timestamped
+  summaries and provenance notes.
+
+## Exit criteria
+
+- [ ] Credit precheck documented immediately before rerun launch.
+- [ ] Arm2 Anthropic reruns completed for run01-run05.
+- [ ] `summary_*.md` artifacts for reruns show non-error outcomes or explicit
+      failure reason with evidence.
+- [ ] Ledger (`summary.json`) policy decided and documented (in-place overwrite
+      vs separate rerun ledger) before artifact updates.
+- [ ] Ticket close after rerun audit confirms expected behavior.

--- a/tickets/0296-standardize-json-eof-newline-policy.erg
+++ b/tickets/0296-standardize-json-eof-newline-policy.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Standardize JSON EOF newline policy across runtime writers
+Created: 2026-05-25
+Author: HDMX-coding-agent
+Tag: deferred
+
+--- log ---
+2026-05-25T00:00Z HDMX-coding-agent created
+2026-05-25T00:00Z HDMX-coding-agent note deferred per user request: schedule after talk / slow day.
+
+--- body ---
+## Context
+
+Current JSON write behavior is inconsistent:
+- Some maintenance scripts append a final newline (`+ "\n"`).
+- Some runtime writers (notably Exp2/Exp3 interactive summary writer) do not.
+
+This creates newline-only diffs (`No newline at end of file`) that are non-semantic but noisy in reviews and audits.
+
+## Scope
+
+- Define project stance: JSON text files should end with exactly one trailing newline.
+- Apply stance to runtime JSON writers (starting with Exp2/Exp3 interactive summary writer).
+- Add/align guardrails (formatter, lint, or test) so behavior remains stable.
+
+## Exit criteria
+
+- [ ] Stance documented in repo policy docs.
+- [ ] Runtime writers updated to emit newline-terminated JSON consistently.
+- [ ] Existing newline-only drifts normalized in touched directories.
+- [ ] Verification command added or documented for future drift checks.
+- [ ] Ticket closed after implementation in a dedicated chore commit.


### PR DESCRIPTION
## Summary
- align Exp3 Arm4 run ledgers (`summary.json`) with on-disk post-run artifacts after reruns
- track timestamped `summary_*.md` snapshots in git for audit recovery
- document raw-vs-derived policy for Exp3 outputs and add discoverability pointer
- onboard follow-up deferred ticket for JSON EOF newline consistency

## Details
- Arm4 `run02`-`run05` ledgers now reflect the full agent material in each run directory
- `.gitignore` now allows tracking `experiments/outputs/sota_exp3_*/**/summary_*.md` while keeping other derived markdown ignored
- policy updated in `experiments/outputs/sota_exp3_DERIVATION_NOTICE.md` and linked from `experiments/outputs/README.md`
- added deferred ticket: `tickets/0296-standardize-json-eof-newline-policy.erg`

**Ticket:** tickets/0295-rerun-exp3-arm2-anthropic-with-credit-precheck.erg

Related (deferred): tickets/0296-standardize-json-eof-newline-policy.erg