### PR TITLE
chore(tickets): raid 290/192/313 lifecycle — close 250/290, open 0320, archive

### DIFF
--- a/tickets/0192-rename-ablation-to-exp1.erg
+++ b/tickets/0192-rename-ablation-to-exp1.erg
@@ -9,6 +9,7 @@ Tag: deferred
 2026-05-21T00:00Z claude note renumbered from 0180 to 0192 to resolve ID collision with closed 0180 (sota-adapter-base-scaffold, PR #337)
 2026-05-21T14:00Z claude note deferred — touches manuscript main.md which 0178 also targets; merge risk too high 5 days before Econom'IA (2026-05-27). Scope decision recorded: Phase 2 ablation sweeps keep their name (genuinely ARE ablation); only Exp 1 mislabeled items rename. Revisit post-conference.
 
+2026-05-25T16:21Z 2026-05-25T18:30Z claude note imagine: keeping deferred. 0178 conflict risk gone but blast radius wider than listed — 7 src/ files + 141 measurements.jsonl path strings + figure regen needed; git mv moot (dir already archived to experiments/archive/). Two YAGNI smuggles: new Makefile target group (separate ticket), ablation/livesearch cleanup (unrelated). p1_composite scope self-contradiction needs deliberate decision. Execute post-conference.
 --- body ---
 ## Context
 

--- a/tickets/0250-run-experiment-3-four-arm-sweep.erg
+++ b/tickets/0250-run-experiment-3-four-arm-sweep.erg
@@ -2,6 +2,7 @@
 Title: Run Experiment 3 intervention arms
 Created: 2026-05-23
 Author: Copilot
+Closed: Exp 3 Arms 3 and 4 runs completed per STATE.md workplan item 1
 
 --- log ---
 2026-05-23T16:02Z Copilot created
@@ -9,6 +10,7 @@ Author: Copilot
 2026-05-23T20:11Z HDMX-coding-agent note blocker 0249 closed — Blocked-by removed.
 2026-05-24T16:00Z HDMX-coding-agent note added Blocked-by 0278 (reprompt bundle: table-first, single-table, no summary tables, max_tokens 64K); 0278 is itself blocked on 0279+0280
 2026-05-24T17:27Z HDMX-coding-agent note blocker 0278 closed — Blocked-by removed.
+2026-05-25T16:15Z HDMX-coding-agent closed — Exp 3 Arms 3 and 4 runs completed per STATE.md workplan item 1
 --- body ---
 ## Context
 The Experiment 3 protocol is drafted and the implementation path is split into an assembler prerequisite and a runtime patch. This ticket covers the actual Experiment 3 runs after the codebase patch lands. Arms 1 and 2 are reused as existing baselines; they are not rerun.

--- a/tickets/0290-fix-no-report-mislabel-exp3-arm3-runs03-04.erg
+++ b/tickets/0290-fix-no-report-mislabel-exp3-arm3-runs03-04.erg
@@ -2,11 +2,13 @@
 Title: Fix no_report mislabel in exp3 arm3 runs 03-04 artifacts
 Created: 2026-05-25
 Author: HDMX-coding-agent
+Closed: Artifacts corrected on main (commit c0d1e958); run03/04 anthropic.json and summary.json reclassified to report; READMEs document the correction
 
 --- log ---
 2026-05-25T00:00Z HDMX-coding-agent created
 2026-05-25T00:00Z HDMX-coding-agent note isolated artifact-only correction in dedicated worktree branch `t0290-no-report-separation`.
 
+2026-05-25T16:18Z HDMX-coding-agent closed — Artifacts corrected on main (commit c0d1e958); run03/04 anthropic.json and summary.json reclassified to report; READMEs document the correction
 --- body ---
 ## Context
 

--- a/tickets/0313-pipeline-audit-scoring-and-exp3-zeros.erg
+++ b/tickets/0313-pipeline-audit-scoring-and-exp3-zeros.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-05-25T17:30Z HDMX-coding-agent created
 
+2026-05-25T16:33Z 2026-05-25T19:00Z claude note imagine: Bug1=stale CSV (LP fix landed after backfill; no scorer code change needed). Bug2=extract_output_text missing 3 format branches: Anthropic-native (content:list), Qwen (output.choices), Mistral-agents (outputs:list); arm4_flat has 9/20 zero-row entries. Model fallback also missing (entry.get(model) when method_params None). _extract_text in build_exp2_mart_views.py has all 4 formats — copy branches across. Fix sequence: (1) fix extract_output_text, (2) re-extract arm4, (3) delete+rebuild sota_cross_eval.csv via score_mechanical loop (4 models x 5 runs, naive arm), (4) make exp2_mart.jsonl + views. exp2_mart.jsonl absent entirely — needs build.
 --- body ---
 ## Context
 

--- a/tickets/0320-fix-cost-usd-fallback-arm4-arms-comparison.erg
+++ b/tickets/0320-fix-cost-usd-fallback-arm4-arms-comparison.erg
@@ -1,0 +1,35 @@
+%erg 0.1
+Title: Fix cost_usd vs total_cost_usd fallback in plot_exp2_arms_comparison for arm4
+Created: 2026-05-25
+Author: claude
+
+--- log ---
+2026-05-25T19:30Z claude created — scope overflow from PR #558 (0313 pipeline fix)
+
+--- body ---
+## Context
+
+`plot_exp2_arms_comparison.py` reads `payload.get("cost_usd")` with no
+fallback to `total_cost_usd`. arm4_flat JSON files use `total_cost_usd`
+(multi-turn schema) while arm1/arm2/arm3 use `cost_usd` (single-turn schema).
+This causes arm4 cost bars in the arms comparison figure to show zero.
+
+Found during /verify review of PR #558.
+
+## Actions
+
+1. In `src/aedist/plot_exp2_arms_comparison.py`, locate the cost column
+   read (likely `row.get("cost_usd")` or similar).
+2. Add fallback: `row.get("cost_usd") or row.get("total_cost_usd")`.
+3. Verify arm4 cost values are non-zero after fix.
+
+## Test
+
+Unit test: pass a row dict with only `total_cost_usd` set; assert the
+plot function extracts a non-zero cost value.
+
+## Exit criteria
+
+- [ ] `plot_exp2_arms_comparison.py` uses `cost_usd` with `total_cost_usd` fallback
+- [ ] arm4 cost bars in `fig_exp2_arms_comparison.pdf` show non-zero values
+- [ ] `make check-fast` passes

--- a/tickets/closed/0250-run-experiment-3-four-arm-sweep.erg
+++ b/tickets/closed/0250-run-experiment-3-four-arm-sweep.erg
@@ -1,0 +1,29 @@
+%erg 0.1
+Title: Run Experiment 3 intervention arms
+Created: 2026-05-23
+Author: Copilot
+Closed: Exp 3 Arms 3 and 4 runs completed per STATE.md workplan item 1
+
+--- log ---
+2026-05-23T16:02Z Copilot created
+
+2026-05-23T20:11Z HDMX-coding-agent note blocker 0249 closed — Blocked-by removed.
+2026-05-24T16:00Z HDMX-coding-agent note added Blocked-by 0278 (reprompt bundle: table-first, single-table, no summary tables, max_tokens 64K); 0278 is itself blocked on 0279+0280
+2026-05-24T17:27Z HDMX-coding-agent note blocker 0278 closed — Blocked-by removed.
+2026-05-25T16:15Z HDMX-coding-agent closed — Exp 3 Arms 3 and 4 runs completed per STATE.md workplan item 1
+--- body ---
+## Context
+The Experiment 3 protocol is drafted and the implementation path is split into an assembler prerequisite and a runtime patch. This ticket covers the actual Experiment 3 runs after the codebase patch lands. Arms 1 and 2 are reused as existing baselines; they are not rerun.
+
+The frozen baseline controls are the archived result set in `experiments/outputs/sota_exp2_naive_arm/` for Arm 1 and the archived result set in `experiments/outputs/sota_exp2_brerun1/` for Arm 2.
+
+## Actions
+1. Confirm the four-subject panel and the frozen prompts for Arms 3 and 4 against the existing Arms 1 and 2 baselines.
+2. Run the Experiment 3 sweep for Arms 3 and 4 once the runtime patch ticket is complete.
+3. Collect the raw outputs, scored outputs, and summary metrics for the intervention arms and compare them to the frozen baseline artifact sets in `experiments/outputs/sota_exp2_naive_arm/` and `experiments/outputs/sota_exp2_brerun1/`.
+
+## Test
+Before dispatching the full sweep, run a single smoke instance to verify that the arm-specific prompt path is producing the expected intervention-arm variants and that the archived baseline artifact sets remain unchanged.
+
+## Exit criteria
+The Arms 3 and 4 Experiment 3 runs complete, the archived baseline artifact sets remain reused as-is, and the run artifacts are ready for downstream scoring or reporting.

--- a/tickets/closed/0290-fix-no-report-mislabel-exp3-arm3-runs03-04.erg
+++ b/tickets/closed/0290-fix-no-report-mislabel-exp3-arm3-runs03-04.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: Fix no_report mislabel in exp3 arm3 runs 03-04 artifacts
+Created: 2026-05-25
+Author: HDMX-coding-agent
+Closed: Artifacts corrected on main (commit c0d1e958); run03/04 anthropic.json and summary.json reclassified to report; READMEs document the correction
+
+--- log ---
+2026-05-25T00:00Z HDMX-coding-agent created
+2026-05-25T00:00Z HDMX-coding-agent note isolated artifact-only correction in dedicated worktree branch `t0290-no-report-separation`.
+
+2026-05-25T16:18Z HDMX-coding-agent closed — Artifacts corrected on main (commit c0d1e958); run03/04 anthropic.json and summary.json reclassified to report; READMEs document the correction
+--- body ---
+## Context
+
+During exp3 arm3 analysis, the classifier output around runs 03-04 produced
+`no_report` inconsistencies relative to the generated report artifacts.
+
+The correction is intentionally scoped to experiment outputs only for run03 and
+run04, with no pipeline code changes in this branch.
+
+## Scope
+
+- Output artifacts under:
+  - `experiments/outputs/sota_exp3_arm3_batch1/run03/`
+  - `experiments/outputs/sota_exp3_arm3_batch1/run04/`
+- Include run-level README/summary notes documenting the correction.
+
+## Exit criteria
+
+- [x] Run03 corrected artifacts isolated in this branch.
+- [x] Run04 corrected artifacts isolated in this branch.
+- [x] No code/test files modified in this branch.
+- [ ] Ticket close after user review/merge decision.


### PR DESCRIPTION
Ticket lifecycle housekeeping from raid on 290, 192, 313.

- Closed 0250 (exp3 runs done per STATE.md workplan)
- Closed 0290 (artifacts already on main, classifier reruns done)
- Logged imagine findings on 0192 (keeping deferred: blast radius larger than listed)
- Logged imagine findings on 0313 (stale CSV + format gaps identified)
- Opened 0320 (cost_usd fallback for arm4 in arms comparison figure)
- Archived closed tickets 0250 and 0290 to tickets/closed/

No code changes — ticket files only.