### PR TITLE
ticket(0299): extract arm2 multi-turn outputs

### DIFF
--- a/src/aedist/extract_arm_multi_turn.py
+++ b/src/aedist/extract_arm_multi_turn.py
@@ -1,0 +1,197 @@
+"""CLI module to extract multi-turn arm2 outputs into flat files.
+
+Walks an input directory shaped like::
+
+    sota_exp3_arm2_batch1/
+      run01/
+        summary.json
+        {agent}_run01/
+          {agent}_turn_01.record.json
+          {agent}_turn_02.record.json
+          ...
+
+and writes per-run×agent flat files into the output directory::
+
+    {agent}_run{N}.json   – normalized metadata
+    {agent}_run{N}.md     – verbatim model text from the last turn
+    {agent}_run{N}_bib.md – bibliography section extracted from that text
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_BIB_HEADING_RE = re.compile(
+    r"^(#{1,3}\s*(?:Annotated\s+)?Bibliography"
+    r"|#{1,3}\s*Sources"
+    r"|#{1,3}\s*References)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_TURN_RE = re.compile(r"_turn_(\d+)\.record\.json$")
+
+
+def extract_agent_name(dir_name: str) -> str:
+    """Derive the agent slug from a subdirectory like ``anthropic_run01``."""
+    return re.sub(r"_run\d+$", "", dir_name)
+
+
+def find_last_turn(agent_dir: Path) -> Path | None:
+    """Return the path to the highest-numbered turn record in *agent_dir*."""
+    candidates: list[tuple[int, Path]] = []
+    for path in agent_dir.glob("*_turn_*.record.json"):
+        match = _TURN_RE.search(path.name)
+        if match:
+            candidates.append((int(match.group(1)), path))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0])
+    return candidates[-1][1]
+
+
+def extract_output_text(record: dict[str, Any]) -> str:
+    """Pull the model's text response out of a record JSON."""
+    for key in ("output", "text", "content", "response"):
+        value = record.get(key)
+        if isinstance(value, str):
+            return value
+    justification = record.get("justification")
+    if isinstance(justification, dict):
+        text = justification.get("output_text")
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def extract_bibliography(text: str) -> tuple[str | None, int]:
+    """Split bibliography section from report text.
+
+    Returns ``(bib_text, n_entries)``.  *bib_text* is ``None`` when no
+    recognised heading is found.
+    """
+    match = _BIB_HEADING_RE.search(text)
+    if not match:
+        return None, 0
+
+    bib_text = text[match.start() :].strip()
+    lines = bib_text.splitlines()
+
+    # Count lines that look like list items (numbered or bulleted)
+    entries = 0
+    for line in lines[1:]:  # skip the heading itself
+        if re.match(r"^\s*(?:\d+\.|[-*])\s", line):
+            entries += 1
+
+    # Fallback: if no list markers, count non-empty lines after the heading
+    if entries == 0:
+        entries = sum(1 for line in lines[1:] if line.strip())
+
+    return bib_text, entries
+
+
+def process_batch(input_dir: Path, output_dir: Path) -> None:
+    """Transform one arm2 batch tree into flat files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for run_dir in sorted(input_dir.glob("run*")):
+        if not run_dir.is_dir():
+            continue
+
+        run_match = re.match(r"run(\d+)", run_dir.name, re.IGNORECASE)
+        if not run_match:
+            continue
+        run_num = int(run_match.group(1))
+
+        summary_path = run_dir / "summary.json"
+        if not summary_path.exists():
+            continue
+        with summary_path.open(encoding="utf-8") as fh:
+            summaries: list[dict[str, Any]] = json.load(fh)
+
+        for entry in summaries:
+            if entry.get("status") != "pass":
+                continue
+
+            agent: str = entry["agent"]
+
+            # Locate the agent subdirectory (e.g. anthropic_run01)
+            agent_dirs = [
+                d
+                for d in run_dir.iterdir()
+                if d.is_dir() and extract_agent_name(d.name) == agent
+            ]
+            if not agent_dirs:
+                continue
+            agent_dir = agent_dirs[0]
+
+            last_turn_path = find_last_turn(agent_dir)
+            if last_turn_path is None:
+                continue
+
+            with last_turn_path.open(encoding="utf-8") as fh:
+                record = json.load(fh)
+
+            text = extract_output_text(record)
+            bib_text, n_bib = extract_bibliography(text)
+
+            model: str | None = None
+            method_params = record.get("method_params")
+            if isinstance(method_params, dict):
+                model = method_params.get("model")
+
+            raw_trace = entry.get("class_trace")
+            class_trace: list[str] = []
+            if isinstance(raw_trace, str) and raw_trace:
+                class_trace = [s.strip() for s in raw_trace.split(",") if s.strip()]
+
+            metadata = {
+                "agent": agent,
+                "model": model,
+                "run": run_num,
+                "classification": entry.get("status"),
+                "total_cost_usd": entry.get("total_cost_usd"),
+                "wall_s": entry.get("wall_s"),
+                "turns": entry.get("turns"),
+                "class_trace": class_trace,
+                "n_rows": entry.get("inventory_rows"),
+                "n_bib_entries": n_bib,
+            }
+
+            base_name = f"{agent}_run{run_num:02d}"
+            (output_dir / f"{base_name}.json").write_text(
+                json.dumps(metadata, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            (output_dir / f"{base_name}.md").write_text(text, encoding="utf-8")
+            (output_dir / f"{base_name}_bib.md").write_text(
+                bib_text if bib_text is not None else "",
+                encoding="utf-8",
+            )
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract arm2 multi-turn outputs into flat files."
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Root directory containing run{N}/ subdirectories.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory where flat files will be written.",
+    )
+    args = parser.parse_args(argv)
+    process_batch(args.input_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extract_arm_multi_turn.py
+++ b/tests/test_extract_arm_multi_turn.py
@@ -1,0 +1,206 @@
+"""Tests for extract_arm_multi_turn."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aedist.extract_arm_multi_turn import (
+    extract_agent_name,
+    extract_bibliography,
+    extract_output_text,
+    find_last_turn,
+    process_batch,
+)
+
+
+def test_extract_agent_name() -> None:
+    assert extract_agent_name("anthropic_run01") == "anthropic"
+    assert extract_agent_name("mistral_run10") == "mistral"
+    assert extract_agent_name("openai_run02") == "openai"
+
+
+def test_find_last_turn_uses_highest_number_not_alphabetic(tmp_path: Path) -> None:
+    """Alphabetic sort would place turn_10 before turn_2; numeric sort must win."""
+    agent_dir = tmp_path / "testagent_run01"
+    agent_dir.mkdir()
+
+    (agent_dir / "testagent_turn_01.record.json").write_text('{"output": "t1"}')
+    (agent_dir / "testagent_turn_02.record.json").write_text('{"output": "t2"}')
+    (agent_dir / "testagent_turn_10.record.json").write_text('{"output": "t10"}')
+
+    last = find_last_turn(agent_dir)
+    assert last is not None
+    assert last.name == "testagent_turn_10.record.json"
+
+
+def test_class_trace_split_into_list(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    run_dir = input_dir / "run01"
+    agent_dir = run_dir / "testagent_run01"
+    agent_dir.mkdir(parents=True)
+
+    summary = [
+        {
+            "agent": "testagent",
+            "status": "pass",
+            "total_cost_usd": 1.0,
+            "wall_s": 10.0,
+            "turns": 2,
+            "class_trace": "no_report,report",
+            "inventory_rows": 5,
+        }
+    ]
+    (run_dir / "summary.json").write_text(json.dumps(summary))
+
+    record = {"output": "hello world", "method_params": {"model": "gpt-4"}}
+    (agent_dir / "testagent_turn_01.record.json").write_text(json.dumps(record))
+
+    process_batch(input_dir, output_dir)
+
+    meta_path = output_dir / "testagent_run01.json"
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text())
+    assert meta["class_trace"] == ["no_report", "report"]
+
+
+def test_bib_extraction_with_sources_heading(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    run_dir = input_dir / "run01"
+    agent_dir = run_dir / "testagent_run01"
+    agent_dir.mkdir(parents=True)
+
+    summary = [
+        {
+            "agent": "testagent",
+            "status": "pass",
+            "total_cost_usd": 1.0,
+            "wall_s": 5.0,
+            "turns": 1,
+            "class_trace": "report",
+            "inventory_rows": 3,
+        }
+    ]
+    (run_dir / "summary.json").write_text(json.dumps(summary))
+
+    text = (
+        "# Report\n\nSome prose here.\n\n"
+        "## Sources\n\n"
+        "1. Foo et al.\n"
+        "2. Bar et al.\n\n"
+        "End of doc.\n"
+    )
+    record = {"output": text, "method_params": {"model": "gpt-4"}}
+    (agent_dir / "testagent_turn_01.record.json").write_text(json.dumps(record))
+
+    process_batch(input_dir, output_dir)
+
+    bib_path = output_dir / "testagent_run01_bib.md"
+    assert bib_path.exists()
+    bib_content = bib_path.read_text()
+    assert "## Sources" in bib_content
+    assert "1. Foo et al." in bib_content
+    assert "2. Bar et al." in bib_content
+
+    meta = json.loads((output_dir / "testagent_run01.json").read_text())
+    assert meta["n_bib_entries"] == 2
+
+
+def test_skip_error_status_silently(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    run_dir = input_dir / "run01"
+    run_dir.mkdir(parents=True)
+
+    summary = [
+        {
+            "agent": "goodagent",
+            "status": "pass",
+            "total_cost_usd": 1.0,
+            "wall_s": 10.0,
+            "turns": 1,
+            "class_trace": "report",
+            "inventory_rows": 5,
+        },
+        {
+            "agent": "badagent",
+            "status": "error",
+            "total_cost_usd": 0.0,
+            "wall_s": 0.0,
+            "turns": 0,
+            "class_trace": "",
+            "inventory_rows": 0,
+        },
+    ]
+    (run_dir / "summary.json").write_text(json.dumps(summary))
+
+    good_dir = run_dir / "goodagent_run01"
+    good_dir.mkdir()
+    (good_dir / "goodagent_turn_01.record.json").write_text(
+        json.dumps({"output": "ok", "method_params": {"model": "gpt-4"}})
+    )
+
+    bad_dir = run_dir / "badagent_run01"
+    bad_dir.mkdir()
+    (bad_dir / "badagent_turn_01.record.json").write_text(
+        json.dumps({"output": "fail", "method_params": {"model": "gpt-4"}})
+    )
+
+    process_batch(input_dir, output_dir)
+
+    assert (output_dir / "goodagent_run01.json").exists()
+    assert (output_dir / "goodagent_run01.md").exists()
+    assert not (output_dir / "badagent_run01.json").exists()
+    assert not (output_dir / "badagent_run01.md").exists()
+
+
+def test_model_extracted_from_record(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    run_dir = input_dir / "run01"
+    agent_dir = run_dir / "testagent_run01"
+    agent_dir.mkdir(parents=True)
+
+    summary = [
+        {
+            "agent": "testagent",
+            "status": "pass",
+            "total_cost_usd": 1.0,
+            "wall_s": 1.0,
+            "turns": 1,
+            "class_trace": "report",
+            "inventory_rows": 1,
+        }
+    ]
+    (run_dir / "summary.json").write_text(json.dumps(summary))
+
+    record = {
+        "justification": {"output_text": "report text"},
+        "method_params": {"model": "claude-opus-4-6"},
+    }
+    (agent_dir / "testagent_turn_01.record.json").write_text(json.dumps(record))
+
+    process_batch(input_dir, output_dir)
+
+    meta = json.loads((output_dir / "testagent_run01.json").read_text())
+    assert meta["model"] == "claude-opus-4-6"
+    assert (output_dir / "testagent_run01.md").read_text() == "report text"
+
+
+def test_extract_output_text_fallbacks() -> None:
+    assert extract_output_text({"output": "out"}) == "out"
+    assert extract_output_text({"text": "txt"}) == "txt"
+    assert extract_output_text({"content": "cnt"}) == "cnt"
+    assert extract_output_text({"response": "resp"}) == "resp"
+    assert extract_output_text({"justification": {"output_text": "jtxt"}}) == "jtxt"
+    assert extract_output_text({"other": "x"}) == ""
+
+
+def test_extract_bibliography_no_heading() -> None:
+    text, n = extract_bibliography("just some text")
+    assert text is None
+    assert n == 0

--- a/tickets/0298-extract-arm1-arm3-flat.erg
+++ b/tickets/0298-extract-arm1-arm3-flat.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: MVP extractor for single-turn arms (arm1, arm3) → derived flat files
+Created: 2026-05-25
+Author: haduong
+Tag: needs-human
+
+--- log ---
+2026-05-25T11:30Z haduong created
+
+--- body ---
+## Context
+
+`build_exp2_mart.py` expects flat `{agent}_run{N}.json` + `{agent}_run{N}.md` files
+at the arm-directory level. The actual data lives in per-run subdirs:
+
+  sota_exp3_arm1_batch1/run{N}/{agent}.json   (metadata, ~200B)
+  sota_exp3_arm1_batch1/run{N}/{agent}.md     (verbatim output)
+
+arm3 is identical in structure, adds `evidence_pack_manifest` field in the JSON.
+
+## Goal
+
+Write `src/aedist/extract_arm_single_turn.py` — a CLI module that:
+1. Walks `--input-dir` (e.g. `sota_exp3_arm1_batch1/`) across all `run{N}/` subdirs
+2. Writes to `--output-dir` (e.g. `experiments/derived/arm1_flat/`) per run×agent:
+   - `{agent}_run{N}.json`    normalized metadata (model, agent, run, classification,
+                               tokens_out, wall_s, cost_usd, classifier_cost_usd,
+                               narrative_chars, n_bib_entries, class_trace=[classification])
+   - `{agent}_run{N}.md`      verbatim output (copy of source .md)
+   - `{agent}_run{N}_bib.md`  bibliography section extracted from output (one bullet/line)
+
+## Notes
+
+- MVP only: no Mistral citation mapping, no table consolidation — those are in 0292
+- `{agent}_run{N}.md` is a straight copy for now; table extraction deferred to 0292
+- Bibliography: split on a `## Sources`, `## References`, or `## Bibliography` heading;
+  strip numbering from lines; emit one bullet per entry
+- `n_bib_entries` = count of bullet lines written to `_bib.md`
+
+## Exit criteria
+
+- [ ] `uv run python -m aedist.extract_arm_single_turn --input-dir ... --output-dir ...` runs
+- [ ] Output dir contains correct files for all 5 runs × 4 agents = 20 triples
+- [ ] `build_exp2_mart.py` fed the output dir produces ≥ 20 run records
+- [ ] Unit test covers the bib extraction split

--- a/tickets/0299-extract-arm2-flat.erg
+++ b/tickets/0299-extract-arm2-flat.erg
@@ -1,0 +1,54 @@
+%erg 0.1
+Title: MVP extractor for multi-turn arm2 → derived flat files
+Created: 2026-05-25
+Author: haduong
+Tag: needs-human
+
+--- log ---
+2026-05-25T11:30Z haduong created
+
+--- body ---
+## Context
+
+arm2 (`sota_exp3_arm2_batch1/`) has per-run nested dirs:
+
+  run{N}/
+    summary.json                         top-level per-agent stats
+    {agent}_run01/
+      {agent}_turn_01.record.json        per-turn record (contains model output text)
+      {agent}_turn_02.record.json
+      ...
+      {agent}_turn_0T.record.json        T = last turn (varies per agent/run)
+
+The last turn's record.json holds the final inventory output.
+`summary.json` has: agent, status, total_cost_usd, wall_s, turns, class_trace, inventory_rows.
+
+## Goal
+
+Write `src/aedist/extract_arm_multi_turn.py` — a CLI module that:
+1. Walks `--input-dir` (e.g. `sota_exp3_arm2_batch1/`) across all `run{N}/` subdirs
+2. Identifies last turn per agent by highest turn number in `{agent}_turn_*.record.json`
+3. Writes to `--output-dir` (e.g. `experiments/derived/arm2_flat/`) per run×agent:
+   - `{agent}_run{N}.json`    normalized metadata (model, agent, run, status→classification,
+                               total_cost_usd, wall_s, turns, class_trace as list,
+                               inventory_rows→n_rows, n_bib_entries)
+   - `{agent}_run{N}.md`      verbatim text from last turn's record.json (`output` field or equivalent)
+   - `{agent}_run{N}_bib.md`  bibliography extracted from that output (same rules as 0298)
+
+## Finding the output text in record.json
+
+Inspect `anthropic_turn_04.record.json` to find the field name holding the model's
+text response. Likely `output`, `text`, `content`, or `response`.
+
+## Notes
+
+- Only `status=pass` entries should be emitted; skip `status=error` silently
+- `class_trace` in summary.json is a comma-separated string — split to list
+- agent name is derived from the subdir name `{agent}_run01` → strip `_run01`
+
+## Exit criteria
+
+- [ ] Runs cleanly on `sota_exp3_arm2_batch1/`
+- [ ] Produces 20 triples (4 agents × 5 runs, all pass)
+- [ ] `build_exp2_mart.py` fed the output dir produces ≥ 20 run records
+- [ ] Unit test: last-turn detection picks highest turn number, not alphabetic sort

--- a/tickets/0300-wire-analysis-pipeline-produce-figures.erg
+++ b/tickets/0300-wire-analysis-pipeline-produce-figures.erg
@@ -1,0 +1,56 @@
+%erg 0.1
+Title: Wire analysis.mk end-to-end and produce talk figures
+Created: 2026-05-25
+Author: haduong
+Blocked-by: 0298
+Blocked-by: 0299
+
+--- log ---
+2026-05-25T11:30Z haduong created
+
+--- body ---
+## Context
+
+Once 0298 and 0299 produce flat derived files, `analysis.mk` needs its default
+paths updated and the full pipeline run to produce PDF figures for the talk.
+
+Current wrong defaults in `analysis.mk`:
+  ANALYSIS_EXP2_NAIVE_DIR    ?= experiments/outputs/sota_exp2_naive_arm   ← does not exist
+  ANALYSIS_EXP2_OPTIMISED_DIR ?= experiments/outputs/sota_exp2_brerun1    ← does not exist
+
+Correct defaults (after 0298/0299):
+  ANALYSIS_EXP2_NAIVE_DIR    ?= experiments/derived/arm1_flat
+  ANALYSIS_EXP2_OPTIMISED_DIR ?= experiments/derived/arm2_flat
+
+## Goal
+
+1. Update the two defaults in `analysis.mk`
+2. Add Make targets for the extraction steps:
+   ```makefile
+   experiments/derived/arm1_flat/.done: $(wildcard experiments/outputs/sota_exp3_arm1_batch1/run*/*.json)
+       uv run python -m aedist.extract_arm_single_turn \
+           --input-dir experiments/outputs/sota_exp3_arm1_batch1 \
+           --output-dir experiments/derived/arm1_flat
+       touch $@
+
+   experiments/derived/arm2_flat/.done: $(wildcard experiments/outputs/sota_exp3_arm2_batch1/run*/summary.json)
+       uv run python -m aedist.extract_arm_multi_turn \
+           --input-dir experiments/outputs/sota_exp3_arm2_batch1 \
+           --output-dir experiments/derived/arm2_flat
+       touch $@
+   ```
+3. Add `.done` stamps as prerequisites to `$(ANALYSIS_EXP2_MART_JSONL)`
+4. Run `make -f experiments/analysis.mk exp2-analysis-report` and verify all
+   PDF figures are produced without errors
+
+## Exit criteria
+
+- [ ] `analysis.mk` defaults point at `experiments/derived/arm{1,2}_flat`
+- [ ] Extraction stamp targets added and wired as prerequisites
+- [ ] `make -f experiments/analysis.mk exp2-analysis-report` completes cleanly
+- [ ] The following PDFs exist and are non-empty:
+      `report/inputs/generated/fig_exp2_arms_comparison.pdf`
+      `report/inputs/generated/fig_exp2_turn_trajectory.pdf`
+      `report/inputs/generated/fig_exp2_coverage_certainty.pdf`
+      `report/inputs/generated/fig_quality_spider.pdf`
+- [ ] Mart contains ≥ 40 run records (4 agents × 5 runs × 2 arms)


### PR DESCRIPTION
## Summary

Implements `src/aedist/extract_arm_multi_turn.py` per ticket 0299:

- Walks `sota_exp3_arm2_batch1/run{N}/` subdirs, reads `summary.json` + last-turn `record.json`
- Writes `{agent}_run{N}.json` + `.md` + `_bib.md` to `--output-dir`
- Last-turn detection uses numeric sort (not alphabetic) — turn_10 > turn_2
- `status=error` entries skipped silently
- `class_trace` split from comma-separated string to list
- Output filenames match `build_exp2_mart.py`'s `_RUN_RE`

Verified on real data: 20 triples (4 agents × 5 runs, all pass).

**Ticket:** tickets/0299-extract-arm2-flat.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code) / aider (moonshotai/kimi-k2.6)