### PR TITLE
tickets: slides Econom'IA 2026 review batch (0324-0343)

### DIFF
--- a/tickets/0324-slides-titre-auteur-logo.erg
+++ b/tickets/0324-slides-titre-auteur-logo.erg
@@ -1,0 +1,25 @@
+%erg v1
+Title: Slides: titre diapo 1, Dr. Minh, multi-logo
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` section « Diapo 1 (Titre) ».
+
+## Context
+Diapo de titre des slides Econom'IA 2026.
+
+## Actions
+1. Ajouter « Dr. » devant Minh dans le champ auteur
+2. Remplacer le second « CIRED - CNRS » par le multi-logo (chercher l'asset logo dans `slides/`)
+   - Fallback si logo absent : logo CIRED avec tutelles en texte
+3. Titre : laisser un `% TODO: revoir titre selon programme Econom'IA` — ne pas modifier le titre actuel
+
+## Exit criteria
+- [ ] « Dr. Minh » apparaît dans le PDF compilé
+- [ ] Second logo remplacé (ou fallback texte en place)
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0324-slides-titre-auteur-logo.erg
+++ b/tickets/0324-slides-titre-auteur-logo.erg
@@ -14,12 +14,17 @@ Voir `slides-review-verbatim.md` section « Diapo 1 (Titre) ».
 Diapo de titre des slides Econom'IA 2026.
 
 ## Actions
-1. Ajouter « Dr. » devant Minh dans le champ auteur
+1. Ajouter « Dr. » devant le nom complet : `Dr. Minh Ha-Duong` (pas seulement « Dr. Minh »)
 2. Remplacer le second « CIRED - CNRS » par le multi-logo (chercher l'asset logo dans `slides/`)
    - Fallback si logo absent : logo CIRED avec tutelles en texte
-3. Titre : laisser un `% TODO: revoir titre selon programme Econom'IA` — ne pas modifier le titre actuel
+3. Titre : laisser un `% TODO` commentaire mentionnant les **3 critères de jugement** :
+   - le résultat principal du papier
+   - le take-home message
+   - l'intitulé annoncé dans le programme Econom'IA
+   Ne pas modifier le titre actuel — l'auteur le fera après ce ticket.
 
 ## Exit criteria
-- [ ] « Dr. Minh » apparaît dans le PDF compilé
+- [ ] « Dr. Minh Ha-Duong » (nom complet) apparaît dans le champ auteur du PDF
 - [ ] Second logo remplacé (ou fallback texte en place)
+- [ ] Commentaire TODO sur le titre liste les 3 critères
 - [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0325-slides-text-diapos-2-3-4.erg
+++ b/tickets/0325-slides-text-diapos-2-3-4.erg
@@ -21,7 +21,8 @@ Voir `slides-review-verbatim.md` sections « Diapo 2 », « Diapo 3 », « Diapo
 4. Remonter le bloc Conditions au niveau du bloc modèle (pas en bas de diapo)
 
 ## Actions — Diapo 4
-1. Layout : image alignée à gauche, colonne de texte alignée à droite avec marge 2em
+1. Layout : image alignée à gauche, colonne de texte **au fer alignée à droite** (`\raggedleft`,
+   pas de justification) avec marge 2em
 2. Titre hardcodé dans le fichier figure : « How do models recall Vietnam's thermal power assets? Not well. »
    (chercher le script Python qui génère cette figure et modifier le titre là)
 

--- a/tickets/0325-slides-text-diapos-2-3-4.erg
+++ b/tickets/0325-slides-text-diapos-2-3-4.erg
@@ -1,0 +1,32 @@
+%erg v1
+Title: Slides: éditions texte diapos 2, 3, 4
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` sections « Diapo 2 », « Diapo 3 », « Diapo 4 ».
+
+## Actions — Diapo 2
+1. Titre : remplacer « Le problème » par « L'IA peut-elle produire des données qualité recherche ? »
+2. Supprimer cette même phrase du corps de la diapo
+
+## Actions — Diapo 3
+1. Vérifier les chiffres cités dans la diapo contre les logs (fichier de run ou measurements.jsonl)
+2. Supprimer le texte du prompt de la diapo ; remplacer par « Engineered, 84 lignes »
+3. Ajouter « Effort de raisonnement par défaut. » dans le bloc Conditions
+4. Remonter le bloc Conditions au niveau du bloc modèle (pas en bas de diapo)
+
+## Actions — Diapo 4
+1. Layout : image alignée à gauche, colonne de texte alignée à droite avec marge 2em
+2. Titre hardcodé dans le fichier figure : « How do models recall Vietnam's thermal power assets? Not well. »
+   (chercher le script Python qui génère cette figure et modifier le titre là)
+
+## Exit criteria
+- [ ] Diapo 2 : titre mis à jour, phrase supprimée du corps
+- [ ] Diapo 3 : chiffres vérifiés, prompt remplacé, Conditions repositionnées
+- [ ] Diapo 4 : layout image/texte correct, titre figure mis à jour
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0326-slides-restructuration-ordre.erg
+++ b/tickets/0326-slides-restructuration-ordre.erg
@@ -21,7 +21,9 @@ Voir `slides-review-verbatim.md` sections « Diapo 5 » et « Diapo 16 (remonte)
 2. Titre : « La bonne statistique exige plus que des vrais chiffres »
 3. Citer « Connaissance : croyance vraie justifiée »
 4. Aligner sur les 4 dimensions du manuscrit (Accuracy, Coherence, Provenance, Temporality)
-5. Ajouter la 5e dimension : « Niveau de détail approprié »
+5. Ajouter la 5e dimension : **« Fit for purpose »** (niveau de détail approprié).
+   Opérationnelle, mesurée. Exemple : pour PyPSA, la colonne Capacité doit être
+   remplie — on le mesure (taux de remplissage des champs critiques pour l'usage aval).
 6. Remplacer « Chaque défaillance a un mécanisme correcteur » par « → Grille de notation multi-axes »
 
 ## Exit criteria

--- a/tickets/0326-slides-restructuration-ordre.erg
+++ b/tickets/0326-slides-restructuration-ordre.erg
@@ -1,0 +1,31 @@
+%erg v1
+Title: Slides: restructuration ordre (diapo 5, 16, section Discussion)
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` sections « Diapo 5 » et « Diapo 16 (remonte) ».
+
+## Actions — Diapo 5
+1. Remplacer la diapo « Qualité du résultat » par une diapo « Quality dimensions » verbatim du prompt
+2. La diapo « Qualité de la méthode » migre dans la section « Architecture » renommée « Discussion »,
+   positionnée juste après « Question centrale » et avant « Directions Futures »
+3. « Directions Futures » remonte dans la section Discussion
+
+## Actions — Diapo 16
+1. La diapo 16 remonte juste après « Which models recall » et avant la diapo prompt
+2. Titre : « La bonne statistique exige plus que des vrais chiffres »
+3. Citer « Connaissance : croyance vraie justifiée »
+4. Aligner sur les 4 dimensions du manuscrit (Accuracy, Coherence, Provenance, Temporality)
+5. Ajouter la 5e dimension : « Niveau de détail approprié »
+6. Remplacer « Chaque défaillance a un mécanisme correcteur » par « → Grille de notation multi-axes »
+
+## Exit criteria
+- [ ] Diapo 5 remplacée par Quality dimensions verbatim
+- [ ] Section Discussion en place avec Qualité méthode + Directions Futures
+- [ ] Diapo 16 repositionnée avec titre et contenu mis à jour
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0327-slides-text-diapos-10-11-12.erg
+++ b/tickets/0327-slides-text-diapos-10-11-12.erg
@@ -29,10 +29,23 @@ Ne jamais utiliser A, B, W.
 
 ## Actions — Diapo 11
 1. Supprimer le second « Infrastructure : »
-2. Remplacer « Même script, .. hash » par « 5 claws : Imagine, Plan, Execute, Verify, Celebrate. »
+2. Remplacer la phrase actuelle « Même script, n'importe quel fournisseur ; les runs sont
+   reproductibles à partir du hash. » par une formulation **qui conserve la garantie de
+   reproductibilité** et ajoute les 5 claws. Proposition :
+   « 5 claws : Imagine, Plan, Execute, Verify, Celebrate. Runs reproductibles à partir du hash. »
+   (Important : ne pas supprimer l'information de reproductibilité hash, c'est une garantie
+   méthodologique valorisée par le public académique.)
 3. Supprimer les « / 4 »
 4. Ajouter « codéveloppé, » avant « relu »
-5. Après « fondées : » rappeler très brièvement les réserves (consulter le manuscrit pour formulation)
+5. Après « fondées : » rappeler très brièvement les réserves.
+   Source : `experiments/sota/protocol_06_validation_round_1.md` (open limitations § 4.3)
+   + round 2 reviews (`experiments/archive/outputs/sota_exp2_protocol_review_round2/`)
+   Réserves maintenues round 2 par Qwen+OpenAI : enforcement instructionnel des bans
+   Wikipedia/subagents (pas API-level), cross-évaluation par les mêmes 4 modèles non
+   indépendante, fuite paramétrique, énergie/CO₂ non exposés par les vendeurs.
+   Formulation recommandée (à choisir selon espace disponible) :
+   - Court : « enforcement instructionnel, cross-éval non indépendante, fuite paramétrique, énergie/CO₂ non exposés »
+   - Télégraphique : « budget · enforcement · leakage · CO₂ »
 
 ## Actions — Diapo 12
 1. Supprimer « (Exp 2) »

--- a/tickets/0327-slides-text-diapos-10-11-12.erg
+++ b/tickets/0327-slides-text-diapos-10-11-12.erg
@@ -1,0 +1,49 @@
+%erg v1
+Title: Slides: éditions texte diapos 10, 11, 12
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` sections « Diapo 10 », « Diapo 11 », « Diapo 12 ».
+
+## Nomenclature labels conditions
+Partout dans les slides : 1N (singleshot, no docs), 5N (multiturn, no docs), 1D (singleshot, docs), 5D (multiturn, docs).
+Ne jamais utiliser A, B, W.
+
+## Actions — Diapo 10
+1. Titre : « Expérience 2 : web search on, (oneshot, multiturn) × (without, with docs) »
+2. Supprimer colonne « Enjeu » et ligne « Facteur, Valeurs »
+3. `(3 relances)` → `(3 à 5)`
+4. Retirer « + web search »
+5. Retirer « 4 SOTA », remplacer « Qwen3-max » par « Qwen 3.7 max »
+6. `Runs` → `Répétitions`
+7. Ajouter ligne **Contrôles** : « Default reasoning effort, Web search allowed, no tools, no code, direct lab API provider, même prompt de base, < $6, < 50 000 tokens »
+8. Ajouter ligne **Documents** : « 18 tables, sources primaires, format MD »
+9. Supprimer le tableau « arm 1... » et la ligne « Les 4 agents... »
+10. À la fin de la diapo, introduire les 4 labels : « Quatre conditions : 1N (single turn, no docs) ; 5N ; 1D ; 5D (multiturn, with docs) »
+11. Résultat : titre + tableau 2 colonnes, colonne de droite = 1 mot en gras
+
+## Actions — Diapo 11
+1. Supprimer le second « Infrastructure : »
+2. Remplacer « Même script, .. hash » par « 5 claws : Imagine, Plan, Execute, Verify, Celebrate. »
+3. Supprimer les « / 4 »
+4. Ajouter « codéveloppé, » avant « relu »
+5. Après « fondées : » rappeler très brièvement les réserves (consulter le manuscrit pour formulation)
+
+## Actions — Diapo 12
+1. Supprimer « (Exp 2) »
+2. Phase A : remplacer « et planifie le job » par « connaissant le protocole »
+3. Supprimer « ($1) »
+4. Remplacer « Un jury de pairs — mais le jury est aussi un modèle » par « Évaluation par les pairs : TBD »
+5. Remplacer « L'agent conçoit son propre protocole, l'exécute, et un autre LLM l'arbitre » par :
+   « *It's LLMs all the way down* — but Knowledge Graphs are not dead. »
+
+## Exit criteria
+- [ ] Diapo 10 : tableau restructuré, labels 1N/5N/1D/5D introduits
+- [ ] Diapo 11 : toutes les éditions appliquées
+- [ ] Diapo 12 : toutes les éditions appliquées
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0328-slides-text-diapos-17-19-merci.erg
+++ b/tickets/0328-slides-text-diapos-17-19-merci.erg
@@ -1,0 +1,33 @@
+%erg v1
+Title: Slides: diapos 17-18, 19, Merci (texte + QR)
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` sections « Diapos 17-18 », « Diapo 19 », « Diapo Merci ».
+
+## Actions — Diapos 17-18
+Reformuler l'intro/titre pour clarifier la fonction : vérification quantitative des messages-clés
+vus sur les graphes — sans aller jusqu'aux p-values.
+
+## Actions — Diapo 19
+Reformuler et réordonner en exactement 4 points :
+1. Multi-tour : pas si utile
+2. Fournir les sources : nécessaire
+3. Coût : de quelques centimes à quelques euros par requête
+4. L'IA produit-elle des données de qualité recherche : pas encore
+
+## Actions — Diapo Merci
+1. Lien vers le repo : s'assurer qu'il est cliquable (hyperlien actif dans le PDF)
+2. Ajouter un QR code en grand vers le repo GitHub du projet
+   (générer le QR code PNG/PDF via `qrencode` ou équivalent disponible)
+
+## Exit criteria
+- [ ] Diapos 17-18 : reformulation en place
+- [ ] Diapo 19 : 4 points dans le bon ordre
+- [ ] Diapo Merci : lien actif + QR code visible en grand
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0328-slides-text-diapos-17-19-merci.erg
+++ b/tickets/0328-slides-text-diapos-17-19-merci.erg
@@ -21,6 +21,11 @@ Reformuler et réordonner en exactement 4 points :
 3. Coût : de quelques centimes à quelques euros par requête
 4. L'IA produit-elle des données de qualité recherche : pas encore
 
+Note : la suppression du point « Anthropic trop cher » (présent dans les messages-clés
+actuels) est **intentionnelle**. Raison auteur : ce résultat de pricing sera discuté
+sur la figure cost/quality et n'est pas stable dans le temps (les prix bougent).
+Ne pas réintroduire ce point.
+
 ## Actions — Diapo Merci
 1. Lien vers le repo : s'assurer qu'il est cliquable (hyperlien actif dans le PDF)
 2. Ajouter un QR code en grand vers le repo GitHub du projet

--- a/tickets/0329-slides-nouvelles-diapos-prompt.erg
+++ b/tickets/0329-slides-nouvelles-diapos-prompt.erg
@@ -1,0 +1,85 @@
+%erg v1
+Title: Slides: 2 nouvelles diapos structure prompt + Quality dimensions
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` sections « Diapo 3 » (structure) et « Diapo 5 » (quality dimensions).
+Source : `experiments/sota/protocol_07_naive_prompt.md`
+
+## Context
+Deux nouvelles diapos à insérer dans la section prompt de la présentation :
+- Slide A (structure) : après la diapo qui mentionne « Engineered, 84 lignes »
+- Slide B (quality dimensions) : remplace l'ancienne diapo « Qualité du résultat » (voir ticket 0326)
+
+## Actions — Slide A : Structure du prompt
+Créer une diapo avec ce contenu verbatim (sections/sous-sections, corps tronqué avec `...`) :
+
+```
+# GOAL
+
+Produce a complete, primary-sourced reference inventory of Vietnam's past, present and future
+thermal generation assets (> 30 MWe). Begin the document directly with the inventory table —
+no title, no preamble, no overview section. Structure it as follows:
+
+- the plant inventory: ...: Name (Vietnamese), Name (English), Province, Fuel
+  (Coal / Domestic gas / Imported LNG), Technology (...), Units × MW, Total MWe, Status,
+  Status as-of-date, COD, Owner/Developer, Confidence, Source 1, Source 2, Notes.
+  Do not add statistical summary, cross-tabulation, or any other pipe tables;
+  fold aggregate statistics into prose.
+- per-asset or per-project explanatory notes: ...
+- an annotated bibliography ...
+
+Scope includes ...
+
+When uncertain, mark confidence... .
+
+Output format: Markdown.
+
+# QUALITY DIMENSIONS
+
+# CONTEXT
+
+## Source quality management
+
+## Calibrated confidence vocabulary
+
+## Asset-row and status rules
+```
+
+## Actions — Slide B : Quality dimensions
+Créer une diapo avec ce contenu verbatim extrait de `protocol_07_naive_prompt.md` :
+
+```
+# QUALITY DIMENSIONS
+
+Your output is judged on four axes:
+
+1. *Accuracy* — right assets and right attributes. Row level: recall and precision against
+   a curated reference (F1). Cell level: capacity, fuel, location, operator, COD, status correct.
+   Confident fabrication is the policed failure mode.
+2. *Coherence* — internally and externally consistent. Totals reconcile with known subtotals;
+   no negative capacities, no double-counted units, no cross-row contradiction; values plausible
+   in unit, magnitude, geography, technology, date. Conflicting sources reconciled explicitly
+   (which chosen and why), not silently.
+3. *Provenance* — each value traces to a source that actually supports it, not a merely plausible
+   citation. Two independent primaries is the ideal; one primary, a regulator database, or a
+   marked secondary is weaker but acceptable if its status is explicit. Unsupported values
+   are the failure.
+4. *Temporality* — every value carries a best-effort as-of date; status changes are flagged.
+   Distinguish current status from past reports, planned from operating capacity, source date
+   from fact date.
+
+We prefer a comprehensive inventory with uncertainty clearly expressed over a
+shortlist of well-known assets.
+```
+
+## Exit criteria
+- [ ] Slide A insérée avec la structure du prompt (sections visibles, corps tronqué)
+- [ ] Slide B insérée avec Quality dimensions verbatim
+- [ ] Ordre des slides cohérent avec ticket 0326
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0329-slides-nouvelles-diapos-prompt.erg
+++ b/tickets/0329-slides-nouvelles-diapos-prompt.erg
@@ -52,7 +52,9 @@ Output format: Markdown.
 ```
 
 ## Actions — Slide B : Quality dimensions
-Créer une diapo avec ce contenu verbatim extrait de `protocol_07_naive_prompt.md` :
+Créer une diapo avec ce contenu **verbatim brut** extrait de `protocol_07_naive_prompt.md`.
+Décision auteur : **pas de chapeau français**, pas de phrase d'introduction française —
+la slide reste en anglais brut, telle quelle.
 
 ```
 # QUALITY DIMENSIONS
@@ -78,8 +80,17 @@ We prefer a comprehensive inventory with uncertainty clearly expressed over a
 shortlist of well-known assets.
 ```
 
+## Note de cohérence avec ticket 0326
+La diapo « Quality dimensions » verbatim ci-dessus contient **4 axes** (Accuracy,
+Coherence, Provenance, Temporality) tels qu'ils apparaissent dans le prompt.
+Le ticket 0326 ajoute une **5e dimension** (« Fit for purpose ») sur la diapo 16
+de notation. Cette 5e dimension est opérationnelle et mesurée mais ne figure
+pas dans le prompt — elle relève de la grille d'évaluation post-hoc et non du
+cahier des charges donné au modèle. Cette asymétrie est intentionnelle ; ne pas
+ajouter « Fit for purpose » au verbatim de la slide B.
+
 ## Exit criteria
 - [ ] Slide A insérée avec la structure du prompt (sections visibles, corps tronqué)
-- [ ] Slide B insérée avec Quality dimensions verbatim
+- [ ] Slide B insérée avec Quality dimensions verbatim (4 axes, sans Fit for purpose)
 - [ ] Ordre des slides cohérent avec ticket 0326
 - [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0330-figures-fix-decalage-global.erg
+++ b/tickets/0330-figures-fix-decalage-global.erg
@@ -1,0 +1,29 @@
+%erg v1
+Title: Figures: fix décalage droite systémique (toutes figures slides)
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` section « Bug global figures ».
+
+## Context
+Toutes les figures des slides débordent/sont clippées à droite.
+Hypothèse : figures générées avec un canvas plus large que le rendu final des slides,
+puis centrées dans ce canvas, ce qui les fait clipper à droite dans Beamer.
+
+## Actions
+1. Identifier comment les figures sont incluses dans les slides (chemin, `\includegraphics` options)
+2. Identifier les scripts Python qui génèrent les figures (chercher dans `src/aedist/plot_*.py`)
+3. Diagnostiquer la cause : figsize trop large ? bbox_inches manquant ? pad_inches ? savefig DPI ?
+4. Appliquer le fix systémique sur tous les scripts concernés (ne pas patcher slide par slide)
+5. Régénérer toutes les figures affectées via `make`
+
+## Exit criteria
+- [ ] Cause du décalage identifiée et documentée dans le log
+- [ ] Fix appliqué à la source (scripts Python), pas dans le LaTeX
+- [ ] Toutes les figures régénérées et alignées à gauche dans le rendu PDF des slides
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0330-figures-fix-decalage-global.erg
+++ b/tickets/0330-figures-fix-decalage-global.erg
@@ -12,18 +12,34 @@ Voir `slides-review-verbatim.md` section « Bug global figures ».
 
 ## Context
 Toutes les figures des slides débordent/sont clippées à droite.
-Hypothèse : figures générées avec un canvas plus large que le rendu final des slides,
-puis centrées dans ce canvas, ce qui les fait clipper à droite dans Beamer.
+
+**Cause identifiée par revue expert** (Lucas Moreau, panel) : les `figsize` des scripts Python
+sont en ratio plus large que le 16:9 du slide Beamer. Exemple : `plot_cost_quality` utilise
+`figsize=(11, 4.5)` → ratio 2,44:1 contre 1,78:1 (16:9). Avec `\includegraphics[width=\paperwidth,
+height=\paperheight,keepaspectratio]`, la contrainte `height=\paperheight` prend le dessus :
+matplotlib rend à ~8,65 pouces de large pour 3,54 pouces de papier disponible → 37 % de la figure
+sort à droite. **Ce n'est pas un problème de centrage LaTeX**, c'est un mauvais ratio source.
 
 ## Actions
-1. Identifier comment les figures sont incluses dans les slides (chemin, `\includegraphics` options)
-2. Identifier les scripts Python qui génèrent les figures (chercher dans `src/aedist/plot_*.py`)
-3. Diagnostiquer la cause : figsize trop large ? bbox_inches manquant ? pad_inches ? savefig DPI ?
-4. Appliquer le fix systémique sur tous les scripts concernés (ne pas patcher slide par slide)
-5. Régénérer toutes les figures affectées via `make`
+1. Auditer tous les scripts `src/aedist/plot_*.py` : relever les `figsize` actuels et leurs ratios
+2. Définir le ratio cible :
+   - Pour figures plein-slide (`\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]`) :
+     ratio ≤ 1,78:1 (16:9). Cible recommandée : `figsize=(10, 5.6)` ou `(11.2, 6.3)`.
+   - Pour figures avec titre de frame (`width=\textwidth`) : ratio plus carré OK.
+3. Ajuster les `figsize` à la source dans chaque script. Ne PAS patcher le LaTeX.
+4. (Préférable) Référencer une constante centrale `SLIDE_FIGSIZE_WIDE` dans `aedist.util` —
+   voir ticket 0338 (N-2) si créé.
+5. Régénérer toutes les figures via `make figures` ou équivalent.
+6. Vérifier visuellement le rendu PDF des slides ; aucune figure ne doit déborder.
+
+## Note sur ticket 0335
+Le ticket 0335 (titres Cost-Accuracy et AI-industry) touche les mêmes scripts. **À exécuter
+dans la même PR que 0330** pour éviter conflits de merge. Ordre : appliquer d'abord les
+corrections de titre (0335), puis le fix figsize (0330), même commit ou commits successifs.
 
 ## Exit criteria
-- [ ] Cause du décalage identifiée et documentée dans le log
-- [ ] Fix appliqué à la source (scripts Python), pas dans le LaTeX
-- [ ] Toutes les figures régénérées et alignées à gauche dans le rendu PDF des slides
+- [ ] Tous les `figsize` des scripts plot_*.py audités et listés dans le log du ticket
+- [ ] Ratios ajustés à ≤ 1,78:1 pour les figures plein-slide
+- [ ] Toutes les figures régénérées
+- [ ] Vérification visuelle PDF : aucune figure ne déborde à droite
 - [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0331-figure-araignees-multipanel-claude.erg
+++ b/tickets/0331-figure-araignees-multipanel-claude.erg
@@ -1,0 +1,37 @@
+%erg v1
+Title: Figure araignées: multipanel + nouvelle diapo Claude seul
+Created: 2026-05-26
+Author: claude
+Blocked-by: 0330
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` section « Diapo 7 (araignées) ».
+
+## Actions — Multipanel existant
+1. Subplot bas-droite : garder seulement Qwen, supprimer DeepSeek
+2. Titre : « Qualité des réponses : ask one shot, reasoning on, websearch off, docs provided none. »
+3. Axes : garder seulement les noms d'axes, supprimer les critères détaillés sur le graphe
+4. Légendes : passer en colonne à côté (pas en dessous) pour gagner de la taille
+5. Titre de panel intègre la légende, non répété. Format :
+   ```
+   (a) Claude
+   — Haiku 4.5
+   — Sonnet 4.6
+   — Opus 4.6
+   ```
+
+## Actions — Nouvelle diapo : araignée Claude seul
+1. Créer une nouvelle figure : une seule araignée en grand pour les 3 modèles Claude
+2. Afficher les 5 axes avec les 2 critères par axe en français explicite (pas d'abréviation)
+3. Insérer cette diapo juste après le multipanel dans les slides
+
+## Exit criteria
+- [ ] Subplot Qwen sans DeepSeek
+- [ ] Titre multipanel mis à jour
+- [ ] Légendes en colonne, titre panel intègre la légende
+- [ ] Nouvelle figure Claude seul générée et insérée
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0331-figure-araignees-multipanel-claude.erg
+++ b/tickets/0331-figure-araignees-multipanel-claude.erg
@@ -15,7 +15,10 @@ Voir `slides-review-verbatim.md` section « Diapo 7 (araignées) ».
 1. Subplot bas-droite : garder seulement Qwen, supprimer DeepSeek
 2. Titre : « Qualité des réponses : ask one shot, reasoning on, websearch off, docs provided none. »
 3. Axes : garder seulement les noms d'axes, supprimer les critères détaillés sur le graphe
-4. Légendes : passer en colonne à côté (pas en dessous) pour gagner de la taille
+4. Légendes : passer **en colonne à droite de chaque subplot** (pas en dessous, pas une colonne
+   globale partagée). Chaque panel polaire a sa propre colonne de légende immédiatement à sa droite.
+   Implémentation matplotlib : `bbox_to_anchor` dans le repère de chaque axes (pas du figure),
+   ou utiliser `GridSpec` avec colonne dédiée par subplot.
 5. Titre de panel intègre la légende, non répété. Format :
    ```
    (a) Claude
@@ -26,8 +29,13 @@ Voir `slides-review-verbatim.md` section « Diapo 7 (araignées) ».
 
 ## Actions — Nouvelle diapo : araignée Claude seul
 1. Créer une nouvelle figure : une seule araignée en grand pour les 3 modèles Claude
-2. Afficher les 5 axes avec les 2 critères par axe en français explicite (pas d'abréviation)
-3. Insérer cette diapo juste après le multipanel dans les slides
+2. Afficher les **5 axes** (Accuracy, Coherence, Provenance, Temporality, **Fit for purpose**)
+   avec les 2 critères par axe en français explicite (pas d'abréviation).
+   Note : la 5e dimension « Fit for purpose » est opérationnelle (exemple PyPSA : taux de
+   remplissage de la colonne Capacité). Elle n'apparaît pas dans le prompt mais est mesurée.
+3. Pour les labels français : ajouter un dictionnaire de traductions dans le script ou
+   dans une config YAML adjacente. Ne pas dupliquer le script anglais existant.
+4. Insérer cette diapo juste après le multipanel dans les slides.
 
 ## Exit criteria
 - [ ] Subplot Qwen sans DeepSeek

--- a/tickets/0332-figure-coverage-costs-exp2-redesign.erg
+++ b/tickets/0332-figure-coverage-costs-exp2-redesign.erg
@@ -1,0 +1,56 @@
+%erg v1
+Title: Figure Coverage and costs exp2: redesign complet
+Created: 2026-05-26
+Author: claude
+Blocked-by: 0330
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` section « Figure Coverage and costs, experiment 2 ».
+
+## Nomenclature
+Labels conditions : 1N (singleshot, no docs), 5N (multiturn, no docs), 1D (singleshot, docs), 5D (multiturn, docs).
+Ne jamais utiliser A, B, W.
+
+## Context
+La figure actuelle s'appelle « One query providing documents... ».
+RAG doit être introduit dans la timeline industrie et dans la diapo description exp2 AVANT cette figure.
+À la fin de la diapo exp2 (ticket 0327), ajouter : « Quatre conditions : 1N ; 5N ; 1D ; 5D »
+
+## Actions — Diapo et contexte
+1. Introduire RAG dans la diapo timeline industrie (chercher dans slides)
+2. Introduire RAG dans la description de l'exp2 (diapo 10 — ticket 0327)
+3. Supprimer « Matched / Hallucinated » du titre/légende actuelle
+
+## Actions — Figure : structure générale
+- Titre : « Coverage and costs, experiment 2 »
+- Sous-titre : légende sur une ligne — « 1N = Singleshot, no doc · 5N = Multiturn, no doc · 1D = Singleshot, docs · 5D = Multiturn, docs »
+- Pour chaque modèle : 4 barres (1N, 5N, 1D, 5D)
+  - Petit espace entre barres d'un même modèle, grand espace entre modèles
+  - Hauteur = moyenne des 5 reps
+  - Couleur = couleur du modèle dans le talk
+  - Variance : ligne noire fine verticale avec les 5 valeurs individuelles comme petits segments horizontaux
+
+## Actions — Panel gauche (Coverage)
+- Hallucinations (faux positifs) en **rouge** dans les négatifs (sous zéro)
+- Assets correctement identifiés en couleur du modèle dans les positifs
+- Même principe que la figure « Which model recalls... » exp1 mais barres verticales à moustaches
+- Conserver axe Y (-50 → +150) avec barre verte horizontale à 0
+- Label axe Y en haut, écriture horizontale : « 163 plants »
+- Titre axe : « Number of assets identified (red are False Positives) »
+
+## Actions — Panel droit (Cost)
+- Même structure 4 barres à moustaches par modèle
+- Titre axe Y : « API Cost per run, USD »
+- Supprimer la légende d'axe Y (redondant avec titre)
+
+## Exit criteria
+- [ ] Titre et sous-titre corrects avec labels 1N/5N/1D/5D
+- [ ] Panel gauche : rouge pour faux positifs, couleur modèle pour vrais positifs, axe Y correct
+- [ ] Panel droit : titre axe correct
+- [ ] Variance inter-run visible (ligne + segments)
+- [ ] Figure régénérée et insérée dans slides
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0332-figure-coverage-costs-exp2-redesign.erg
+++ b/tickets/0332-figure-coverage-costs-exp2-redesign.erg
@@ -3,6 +3,7 @@ Title: Figure Coverage and costs exp2: redesign complet
 Created: 2026-05-26
 Author: claude
 Blocked-by: 0330
+Blocked-by: 0336
 
 --- log ---
 2026-05-26T10:00Z claude created
@@ -31,8 +32,12 @@ RAG doit être introduit dans la timeline industrie et dans la diapo description
 - Pour chaque modèle : 4 barres (1N, 5N, 1D, 5D)
   - Petit espace entre barres d'un même modèle, grand espace entre modèles
   - Hauteur = moyenne des 5 reps
-  - Couleur = couleur du modèle dans le talk
-  - Variance : ligne noire fine verticale avec les 5 valeurs individuelles comme petits segments horizontaux
+  - Couleur = couleur du modèle dans le talk via `aedist.util.model_family_color()`
+    (palette dans `palette.toml` section `[model_families]` : Claude=#0072B2, GPT=#D55E00,
+    Mistral=#009E73, Qwen=#CC79A7, DeepSeek=#E69F00). Ne pas redéfinir localement.
+  - Variance : ligne noire fine verticale (`ax.vlines`) + 5 segments horizontaux courts
+    (`ax.hlines`) un par run. Largeur des segments ≈ 60% de la largeur d'une barre.
+    But : montrer la dispersion des 5 répétitions par condition.
 
 ## Actions — Panel gauche (Coverage)
 - Hallucinations (faux positifs) en **rouge** dans les négatifs (sous zéro)

--- a/tickets/0333-figure-coverage-corroboration.erg
+++ b/tickets/0333-figure-coverage-corroboration.erg
@@ -1,0 +1,33 @@
+%erg v1
+Title: Figure Coverage vs Corroboration: alpha, rouge, cap 163, titre
+Created: 2026-05-26
+Author: claude
+Blocked-by: 0330
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` section « Figure Coverage vs Corroboration ».
+
+## Nomenclature
+Labels conditions : 1N, 5N, 1D, 5D. Ne jamais utiliser A, B, W.
+
+## Actions
+1. Titre : « How many rows are justified by two sources? »
+2. Sous-titre : légende glyph style sur une ligne avec 1N, 5N, 1D, 5D (sans nommer les arms)
+3. Runs individuels : alpha très faible (quasi invisible)
+4. Moyennes : alpha normal (pleinement visibles)
+5. Debug valeur max : plafonner l'axe X à 163 (163 = nombre d'assets de référence)
+   — valeur 175+ est incohérente, vérifier et corriger dans le script
+6. Ajouter les hallucinations en **rouge** (points/glyphs sans label de modèle) :
+   montrer si les hallucinations sont quand même corroborées par 2 sources
+
+## Exit criteria
+- [ ] Titre et sous-titre corrects avec labels 1N/5N/1D/5D
+- [ ] Runs individuels quasi invisibles, moyennes en alpha normal
+- [ ] Axe X plafonné à 163, valeur 175+ disparue
+- [ ] Hallucinations en rouge visibles sur la figure
+- [ ] Figure régénérée et insérée dans slides
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0333-figure-coverage-corroboration.erg
+++ b/tickets/0333-figure-coverage-corroboration.erg
@@ -3,6 +3,7 @@ Title: Figure Coverage vs Corroboration: alpha, rouge, cap 163, titre
 Created: 2026-05-26
 Author: claude
 Blocked-by: 0330
+Blocked-by: 0336
 
 --- log ---
 2026-05-26T10:00Z claude created
@@ -19,10 +20,20 @@ Labels conditions : 1N, 5N, 1D, 5D. Ne jamais utiliser A, B, W.
 2. Sous-titre : légende glyph style sur une ligne avec 1N, 5N, 1D, 5D (sans nommer les arms)
 3. Runs individuels : alpha très faible (quasi invisible)
 4. Moyennes : alpha normal (pleinement visibles)
-5. Debug valeur max : plafonner l'axe X à 163 (163 = nombre d'assets de référence)
-   — valeur 175+ est incohérente, vérifier et corriger dans le script
-6. Ajouter les hallucinations en **rouge** (points/glyphs sans label de modèle) :
-   montrer si les hallucinations sont quand même corroborées par 2 sources
+5. Debug valeur max **(préreq : ticket 0336)** : la valeur 175+ vient probablement de
+   `n_rows = len(data_rows)` qui compte les lignes du tableau MD brut, pas les assets
+   correctement identifiés (n_matched). Le ticket 0336 investigue cette sémantique.
+   - Si n_rows ≠ n_matched : changer l'axe X pour utiliser n_matched (cohérent avec
+     la figure précédente) ; renommer l'axe en conséquence ; plafonner à 163.
+   - Si n_rows = n_matched mais valeur > 163 : c'est un bug de scoring à investiguer.
+
+6. Ajouter les hallucinations en **rouge** (points/glyphs sans label de modèle).
+   Définition formelle requise :
+   - X = nombre d'assets correctement identifiés du run (n_matched, même axe que le bleu)
+   - Y = nombre d'hallucinations corroborées par 2 sources dans ce run
+   - Un point rouge par run, sans label de modèle (anonymisé)
+   But : montrer si les hallucinations sont quand même justifiées par 2 sources.
+   **Prérequis 0336** : la colonne `n_halluc_with_2_sources` doit exister dans le CSV.
 
 ## Exit criteria
 - [ ] Titre et sous-titre corrects avec labels 1N/5N/1D/5D

--- a/tickets/0334-prompt-ameliorations-format-reponse.erg
+++ b/tickets/0334-prompt-ameliorations-format-reponse.erg
@@ -1,0 +1,36 @@
+%erg v1
+Title: Prompt améliorations: format réponse, caption, notes, sources
+Created: 2026-05-26
+Author: claude
+Tag: deferred
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` section « Ticket DÉFERRÉ (hors slides, créé pendant diapo 3) ».
+
+## Context
+Améliorations au prompt `prompts/sotal/protocol_07...` pour forcer un format de réponse plus
+structuré et traçable. Déferré car non bloquant pour Econom'IA 2026.
+
+## Actions
+1. Ajouter une instruction pour commencer la réponse EXACTEMENT par :
+   `| Status | Nom (Tieng Viet) | Nom (EN) | Province | Fuel | Capacity | ...`
+   suivi de 2 lignes d'exemples concrets.
+
+2. Ajouter une instruction pour inclure après la table un `# Caption` avec ce modèle à trou :
+   « Inventaire historico-prospectif des assets et projets de génération thermique au Vietnam.
+   Table statistique générée le <YYYY-MM-DD> à <HH-MM-SS> par <NOM DU MODELE, VARIANTE>
+   pour Minh Ha-Duong (CIRED-CNRS). »
+
+3. Après le `# Caption` : section `# Notes to the table`
+
+4. Après les notes : section `# Sources`
+
+## Exit criteria
+- [ ] Instructions ajoutées au prompt
+- [ ] Test sur 1 modèle : réponse commence bien par le header de table
+- [ ] Caption présent avec les champs de remplissage corrects
+- [ ] `make check` passe

--- a/tickets/0335-figures-titres-cost-accuracy-ai-industry.erg
+++ b/tickets/0335-figures-titres-cost-accuracy-ai-industry.erg
@@ -22,6 +22,10 @@ Voir `slides-review-verbatim.md` sections « Figure Cost vs Accuracy » et « Fi
 Le décalage à droite de ces deux figures est traité dans le ticket 0330 (fix systémique).
 Ce ticket couvre uniquement les corrections de titre.
 
+**À exécuter dans la même PR que 0330** (mêmes fichiers scripts touchés → risque de conflit
+merge sinon). Ordre suggéré : appliquer 0335 (titre) puis 0330 (figsize) dans le même commit
+ou commits successifs sur la même branche.
+
 ## Exit criteria
 - [ ] Titre Cost vs Accuracy mis à jour dans le script Python
 - [ ] Titre AI industry mis à jour dans le script Python

--- a/tickets/0335-figures-titres-cost-accuracy-ai-industry.erg
+++ b/tickets/0335-figures-titres-cost-accuracy-ai-industry.erg
@@ -1,0 +1,29 @@
+%erg v1
+Title: Figures: titres Cost-Accuracy et AI-industry
+Created: 2026-05-26
+Author: claude
+Blocked-by: 0330
+
+--- log ---
+2026-05-26T10:00Z claude created
+
+--- body ---
+## Verbatim
+Voir `slides-review-verbatim.md` sections « Figure Cost vs Accuracy » et « Figure suivante (AI industry) ».
+
+## Actions — Figure Cost vs Accuracy
+1. Titre : « Cost vs Accuracy across 5 model families (no search, one shot, no docs) »
+   (correction : « familly » → « families »)
+
+## Actions — Figure AI industry
+1. Dans le titre : remplacer « AI » par « AI industry »
+
+## Note
+Le décalage à droite de ces deux figures est traité dans le ticket 0330 (fix systémique).
+Ce ticket couvre uniquement les corrections de titre.
+
+## Exit criteria
+- [ ] Titre Cost vs Accuracy mis à jour dans le script Python
+- [ ] Titre AI industry mis à jour dans le script Python
+- [ ] Figures régénérées
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0336-exp2-data-n-matched-investigation.erg
+++ b/tickets/0336-exp2-data-n-matched-investigation.erg
@@ -1,0 +1,47 @@
+%erg v1
+Title: Exp2 data: investiguer n_matched et n_rows pour figures coverage
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created bloqueur identifié par panel review (Lucas Moreau)
+
+--- body ---
+## Context
+Bloqueur identifié par le panel de révision (Dr. Lucas Moreau, expert dataviz) :
+
+**Problème 1** : `tab_exp2_arms_runs.csv` n'a pas de colonne `n_matched`. La figure
+Coverage and costs exp2 (ticket 0332) demande des barres rouges pour les faux positifs
+(hallucinations) sous zéro — ce qui exige `n_halluc = n_inventory - n_matched`. Sans
+`n_matched` la décomposition TP/FP est impossible.
+
+**Problème 2** : `tab_exp2_bib_quality.csv` contient `n_rows = len(data_rows)` qui compte
+les lignes du tableau MD brut, pas les assets correctement identifiés. C'est pourquoi
+des valeurs > 163 apparaissent (ex. OpenAI/optimised n_rows=181). Le ticket 0333
+proposait de plafonner l'axe à 163 — ce serait masquer une erreur sémantique.
+
+## Actions
+1. Auditer le pipeline cross-eval Exp2 :
+   - `experiments/sota/exp2_naive_arm.py` et `exp2_phase_b0_consolidate.py`
+   - Identifier où n_matched devrait être calculé
+   - Vérifier si MILP matching ou name-similarity threshold est déjà appliqué
+2. Si n_matched n'est calculé nulle part : implémenter le calcul (matching contre
+   gold standard 163 plants, même métrique que Exp1)
+3. Ajouter la colonne `n_matched` à `tab_exp2_arms_runs.csv` et la régénérer
+4. Pour `tab_exp2_bib_quality.csv` : renommer `n_rows` en quelque chose de précis
+   (ex. `n_table_rows`) si elle ne représente pas n_matched, OU calculer n_matched
+   en parallèle et l'utiliser comme axe X dans la figure 0333
+5. Pour la figure 0333 (Coverage vs Corroboration) : ajouter aussi la colonne
+   `n_halluc_with_2_sources` (hallucinations corroborées par 2 sources)
+6. Documenter dans le log du ticket la définition exacte de chaque métrique
+
+## Bloque
+- 0332 (figure coverage and costs exp2)
+- 0333 (figure coverage vs corroboration)
+
+## Exit criteria
+- [ ] `n_matched` calculé et présent dans `tab_exp2_arms_runs.csv`
+- [ ] Sémantique de `n_rows` clarifiée dans `tab_exp2_bib_quality.csv` (renommée si nécessaire)
+- [ ] `n_halluc_with_2_sources` calculé et présent dans le CSV bib_quality
+- [ ] Documentation des définitions dans le log du ticket ou un README adjacent
+- [ ] `make` régénère les CSVs sans erreur

--- a/tickets/0337-sweep-1w-5w-to-1d-5d-global.erg
+++ b/tickets/0337-sweep-1w-5w-to-1d-5d-global.erg
@@ -1,0 +1,36 @@
+%erg v1
+Title: Sweep global 1W/5W → 1D/5D dans tout le codebase
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Sophie Lefèbvre C-8)
+
+--- body ---
+## Context
+Décision auteur : renommer la convention des conditions Exp2.
+- `1W` (singleshot With docs) → `1D` (singleshot Docs)
+- `5W` (multiturn With docs) → `5D` (multiturn Docs)
+
+Le ticket 0327 traite uniquement les diapos 10-12. Ce ticket couvre le reste du codebase
+pour éviter des occurrences résiduelles dans figures, scripts, outputs.
+
+## Actions
+1. Grep `1W\|5W` dans tout le repo (hors archive/ et .claude/)
+2. Lister les fichiers concernés : scripts Python, configs YAML/TOML, fichiers de données,
+   tex hors slides.tex, documentation manuscript, etc.
+3. Décider par fichier : remplacer, garder (ex. archive figée), ou autre traitement
+4. Remplacer là où c'est pertinent
+5. Régénérer les artefacts dépendants (figures, tables) après le sweep
+
+## Hors scope
+- `experiments/archive/**` : on n'altère pas les runs historiques
+- `.claude/worktrees/**` : worktrees jetables
+- Les diapos 10-12 sont déjà couvertes par 0327
+
+## Exit criteria
+- [ ] `grep -rE '\b[15]W\b' --include="*.py" --include="*.toml" --include="*.yaml" --include="*.tex" --include="*.md"`
+  ne retourne plus d'occurrences pertinentes (sauf archive/)
+- [ ] Figures et tables régénérées
+- [ ] `make check` passe
+- [ ] `tectonic` builds passent

--- a/tickets/0338-slide-figsize-constants-util.erg
+++ b/tickets/0338-slide-figsize-constants-util.erg
@@ -1,0 +1,44 @@
+%erg v1
+Title: Définir constantes figsize standards Beamer dans aedist.util
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Lucas Moreau LM-11)
+
+--- body ---
+## Context
+Le bug systémique de décalage des figures (ticket 0330) vient de figsize en ratios trop
+larges pour le 16:9 Beamer. Sans constante centrale, chaque nouvelle figure créée risque
+de régresser. Définir des constantes garantit la cohérence et facilite l'audit.
+
+## Actions
+1. Ajouter dans `src/aedist/util.py` (ou module équivalent) :
+   ```python
+   # Beamer 16:9 — figures plein-slide via \includegraphics[width=\paperwidth,
+   # height=\paperheight,keepaspectratio]. Ratio ≤ 1.78 pour éviter clipping droit.
+   SLIDE_FIGSIZE_FULL = (10.0, 5.6)   # 16:9
+   SLIDE_FIGSIZE_WIDE = (11.2, 6.3)   # 16:9 plus grand
+
+   # Figures à côté d'un texte (column 0.55-0.6 textwidth)
+   SLIDE_FIGSIZE_HALF = (5.5, 4.0)    # ratio plus carré OK avec width=\textwidth
+
+   # Figures multipanel polaire (araignées)
+   SLIDE_FIGSIZE_POLAR_2x2 = (10.0, 8.0)
+   ```
+2. Refactorer les scripts plot_*.py existants pour utiliser ces constantes
+   (à coordonner avec le ticket 0330)
+3. Ajouter un test d'adhérence qui détecte les `figsize=(...)` hardcodés dans plot_*.py
+   et fail si la valeur n'est pas une constante importée
+
+## Lien avec 0330
+0330 corrige les figsize au cas par cas dans les scripts existants. 0338 introduit la
+constante centrale. **Ordre suggéré** : 0338 d'abord (créer les constantes), 0330 ensuite
+(les utiliser dans le refactor). Si 0330 est exécuté en premier, c'est OK aussi —
+0338 ajoute la constante et migre les valeurs.
+
+## Exit criteria
+- [ ] Constantes définies dans `aedist.util`
+- [ ] Scripts plot_*.py refactorés pour les utiliser
+- [ ] Test d'adhérence en place
+- [ ] `make check` passe

--- a/tickets/0339-slide-transition-exp1-exp2.erg
+++ b/tickets/0339-slide-transition-exp1-exp2.erg
@@ -1,0 +1,34 @@
+%erg v1
+Title: Ajouter slide de transition Exp1 → Exp2
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Isabelle Charpentier IC-8)
+
+--- body ---
+## Context
+Le panel de communication (Dr. Isabelle Charpentier) a noté qu'entre la fin Exp1 et la
+diapo « Expérience 2 » (diapo 10), il n'y a aucune slide de transition. Le public d'économistes
+bascule sans accroche narrative d'une expérience à l'autre, ce qui affaiblit la motivation
+de l'Exp 2.
+
+## Actions
+1. Ajouter une slide juste avant « Expérience 2 : web search on... » (diapo 10 actuelle)
+2. Contenu suggéré (1 slide, court) :
+   - Titre : « De Exp 1 à Exp 2 : si la mémoire ne suffit pas, les sources peuvent-elles aider ? »
+   - Corps :
+     - Bilan Exp 1 : les modèles connaissent mal les actifs vietnamiens (one shot, no docs).
+     - Question Exp 2 : fournir des documents primaires résout-il le problème ?
+     - Et un second axe : un dialogue multitour peut-il aider à explorer la connaissance ?
+   - (À ajuster avec le ton du reste du talk)
+3. Si l'auteur préfère, alternative minimaliste : un sous-titre de section ou un teaser
+   en 1 phrase ajouté en bas de la dernière slide Exp 1
+
+## Note
+À coordonner avec ticket 0341 (ordre final des slides).
+
+## Exit criteria
+- [ ] Slide de transition (ou phrase de teaser) en place avant la diapo 10
+- [ ] `tectonic slides/slides.tex` passe sans erreur
+- [ ] Lisibilité confirmée par lecture critique

--- a/tickets/0340-definir-rag-public-economiste.erg
+++ b/tickets/0340-definir-rag-public-economiste.erg
@@ -1,0 +1,32 @@
+%erg v1
+Title: Définir RAG pour public économiste (1 phrase)
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Isabelle Charpentier IC-4)
+
+--- body ---
+## Context
+Le titre du talk contient « Beyond RAG » et la section architecturale en fait le pivot.
+Aucune diapo ne définit RAG pour un public d'économistes non spécialistes IA. Sans définition
+minimale, le public peut suivre les résultats (« avec sources ça marche mieux ») sans
+comprendre pourquoi l'architecture est intéressante.
+
+## Actions
+1. Ajouter une définition courte de RAG sur :
+   - **soit** la diapo timeline industrie (avant son premier usage technique)
+   - **soit** la diapo Expérience 2 (description)
+   - **soit** une note en bas de slide quand le sigle apparaît pour la première fois
+
+2. Formulation suggérée (1 phrase, 1 ligne) :
+   > RAG (Retrieval-Augmented Generation) : le modèle reçoit des documents sources en
+   > entrée et génère sa réponse à partir de ces documents, plutôt que de répondre de mémoire.
+
+3. À coordonner avec ticket 0332 qui demande aussi d'introduire RAG dans la timeline et
+   la description Exp 2 — pour éviter de dupliquer le travail.
+
+## Exit criteria
+- [ ] Définition de RAG présente avant son premier usage dans le talk
+- [ ] Définition tient en 1-2 lignes maximum (pas un encart pédagogique long)
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0341-sequence-finale-slides.erg
+++ b/tickets/0341-sequence-finale-slides.erg
@@ -1,0 +1,55 @@
+%erg v1
+Title: Séquence finale des slides — ordre cible global
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Sophie Lefèbvre C-10)
+
+--- body ---
+## Context
+Plusieurs tickets bougent des slides indépendamment :
+- 0326 : restructure section Architecture en Discussion ; remonte diapo 16 ; déplace Qualité méthode
+- 0329 : insère 2 nouvelles slides (structure prompt + Quality dimensions)
+- 0339 : ajoute slide de transition Exp1 → Exp2
+
+Sans séquence cible écrite, ces tickets peuvent être exécutés dans un ordre contradictoire
+et produire des résultats incohérents (ex. 0329 insère après diapo 3 en supposant un ordre
+que 0326 va casser).
+
+## Actions
+1. Établir l'ordre final cible de toutes les slides, du titre à la slide Merci
+2. Documenter la séquence dans ce ticket et la communiquer aux tickets dépendants
+3. Indiquer pour chaque slide : son ID, son titre, et le ticket qui la modifie/crée
+
+## Séquence cible (proposition initiale — à valider)
+1. **Titre** — Dr. Minh Ha-Duong (T-0324)
+2. **L'IA peut-elle produire des données qualité recherche ?** (T-0325)
+3. **Expérience 1** — Engineered 84 lignes, conditions (T-0325)
+4. **Slide A** — Structure du prompt (T-0329)
+5. **Slide B** — Quality dimensions verbatim (T-0329)
+6. **Figure** — How do models recall Vietnam's thermal power assets? Not well. (T-0325)
+7. **La bonne statistique exige plus que des vrais chiffres** (T-0326 — diapo 16 remontée)
+8. **Figure araignées** — multipanel (T-0331)
+9. **Figure araignée Claude seul** (T-0331 — nouvelle)
+10. **Figure Cost vs Accuracy** (T-0335)
+11. **Transition Exp 1 → Exp 2** (T-0339)
+12. **Timeline industrie + RAG** (T-0335, T-0340)
+13. **Expérience 2** — design (T-0327)
+14. **Infrastructure** (T-0327)
+15. **Protocole multitour** (T-0327)
+16. **Figure Coverage and costs exp2** (T-0332)
+17. **Figure Coverage vs Corroboration** (T-0333)
+18. **Diapos 17-18 vérif quanti** (T-0328)
+19. **Section Discussion**
+    - Question centrale
+    - Qualité de la méthode (T-0326, déplacée)
+    - Messages clés (diapo 19 réordonnée) (T-0328)
+    - Directions Futures (T-0326, remontée)
+20. **Merci** — QR code + lien actif (T-0328)
+
+## Exit criteria
+- [ ] Séquence validée par l'auteur
+- [ ] Tous les tickets impactés mis à jour pour référencer cette séquence
+- [ ] Slides en ordre dans le PDF final
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0342-justifier-selection-modeles-exp2.erg
+++ b/tickets/0342-justifier-selection-modeles-exp2.erg
@@ -1,0 +1,32 @@
+%erg v1
+Title: Justifier la sélection des 4 modèles SOTA pour Exp 2
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Antoine Maurel AM-10)
+
+--- body ---
+## Context
+Le ticket 0327 retire la mention « 4 SOTA » du tableau Exp 2. Mais aucun ticket ne demande
+d'expliciter **pourquoi** les 4 modèles retenus (Opus 4.6, GPT-5.5, Mistral Large, Qwen 3.7 max)
+ont été choisis parmi les 46 testés en Exp 1. Pour un public académique, l'absence de critère
+de sélection explicite fragilise la généralisabilité.
+
+Le ticket 0327 supprime aussi la colonne « Enjeu » du tableau, réduisant l'espace narratif
+pour cette justification.
+
+## Actions
+1. Vérifier la motivation de la sélection (top-4 par F1 en Exp 1 ? top-4 par famille ?
+   sélection stratégique pour couvrir les principaux fournisseurs ?)
+2. Ajouter une ligne sur la diapo 10 (après l'application de 0327) :
+   - Soit en pied de tableau (note bas de slide)
+   - Soit en ligne ajoutée au tableau 2-colonnes : « Sélection : 4 SOTA, un par fournisseur principal
+     (Anthropic, OpenAI, Mistral, Alibaba) »
+   - Soit dans la slide de transition créée par 0339
+3. Formulation à valider avec l'auteur si la motivation exacte n'est pas évidente dans le manuscrit
+
+## Exit criteria
+- [ ] Justification de sélection présente dans le talk avant la présentation des résultats Exp 2
+- [ ] Formulation tient en 1 ligne maximum
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/0343-unifier-metrique-exp1-exp2.erg
+++ b/tickets/0343-unifier-metrique-exp1-exp2.erg
@@ -1,0 +1,34 @@
+%erg v1
+Title: Unifier la métrique principale entre Exp 1 et Exp 2 dans le talk
+Created: 2026-05-26
+Author: claude
+
+--- log ---
+2026-05-26T10:00Z claude created suite panel review (Antoine Maurel AM-9)
+
+--- body ---
+## Context
+Le talk présente plusieurs métriques sans unification explicite :
+- Exp 1 : TP/FP bruts (centrales identifiées / hallucinées) et F1
+- Tableau RAG : médiane du nombre de « centrales trouvées »
+- Figure Coverage Exp 2 : couverture en nombre d'assets
+
+Pour un public d'économistes, ce glissement entre F1, nombre brut et couverture est source
+de confusion : « sont-ce les mêmes 163 centrales ? Pourquoi le score change de forme ? »
+
+## Actions
+1. Décider de la métrique principale du talk (recommandation : nombre d'assets identifiés
+   sur 163, plus intuitif que F1 pour un public économiste)
+2. Ajouter un rappel court de la définition à un endroit stratégique :
+   - Soit sur la slide de transition Exp1→Exp2 (T-0339)
+   - Soit sur la slide « La bonne statistique exige plus que des vrais chiffres » (T-0326)
+   - Soit en pied de figure sur la première occurrence
+3. Si F1 est conservé : ajouter une phrase « F1 = moyenne harmonique de précision et recall
+   sur les 163 plants de référence »
+4. Vérifier que toutes les figures utilisent la même unité d'axe (ou justifient le changement)
+
+## Exit criteria
+- [ ] Métrique principale identifiée et nommée dans le talk
+- [ ] Rappel de définition présent à au moins un endroit avant la première figure complexe
+- [ ] Cohérence vérifiée entre figures (mêmes 163 plants, même formule)
+- [ ] `tectonic slides/slides.tex` passe sans erreur

--- a/tickets/2026-05-26-slides-review-verbatim.md
+++ b/tickets/2026-05-26-slides-review-verbatim.md
@@ -1,0 +1,141 @@
+# Verbatim remarques slides — session 2026-05-26
+
+## Diapo 1 (Titre)
+> Titre: revoir en fonction du résultat principal, du take home message, de l'annonce sur le programme
+> Mettre Dr. avant Minh
+> Remplace second CIRED - CNRS par le multi logo (fallback text = logo CIRED avec les tutelles)
+
+## Diapo 2
+> 2. Titre: remplacer Le problème par L'IA peut-elle produire des données qualité recherche ?  ( le supprimer du corps)
+
+## Diapo 3
+> 3. Vérifier les chiffres dans les logs.
+> Supprimer le prompt de la slide, dire Engineered, 84 lignes
+> Ajouter une slide montrant la structure du prompt  prompts/sotal/protocol_07 ... (sections, sous sections ou 1er para).
+> Condition: ajouter "Effort de raisonnement par défaut."
+
+> [retour diapo 3] Remonter Conditions au bloc modèle de la slide
+
+## Ticket DÉFERRÉ (hors slides, créé pendant diapo 3)
+> TICKET à créer en Deferré: Prompt amélios:
+> Ordonner de commencer la réponse exactement par -> | Status | Nom (Tieng Viet) | Nom (EN) | Province | Fuel | Capacity | ... + donner 2 lignes d'exemples.
+> Dire d'ajouter un # Caption sous la table avec un modèle à trou "Inventaire historico-prospectif des assets et projets de génération thermique au Vietnam. Table statistique générée le <YYYY-MM-DD> à <HH-MM-SS> par <NOM DU MODELE, VARIANTE> pour Minh Ha-Duong (CIRED-CNRS).
+> Puis les # Notes to the table, puis les # Sources
+
+## Diapo 4
+> 4. Image alignée à gauche dans la slide, colonne de texte au fer alignée à droite dans la slide marge 2em.
+> Titre (hardcodé dans le fichier figure): How do models recall Vietnam's thermal power assets ? Not well.
+
+## Diapo 5
+> 5. Remplacer slide 5. Qualité du résultat  par une slide "# Quality dimensions" verbatim du prompt. (2 slides avant on avait seulement montré le plan du prompt). La slide Qualité de la méthode va dans la section Architecture rebaptisée Discussion, juste après Question centrale et avant DIrections Futures qui monte là.
+
+## Diapo 7 (araignées)
+> 7. Figure des araignées.
+> subplot en bas droite, garder seulement Qwen, supprimer DeepSeek
+> titre: Qualité des réponses: ask one shot, reasoning on, websearch off, docs provided none.
+>
+> - ajouter une slide avec une seule araignée en grand. Celle des 3 Claude. Avec la mention des 5 axes et des 2 critères par axe en français en clair.
+>
+> - sur le multipanel, on garde seulement le nom des axes pas les critères. Les légendes nom des 3 modèles: sur une colonne, à côté pas en dessous, pour gagner un peu de taille et de lisibilité. Le titre de panel intègre la légende et n'est pas repris Exemple:
+> (a) Claude
+> -- Haiku 4.5
+> -- Sonnet 4.6
+> -- Opus 4.6
+
+## Figure Cost vs Accuracy
+> Figure suivante, 2 panels cost vs accuracy
+> Titre -> Cost vs Accuracy across 5 model familly (no search, one shot, no docs)
+> La figure déborde à droite. Translater à gauche, sans réduore la taille,
+
+## Figure suivante (AI industry)
+> Figure suivante: remplacer "AI" par "AI industry" dans le titre. Idem précédente, translater à gauche sans réduire
+
+## Diapo 10
+> 10. Titre -> Expérience 2: web search on, (oneshot,  multiturn) x (without , with docs)
+> Drop la colonne Enjeu et la ligne Facteur, Valeurs
+> (3 relances) -> (3 à 5)
+> retirer + web search
+> Retirer 4 SOTA, remplacer Qwen3-max par Qwen 3.7 max
+> Runs -> Répétitions
+> Ajouter une ligne Contrôles  Default reasoning effort, Web search allowed, no tools, no code, direct lab API provider, même prompt de base
+> Ajouter une ligne: Documents  18 tables, sources primaires, format MD
+> Supprimer le tableau arm 1... et la ligne Les 4 agents...
+> Au final la slide c'est titre + tableau 2 colonnes, avec la col de droite 1 mot en gras
+
+> [retour diapo 10] Dans les contrôles ajouter < $6, < 50,000 tokens
+
+## Diapo 11
+> 11. Supprimer le second  "Infrastructure :"
+> Remplacer "Même script, .. hash" par "5 claws: Imagine, Plan, Execute, Verify, Celebrate."
+> Supprimer les "/ 4"
+> Ajouter "codéveloppé, " avant relu
+> Rappeler très brievement les réserves après "fondées: "
+
+## Diapo 12
+> 12. Supprimer (Exp 2)
+> Phase A. Remplacer "et planifie le job" par "connaissant le protocole". Supprimer ($1)
+> Remplacer "Un jury de pairs -- mais le jury est aussi un modèle" par "Évaluattion par les pairs: TBD"
+
+> [discussion inline] remplacer "L'agent conçoit son propre protocole, l'exécute, et un autre LLM l'arbitre" par "It's LLMs all the way down — but Knowledge Graphs are not dead."
+
+## Diapo 16 (remonte)
+> Slide 16. elle remonte juste après la slide "Which models recall"  et avant le prompt, titre "La bonne statistique exige plus que des vrais chiffres". Citer "Connaissance: croyance vraie justifiée". Aligner sur les 4 dimensions suivant le manuscrit. Noter la 5e qui est le Niveau de détail approprié. Remplacer "Chaque défaillance a un mécanisme correcteur" par "-> Grille de notation multi-axes"
+
+## Figure Coverage and costs, experiment 2
+> Figure One query providing documents..
+> Titrer -> Coverage and costs, experiment 2
+> Le sous titre est les 4 modalités: "1B = Singleshot, no doc.    5B = Multiturn no doc   1A = Singleshot RAG   5A = Multiturn RAG". Supprimer Matched / Hallucinated
+> il faut introduire RAG avant, au moment de la description et dans la timeline industrie
+> Il faut introduire les 4 labels avant: à la fin de la slide présenant l'éxperience, on dit: Quatre conditions 1N (single turn, no docs) ; 5N ; 1W ; 5W (multiturn, with docs)
+>
+> Principe de la figure
+> Pour chaque modèle un bar graph avec 4 barres labelisées 1N, 5N, 1W, 5W,
+> 4 barres séparées par un petit blanc, avec plus d'espace entre les 4 modèles.
+> Hauteur de barre = moyenne des 5 reps. Couleur = celle du modèle dans le talk.
+> Variance inter-run montrée: On ajoute par dessus une ligne d'incertitude fine en noir avec les 5 valeurs en petits segments horizontaux sur la ligne.
+> Panel de gauche (Coverage): les hallucinations sont uniformément EN ROUGE dans les négatifs, le nombre d assets bien reconnus en couleur du modèle dans les positifs. Même principe que pour la figure "Which model recalls..." de l'exp 1 mais en mode barrre à moustache vertical. Conserver l'axe vertical avec ses ticks de -50 à +150 et la barre verte horizontale. La légende d'axe Y en haut de l'axe, écriture horizontale, "163 plants". Remplacer Coverage par "Number of assets identified (red are False Positive)."
+> Panel de droite (Cost). Idem faire un 4 bars plot à moustaches par modèle.  Remplacer Cost par "API Cost per run, USD" et supprimer la légende d'axe y.
+
+> [Et translater à gauche un peu sans réduire. Toutes les figures, ca doit Être un bug. Suspect: positionné centré  dans le form factor plus wide que le rendu final, puis clipé]
+
+## Figure Coverage vs Corroboration
+> Figure Coverage vs. Corroboration (out of 163 assets).
+> Titrer : How many rows are justified by two sources ?
+> Sous titre = la légende glyph style sur une ligne, sans nommer les arm mais 1N, 5N, 1W, 5W .
+> Dans TOUT ce qui précède, remplacer le W de 1W et 5W par le D de documents -> 1D, 5D.
+> Declutter: Mettre les 5 run en alpha faible (quasi invisible), et les seulement moyennes en alpha normal
+> Debug: 175+ c
+
+> [175+ c'est pas possible. Cohérence avec la figure precédente, on montre les assets correctly identified.
+> On place aussi les hallucitaions, en ROUGE (sans dénoncer personne): on verra sont elles justifiées quand même?]
+
+## Diapos 17-18
+> 17, 18: la fonction de ces slides est de vérifier de façon plus quanti  les messages clé qu'on a vu sur les graphes et qu'on va rabacher en conclusion sur la suivante. Sans aller jusqu au p-values.
+
+## Diapo 19
+> 19: Reformuler, réordonner
+> 1. Multi-tour: pas si utile
+> 2. Fournir les sources: nécessaire
+> 3. Coût: de quelques centimes à quelques euros par requête
+> 4. L'IA produit elle des données de qualité recherche: pas encore
+
+## Diapo Merci
+> Merci: lien cliquable  ctif dans le PDF, + code barre vers le repo (en gros).
+
+## Contenu verbatim diapo Quality dimensions (fourni en session)
+Source : `experiments/sota/protocol_07_naive_prompt.md` lignes 15-26
+
+> # QUALITY DIMENSIONS
+>
+> Your output is judged on four axes:
+>
+> 1. *Accuracy* — right assets and right attributes. Row level: recall and precision against a curated reference (F1). Cell level: capacity, fuel, location, operator, COD, status correct. Confident fabrication is the policed failure mode.
+> 2. *Coherence* — internally and externally consistent. Totals reconcile with known subtotals; no negative capacities, no double-counted units, no cross-row contradiction; values plausible in unit, magnitude, geography, technology, date. Conflicting sources reconciled explicitly (which chosen and why), not silently.
+> 3. *Provenance* — each value traces to a source that actually supports it, not a merely plausible citation. Two independent primaries is the ideal; one primary, a regulator database, or a marked secondary is weaker but acceptable if its status is explicit. Unsupported values are the failure.
+> 4. *Temporality* — every value carries a best-effort as-of date; status changes are flagged. Distinguish current status from past reports, planned from operating capacity, source date from fact date.
+>
+> We prefer a comprehensive inventory with uncertainty clearly expressed over a shortlist of well-known assets.
+
+## Corrections globales
+> Dans TOUT ce qui précède, remplacer 1W → 1D et 5W → 5D (W → D pour « documents »)
+> Bug toutes figures : décalage à droite — fix systémique suspicion canvas trop large puis clippé

--- a/tickets/2026-05-26-slides-review-verbatim.md
+++ b/tickets/2026-05-26-slides-review-verbatim.md
@@ -136,6 +136,36 @@ Source : `experiments/sota/protocol_07_naive_prompt.md` lignes 15-26
 >
 > We prefer a comprehensive inventory with uncertainty clearly expressed over a shortlist of well-known assets.
 
+## Réponses auteur (post-panel review)
+
+### Q-1 (réserves diapo 11)
+Sources trouvées : `experiments/sota/protocol_06_validation_round_1.md` (§4.3 open limitations)
++ round 2 reviews `experiments/archive/outputs/sota_exp2_protocol_review_round2/`.
+Réserves round 2 par Qwen+OpenAI : enforcement instructionnel (bans Wikipedia/subagents pas API-level), cross-éval non indépendante, fuite paramétrique, énergie/CO₂ non exposés.
+
+### Q-2 (« Anthropic trop cher »)
+> Intentionnelle (on le discutera sur la figure, ce n'est pas un résultat stable dans le temps)
+
+Suppression intentionnelle — sera discuté sur la figure cost/quality. Prix non stable dans le temps.
+
+### Q-3 (5e dimension)
+> La 5e dim est opérationnelle, Fit for purpose: pour PyPSA il faut que la colonne Capacité soit remplie, on le mesure.
+
+5e dimension = **Fit for purpose**. Opérationnelle, mesurée. Exemple PyPSA :
+taux de remplissage de la colonne Capacité. Asymétrie intentionnelle entre prompt
+(4 axes) et grille de notation (5 axes) — la 5e dimension est post-hoc, pas demandée
+au modèle dans le prompt.
+
+### Q-4 (slide Quality dimensions en anglais)
+> Verbatim
+
+Laisser verbatim brut. Pas de chapeau français. La slide reste en anglais comme dans le prompt.
+
+### Q-5 (« KG » dans la punchline)
+> Développer
+
+« Knowledge Graphs » écrit en toutes lettres (déjà fait dans ticket 0327). Pas de sigle KG.
+
 ## Corrections globales
 > Dans TOUT ce qui précède, remplacer 1W → 1D et 5W → 5D (W → D pour « documents »)
 > Bug toutes figures : décalage à droite — fix systémique suspicion canvas trop large puis clippé


### PR DESCRIPTION
## Summary

Batch of 20 ticket changes (12 created + 8 new from panel review) for the slides review session ahead of Econom'IA 2026 (2026-05-27).

**Initial batch (0324-0335)** — 12 tickets from Phase A author review:
- Bloc 1 (text/structure): 0324-0328
- Bloc 2 (new prompt slides): 0329
- Bloc 3 (figures): 0330-0333, 0335
- Bloc 4 (deferred): 0334

**Panel review corrections** — 4-expert panel raised 43 comments. 9 corrections applied to existing tickets:
- Full author name "Dr. Minh Ha-Duong" in exit criterion (0324)
- Title selection criteria spelled out (0324)
- `\\raggedleft` for "au fer alignée à droite" (0325)
- Reproducibility hash info preserved alongside "5 claws" (0327)
- Figsize ratio diagnosis specified in 0330 (not centering issue)
- Polar legend layout clarified (0331)
- `model_family_color()` referenced explicitly (0332)
- 0335/0330 coordination noted to prevent merge conflicts
- 0332/0333 blocked by 0336 (data investigation)

**8 new tickets (0336-0343)**:
- 0336: Exp2 data n_matched/n_rows investigation (blocker)
- 0337: Sweep 1W/5W → 1D/5D global
- 0338: SLIDE_FIGSIZE constants in aedist.util
- 0339: Transition slide Exp1 → Exp2
- 0340: Define RAG for economist audience
- 0341: Final slide sequence (coordination)
- 0342: Justify SOTA model selection for Exp2
- 0343: Unify principal metric Exp1 ↔ Exp2

**Author questions resolved** (5/5):
- Reserves diapo 11: sourced from protocol_06 + round 2 reviews
- "Anthropic trop cher" suppression: intentional (price not stable)
- 5th dimension: "Fit for purpose" (operational, PyPSA example)
- Quality dimensions slide: verbatim brut, no French wrapper
- "Knowledge Graphs" spelled out (not KG)

Verbatim and panel state preserved in tickets/2026-05-26-slides-review-verbatim.md.

## Test plan

- [x] Erg validator passes on all 0324-0343 tickets
- [ ] CI status checks pass