### PR TITLE
polish(0298): header-level lstrip, sort_keys, parametrized bib tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ Thumbs.db
 
 # git-erg compiled binary
 tickets/tools/go/erg
+.aider*

--- a/src/aedist/extract_arm_single_turn.py
+++ b/src/aedist/extract_arm_single_turn.py
@@ -62,7 +62,8 @@ def _extract_markdown_from_payload(payload: dict) -> str:
             texts = [
                 part.get("text", "")
                 for part in parts
-                if part.get("type") in {"output_text", "text"} and isinstance(part.get("text"), str)
+                if part.get("type") in {"output_text", "text"}
+                and isinstance(part.get("text"), str)
             ]
             markdown = "".join(texts).strip()
             if markdown:
@@ -98,7 +99,7 @@ def _extract_bib_section(markdown: str) -> str:
         stripped = line.strip()
         if _BIB_HEADER_RE.match(stripped):
             start = index + 1
-            header_level = len(stripped.split()[0])
+            header_level = len(stripped) - len(stripped.lstrip("#"))
             break
 
     if start is None:
@@ -108,7 +109,7 @@ def _extract_bib_section(markdown: str) -> str:
     for line in lines[start:]:
         stripped = line.strip()
         if stripped.startswith("#"):
-            level = len(stripped.split()[0])
+            level = len(stripped) - len(stripped.lstrip("#"))
             if level <= header_level:
                 break
         section.append(line)
@@ -180,7 +181,9 @@ def flatten_single_turn_arm(input_dir: Path, output_dir: Path) -> list[Path]:
 
             normalized = dict(meta)
             normalized["run"] = run
-            normalized["class_trace"] = [meta.get("classification")] if meta.get("classification") else []
+            normalized["class_trace"] = (
+                [meta.get("classification")] if meta.get("classification") else []
+            )
             normalized["n_bib_entries"] = len(bib_entries)
 
             base_name = f"{agent}_run{run:02d}"
@@ -188,7 +191,9 @@ def flatten_single_turn_arm(input_dir: Path, output_dir: Path) -> list[Path]:
             md_path = output_dir / f"{base_name}.md"
             bib_path = output_dir / f"{base_name}_bib.md"
 
-            _write_text(json_path, json.dumps(normalized, indent=2, ensure_ascii=False))
+            _write_text(
+                json_path, json.dumps(normalized, indent=2, sort_keys=True, ensure_ascii=False)
+            )
             _write_text(md_path, markdown)
             bib_content = "\n".join(f"- {entry}" for entry in bib_entries)
             _write_text(bib_path, bib_content)
@@ -198,7 +203,9 @@ def flatten_single_turn_arm(input_dir: Path, output_dir: Path) -> list[Path]:
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Flatten single-turn arm outputs into per-run artifacts")
+    parser = argparse.ArgumentParser(
+        description="Flatten single-turn arm outputs into per-run artifacts"
+    )
     parser.add_argument("--input-dir", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path, required=True)
     args = parser.parse_args(argv)

--- a/tests/test_extract_arm_single_turn.py
+++ b/tests/test_extract_arm_single_turn.py
@@ -1,6 +1,8 @@
 import csv
 import json
 
+import pytest
+
 from aedist.build_exp2_mart import build_exp2_mart
 from aedist.extract_arm_single_turn import (
     _extract_bibliography_entries,
@@ -57,24 +59,32 @@ def _score_row(arm, model, run):
     }
 
 
-def test_extract_bibliography_entries_supports_sources_heading():
-    markdown = """# Report
+@pytest.mark.parametrize(
+    "heading",
+    ["## Sources", "## References", "## Bibliography", "## Annotated Bibliography"],
+)
+def test_extract_bibliography_entries_heading_variants(heading):
+    markdown = f"""# Report
 
-## Sources
+{heading}
 
-**[1]** First source title.
-Continuation line.
+**[1]** First source.
 
-2. Second source title.
+2. Second source.
 
 ## Next Section
 Ignored.
 """
+    assert _extract_bibliography_entries(markdown) == ["First source.", "Second source."]
 
-    assert _extract_bibliography_entries(markdown) == [
-        "First source title. Continuation line.",
-        "Second source title.",
-    ]
+
+def test_extract_bibliography_entries_empty_section():
+    markdown = "# Report\n\n## Sources\n\n## Next Section\nText.\n"
+    assert _extract_bibliography_entries(markdown) == []
+
+
+def test_extract_bibliography_entries_no_section():
+    assert _extract_bibliography_entries("Just a table.\n| A | B |\n") == []
 
 
 def test_flatten_single_turn_arm_outputs_mart_compatible_files(tmp_path):
@@ -168,7 +178,10 @@ def test_flatten_single_turn_arm_outputs_mart_compatible_files(tmp_path):
                 {
                     "role": "assistant",
                     "content": [
-                        {"type": "text", "text": "| A | B |\n|---|---|\n| m | n |\n\n## References\n\n- Mistral source."},
+                        {
+                            "type": "text",
+                            "text": "| A | B |\n|---|---|\n| m | n |\n\n## References\n\n- Mistral source.",
+                        },
                         {"type": "tool_reference", "url": "https://example.com"},
                     ],
                 }
@@ -182,8 +195,12 @@ def test_flatten_single_turn_arm_outputs_mart_compatible_files(tmp_path):
     anthropic_meta = json.loads((output_dir / "anthropic_run01.json").read_text(encoding="utf-8"))
     assert anthropic_meta["class_trace"] == ["report"]
     assert anthropic_meta["n_bib_entries"] == 1
-    assert (output_dir / "anthropic_run01_bib.md").read_text(encoding="utf-8") == "- Anthropic source.\n"
-    assert (output_dir / "mistral_run01_bib.md").read_text(encoding="utf-8") == "- Mistral source.\n"
+    assert (output_dir / "anthropic_run01_bib.md").read_text(
+        encoding="utf-8"
+    ) == "- Anthropic source.\n"
+    assert (output_dir / "mistral_run01_bib.md").read_text(
+        encoding="utf-8"
+    ) == "- Mistral source.\n"
     assert (output_dir / "openai_run01_bib.md").read_text(encoding="utf-8") == "- OpenAI source.\n"
 
     _write_json(
@@ -207,7 +224,10 @@ def test_flatten_single_turn_arm_outputs_mart_compatible_files(tmp_path):
     probe_dir = optimised_dir / "probes" / "anthropic_run01"
     probe_dir.mkdir(parents=True)
     _write_json(probe_dir / "anthropic_turn_01.classification.json", {"class": "report"})
-    _write_json(probe_dir / "anthropic_turn_01.raw.json", {"content": [{"type": "text", "text": "| B | 2 |\n"}]})
+    _write_json(
+        probe_dir / "anthropic_turn_01.raw.json",
+        {"content": [{"type": "text", "text": "| B | 2 |\n"}]},
+    )
 
     _write_cross_eval_csv(
         tmp_path / "sota_cross_eval.csv",
@@ -226,5 +246,7 @@ def test_flatten_single_turn_arm_outputs_mart_compatible_files(tmp_path):
         repo_root=tmp_path,
     )
 
-    run_records = [record for record in records if record.record_kind == "run" and record.arm == "naive"]
+    run_records = [
+        record for record in records if record.record_kind == "run" and record.arm == "naive"
+    ]
     assert len(run_records) == 3


### PR DESCRIPTION
Three small fixes identified in post-merge review of #531:

- `lstrip('#')` for correct header level counting (was `split()[0]`)
- `sort_keys=True` on `json.dumps` for stable diffs
- Parametrized bib heading test covering all 4 variants; empty section and no-section cases added

🤖 Generated with [Claude Code](https://claude.com/claude-code)