### PR TITLE
chore(tickets): open 0302–0311 — analysis figures wave

### DIFF
--- a/tickets/0302-lp-matcher-llm-validation.erg
+++ b/tickets/0302-lp-matcher-llm-validation.erg
@@ -1,0 +1,60 @@
+%erg 0.1
+Title: LP matcher LLM validation — fixture tests + Sonnet 4.6 bug hunt
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The LP matcher assigns model-generated plant names to the 163-plant gold
+reference via string similarity + capacity weight. Exp 1 results show
+claude-sonnet-4-6 achieving implausibly high match counts on a run known
+to hallucinate. This points at a method bug: either the LP matcher is
+over-matching (accepting false positives), or the "no hallucinations"
+verdict is computed incorrectly.
+
+We need LLM-based spot-checking to build trust in the matcher's verdicts
+before presenting Exp 1 figures publicly.
+
+## Scope
+
+1. **Fixture tests.** Write parametrised pytest cases covering:
+   - True positive: model name is a known alias for a reference plant
+     (e.g. "Nhiet dien Duyen Hai 1" → "Nhiệt điện Duyên Hải 1")
+   - True negative: model name has no plausible reference match
+     (hallucinated plant, correct fuel/province but non-existent name)
+   - Near-miss: same province + fuel + plausible capacity but wrong name
+   - Duplicate: two model rows mapping to the same reference row (only
+     one should be accepted)
+   Each fixture includes expected match verdict (matched / unmatched) and
+   the minimum similarity score threshold under which it should flip.
+
+2. **Sonnet 4.6 case investigation.** For the suspicious run, produce a
+   diff table: reference plant ↔ matched model row ↔ similarity score ↔
+   capacity difference. Flag every match where similarity < 80 OR
+   capacity_diff_pct > 30. Output as `experiments/derived/sonnet46_match_audit.csv`.
+
+3. **LLM adjudication sample.** For 20 randomly-sampled matched pairs
+   (across all Exp 1 models, seed=42), prompt a cheap LLM judge
+   (mistral-small-latest) with: "Is this a genuine match? Answer yes/no
+   and one sentence." Record judgements in
+   `experiments/derived/lp_matcher_llm_sample.csv`. Report agreement rate.
+
+## Notes
+
+- Do NOT change the LP matcher itself unless the audit finds a clear bug.
+  File a child ticket for any matcher change.
+- Provenance spot-check of URLs is out of scope here (ticket 0281 handles
+  that post-conference).
+
+## Exit criteria
+
+- [ ] Fixture tests in `tests/test_lp_matcher_validation.py` — all pass
+- [ ] `experiments/derived/sonnet46_match_audit.csv` written and reviewed;
+      any bug found is documented in the log, child ticket filed if fix needed
+- [ ] `experiments/derived/lp_matcher_llm_sample.csv` with ≥ 20 rows,
+      agreement rate ≥ 80% OR known bugs filed
+- [ ] `make check-fast` passes

--- a/tickets/0303-score-exp1-all-quality-axes.erg
+++ b/tickets/0303-score-exp1-all-quality-axes.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Score Exp 1 outputs on all 8 quality axes
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`score_mechanical.py` already computes all 8 quality axes (accuracy
+coverage/precision/fuel/status/province, coherence, provenance-structural,
+temporality) from a list of canonical CSV rows. The `score_ingest.py`
+pipeline resolves those rows for Exp 2 arms via RunLocator. Exp 1 outputs
+are flat CSVs in `experiments/outputs/exp1_batch2/{model}-run{N}.csv` and
+need no ingestion — they are already in canonical form.
+
+The prompt for Exp 1 was aligned to request source_1, source_2, and
+status_as_of columns. Those columns are present in the CSVs. Therefore
+the full 8-axis profile can be computed for every Exp 1 run at no
+additional API cost; this unlocks the Exp 1 spider figure (ticket 0306).
+
+## Design
+
+Write `src/aedist/score_exp1.py`:
+- Accept `--input-dir experiments/outputs/exp1_batch2` and
+  `--output experiments/derived/exp1_cross_eval.csv`
+- For each `{model}-run{N}.csv` file in input-dir:
+  - Parse model name and run number from the filename stem
+  - Load rows via `csv.DictReader`
+  - Call `score_accuracy`, `score_coherence`, `score_provenance_structural`,
+    `score_temporality`, `score_field_completeness` from `score_mechanical`
+  - Emit one row to the output CSV with columns matching `sota_cross_eval.csv`
+    schema (arm="parametric", model, run, plus all score columns)
+- Append to `exp1_cross_eval.csv` (do not clobber)
+- Wire into `analysis.mk` as a stamp target depending on all
+  `experiments/outputs/exp1_batch2/*.csv`
+
+The output schema must be compatible with `sota_cross_eval.csv` so the
+spider figure can load both files with identical code.
+
+## Exit criteria
+
+- [ ] `src/aedist/score_exp1.py` implemented and tested
+- [ ] `experiments/derived/exp1_cross_eval.csv` produced; spot-check
+      ≥ 3 rows manually against source CSVs
+- [ ] Schema matches `sota_cross_eval.csv` column for column
+- [ ] `analysis.mk` target wired
+- [ ] `make check-fast` passes

--- a/tickets/0304-arm3-arm4-extractors.erg
+++ b/tickets/0304-arm3-arm4-extractors.erg
@@ -1,0 +1,68 @@
+%erg 0.1
+Title: Extractors for arm 3 and arm 4 flat artifacts
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The arms comparison figure (ticket 0305) and the Exp 2 4-way spider
+(ticket 0311) need flat artifacts for all four arms. arm1_flat/ and
+arm2_flat/ already exist. arm3 (web + evidence pack, single-turn) and
+arm4 (web + evidence pack, multi-turn) have raw data under
+`experiments/outputs/sota_exp3_arm3_batch1/` and
+`experiments/outputs/sota_exp3_arm4_batch1/` but no extractors.
+
+arm3 directory layout:
+  run{N}/
+    {agent}.json   — metadata (has evidence_pack_manifest key)
+    {agent}.md     — narrative report (pre-extracted)
+    {agent}-direct-*.json  — raw API payload (large)
+
+arm4 directory layout:
+  run{N}/
+    {agent}_run{N}/   — per-agent per-run subdir
+      {agent}_turn_*.raw.json   — multi-turn conversation
+      {agent}_turn_*.classification.json
+      ...
+
+arm3 is structurally similar to arm1 (single-turn); the existing
+`extract_arm_single_turn.flatten_single_turn_arm` should work with
+path adaptation since the markdown is already extracted as `{agent}.md`.
+
+arm4 is structurally similar to arm2 (multi-turn); the existing
+`extract_arm_multi_turn` should work with path adaptation.
+
+## Scope
+
+1. Adapt or extend `extract_arm_single_turn.py` to handle arm3's layout:
+   - Fallback: when no raw payload found, read `{agent}.md` directly
+   - Preserve `evidence_pack_manifest` metadata field in output JSON
+
+2. Adapt or extend `extract_arm_multi_turn.py` for arm4's layout:
+   - The per-agent subdir is named `{agent}_run{N}` (not just `{agent}`)
+   - Fix `inventory_rows: 0` bug: arm4 `summary.json` has `inventory_rows`
+     field but it is always 0 — the extractor must count rows from the
+     extracted markdown table, not trust summary.json
+
+3. Add `analysis.mk` stamp targets:
+   - `$(ANALYSIS_DERIVED_DIR)/arm3_flat/.done`
+   - `$(ANALYSIS_DERIVED_DIR)/arm4_flat/.done`
+
+4. Also score arm1 remaining models: `sota_cross_eval.csv` currently has
+   only `naive, gpt-5.5, run 1`. Run `score_mechanical.py` for all
+   remaining arm1 models (anthropic, mistral, qwen, runs 1-5). Fix the
+   hardcoded path in `score_ingest.py` (`sota_exp2_naive_arm` →
+   `sota_exp3_arm1_batch1`) before running.
+
+## Exit criteria
+
+- [ ] `experiments/derived/arm3_flat/` populated (≥ 4 agents × 5 runs)
+- [ ] `experiments/derived/arm4_flat/` populated with correct `inventory_rows`
+      (not all zeros)
+- [ ] `sota_cross_eval.csv` has rows for all 4 arm1 agents × runs
+- [ ] `analysis.mk` stamp targets in place
+- [ ] `make check-fast` passes

--- a/tickets/0305-arms-comparison-figure-redesign.erg
+++ b/tickets/0305-arms-comparison-figure-redesign.erg
@@ -1,0 +1,47 @@
+%erg 0.1
+Title: fig_exp2_arms_comparison — 4-arm redesign
+Created: 2026-05-25
+Author: HDMX-coding-agent
+Blocked-by: 0304
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The current `plot_exp2_arms_comparison.py` shows two arms (naive /
+optimised, i.e. arm1 / arm2) in a 3-panel layout (A coverage, B output
+richness, C cost). The experiment has four arms:
+
+  arm1 — web, single-shot (naive)
+  arm2 — web, multi-turn (optimised)
+  arm3 — web + evidence pack, single-shot
+  arm4 — web + evidence pack, multi-turn
+
+Changes requested:
+- Show all four arms
+- Drop panel B (output richness — narrative_chars)
+- Add horizontal reference line at 163 (N_REFERENCE_PLANTS, dashed green)
+- Zeroes from arm4 are extractor failures (fixed by 0304); render
+  no_report runs as × markers at y=0 as before, but do not show genuine
+  zeros as × unless classification == "no_report"
+- Per-model colour from `model_family_color()` (not per-arm colour)
+- Glyph encodes arm: ○ single-shot/direct, ◇ multi-turn;
+  fill encodes evidence pack: open = no pack, filled = with pack
+
+Resulting layout: 2 panels (A coverage, B cost), 4 agent groups × 4
+arm columns each. Or — if 4×4 is too busy — one panel per arm
+(2×2 grid) showing per-agent coverage + cost as two y-axes.
+Use whichever layout is clearer; favour the one that makes the
+"datapack lifts all models to 163" claim immediately visible.
+
+## Exit criteria
+
+- [ ] Figure shows all 4 arms, all 4 agents
+- [ ] No panel B (output richness)
+- [ ] 163 reference line visible on the coverage panel
+- [ ] Glyph + fill correctly encode arm type (single/multi × pack/no-pack)
+- [ ] Per-model colour from palette (no ARM_NAIVE / ARM_OPTIMISED colours)
+- [ ] `make check-fast` passes
+- [ ] Figure committed to `report/inputs/generated/`

--- a/tickets/0306-spider-exp1-family-panels.erg
+++ b/tickets/0306-spider-exp1-family-panels.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Spider — Exp 1 quality profiles, 4-panel by model family
+Created: 2026-05-25
+Author: HDMX-coding-agent
+Blocked-by: 0303
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Once ticket 0303 produces `experiments/derived/exp1_cross_eval.csv` with
+all 8 axes for all Exp 1 models, we can render a quality spider showing
+the parametric ceiling visually. The expected shape: high accuracy arcs
+(matching Exp 1 F1 results) but near-zero provenance and temporality arcs
+(models cite from memory, cannot produce real URLs). This contrast is the
+§2 quality-bar argument made visual.
+
+## Design
+
+New script `plot_quality_spider_exp1.py` (or extend
+`plot_quality_spider.py` with a `--mode exp1` flag — prefer the latter
+to avoid code duplication).
+
+Layout: 4 panels in a 2×2 grid, one per model family:
+  (a) Claude   — haiku-4.5, sonnet-4.6, opus-4.6
+  (b) GPT      — gpt-4o, gpt-4o-mini, gpt-5.5, gpt-oss-*
+  (c) Mistral  — small, medium, large
+  (d) Qwen / DeepSeek — qwen3-* sizes + deepseek-v3, deepseek-r1
+
+Within each panel: superpose all models of that family as overlapping
+spiders, using a lightness ramp within the family colour (lightest =
+smallest model, darkest = largest). Legend shows model names.
+
+Axes (8): accuracy_coverage, accuracy_precision, accuracy_fuel,
+accuracy_status, accuracy_province, provenance_source_presence,
+temporality_asof_presence, field_completeness_core.
+(Omit provenance_high_conf_dual_source and temporality_plausible_range
+if median across all Exp1 models is < 0.05 — not enough signal.)
+
+Median across runs is plotted. Shaded band: min–max across runs (5 reps).
+
+## Exit criteria
+
+- [ ] Figure produced as `report/inputs/generated/fig_spider_exp1_families.pdf`
+- [ ] 4 panels, one per family, models superposed with lightness ramp
+- [ ] Provenance + temporality axes included; annotation if near-zero
+- [ ] Wired in `Makefile` and `slides/manuscript/main.md`
+- [ ] `make check-fast` passes

--- a/tickets/0307-remove-turn-trajectory-figure.erg
+++ b/tickets/0307-remove-turn-trajectory-figure.erg
@@ -1,0 +1,30 @@
+%erg 0.1
+Title: Remove fig_exp2_turn_trajectory from manuscript and Makefile
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`fig_exp2_turn_trajectory.pdf` is included in `slides/manuscript/main.md`
+but the underlying data (probe records per turn) is missing from the
+current exp2 mart — the mart builder's `_build_probe_records()` looks for
+a `probes/` subdir that does not exist in the flat arm directories. The
+figure renders empty. Removing it from the critical path avoids a
+blank figure in the talk.
+
+Defer the figure itself (do not delete the plot script); just unlink it
+from the manuscript and Makefile until the data is available.
+
+## Exit criteria
+
+- [ ] `slides/manuscript/main.md`: `fig_exp2_turn_trajectory` reference
+      removed (or commented with a TODO note)
+- [ ] `Makefile`: `fig_exp2_turn_trajectory.pdf` target removed from the
+      `figures:` phony dependency list (script and rule may stay)
+- [ ] No broken references remain (grep for `turn_trajectory` in .tex,
+      .md, and Makefile)
+- [ ] `make check-fast` passes

--- a/tickets/0308-glyph-palette-unification.erg
+++ b/tickets/0308-glyph-palette-unification.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: Unified glyph + palette across all figures
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Figures currently use inconsistent marker/colour conventions. For the
+talk the reader must be able to identify any data point by family and
+method at a glance. A single legend should suffice across all figures.
+
+## Glyph code (to be enforced in all new and existing plot scripts)
+
+Method axis (shape):
+  ●  small filled circle  — parametric (Exp 1, no web)
+  ○  open circle          — web search, single-shot (arm1 / direct)
+  ◆  filled diamond       — web search, multi-turn (arm2)
+  ◇  open diamond         — web search + evidence pack, single-shot (arm3)
+  ⬧  filled diamond (alt) — web search + evidence pack, multi-turn (arm4)
+
+In matplotlib terms:
+  parametric  → marker="o", s=18, filled
+  arm1        → marker="o", s=25, facecolor="none" (open)
+  arm2        → marker="D", s=20, filled
+  arm3        → marker="D", s=25, facecolor="none" (open)
+  arm4        → marker="D", s=20, filled (distinct colour from arm2 via edge)
+
+Colour axis (model family, already defined in palette.toml):
+  Claude / Anthropic  — existing palette colour
+  GPT / OpenAI        — existing palette colour
+  Mistral             — existing palette colour
+  Qwen / Alibaba      — existing palette colour
+  DeepSeek            — existing palette colour
+
+## Implementation
+
+1. Add `glyph_for_method(method: str) -> dict` to `src/aedist/util.py`
+   returning a dict of scatter kwargs: `{"marker": …, "s": …,
+   "facecolors": …, "edgecolors": "auto"}`. Methods: "parametric",
+   "arm1", "arm2", "arm3", "arm4".
+
+2. Update each affected plot script to call `glyph_for_method()` instead
+   of hardcoded marker/size values:
+   - `plot_cost_quality.py`
+   - `plot_exp2_arms_comparison.py`
+   - `plot_quality_spider.py` / `plot_quality_spider_exp1.py`
+   - Any others found by grep
+
+3. Add a shared `plot_legend_patch(ax)` helper (or a standalone
+   legend-only figure) so each figure can include a consistent legend.
+
+## Exit criteria
+
+- [ ] `glyph_for_method()` in `util.py`, covered by unit tests
+- [ ] All listed scripts updated (grep for hardcoded `marker=` in plot_*.py)
+- [ ] Visual spot-check: regenerate PDF for each affected figure; confirm
+      consistent glyphs and colours
+- [ ] `make check-fast` passes

--- a/tickets/0309-figure-title-label-fixes.erg
+++ b/tickets/0309-figure-title-label-fixes.erg
@@ -1,0 +1,34 @@
+%erg 0.1
+Title: Figure title and label fixes — per run, no web search, axis labels
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Three small cosmetic fixes identified during figure review:
+
+1. **Cost axis label**: currently reads "Coût par requête (cents USD)".
+   Change to "Coût par appel (cents USD)" → "Cost per run (USD cents)"
+   consistently. Affects `plot_cost_quality.py` (`fig.supxlabel`).
+
+2. **Cost/quality figure title**: the figure has no title indicating the
+   experimental condition. Add "(no web search)" or "(sans accès web)"
+   as a figure-level subtitle or annotation so readers know Exp 1 is
+   the parametric baseline. Affects `plot_cost_quality.py` /
+   `write_pdf()`.
+
+3. **Y-axis label `fig_direct_p1_base`**: verify the axis label reads
+   "Nombre de centrales bien identifiées" (French, consistent with
+   cost_quality). Standardise if divergent.
+
+## Exit criteria
+
+- [ ] `plot_cost_quality.py`: supxlabel updated to "per run"; panel or
+      figure title annotated "(no web search)"
+- [ ] `plot_method_convergence.py` y-axis label verified / aligned
+- [ ] Regenerated PDFs committed to `report/inputs/generated/`
+- [ ] `make check-fast` passes

--- a/tickets/0310-manuscript-title.erg
+++ b/tickets/0310-manuscript-title.erg
@@ -1,0 +1,44 @@
+%erg 0.1
+Title: Manuscript title — self-explaining with subtitle
+Created: 2026-05-25
+Author: HDMX-coding-agent
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The current manuscript title does not immediately convey what the paper
+measures, what dataset it targets, or what the finding is. Reviewers
+and conference attendees should understand the contribution from the
+title alone.
+
+Requirements from the author:
+- Self-explaining: reader understands the object (energy statistics /
+  power plant inventory), the method (LLM / AI agents), and the verdict
+  (quality gap, or "does it reach research quality?")
+- Subtitle: one sharper clause that adds the key finding or scope
+- Language: English (or bilingual if the venue norm is French)
+
+## Candidate frame (to iterate with author)
+
+Example structure:
+  "Can AI Agents Produce Research-Quality Energy Statistics?
+   A Benchmark Study on Vietnam's Thermal Power Fleet"
+
+Or:
+  "From Parametric Recall to Agentic Retrieval:
+   Evaluating LLM-Generated Power Plant Inventories Against a
+   163-Plant Gold Standard"
+
+The author must approve the final title. This ticket is complete when
+the title is updated in `slides/slides.tex`, `slides/manuscript/main.md`,
+and any metadata files (BibTeX, YAML front-matter).
+
+## Exit criteria
+
+- [ ] Author has approved the new title
+- [ ] Updated in `slides/slides.tex` title block
+- [ ] Updated in `slides/manuscript/main.md` YAML front-matter
+- [ ] `make check-fast` passes

--- a/tickets/0311-spider-exp2-four-way.erg
+++ b/tickets/0311-spider-exp2-four-way.erg
@@ -1,0 +1,43 @@
+%erg 0.1
+Title: Spider — Exp 2 4-way quality profile (2×2 arms)
+Created: 2026-05-25
+Author: HDMX-coding-agent
+Blocked-by: 0304
+
+--- log ---
+2026-05-25T15:00Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Exp 2 runs a 2×2 design: {single-shot, multi-turn} × {no pack, with
+pack}. A 4-panel quality spider — one panel per arm, with all 4 SOTA
+agents superposed — shows both the method effect (single vs multi-turn)
+and the data-augmentation effect (pack vs no-pack) on all 8 quality axes.
+
+This ticket is blocked on:
+- 0304 (arm3/arm4 extractors + arm1 full scoring)
+- Phase C: `sota_cross_eval.csv` needs scoring rows for all 4 arms ×
+  4 agents × ≥1 run. Currently only `naive, gpt-5.5, run 1` is scored.
+  Running score_mechanical for the remaining models is a compute job
+  estimated at ~20 API calls × $0.01 = ~$0.20 once ingestion is fixed.
+
+## Design
+
+Extend `plot_quality_spider.py` with a new entry point or flag
+`--mode exp2-4way`. Layout: 2×2 grid.
+  Panel (a) arm1 — naive, no pack
+  Panel (b) arm2 — optimised, no pack
+  Panel (c) arm3 — naive, with pack
+  Panel (d) arm4 — optimised, with pack
+
+Within each panel: 4 agent traces (Anthropic/GPT/Mistral/Qwen) in family
+colours, median of available runs. Reuse the first panel from the simpler
+Exp2-arm1-only spider so layout is consistent.
+
+## Exit criteria
+
+- [ ] All 4 arms × 4 agents have ≥ 1 scored row in `sota_cross_eval.csv`
+- [ ] Figure produced as `report/inputs/generated/fig_spider_exp2_4way.pdf`
+- [ ] Wired in `Makefile` and `slides/manuscript/main.md`
+- [ ] `make check-fast` passes


### PR DESCRIPTION
10 tickets covering the full analysis/figures workplan from the 2026-05-25 session.

| Ticket | Scope |
|--------|-------|
| 0302 | LP matcher LLM validation + Sonnet 4.6 bug hunt |
| 0303 | Score Exp1 outputs on all 8 quality axes |
| 0304 | Arm3/arm4 extractors + fix arm1 scoring pipeline |
| 0305 | Arms comparison figure — 4-arm redesign |
| 0306 | Spider Exp1 — 4-panel by family (blocked on 0303) |
| 0307 | Remove turn trajectory figure (empty data, off critical path) |
| 0308 | Glyph + palette unification across all figures |
| 0309 | Figure title/label fixes (per run, no web search) |
| 0310 | Manuscript title — self-explaining with subtitle |
| 0311 | Spider Exp2 4-way 2×2 (blocked on 0304) |

No code changes — tickets only. CI chore-bypass applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)