### PR TITLE
chore(tickets): amend 0305 and 0308

### DIFF
--- a/tickets/0305-arms-comparison-figure-redesign.erg
+++ b/tickets/0305-arms-comparison-figure-redesign.erg
@@ -1,47 +1,58 @@
 %erg 0.1
-Title: fig_exp2_arms_comparison — 4-arm redesign
+Title: fig_exp2_arms_comparison — 4-arm 2×2 redesign
 Created: 2026-05-25
 Author: HDMX-coding-agent
 Blocked-by: 0304
 
 --- log ---
 2026-05-25T15:00Z HDMX-coding-agent created
+2026-05-25T16:00Z HDMX-coding-agent amended — 2×2 layout confirmed; full glyph spec added
 
 --- body ---
 ## Context
 
-The current `plot_exp2_arms_comparison.py` shows two arms (naive /
-optimised, i.e. arm1 / arm2) in a 3-panel layout (A coverage, B output
-richness, C cost). The experiment has four arms:
+The current figure shows two arms (arm1 naive / arm2 optimised) in a
+3-panel layout. The experiment is a 2×2 design:
 
-  arm1 — web, single-shot (naive)
-  arm2 — web, multi-turn (optimised)
-  arm3 — web + evidence pack, single-shot
-  arm4 — web + evidence pack, multi-turn
+               single-shot (direct) │ multi-turn
+  no pack          arm1             │    arm2
+  with pack        arm3             │    arm4
 
 Changes requested:
-- Show all four arms
-- Drop panel B (output richness — narrative_chars)
-- Add horizontal reference line at 163 (N_REFERENCE_PLANTS, dashed green)
-- Zeroes from arm4 are extractor failures (fixed by 0304); render
-  no_report runs as × markers at y=0 as before, but do not show genuine
-  zeros as × unless classification == "no_report"
-- Per-model colour from `model_family_color()` (not per-arm colour)
-- Glyph encodes arm: ○ single-shot/direct, ◇ multi-turn;
-  fill encodes evidence pack: open = no pack, filled = with pack
+- 2×2 grid of panels, one panel per arm (layout above)
+- Each panel: 4 agent groups on x-axis, y-axis = plants enumerated
+- Add horizontal reference line at 163 (N_REFERENCE_PLANTS, dashed,
+  colour = COLOR_REFERENCE from palette)
+- Drop the old 3-column layout (A coverage / B output richness / C cost);
+  coverage is the single y-axis; cost moves to a separate row label or
+  is dropped
+- Structural zeros (classification == no_report) rendered as × at y=0
+- Per-model colour from `model_family_color()` — retire COLOR_ARM_NAIVE
+  and COLOR_ARM_OPTIMISED for this figure
+- Glyph encodes arm per palette.toml [glyphs] section (ticket 0308):
+  arm1 = open circle, arm2 = open diamond, arm3 = filled circle,
+  arm4 = filled diamond. Until 0308 lands, hardcode these four glyphs.
+- Shared y-axis across all four panels so the "datapack lifts to 163"
+  effect is immediately visible at a glance
 
-Resulting layout: 2 panels (A coverage, B cost), 4 agent groups × 4
-arm columns each. Or — if 4×4 is too busy — one panel per arm
-(2×2 grid) showing per-agent coverage + cost as two y-axes.
-Use whichever layout is clearer; favour the one that makes the
-"datapack lifts all models to 163" claim immediately visible.
+## Suggested layout sketch
+
+  ┌──────────────┬──────────────┐
+  │ (a) arm1     │ (b) arm2     │
+  │ web, direct  │ web, multi   │
+  ├──────────────┼──────────────┤
+  │ (c) arm3     │ (d) arm4     │
+  │ +pack, direct│ +pack, multi │
+  └──────────────┴──────────────┘
+  x-axis of each panel: Anthropic / Mistral / OpenAI / Qwen
+  y-axis (shared): plants enumerated (0–180), 163 reference line
 
 ## Exit criteria
 
-- [ ] Figure shows all 4 arms, all 4 agents
+- [ ] Figure is a 2×2 grid with panels labelled (a)–(d)
+- [ ] All 4 arms visible; 163 reference line on every panel
 - [ ] No panel B (output richness)
-- [ ] 163 reference line visible on the coverage panel
-- [ ] Glyph + fill correctly encode arm type (single/multi × pack/no-pack)
-- [ ] Per-model colour from palette (no ARM_NAIVE / ARM_OPTIMISED colours)
+- [ ] Per-model colour; glyph per arm
+- [ ] Structural zeros rendered as × at y=0
 - [ ] `make check-fast` passes
 - [ ] Figure committed to `report/inputs/generated/`

--- a/tickets/0308-glyph-palette-unification.erg
+++ b/tickets/0308-glyph-palette-unification.erg
@@ -1,62 +1,117 @@
 %erg 0.1
-Title: Unified glyph + palette across all figures
+Title: Glyph config in palette.toml + display-case PDF for validation
 Created: 2026-05-25
 Author: HDMX-coding-agent
 
 --- log ---
 2026-05-25T15:00Z HDMX-coding-agent created
+2026-05-25T16:00Z HDMX-coding-agent amended — config-file-first design; display case PDF required before applying to figures
 
 --- body ---
 ## Context
 
-Figures currently use inconsistent marker/colour conventions. For the
-talk the reader must be able to identify any data point by family and
-method at a glance. A single legend should suffice across all figures.
+Glyphs (marker shape, size, fill) are currently hardcoded per plot
+script. When a marker choice needs to change — accessibility review,
+journal style guide, B&W printing — the change must be hunted across
+every script. Moving glyph specs into `palette.toml` gives a single
+edit point; `make figures` then propagates the change everywhere.
 
-## Glyph code (to be enforced in all new and existing plot scripts)
+The author must visually validate the glyph code before it is applied
+to figures. A display-case PDF is therefore the primary deliverable;
+updating the actual plot scripts is gated on author sign-off.
 
-Method axis (shape):
-  ●  small filled circle  — parametric (Exp 1, no web)
-  ○  open circle          — web search, single-shot (arm1 / direct)
-  ◆  filled diamond       — web search, multi-turn (arm2)
-  ◇  open diamond         — web search + evidence pack, single-shot (arm3)
-  ⬧  filled diamond (alt) — web search + evidence pack, multi-turn (arm4)
+## Glyph encoding (two orthogonal dimensions)
 
-In matplotlib terms:
-  parametric  → marker="o", s=18, filled
-  arm1        → marker="o", s=25, facecolor="none" (open)
-  arm2        → marker="D", s=20, filled
-  arm3        → marker="D", s=25, facecolor="none" (open)
-  arm4        → marker="D", s=20, filled (distinct colour from arm2 via edge)
+Shape encodes method type:
+  round (circle 'o') = direct / single-shot access
+  diamond ('D')      = multi-turn interaction
 
-Colour axis (model family, already defined in palette.toml):
-  Claude / Anthropic  — existing palette colour
-  GPT / OpenAI        — existing palette colour
-  Mistral             — existing palette colour
-  Qwen / Alibaba      — existing palette colour
-  DeepSeek            — existing palette colour
+Fill encodes data source:
+  small dot ('.')    = parametric (no web, memory only)
+  open (hollow)      = web search
+  filled (solid)     = web search + evidence pack
+
+Resulting 5 distinct glyphs:
+  parametric  → '.', s=20,  filled
+  arm1        → 'o', s=30,  open (facecolor='none')
+  arm2        → 'D', s=25,  open (facecolor='none')
+  arm3        → 'o', s=30,  filled
+  arm4        → 'D', s=25,  filled
 
 ## Implementation
 
-1. Add `glyph_for_method(method: str) -> dict` to `src/aedist/util.py`
-   returning a dict of scatter kwargs: `{"marker": …, "s": …,
-   "facecolors": …, "edgecolors": "auto"}`. Methods: "parametric",
-   "arm1", "arm2", "arm3", "arm4".
+### Step 1 — Add [glyphs] section to palette.toml
 
-2. Update each affected plot script to call `glyph_for_method()` instead
-   of hardcoded marker/size values:
-   - `plot_cost_quality.py`
-   - `plot_exp2_arms_comparison.py`
-   - `plot_quality_spider.py` / `plot_quality_spider_exp1.py`
-   - Any others found by grep
+```toml
+# Glyph encoding — single source of truth for marker shape, size, fill.
+# Shape = method type (round=direct, diamond=multi-turn).
+# Fill  = data source (dot=parametric, open=web, filled=web+pack).
+[glyphs.parametric]
+marker = "."
+size   = 20
+fill   = "full"
+label  = "Parametric — memory only, no web"
 
-3. Add a shared `plot_legend_patch(ax)` helper (or a standalone
-   legend-only figure) so each figure can include a consistent legend.
+[glyphs.arm1]
+marker = "o"
+size   = 30
+fill   = "none"
+label  = "Web, single-shot"
+
+[glyphs.arm2]
+marker = "D"
+size   = 25
+fill   = "none"
+label  = "Web, multi-turn"
+
+[glyphs.arm3]
+marker = "o"
+size   = 30
+fill   = "full"
+label  = "Web + evidence pack, single-shot"
+
+[glyphs.arm4]
+marker = "D"
+size   = 25
+fill   = "full"
+label  = "Web + evidence pack, multi-turn"
+```
+
+### Step 2 — Add `glyph_for_method(method: str) -> dict` to util.py
+
+Returns scatter kwargs:
+  {"marker": …, "s": …, "facecolors": colour|"none", "edgecolors": colour}
+where `colour` is the caller-supplied family colour. If `method` is not
+found in the config, log a warning and return the fallback dot.
+
+### Step 3 — Generate display-case PDF
+
+New script `src/aedist/plot_glyph_display.py`:
+- Reads `[glyphs]` from palette.toml and `[model_families]` colours
+- Draws a grid: rows = methods (parametric, arm1–4), columns = families
+  (Claude, GPT, Mistral, Qwen, DeepSeek)
+- Each cell: 5 jittered dots using the correct marker + colour
+- Row labels on the left (method label from config)
+- Column headers (family name, family colour)
+- Bottom legend: shape = method type, fill = data source
+- Output: `report/inputs/generated/fig_glyph_display.pdf`
+
+**This PDF is the deliverable that gates Step 4.**
+
+### Step 4 — Apply to plot scripts (after author validation)
+
+Update each affected script to call `glyph_for_method()`:
+- `plot_cost_quality.py`
+- `plot_exp2_arms_comparison.py`
+- `plot_quality_spider.py`
+- Others found by grep for hardcoded `marker=`
 
 ## Exit criteria
 
-- [ ] `glyph_for_method()` in `util.py`, covered by unit tests
-- [ ] All listed scripts updated (grep for hardcoded `marker=` in plot_*.py)
-- [ ] Visual spot-check: regenerate PDF for each affected figure; confirm
-      consistent glyphs and colours
+- [ ] `[glyphs]` section added to `palette.toml`
+- [ ] `glyph_for_method()` in `util.py`, unit-tested
+- [ ] `plot_glyph_display.py` written; display case PDF generated and
+      committed to `report/inputs/generated/fig_glyph_display.pdf`
+- [ ] **Author has validated the display case** (log entry required)
+- [ ] Plot scripts updated to call `glyph_for_method()` (after validation)
 - [ ] `make check-fast` passes


### PR DESCRIPTION
- **0305**: 2×2 layout confirmed (rows = pack/no-pack, columns = direct/multi-turn); layout sketch added; shared y-axis requirement noted
- **0308**: config-file-first design — glyphs in `palette.toml [glyphs]`; display-case PDF gates author validation before any plot script is touched; glyph encoding documented (shape = method type, fill = data source)

Ticket-only changes, CI chore-bypass applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)