### PR TITLE
feat(analysis): jumpstart exp2 analysis pipeline

### DIFF
--- a/experiments/analysis.mk
+++ b/experiments/analysis.mk
@@ -1,0 +1,226 @@
+# Exp2 analysis DAG
+#
+# This file declares the analysis pipeline from run outputs to report-ready
+# artifacts. Override the path variables below to relocate the repository or
+# point at alternate output trees.
+
+ANALYSIS_REPO_ROOT ?= .
+ANALYSIS_EXPERIMENTS_DIR ?= $(ANALYSIS_REPO_ROOT)/experiments
+ANALYSIS_REPORT_DIR ?= $(ANALYSIS_REPO_ROOT)/report
+ANALYSIS_GENERATED_DIR ?= $(ANALYSIS_REPORT_DIR)/inputs/generated
+ANALYSIS_GEN ?= $(ANALYSIS_GENERATED_DIR)
+ANALYSIS_OUTPUTS_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/outputs
+ANALYSIS_DERIVED_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/derived
+
+ANALYSIS_EXP2_NAIVE_DIR ?= $(ANALYSIS_OUTPUTS_DIR)/sota_exp2_naive_arm
+ANALYSIS_EXP2_OPTIMISED_DIR ?= $(ANALYSIS_OUTPUTS_DIR)/sota_exp2_brerun1
+ANALYSIS_EXP2_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/sota_cross_eval.csv
+
+ANALYSIS_EXP2_NAIVE_JSONS := $(wildcard $(ANALYSIS_EXP2_NAIVE_DIR)/*.json)
+ANALYSIS_EXP2_OPTIMISED_JSONS := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/*.json)
+ANALYSIS_EXP2_NAIVE_MDS := $(wildcard $(ANALYSIS_EXP2_NAIVE_DIR)/*.md)
+ANALYSIS_EXP2_OPTIMISED_MDS := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/*.md)
+ANALYSIS_EXP2_PROBE_RAWS := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/probes/*/*.raw.json)
+ANALYSIS_EXP2_PROBE_CLSF := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/probes/*/*.classification.json)
+
+ANALYSIS_EXP2_MART_JSONL := $(ANALYSIS_GEN)/exp2_mart.jsonl
+ANALYSIS_EXP2_MART_VIEWS := \
+	$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
+	$(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
+	$(ANALYSIS_GEN)/exp2_turn_trajectory_view.csv \
+	$(ANALYSIS_GEN)/sota_cross_eval_view.csv
+
+ANALYSIS_EXP2_TABLE := $(ANALYSIS_GEN)/tab_exp2_arms.tex
+ANALYSIS_EXP2_ARM_FIG := $(ANALYSIS_GEN)/fig_exp2_arms_comparison.pdf
+ANALYSIS_EXP2_TURN_FIG := $(ANALYSIS_GEN)/fig_exp2_turn_trajectory.pdf
+ANALYSIS_EXP2_BIB_TABLE := $(ANALYSIS_GEN)/tab_exp2_bib_quality.tex
+ANALYSIS_EXP2_COVERAGE_FIG := $(ANALYSIS_GEN)/fig_exp2_coverage_certainty.pdf
+ANALYSIS_EXP2_SPIRE_FIG := $(ANALYSIS_GEN)/fig_quality_spider.pdf
+
+ANALYSIS_EXP2_OUTLINE_ARTIFACTS := \
+	$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex \
+	$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_hypotheses_map.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_protocol_fidelity.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h1.tex \
+	$(ANALYSIS_GEN)/fig_exp2_outline_h2.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h3.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h4.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h5.tex \
+	$(ANALYSIS_GEN)/fig_exp2_outline_h6.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex
+
+# --- Canonical mart and mart-derived views ---------------------------------
+
+$(ANALYSIS_EXP2_MART_JSONL): $(ANALYSIS_EXP2_NAIVE_JSONS) $(ANALYSIS_EXP2_NAIVE_MDS) \
+		$(ANALYSIS_EXP2_OPTIMISED_JSONS) $(ANALYSIS_EXP2_OPTIMISED_MDS) \
+		$(ANALYSIS_EXP2_CROSS_EVAL_CSV) $(ANALYSIS_EXP2_PROBE_RAWS) $(ANALYSIS_EXP2_PROBE_CLSF)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart \
+	    --naive-dir $(ANALYSIS_EXP2_NAIVE_DIR) \
+	    --optimised-dir $(ANALYSIS_EXP2_OPTIMISED_DIR) \
+	    --cross-eval-csv $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
+	    --output $@ \
+	    --repo-root $(ANALYSIS_REPO_ROOT)
+
+$(ANALYSIS_EXP2_MART_VIEWS): $(ANALYSIS_EXP2_MART_JSONL)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart_views \
+	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
+	    --output-dir $(ANALYSIS_GEN) \
+	    --repo-root $(ANALYSIS_REPO_ROOT)
+
+# --- Dual-run parity staging -------------------------------------------------
+
+ANALYSIS_EXP2_OLD_STAGE := $(ANALYSIS_GEN)/exp2-old-path
+ANALYSIS_EXP2_MART_STAGE := $(ANALYSIS_GEN)/exp2-mart-path
+
+$(ANALYSIS_EXP2_OLD_STAGE)/tab_exp2_arms_runs.csv: $(ANALYSIS_EXP2_NAIVE_JSONS) $(ANALYSIS_EXP2_NAIVE_MDS) $(ANALYSIS_EXP2_OPTIMISED_JSONS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_arms_runs \
+	    --naive-dir $(ANALYSIS_EXP2_NAIVE_DIR) \
+	    --optimised-dir $(ANALYSIS_EXP2_OPTIMISED_DIR) \
+	    --output $@
+
+$(ANALYSIS_EXP2_OLD_STAGE)/tab_exp2_bib_quality.csv: $(ANALYSIS_EXP2_NAIVE_MDS) $(ANALYSIS_EXP2_OPTIMISED_MDS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.extract_exp2_bib \
+	    --naive-dir $(ANALYSIS_EXP2_NAIVE_DIR) \
+	    --optimised-dir $(ANALYSIS_EXP2_OPTIMISED_DIR) \
+	    --output $@
+
+$(ANALYSIS_EXP2_OLD_STAGE)/exp2_turn_trajectory.csv: $(ANALYSIS_EXP2_PROBE_RAWS) $(ANALYSIS_EXP2_PROBE_CLSF)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.export_exp2_turn_trajectory_csv \
+	    --probes-dir $(ANALYSIS_EXP2_OPTIMISED_DIR)/probes \
+	    --output $@
+
+$(ANALYSIS_EXP2_OLD_STAGE)/sota_cross_eval.csv: $(ANALYSIS_EXP2_CROSS_EVAL_CSV)
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+$(ANALYSIS_EXP2_MART_STAGE)/tab_exp2_arms_runs_view.csv $(ANALYSIS_EXP2_MART_STAGE)/tab_exp2_bib_quality_view.csv \
+$(ANALYSIS_EXP2_MART_STAGE)/exp2_turn_trajectory_view.csv $(ANALYSIS_EXP2_MART_STAGE)/sota_cross_eval_view.csv: $(ANALYSIS_EXP2_MART_JSONL)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart_views \
+	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
+	    --output-dir $(ANALYSIS_EXP2_MART_STAGE) \
+	    --repo-root $(ANALYSIS_REPO_ROOT)
+
+exp2-old-path: \
+	$(ANALYSIS_EXP2_OLD_STAGE)/tab_exp2_arms_runs.csv \
+	$(ANALYSIS_EXP2_OLD_STAGE)/tab_exp2_bib_quality.csv \
+	$(ANALYSIS_EXP2_OLD_STAGE)/exp2_turn_trajectory.csv \
+	$(ANALYSIS_EXP2_OLD_STAGE)/sota_cross_eval.csv
+
+exp2-mart-path: \
+	$(ANALYSIS_EXP2_MART_STAGE)/tab_exp2_arms_runs_view.csv \
+	$(ANALYSIS_EXP2_MART_STAGE)/tab_exp2_bib_quality_view.csv \
+	$(ANALYSIS_EXP2_MART_STAGE)/exp2_turn_trajectory_view.csv \
+	$(ANALYSIS_EXP2_MART_STAGE)/sota_cross_eval_view.csv
+
+check-mart-parity: exp2-old-path exp2-mart-path
+	uv run python -m aedist.check_exp2_mart_parity \
+	    --left-dir $(ANALYSIS_EXP2_OLD_STAGE) \
+	    --right-dir $(ANALYSIS_EXP2_MART_STAGE)
+
+# --- Tables and figures -----------------------------------------------------
+
+$(ANALYSIS_EXP2_TABLE): $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_arms \
+	    --input $< \
+	    --naive-dir $(ANALYSIS_EXP2_NAIVE_DIR) \
+	    --optimised-dir $(ANALYSIS_EXP2_OPTIMISED_DIR) \
+	    --output $@
+
+$(ANALYSIS_EXP2_ARM_FIG): $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_arms_comparison \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_TURN_FIG): $(ANALYSIS_GEN)/exp2_turn_trajectory_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_turn_trajectory \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_BIB_TABLE): $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_bib_quality \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_COVERAGE_FIG): $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_coverage_certainty \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_SPIRE_FIG): $(ANALYSIS_GEN)/sota_cross_eval_view.csv experiments/quality_spider_config.yaml
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_quality_spider \
+	    --input $< \
+	    --config experiments/quality_spider_config.yaml \
+	    --output $@
+
+# --- Outline placeholder artifacts (post-conference skeleton) ----------------
+
+$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_dataset --output $@
+
+$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_outline_dataset --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_hypotheses_map.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_hypotheses_map --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_protocol_fidelity.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_protocol_fidelity --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h1.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h1 --output $@
+
+$(ANALYSIS_GEN)/fig_exp2_outline_h2.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_outline_h2 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h3.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h3 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h4.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h4 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h5.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h5 --output $@
+
+$(ANALYSIS_GEN)/fig_exp2_outline_h6.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_outline_h6 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_hypothesis_status --output $@
+
+ANALYSIS_EXP2_REPORT_TARGETS := \
+	$(ANALYSIS_EXP2_MART_VIEWS) \
+	$(ANALYSIS_EXP2_TABLE) \
+	$(ANALYSIS_EXP2_ARM_FIG) \
+	$(ANALYSIS_EXP2_TURN_FIG) \
+	$(ANALYSIS_EXP2_BIB_TABLE) \
+	$(ANALYSIS_EXP2_COVERAGE_FIG) \
+	$(ANALYSIS_EXP2_SPIRE_FIG) \
+	$(ANALYSIS_EXP2_OUTLINE_ARTIFACTS)
+
+.PHONY: exp2-analysis-report
+
+exp2-analysis-report: $(ANALYSIS_EXP2_REPORT_TARGETS)

--- a/src/aedist/build_exp2_mart.py
+++ b/src/aedist/build_exp2_mart.py
@@ -44,6 +44,11 @@ def _pointer(path: Path, repo_root: Path) -> ArtifactPointer:
     return ArtifactPointer(path=relative_path.as_posix(), sha256=_sha256(path))
 
 
+def _resolve_repo_path(repo_root: Path, value: Path | None, default: Path) -> Path:
+    candidate = default if value is None else value
+    return candidate if candidate.is_absolute() else repo_root / candidate
+
+
 def _record_id(arm: str, model: str, run: int, suffix: str = "") -> str:
     safe_model = model.replace("/", "_")
     base = f"exp2/{arm}/{safe_model}/run{run:02d}"
@@ -261,12 +266,15 @@ def _build_probe_records(
 
 
 def build_exp2_mart(
-    naive_dir: Path = _DEFAULT_NAIVE_DIR,
-    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
-    cross_eval_csv: Path = _DEFAULT_CROSS_EVAL,
+    naive_dir: Path | None = None,
+    optimised_dir: Path | None = None,
+    cross_eval_csv: Path | None = None,
     repo_root: Path | None = None,
 ) -> list[Exp2RunMartRecord | Exp2ScoreMartRecord]:
-    repo_root = repo_root or Path.cwd()
+    repo_root = (repo_root or Path.cwd()).resolve()
+    naive_dir = _resolve_repo_path(repo_root, naive_dir, _DEFAULT_NAIVE_DIR)
+    optimised_dir = _resolve_repo_path(repo_root, optimised_dir, _DEFAULT_OPTIMISED_DIR)
+    cross_eval_csv = _resolve_repo_path(repo_root, cross_eval_csv, _DEFAULT_CROSS_EVAL)
     score_rows, _rows_by_arm_run, rows_by_arm_agent_run = _load_score_rows(cross_eval_csv)
     records: list[Exp2RunMartRecord | Exp2ScoreMartRecord] = []
 
@@ -311,9 +319,9 @@ def build_exp2_mart(
 
 def write_exp2_mart(
     output: Path,
-    naive_dir: Path = _DEFAULT_NAIVE_DIR,
-    optimised_dir: Path = _DEFAULT_OPTIMISED_DIR,
-    cross_eval_csv: Path = _DEFAULT_CROSS_EVAL,
+    naive_dir: Path | None = None,
+    optimised_dir: Path | None = None,
+    cross_eval_csv: Path | None = None,
     repo_root: Path | None = None,
 ) -> list[Exp2RunMartRecord | Exp2ScoreMartRecord]:
     records = build_exp2_mart(
@@ -333,21 +341,35 @@ def write_exp2_mart(
 def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     parser = argparse.ArgumentParser(description="Build the Exp2 mart JSONL artifact")
-    parser.add_argument("--output", default=str(_DEFAULT_OUTPUT))
-    parser.add_argument("--naive-dir", default=str(_DEFAULT_NAIVE_DIR))
-    parser.add_argument("--optimised-dir", default=str(_DEFAULT_OPTIMISED_DIR))
-    parser.add_argument("--cross-eval-csv", default=str(_DEFAULT_CROSS_EVAL))
-    parser.add_argument("--repo-root", default=str(Path.cwd()))
+    parser.add_argument("--output")
+    parser.add_argument("--naive-dir")
+    parser.add_argument("--optimised-dir")
+    parser.add_argument("--cross-eval-csv")
+    parser.add_argument("--repo-root")
     args = parser.parse_args(argv)
 
-    records = write_exp2_mart(
-        Path(args.output),
-        naive_dir=Path(args.naive_dir),
-        optimised_dir=Path(args.optimised_dir),
-        cross_eval_csv=Path(args.cross_eval_csv),
-        repo_root=Path(args.repo_root),
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path.cwd().resolve()
+    output = _resolve_repo_path(repo_root, Path(args.output) if args.output else None, _DEFAULT_OUTPUT)
+    naive_dir = _resolve_repo_path(repo_root, Path(args.naive_dir) if args.naive_dir else None, _DEFAULT_NAIVE_DIR)
+    optimised_dir = _resolve_repo_path(
+        repo_root,
+        Path(args.optimised_dir) if args.optimised_dir else None,
+        _DEFAULT_OPTIMISED_DIR,
     )
-    log.info("Wrote %d mart records to %s", len(records), args.output)
+    cross_eval_csv = _resolve_repo_path(
+        repo_root,
+        Path(args.cross_eval_csv) if args.cross_eval_csv else None,
+        _DEFAULT_CROSS_EVAL,
+    )
+
+    records = write_exp2_mart(
+        output,
+        naive_dir=naive_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=cross_eval_csv,
+        repo_root=repo_root,
+    )
+    log.info("Wrote %d mart records to %s", len(records), output)
 
 
 if __name__ == "__main__":

--- a/tests/test_build_exp2_mart.py
+++ b/tests/test_build_exp2_mart.py
@@ -1,6 +1,7 @@
 """Tests for the Exp2 mart builder."""
 
 import json
+from pathlib import Path
 
 from aedist.build_exp2_mart import build_exp2_mart, write_exp2_mart
 
@@ -127,6 +128,56 @@ def test_build_exp2_mart_ignores_raw_payload_files(tmp_path):
     assert run_record.run_summary.n_rows == 1
     assert probe_record.probe_summary.turn == 1
     assert score_record.score_summary.accuracy.coverage.value == 0.5
+
+
+def test_build_exp2_mart_resolves_repo_relative_paths_from_repo_root(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    cwd = tmp_path / "elsewhere"
+    naive_dir = repo_root / "experiments" / "outputs" / "sota_exp2_naive_arm"
+    optimised_dir = repo_root / "experiments" / "outputs" / "sota_exp2_brerun1"
+    naive_dir.mkdir(parents=True)
+    optimised_dir.mkdir(parents=True)
+    cwd.mkdir()
+
+    for arm_dir, arm_name in ((naive_dir, "naive"), (optimised_dir, "optimised")):
+        _write_json(
+            arm_dir / "anthropic_run01.json",
+            {
+                "model": "claude-opus-4-6",
+                "run": 1,
+                "arm": arm_name,
+                "classification": "report",
+                "turns": 1 if arm_name == "naive" else 3,
+                "narrative_chars": 4,
+                "cost_usd": 0.1,
+            },
+        )
+        _write_md(
+            arm_dir / "anthropic_run01.md",
+            "| Name | Fuel | Capacity | Status | COD | Province |\n"
+            "| --- | --- | --- | --- | --- | --- |\n"
+            "| A | Coal | 1 | Operating | 1983 | HN |\n",
+        )
+
+    (repo_root / "experiments" / "derived").mkdir(parents=True)
+    _write_cross_eval_csv(
+        repo_root / "experiments" / "derived" / "sota_cross_eval.csv",
+        [
+            _score_row("naive", "claude-opus-4-6", 1),
+            _score_row("optimised", "claude-opus-4-6", 1),
+        ],
+    )
+
+    monkeypatch.chdir(cwd)
+    records = build_exp2_mart(
+        naive_dir=Path("experiments/outputs/sota_exp2_naive_arm"),
+        optimised_dir=Path("experiments/outputs/sota_exp2_brerun1"),
+        cross_eval_csv=Path("experiments/derived/sota_cross_eval.csv"),
+        repo_root=repo_root,
+    )
+
+    assert len(records) == 4
+    assert any(record.record_kind == "score" for record in records)
 
 
 def test_write_exp2_mart_writes_jsonl(tmp_path):


### PR DESCRIPTION
## Summary

- Add `experiments/analysis.mk` — Make DAG from run outputs to report-ready artifacts
- Fix `build_exp2_mart.py` path resolution: args now default to `None`, resolved against `--repo-root` at call time (fixes off-CWD invocation from Makefile)
- Add regression test for the off-CWD path resolution case

## Test plan

- [ ] `make check-fast` passes
- [ ] `make -f experiments/analysis.mk` (dry-run with `-n`) resolves targets cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)