### PR TITLE
tickets: close 0320 0321 0322 after raid

### DIFF
--- a/tickets/closed/0320-fix-cost-usd-fallback-arm4-arms-comparison.erg
+++ b/tickets/closed/0320-fix-cost-usd-fallback-arm4-arms-comparison.erg
@@ -2,10 +2,12 @@
 Title: Fix cost_usd vs total_cost_usd fallback in plot_exp2_arms_comparison for arm4
 Created: 2026-05-25
 Author: claude
+Closed: cost_usd fallback fixed in PR #565
 
 --- log ---
 2026-05-25T19:30Z claude created — scope overflow from PR #558 (0313 pipeline fix)
 
+2026-05-25T18:50Z HDMX-coding-agent closed — cost_usd fallback fixed in PR #565
 --- body ---
 ## Context
 

--- a/tickets/closed/0321-makefile-rule-rebuild-sota-cross-eval-csv.erg
+++ b/tickets/closed/0321-makefile-rule-rebuild-sota-cross-eval-csv.erg
@@ -2,10 +2,12 @@
 Title: Add Makefile rule to rebuild sota_cross_eval.csv from arm1_flat
 Created: 2026-05-25
 Author: claude
+Closed: Makefile rule added, CSV regenerated with correct columns — PR #567
 
 --- log ---
 2026-05-25T20:00Z claude created — gap identified during PR #558 review (0313)
 
+2026-05-25T19:23Z HDMX-coding-agent closed — Makefile rule added, CSV regenerated with correct columns — PR #567
 --- body ---
 ## Context
 

--- a/tickets/closed/0322-fix-scorer-column-name-mismatch-coherence.erg
+++ b/tickets/closed/0322-fix-scorer-column-name-mismatch-coherence.erg
@@ -2,10 +2,12 @@
 Title: Fix scorer column name mismatch — coherence_status_vocab_adherence vs coherence_capacity_nonnegative
 Created: 2026-05-25
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #566
 
 --- log ---
 2026-05-25T22:30Z HDMX-coding-agent created — found during /celebrate sweep after raid 314–317
 
+2026-05-25T18:50Z HDMX-coding-agent closed — autoclosed — PR #566
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes out the raid-320-321-322 ticket lifecycle.

All three PRs have merged:
- PR #565 — 0320: cost_usd fallback for arm4 in plot_exp2_arms_comparison
- PR #566 — 0322: coherence_capacity_nonnegative replaces wrong column name
- PR #567 — 0321: Makefile rule to rebuild sota_cross_eval.csv

This commit archives the three `.erg` tickets to `tickets/closed/`.

No `**Ticket:**` line — this is lifecycle housekeeping, not a feature PR.