### PR TITLE
chore: gitignore generated intermediates; track slides/inputs/README.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ htmlcov/
 # Generated slide data (report inputs are tracked)
 slides/inputs/generated/
 
+# Intermediate report-generated files — rebuilt by make, not handoff artifacts
+report/inputs/generated/census_bars.csv
+report/inputs/generated/cost_quality.csv
+report/inputs/generated/macros_p1_base.tex
+
 # Experiment working files (large intermediates, not needed for analysis)
 experiments/data/rag_work/
 experiments/jobs/

--- a/slides/inputs/README.txt
+++ b/slides/inputs/README.txt
@@ -1,0 +1,2 @@
+Stale directory.
+Figures are under report/inputs/generated


### PR DESCRIPTION
- Gitignore `report/inputs/generated/census_bars.csv`, `cost_quality.csv`, `macros_p1_base.tex` — rebuilt by `make` from `measurements.jsonl`, not handoff artifacts
- Track `slides/inputs/README.txt` — human pointer noting figures moved to `report/inputs/generated/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)