### PR TITLE
slides: 7 text/content edits for Econom'IA 2026 deck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ $(GEN)/fig_direct_p1_base.pdf: $(MEASUREMENTS) $(EXP1_BATCH2_RECORDS)
 	    --output $@ --methods direct \
 	    --label-x 100 --label-ha left \
 	    --xlabel "Assets identified (1 dot = 1 power plant / project)" \
-	    --title "Which models recall Vietnam's 163 thermal power plants projects from memory?" \
+	    --title "How do models recall Vietnam's thermal power assets? Not well." \
 	    --ui-scale 1.35 \
 	    --fig-width 12 --fig-height-min 8 --fig-height-per-run 0.06 --fig-height-per-method 0.35 \
 	    --result-dir experiments/outputs/exp1_batch2/ \

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -30,10 +30,17 @@
 \definecolor{qualgreen}{HTML}{27AE60}
 \definecolor{qualblue}{HTML}{2E86AB}
 
+% TODO (auteur) : revoir le titre en fonction des 3 critères de jugement —
+%   (1) le résultat principal du papier, (2) le take-home message,
+%   (3) l'intitulé annoncé dans le programme Econom'IA.
+%   Ne pas modifier le titre dans ce ticket : l'auteur le tranchera ensuite.
 \title{Beyond RAG}
 \subtitle{Vers des statistiques économiques fiables}
-\author{Minh Ha-Duong\\CIRED -- CNRS}
-\institute{CIRED -- CNRS}
+\author{Dr. Minh Ha-Duong}
+% TODO (auteur) : remplacer le bloc affiliation ci-dessous par le multi-logo
+%   (CIRED + tutelles) lorsque l'asset image sera disponible dans slides/.
+%   Fallback texte (logo CIRED avec tutelles) en place ci-dessous.
+\institute{CIRED -- CNRS\\{\small CNRS \textperiodcentered{} École des Ponts ParisTech \textperiodcentered{} AgroParisTech \textperiodcentered{} EHESS \textperiodcentered{} UPEC \textperiodcentered{} Université Gustave Eiffel}}
 \date{Econom'IA 2026 --- Thema, Cergy --- 27 mai 2026}
 
 \begin{document}

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -93,6 +93,7 @@ prompt \textit{Engineered}, 84 lignes.
 
 \medskip
 \textbf{Résultats (163 centrales à identifier)~:}
+{\small\textit{Métrique principale du talk~: nombre d'assets identifiés sur 163 (F1 = moyenne harmonique précision/recall sur ce même référentiel).}}
 \begin{itemize}\setlength\itemsep{0pt}
   \item Centrales identifiées~: \CensusTPMin{}--\CensusTPMax{} par run
   \item Centrales hallucinées~: \CensusFPMin{}--\CensusFPMax{} par run

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -281,6 +281,9 @@ et où mènent les architectures à états agentiques.}
 
 % -------------------------------------------------------------------
 \begin{frame}{Le RAG élève le plancher~: régime de documentation}
+{\small\textit{Vérifions sur les chiffres les messages-clés lus sur les graphes --- sans aller jusqu'aux p-values.}}
+
+\smallskip
 \textbf{Mêmes 5 modèles}, 3 conditions $\times$ 3 runs
 
 \medskip
@@ -340,17 +343,15 @@ Avec RAG, un modèle à \$0{,}15/M \textbf{surpasse} un modèle à \$2{,}50/M sa
 % -------------------------------------------------------------------
 \begin{frame}{Messages clés}
 \begin{enumerate}\setlength\itemsep{1.2em}
-  \item \textbf{RAG FTW~: la méthode domine le modèle.}\\
-        {\small +18--43\,pp de F1 avec RAG~; un modèle bon marché + RAG surpasse
-        les modèles chers sans RAG.}
+  \item \textbf{Multi-tour~: pas si utile.}\\
+        {\small L'ajout de tours conversationnels n'explique qu'une fraction du gain.}
 
-  \item \textbf{Multi-tours~: pas si utile.}\\
-        {\small L'ajout de tours conversationnels n'explique qu'une fraction du gain~;
-        le RAG massif est l'intervention dominante.}
+  \item \textbf{Fournir les sources~: nécessaire.}\\
+        {\small Le RAG massif est l'intervention dominante~; la méthode domine le modèle.}
 
-  \item \textbf{Anthropic trop cher~--- mais c'est juste une question de temps.}\\
-        {\small Opus~4.6 à \$1{,}23 total~: F1 moyen 0{,}46. GPT-OSS-20B à \$0{,}01~: F1 0{,}58.\\
-        Les modèles locaux approchent déjà la frontière.}
+  \item \textbf{Coût~: de quelques centimes à quelques euros par requête.}
+
+  \item \textbf{L'IA produit-elle des données de qualité recherche~? Pas encore.}
 \end{enumerate}
 \end{frame}
 
@@ -383,7 +384,12 @@ Avec RAG, un modèle à \$0{,}15/M \textbf{surpasse} un modèle à \$2{,}50/M sa
 
 \medskip
 \normalsize
-Code \& données~: \texttt{github.com/minhhaduong/aedist-technical-report}
+Code \& données~: \href{https://github.com/minhhaduong/aedist-technical-report}{\texttt{github.com/minhhaduong/aedist-technical-report}}
+% TODO (auteur) : ajouter un QR code EN GROS vers le repo GitHub.
+%   Aucun générateur de QR disponible dans cet environnement (ni qrencode,
+%   ni la lib Python qrcode). Générer le QR (PNG/PDF), le déposer dans
+%   slides/inputs/ puis l'inclure ici, par ex. :
+%   \includegraphics[width=0.4\paperwidth]{inputs/qr_repo.pdf}
 \end{center}
 \end{frame}
 

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -54,7 +54,7 @@
 \section{Problème}
 
 % -------------------------------------------------------------------
-\begin{frame}{Le problème}
+\begin{frame}{L'IA peut-elle produire des données qualité recherche~?}
 \begin{columns}[T]
 \column{0.55\textwidth}
 \textbf{Les modèles ont besoin de données fiables.}
@@ -64,9 +64,6 @@ Exemple: Un modèle électrique de l'ASEAN nécessite des inventaires de central
 
 \smallskip
 Dans les pays à agences statistiques faibles, ces données sont difficiles d'accès.
-
-\smallskip
-\textbf{L'IA peut-elle produire des données de qualité recherche~?}
 
 \column{0.42\textwidth}
 \textbf{Difficultés~:}
@@ -89,9 +86,12 @@ Gold standard: liste compilée par l'auteur sur plusieurs années, en ligne.}
 \begin{frame}{Expérience 1 : utiliser un générateur de mots aléatoires}
 
 \textbf{\NumCensusModels{} modèles, 5 runs chacun (\CensusNumRuns{} runs, \CensusNumOk{} ok, \CensusNumRefusal{} refus)~:}
-``{\ttfamily \input{../experiments/prompts/prompt_extract.txt}}''
+prompt \textit{Engineered}, 84 lignes.
 
 \smallskip
+{\small \textit{Conditions~: \textbf{one shot}, connaissance paramétrique uniquement. Aucun document fourni. Web search désactivé. Effort de raisonnement par défaut.}}
+
+\medskip
 \textbf{Résultats (163 centrales à identifier)~:}
 \begin{itemize}\setlength\itemsep{0pt}
   \item Centrales identifiées~: \CensusTPMin{}--\CensusTPMax{} par run
@@ -99,17 +99,14 @@ Gold standard: liste compilée par l'auteur sur plusieurs années, en ligne.}
   \item Durée~: \CensusWallMin{}--\CensusWallMax{}~s
   \item Coût~: \CensusCostTotal{}\,\$ total (\CensusCostMin{}--\CensusCostMax{}\,\$ par run)
 \end{itemize}
-
-\medskip
-{\small \textit{Condition~: \textbf{one shot}, connaissance paramétrique uniquement. Aucun document fourni. Web search désactivé.}}
 \end{frame}
 
 % -------------------------------------------------------------------
 \begin{frame}[plain]
-\centering
+\noindent
 \includegraphics[height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_direct_p1_base.pdf}
 \begin{tikzpicture}[remember picture,overlay]
-\node[anchor=east,align=left,font=\bfseries\small] at ([xshift=-0.5cm]current page.east) {
+\node[anchor=east,align=right,font=\bfseries\small] at ([xshift=-2em]current page.east) {
 \sout{Récalcitrant}\\
 Incomplet\\
 Hallucinant\\

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -193,6 +193,9 @@ Non-monotone
 \bottomrule
 \end{tabular}
 
+\medskip
+{\footnotesize RAG (\emph{Retrieval-Augmented Generation})~: le modèle reçoit des documents sources en entrée et génère sa réponse à partir de ces documents, plutôt que de répondre de mémoire.}
+
 \bigskip
 {\small \textit{Quatre conditions : 1N (single turn, no docs)~; 5N~; 1D~; 5D (multiturn, with docs).}}
 \end{center}

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -179,62 +179,50 @@ Non-monotone
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Expérience 2 : le SOTA avec web search ne suffit pas}
+\begin{frame}{Expérience 2 : web search on, (oneshot, multiturn) × (without, with docs)}
 \begin{center}
 \small
-\begin{tabular}{@{}lll@{}}
+\begin{tabular}{@{}l p{8.5cm}@{}}
 \toprule
-\textbf{Facteur} & \textbf{Valeurs} & \textbf{Enjeu} \\
-\midrule
-\textbf{Nombre de tours}  & passe unique / multi-tours (3 relances) & protocole \\
-\textbf{Documentation}    & aucune / RAG massif (155 ko) + web search & ancrage \\
-\textbf{Agents}           & 4 SOTA : Opus~4.6, GPT-5.5, Mistral Large, Qwen3-Max & contrôle \\
-\textbf{Runs}             & 5 par cellule & variance \\
+\textbf{Nombre de tours}  & passe unique / \textbf{multi-tours} (3 à 5) \\
+\textbf{Documentation}    & aucune / \textbf{RAG} massif (155 ko) \\
+\textbf{Agents}           & Opus~4.6, GPT-5.5, Mistral Large, \textbf{Qwen 3.7 max} \\
+\textbf{Documents}        & 18 tables, sources primaires, format \textbf{MD} \\
+\textbf{Répétitions}      & 5 par \textbf{cellule} \\
+\textbf{Contrôles}        & default reasoning effort, web search allowed, no tools, no code, direct lab API provider, même prompt de base, \textbf{< \$6}, < 50\,000 tokens \\
 \bottomrule
 \end{tabular}
 
 \bigskip
-\begin{tabular}{@{}lcccc@{}}
-\toprule
-& \textbf{arm 1} & \textbf{arm 2} & \textbf{arm 3} & \textbf{arm 4} \\
-& passe unique & multi-tours & +docs, passe unique & +docs, multi-tours \\
-\midrule
-Nombre de tours & 1 & 3+ & 1 & 3+ \\
-Docs + web      & \texttimes & \texttimes & \checkmark & \checkmark \\
-\bottomrule
-\end{tabular}
-
-\bigskip
-{\small \textit{Les 4 agents ont accès au même corpus RAG vérifié manuellement (PDP7, PDP7A, PDP8, EVN).}}
+{\small \textit{Quatre conditions : 1N (single turn, no docs)~; 5N~; 1D~; 5D (multiturn, with docs).}}
 \end{center}
 \end{frame}
 
 % -------------------------------------------------------------------
 \begin{frame}{La méthode --- Infrastructure}
-\textbf{Infrastructure~:}
 \begin{itemize}\setlength\itemsep{6pt}
   \item \textbf{git-erg}~: gestion de tickets locale, agent-friendly\\
         {\small Format texte versionné~; les agents lisent et ferment les tickets comme des humains.}
   \item \textbf{Imperial Dragon Harness}~: harnais de développement agent-agnostic\\
-        {\small Même script, n'importe quel fournisseur~; les runs sont reproductibles à partir du hash.}
-  \item \textbf{Protocole relu et validé par les LLM eux-mêmes}\\
-        {\small 4 agents consultés~: 2/4 ont validé sans réserve, 2/4 avec réserves.\\
-        \textit{(Les réserves étaient fondées.)}}
+        {\small 5 claws~: Imagine, Plan, Execute, Verify, Celebrate. Runs reproductibles à partir du hash.}
+  \item \textbf{Protocole codéveloppé, relu et validé par les LLM eux-mêmes}\\
+        {\small Agents consultés~: 2 ont validé sans réserve, 2 avec réserves.\\
+        \textit{(Les réserves étaient fondées~: enforcement instructionnel, cross-éval non indépendante, fuite paramétrique, énergie/CO\textsubscript{2} non exposés.)}}
 \end{itemize}
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{La méthode --- Protocole multi-tours (Exp~2)}
+\begin{frame}{La méthode --- Protocole multi-tours}
 \begin{description}\setlength\itemsep{8pt}
-  \item[\textbf{Phase A}] Chaque agent optimise son propre prompt et planifie le job ($\leq$\$1).
+  \item[\textbf{Phase A}] Chaque agent optimise son propre prompt connaissant le protocole.
   \item[\textbf{Phase B}] Jusqu'à 3 tours de recherche + 1 tour de finalisation.
   \item[\textbf{Transitions}] Script state machine~; un LLM juge à chaque tour si l'agent a produit un rapport ou doit continuer.
+  \item[\textbf{Évaluation par les pairs}] TBD.
 \end{description}
 
 \medskip
 \begin{center}
-{\small\textit{L'agent conçoit son propre protocole, l'exécute, et un autre LLM arbitre.\\
-Un jury de pairs --- mais le jury est aussi un modèle.}}
+{\small\textit{It's LLMs all the way down --- but Knowledge Graphs are not dead.}}
 \end{center}
 \end{frame}
 

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -193,6 +193,9 @@ Non-monotone
 \bottomrule
 \end{tabular}
 
+\smallskip
+{\footnotesize Sélection~: 4 SOTA, un par fournisseur principal (Anthropic, OpenAI, Mistral, Alibaba).}
+
 \medskip
 {\footnotesize RAG (\emph{Retrieval-Augmented Generation})~: le modèle reçoit des documents sources en entrée et génère sa réponse à partir de ces documents, plutôt que de répondre de mémoire.}
 


### PR DESCRIPTION
## Summary

Seven slide-text/content tickets applied sequentially to the single Beamer source `slides/slides.tex` (plus one Makefile `--title` line for a figure). The deck builds; per-ticket commits give clean checkpoints. No whole slides added or reordered — that is other tickets' scope.

**Ticket:** tickets/0324-slides-titre-auteur-logo.erg

### Also closes (manual): 0325, 0327, 0328, 0340, 0342, 0343

- **0324** — Diapo 1: author field now `Dr. Minh Ha-Duong`; second "CIRED - CNRS" replaced by fallback text listing CNRS tutelles (no logo asset in `slides/` — TODO left for the auteur to drop in the multi-logo image); title left unchanged with a TODO comment listing the 3 judging criteria.
- **0325** — Diapo 2 retitled "L'IA peut-elle produire des données qualité recherche ?" (duplicate body sentence removed); Diapo 3 prompt display replaced by "prompt Engineered, 84 lignes" (verified: `protocol_07_naive_prompt.md` is exactly 84 lines), Conditions block moved up under the model line + "Effort de raisonnement par défaut." appended; Diapo 4 image flush-left, word column right-aligned at 2em, and the figure `--title` in the Makefile recipe updated to "How do models recall Vietnam's thermal power assets? Not well."
- **0327** — Diapo 10 retitled and collapsed to one 2-column table (dropped Enjeu column, arm sub-table, "Les 4 agents" line; 3 relances→3 à 5; removed "+web search"/"4 SOTA"; Qwen3-Max→Qwen 3.7 max; Runs→Répétitions; added Documents + Contrôles rows incl. <$6/<50 000 tokens; added 1N/5N/1D/5D legend); Diapo 11 dropped duplicate "Infrastructure :", swapped in "5 claws: Imagine, Plan, Execute, Verify, Celebrate. Runs reproductibles à partir du hash." (kept the hash guarantee), dropped "/4", added "codéveloppé,", spelled out the 4 reserves; Diapo 12 dropped "(Exp 2)", Phase A "planifie le job ($1)"→"connaissant le protocole", added "Évaluation par les pairs : TBD", punchline now "It's LLMs all the way down — but Knowledge Graphs are not dead."
- **0328** — Diapos 17-18: one-line framing clarifying their function (quantitative check of key messages, no p-values); Diapo 19 reordered to the 4 specified points, dropping the "Anthropic trop cher" point (intentional per author); Merci repo URL now a clickable `\href` — QR code left as a TODO (no `qrencode`/python `qrcode` available in this env).
- **0340** — Added a one-line RAG definition (Retrieval-Augmented Generation) on diapo 10 where the acronym first appears as a labeled condition.
- **0342** — Added "Sélection : 4 SOTA, un par fournisseur principal (Anthropic, OpenAI, Mistral, Alibaba)" on diapo 10; verified against `protocol_01_ask.md`.
- **0343** — Named the talk's primary metric on diapo 3 ("nombre d'assets identifiés sur 163", F1 = harmonic mean precision/recall on the same reference).

## Flags / out-of-scope

- **Pre-existing baseline build break (not introduced here):** `fig_spider_exp1_families.pdf` and `fig_capability_timeline.pdf` are referenced by the deck but not present in `report/inputs/generated/`. Verified with `tectonic -Z continue-on-errors` — the PDF builds (~204 KB) and only those two known errors remain. Figure generation/renaming is other tickets' scope.
- **0325 diapo 4 figure title:** changed at the Makefile `--title` source only; the rendered PDF still shows the old title until the next figure rebuild (`make`).
- **0328 QR code:** deferred — no QR generator available; TODO + include snippet left in the Merci frame.
- **0343 cross-figure unit consistency** (third exit criterion): data-pipeline audit across figure scripts, outside text-only scope — not verified here.

## Test plan

- [ ] `tectonic slides/slides.tex` builds once the two missing figure PDFs are generated by their owning tickets
- [ ] Author swaps in the multi-logo asset (0324 TODO) and QR code (0328 TODO)
- [ ] Author finalizes diapo 1 title per the 3 criteria in the TODO comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)