### PR TITLE
fix: count inventory rows when narrative is glued to table header

### DIFF
--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -102,6 +102,15 @@ def _extract_pipe_tables(text: str) -> list[str]:
 
     for ln in lines:
         stripped = ln.strip()
+        # Some models (observed in streaming anthropic output) emit a reasoning
+        # preamble glued onto the same physical line as the table header, e.g.
+        # "Let me search.| Name | Fuel |". The leading prose adds a phantom
+        # first cell to the header, so every data row is later dropped as a
+        # column-count mismatch. A genuine pipe-table row opens with `|`; when a
+        # line ends with `|` but does not start with one, the text before the
+        # first `|` is a glued prefix — slice it off so cell counts align.
+        if stripped.endswith("|") and not stripped.startswith("|") and stripped.count("|") >= 3:
+            stripped = stripped[stripped.index("|") :]
         if "|" in stripped and stripped.count("|") >= 3:
             if re.match(r"^\|?[\s\-:|]+\|?$", stripped):
                 continue  # skip separator rows
@@ -138,10 +147,7 @@ def _is_inventory_header(header_line: str) -> bool:
     except Exception:
         return False
 
-    canonical = {
-        map_header_to_canonical(norm_header(cell))
-        for cell in header_cells
-    }
+    canonical = {map_header_to_canonical(norm_header(cell)) for cell in header_cells}
     canonical.discard(None)
 
     # Inventory table must have a plant-name column and enough plant-attribute

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -63,9 +63,7 @@ class TestHeaderMapping:
         assert map_header_to_canonical(norm_header("Orig. Cap (MW)")) == "capacity_mwe"
 
     def test_current_status_resolution_header(self):
-        assert (
-            map_header_to_canonical(norm_header("Current Status / Resolution")) == "status"
-        )
+        assert map_header_to_canonical(norm_header("Current Status / Resolution")) == "status"
 
 
 class TestPipeTable:
@@ -182,6 +180,23 @@ class TestCountBestTableRows:
     def test_returns_zero_when_no_parseable_inventory_table_exists(self):
         text = "| Fuel | Capacity |\n| --- | --- |\n| Coal | 2910 |\n"
         assert count_best_table_rows(text) == 0
+
+    def test_counts_rows_when_narrative_glued_to_header(self):
+        """Arm3 (single-turn with docs) anthropic runs stream a reasoning
+        preamble onto the same physical line as the table header, e.g.
+        ``Let me search.| Name | Fuel |``. The glued prose must not add a
+        phantom header cell that drops every data row as a count mismatch.
+        """
+        text = (
+            "I need to research the current status of Vietnam's thermal "
+            "projects. Let me conduct several targeted searches."
+            "| Name | Fuel | Province | Capacity | Status | COD |\n"
+            "|---|---|---|---|---|---|\n"
+            "| Pha Lai | Coal | Hai Duong | 1040 | Operating | 1983 |\n"
+            "| Uong Bi | Coal | Quang Ninh | 630 | Operating | 2002 |\n"
+            "| Vinh Tan 1 | Coal | Binh Thuan | 1240 | Operating | 2018 |\n"
+        )
+        assert count_best_table_rows(text) == 3
 
     def test_merges_split_inventory_subtables_before_counting(self):
         text = (
@@ -355,7 +370,9 @@ class TestNormHeaderDiacritics:
 # ---------------------------------------------------------------------------
 class TestParseAndCanonicalize:
     def test_basic_csv(self):
-        csv_text = "Name,Fuel,Status,COD,Province,Capacity\nPha Lai,Coal,Operating,2001,Hai Duong,600"
+        csv_text = (
+            "Name,Fuel,Status,COD,Province,Capacity\nPha Lai,Coal,Operating,2001,Hai Duong,600"
+        )
         result = parse_and_canonicalize(csv_text)
         assert "Pha Lai" in result
         assert "600.0" in result
@@ -419,7 +436,7 @@ class TestParseAndCanonicalize:
         """parse_and_canonicalize keeps source_1, source_2, note from sourced runs."""
         csv_text = (
             "name,fuel,status,cod,province,capacity_mwe,source_1,source_2,note\n"
-            'Pha Lai,coal,operational,1983,Hai Duong,440,'
+            "Pha Lai,coal,operational,1983,Hai Duong,440,"
             '"Decision 1195/QD-TTg","EVN Annual Report 2017 p14","4x110MW Soviet-built"\n'
         )
         result = parse_and_canonicalize(csv_text)
@@ -623,9 +640,7 @@ class TestMainSkipsDerivedJson:
             json.dumps({"response": "```csv\nName,Fuel\nPha Lai,Coal\n```"})
         )
         # Eval file that should be skipped
-        (inp / "model-run1.eval.json").write_text(
-            json.dumps({"f1": 0.5, "precision": 0.6})
-        )
+        (inp / "model-run1.eval.json").write_text(json.dumps({"f1": 0.5, "precision": 0.6}))
         main(["--input", str(inp), "--output", str(out)])
         # Only the model reply should produce a CSV
         assert (out / "model-run1.csv").exists()


### PR DESCRIPTION
## Summary

Single-turn arm row counting returned `n_rows=0` for 3 arm3 (single-turn-with-docs) anthropic runs and 1 arm1 (naive) anthropic run, even though the markdown clearly contained a 100+-row inventory table.

**Root cause** (in `extract.py:_extract_pipe_tables`, *not* `extract_arm_single_turn.py`): some models stream their reasoning preamble onto the same physical line as the table header, e.g. `Let me search.| Name | Fuel | ... |`. The glued prose gives the header one extra cell, so every data row is later dropped as a column-count mismatch and the table never emits — `count_best_table_rows` returns 0.

**Fix:** a genuine pipe-table row opens with `|`. When a line ends with `|` but does not start with one, the leading text is a glued prefix; slice it off before counting cells. Minimal change, no touch to separator detection, scoring, or merge logic.

## Effect

- arm3 anthropic runs 03/04/05: `n_rows` 0 → 107 / 110 / 103
- arm1 anthropic_run04: `n_rows` 0 → 74 (same bug, same model, "working" arm)
- All other 17 arm3 runs and 14 arm1 runs: **unchanged** (verified row-by-row)

The single-turn flat artifacts (`arm1_flat/`, `arm3_flat/`) are **byte-identical** after regeneration — they carry `narrative_chars`/`n_bib_entries`, never `n_rows`. Only downstream `count_best_table_rows` consumers (mart, tabulate, plots) see the change. The exp2 mart is **not** rebuilt here (out of scope); on its next rebuild the arm1 anthropic_run04 record will flip 0 → 74.

### arm3 n_rows after fix (all 20 runs)

| agent | run01 | run02 | run03 | run04 | run05 |
|-------|-------|-------|-------|-------|-------|
| anthropic | 51 | 55 | **107** | **110** | **103** |
| mistral | 24 | 108 | 100 | 101 | 88 |
| openai | 117 | 103 | 139 | 151 | 133 |
| qwen | 92 | 91 | 84 | 72 | 67 |

(bold = flipped from 0)

## Test plan

- [x] New focused unit test `test_counts_rows_when_narrative_glued_to_header` (arm3-shaped: narrative + header on one line, separator, 3 data rows → asserts 3 rows)
- [x] `pytest tests/test_extract.py` — 83 passed
- [x] `pytest -m "not slow and not integration"` — 1681 passed, 5 skipped
- [x] `pytest -m adherence` — 14 passed
- [x] `git diff experiments/derived/arm1_flat/` empty (byte-identical)

Raid bugfix — no ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)