### PR TITLE
ticket(0298): extract arm1/arm3 single-turn outputs

### DIFF
--- a/src/aedist/extract_arm_single_turn.py
+++ b/src/aedist/extract_arm_single_turn.py
@@ -1,0 +1,212 @@
+"""Flatten single-turn arm outputs into Exp2-mart-compatible per-run artifacts."""
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_META_JSON_RE = re.compile(r"^[a-z]+\.json$")
+_RUN_DIR_RE = re.compile(r"^run(\d+)$")
+_BIB_HEADER_RE = re.compile(
+    r"^#{1,6}\s+.*(?:sources|references|bibliography|annotated\s+bibliography)",
+    re.IGNORECASE,
+)
+_BIB_ENTRY_RE = re.compile(r"^(?:[-*+]\s+|\d+[.)]\s+|\*\*\[[^\]]+\]\*\*\s*|\[[^\]]+\]\s*)")
+
+
+def _extract_markdown_from_payload(payload: dict) -> str:
+    run_record = payload.get("run_record")
+    if isinstance(run_record, dict):
+        messages = run_record.get("method_params", {}).get("extra", {}).get("messages", [])
+        for message in reversed(messages):
+            if message.get("role") == "assistant" and isinstance(message.get("content"), str):
+                return message["content"]
+
+    outputs = payload.get("outputs")
+    if isinstance(outputs, list):
+        for item in reversed(outputs):
+            if item.get("role") != "assistant":
+                continue
+            content = item.get("content", [])
+            if isinstance(content, str) and content.strip():
+                return content
+            parts = content
+            texts = [
+                part.get("text", "")
+                for part in parts
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ]
+            markdown = "".join(texts).strip()
+            if markdown:
+                return markdown
+
+    output = payload.get("output")
+    if isinstance(output, dict):
+        choices = output.get("choices", [])
+        for choice in choices:
+            message = choice.get("message", {})
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                return content
+
+    if isinstance(output, list):
+        for item in reversed(output):
+            if item.get("type") != "message":
+                continue
+            parts = item.get("content", [])
+            texts = [
+                part.get("text", "")
+                for part in parts
+                if part.get("type") in {"output_text", "text"} and isinstance(part.get("text"), str)
+            ]
+            markdown = "".join(texts).strip()
+            if markdown:
+                return markdown
+
+    raise ValueError("unable to extract assistant markdown from payload")
+
+
+def _load_json(path: Path) -> dict | list:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _find_raw_payload(run_dir: Path, agent: str) -> dict:
+    for candidate in sorted(run_dir.glob(f"{agent}*.json")):
+        if candidate.name == f"{agent}.json":
+            continue
+        payload = _load_json(candidate)
+        if isinstance(payload, dict):
+            try:
+                _extract_markdown_from_payload(payload)
+            except ValueError:
+                continue
+            return payload
+    raise FileNotFoundError(f"no raw payload found for {agent} in {run_dir}")
+
+
+def _extract_bib_section(markdown: str) -> str:
+    lines = markdown.splitlines()
+    start = None
+    header_level = None
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if _BIB_HEADER_RE.match(stripped):
+            start = index + 1
+            header_level = len(stripped.split()[0])
+            break
+
+    if start is None:
+        return ""
+
+    section: list[str] = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            level = len(stripped.split()[0])
+            if level <= header_level:
+                break
+        section.append(line)
+
+    return "\n".join(section).strip()
+
+
+def _normalize_bib_entry(text: str) -> str:
+    normalized = _BIB_ENTRY_RE.sub("", text.strip())
+    normalized = re.sub(r"^\*\*|\*\*$", "", normalized)
+    return normalized.strip()
+
+
+def _extract_bibliography_entries(markdown: str) -> list[str]:
+    section = _extract_bib_section(markdown)
+    if not section:
+        return []
+
+    entries: list[str] = []
+    current: list[str] = []
+    for raw_line in section.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("|"):
+            continue
+        if _BIB_ENTRY_RE.match(line):
+            if current:
+                entry = _normalize_bib_entry(" ".join(current))
+                if entry:
+                    entries.append(entry)
+            current = [line]
+            continue
+        if current:
+            current.append(line)
+
+    if current:
+        entry = _normalize_bib_entry(" ".join(current))
+        if entry:
+            entries.append(entry)
+    return entries
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(f"{content.rstrip()}\n", encoding="utf-8")
+
+
+def flatten_single_turn_arm(input_dir: Path, output_dir: Path) -> list[Path]:
+    written: list[Path] = []
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for run_dir in sorted(path for path in input_dir.iterdir() if path.is_dir()):
+        run_match = _RUN_DIR_RE.match(run_dir.name)
+        if run_match is None:
+            continue
+        run = int(run_match.group(1))
+
+        for meta_path in sorted(run_dir.glob("*.json")):
+            if not _META_JSON_RE.match(meta_path.name) or meta_path.stem == "summary":
+                continue
+            meta = _load_json(meta_path)
+            if not isinstance(meta, dict) or meta.get("agent") != meta_path.stem:
+                continue
+
+            agent = str(meta["agent"])
+            payload = _find_raw_payload(run_dir, agent)
+            markdown = _extract_markdown_from_payload(payload)
+            bib_entries = _extract_bibliography_entries(markdown)
+
+            normalized = dict(meta)
+            normalized["run"] = run
+            normalized["class_trace"] = [meta.get("classification")] if meta.get("classification") else []
+            normalized["n_bib_entries"] = len(bib_entries)
+
+            base_name = f"{agent}_run{run:02d}"
+            json_path = output_dir / f"{base_name}.json"
+            md_path = output_dir / f"{base_name}.md"
+            bib_path = output_dir / f"{base_name}_bib.md"
+
+            _write_text(json_path, json.dumps(normalized, indent=2, ensure_ascii=False))
+            _write_text(md_path, markdown)
+            bib_content = "\n".join(f"- {entry}" for entry in bib_entries)
+            _write_text(bib_path, bib_content)
+            written.extend([json_path, md_path, bib_path])
+
+    return written
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Flatten single-turn arm outputs into per-run artifacts")
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    written = flatten_single_turn_arm(args.input_dir, args.output_dir)
+    log.info("wrote %d artifacts to %s", len(written), args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extract_arm_single_turn.py
+++ b/tests/test_extract_arm_single_turn.py
@@ -1,0 +1,230 @@
+import csv
+import json
+
+from aedist.build_exp2_mart import build_exp2_mart
+from aedist.extract_arm_single_turn import (
+    _extract_bibliography_entries,
+    flatten_single_turn_arm,
+)
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_cross_eval_csv(path, rows):
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _score_row(arm, model, run):
+    return {
+        "arm": arm,
+        "model": model,
+        "run": str(run),
+        "prompt_version": "exp2",
+        "n_rows": "1",
+        "accuracy_coverage": "0.5000",
+        "accuracy_coverage_annotation": "",
+        "accuracy_precision": "1.0000",
+        "accuracy_precision_annotation": "",
+        "accuracy_f1": "0.6667",
+        "accuracy_f1_annotation": "",
+        "accuracy_fuel": "1.0000",
+        "accuracy_fuel_annotation": "",
+        "accuracy_status": "1.0000",
+        "accuracy_status_annotation": "",
+        "accuracy_province": "1.0000",
+        "accuracy_province_annotation": "",
+        "coherence_vocab_adherence": "1.0000",
+        "coherence_vocab_adherence_annotation": "",
+        "coherence_status_vocab_adherence": "1.0000",
+        "coherence_status_vocab_adherence_annotation": "",
+        "provenance_source_presence": "1.0000",
+        "provenance_source_presence_annotation": "",
+        "provenance_high_conf_dual_source": "1.0000",
+        "provenance_high_conf_dual_source_annotation": "",
+        "temporality_asof_presence": "1.0000",
+        "temporality_asof_presence_annotation": "",
+        "temporality_plausible_range": "1.0000",
+        "temporality_plausible_range_annotation": "",
+        "field_completeness_core": "1.0000",
+        "field_completeness_core_annotation": "",
+        "field_completeness_capacity": "1.0000",
+        "field_completeness_capacity_annotation": "",
+    }
+
+
+def test_extract_bibliography_entries_supports_sources_heading():
+    markdown = """# Report
+
+## Sources
+
+**[1]** First source title.
+Continuation line.
+
+2. Second source title.
+
+## Next Section
+Ignored.
+"""
+
+    assert _extract_bibliography_entries(markdown) == [
+        "First source title. Continuation line.",
+        "Second source title.",
+    ]
+
+
+def test_flatten_single_turn_arm_outputs_mart_compatible_files(tmp_path):
+    input_dir = tmp_path / "arm1"
+    output_dir = tmp_path / "arm1_flat"
+    optimised_dir = tmp_path / "optimised"
+    run_dir = input_dir / "run01"
+    run_dir.mkdir(parents=True)
+    optimised_dir.mkdir()
+
+    _write_json(
+        run_dir / "anthropic.json",
+        {
+            "agent": "anthropic",
+            "run": 1,
+            "model": "claude-opus-4-6",
+            "classification": "report",
+            "tokens_out": 12,
+            "wall_s": 1.2,
+            "cost_usd": 0.3,
+            "classifier_cost_usd": 0.01,
+            "narrative_chars": 120,
+        },
+    )
+    _write_json(
+        run_dir / "anthropic-direct-claude-opus-4-6-run1.json",
+        {
+            "run_record": {
+                "method_params": {
+                    "extra": {
+                        "messages": [
+                            {"role": "user", "content": "prompt"},
+                            {
+                                "role": "assistant",
+                                "content": "| A | B |\n|---|---|\n| x | y |\n\n## Bibliography\n\n**[1]** Anthropic source.",
+                            },
+                        ]
+                    }
+                }
+            }
+        },
+    )
+    _write_json(
+        run_dir / "openai.json",
+        {
+            "agent": "openai",
+            "run": 1,
+            "model": "gpt-5.5",
+            "classification": "report",
+            "tokens_out": 14,
+            "wall_s": 1.4,
+            "cost_usd": 0.4,
+            "classifier_cost_usd": 0.02,
+            "narrative_chars": 140,
+        },
+    )
+    _write_json(
+        run_dir / "openai_probe.raw.json",
+        {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "| A | B |\n|---|---|\n| q | z |\n\n## Sources\n\n1. OpenAI source.",
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    _write_json(
+        run_dir / "mistral.json",
+        {
+            "agent": "mistral",
+            "run": 1,
+            "model": "mistral-large-2512",
+            "classification": "report",
+            "tokens_out": 16,
+            "wall_s": 1.6,
+            "cost_usd": 0.5,
+            "classifier_cost_usd": 0.03,
+            "narrative_chars": 160,
+        },
+    )
+    _write_json(
+        run_dir / "mistral_probe.raw.json",
+        {
+            "outputs": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "| A | B |\n|---|---|\n| m | n |\n\n## References\n\n- Mistral source."},
+                        {"type": "tool_reference", "url": "https://example.com"},
+                    ],
+                }
+            ]
+        },
+    )
+
+    written = flatten_single_turn_arm(input_dir, output_dir)
+
+    assert len(written) == 9
+    anthropic_meta = json.loads((output_dir / "anthropic_run01.json").read_text(encoding="utf-8"))
+    assert anthropic_meta["class_trace"] == ["report"]
+    assert anthropic_meta["n_bib_entries"] == 1
+    assert (output_dir / "anthropic_run01_bib.md").read_text(encoding="utf-8") == "- Anthropic source.\n"
+    assert (output_dir / "mistral_run01_bib.md").read_text(encoding="utf-8") == "- Mistral source.\n"
+    assert (output_dir / "openai_run01_bib.md").read_text(encoding="utf-8") == "- OpenAI source.\n"
+
+    _write_json(
+        optimised_dir / "anthropic_run01.json",
+        {
+            "model": "claude-opus-4-6",
+            "run": 1,
+            "arm": "optimised",
+            "classification": "report",
+            "turns": 3,
+            "narrative_chars": 8,
+            "total_cost_usd": 1.0,
+        },
+    )
+    (optimised_dir / "anthropic_run01.md").write_text(
+        "| Name | Fuel | Capacity | Status | COD | Province |\n"
+        "| --- | --- | --- | --- | --- | --- |\n"
+        "| B | Gas | 2 | Operating | 1984 | HN |\n",
+        encoding="utf-8",
+    )
+    probe_dir = optimised_dir / "probes" / "anthropic_run01"
+    probe_dir.mkdir(parents=True)
+    _write_json(probe_dir / "anthropic_turn_01.classification.json", {"class": "report"})
+    _write_json(probe_dir / "anthropic_turn_01.raw.json", {"content": [{"type": "text", "text": "| B | 2 |\n"}]})
+
+    _write_cross_eval_csv(
+        tmp_path / "sota_cross_eval.csv",
+        [
+            _score_row("naive", "claude-opus-4-6", 1),
+            _score_row("naive", "gpt-5.5", 1),
+            _score_row("naive", "mistral-large-2512", 1),
+            _score_row("optimised", "claude-opus-4-6", 1),
+        ],
+    )
+
+    records = build_exp2_mart(
+        naive_dir=output_dir,
+        optimised_dir=optimised_dir,
+        cross_eval_csv=tmp_path / "sota_cross_eval.csv",
+        repo_root=tmp_path,
+    )
+
+    run_records = [record for record in records if record.record_kind == "run" and record.arm == "naive"]
+    assert len(run_records) == 3

--- a/tickets/0298-extract-arm1-arm3-flat.erg
+++ b/tickets/0298-extract-arm1-arm3-flat.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: MVP extractor for single-turn arms (arm1, arm3) -> derived flat files
+Created: 2026-05-25
+Author: haduong
+Tag: needs-human
+
+--- log ---
+2026-05-25T11:30Z haduong created
+
+--- body ---
+## Context
+
+`build_exp2_mart.py` expects flat `{agent}_run{N}.json` + `{agent}_run{N}.md` files
+at the arm-directory level. The actual data lives in per-run subdirs:
+
+  sota_exp3_arm1_batch1/run{N}/{agent}.json   (metadata, ~200B)
+  sota_exp3_arm1_batch1/run{N}/{agent}.md     (verbatim output)
+
+arm3 is identical in structure, adds `evidence_pack_manifest` field in the JSON.
+
+## Goal
+
+Write `src/aedist/extract_arm_single_turn.py` -- a CLI module that:
+1. Walks `--input-dir` (e.g. `sota_exp3_arm1_batch1/`) across all `run{N}/` subdirs
+2. Writes to `--output-dir` (e.g. `experiments/derived/arm1_flat/`) per run×agent:
+   - `{agent}_run{N}.json`    normalized metadata (model, agent, run, classification,
+                               tokens_out, wall_s, cost_usd, classifier_cost_usd,
+                               narrative_chars, n_bib_entries, class_trace=[classification])
+   - `{agent}_run{N}.md`      verbatim output (copy of source .md)
+   - `{agent}_run{N}_bib.md`  bibliography section extracted from output (one bullet/line)
+
+## Notes
+
+- MVP only: no Mistral citation mapping, no table consolidation -- those are in 0292
+- `{agent}_run{N}.md` is a straight copy for now; table extraction deferred to 0292
+- Bibliography: split on a `## Sources`, `## References`, or `## Bibliography` heading;
+  strip numbering from lines; emit one bullet per entry
+- `n_bib_entries` = count of bullet lines written to `_bib.md`
+
+## Exit criteria
+
+- [ ] `uv run python -m aedist.extract_arm_single_turn --input-dir ... --output-dir ...` runs
+- [ ] Output dir contains correct files for all 5 runs × 4 agents = 20 triples
+- [ ] `build_exp2_mart.py` fed the output dir produces ≥ 20 run records
+- [ ] Unit test covers the bib extraction split


### PR DESCRIPTION
## Summary
- add a single-turn extractor that reconstructs per-run JSON, markdown, and bibliography artifacts from the raw provider payloads in arm1 and arm3 output trees
- support the payload variants currently present in repo data, including anthropic-direct messages, OpenAI-style output blocks, choices/message content, and assistant outputs arrays with either text-part lists or raw strings
- add focused tests that cover bibliography parsing and prove the flattened outputs remain compatible with the exp2 mart builder

## Why
The ticket assumption that per-agent markdown files already existed in the arm output directories was stale. The real source of truth is the raw provider payload JSON, so downstream analysis needs a normalization step that rebuilds the flat contract expected by the mart pipeline.

## Validation
- `uv run ruff check src/aedist/extract_arm_single_turn.py tests/test_extract_arm_single_turn.py`
- `uv run pytest tests/test_extract_arm_single_turn.py`
- real-data temp extraction for `experiments/outputs/sota_exp3_arm1_batch1` produced 60 artifacts
- real-data temp extraction for `experiments/outputs/sota_exp3_arm3_batch1` produced 60 artifacts
- repo commit hook also ran a broader pytest subset: `12 passed, 1642 deselected`

## Notes
- broader pipeline wiring in `experiments/analysis.mk` remains separate follow-on work
- arm2 multi-turn flattening remains ticket 0299 work

**Ticket:** tickets/0298-extract-arm1-arm3-flat.erg