### PR TITLE
slides: drop TBD peer-evaluation item

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -248,7 +248,6 @@ LLM \textit{actual competencies: reformulation, translation, comparison, synthes
   \item[\textbf{Phase A}] Chaque agent optimise son propre prompt connaissant le protocole.
   \item[\textbf{Phase B}] Jusqu'à 3 tours de recherche + 1 tour de finalisation.
   \item[\textbf{Transitions}] Script state machine~; un LLM juge à chaque tour si l'agent a produit un rapport ou doit continuer.
-  \item[\textbf{Évaluation par les pairs}] TBD.
 \end{description}
 
 \medskip


### PR DESCRIPTION
Removes the dangling `TBD` from the "Protocole multi-tours" frame.
The peer-evaluation was planned but not executed in this pilot;
the Limites slide already covers it honestly ("pas encore réalisés").

No ticket — one-liner pre-talk cleanup.