### PR TITLE
slides: split Exp2 arms figure, add Exp1 memory-only baseline bar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,14 @@ $(GEN)/fig_capability_dag.pdf: data/capability_timeline.csv
 	uv run python -m aedist.plot_capability_dag \
 	    --input $< --output $@
 
+$(GEN)/fig_exp2_coverage.pdf $(GEN)/fig_exp2_cost.pdf &: $(GEN)/tab_exp2_arms_runs.csv $(GEN)/cost_quality.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_arms_split \
+	    --input $(GEN)/tab_exp2_arms_runs.csv \
+	    --exp1-input $(GEN)/cost_quality.csv \
+	    --coverage-output $(GEN)/fig_exp2_coverage.pdf \
+	    --cost-output $(GEN)/fig_exp2_cost.pdf
+
 $(SLIDE_GEN)/macros.tex: $(GEN)/census_bars.csv $(MEASUREMENTS)
 	uv run python -m aedist.tabulate_macros --census-csv $< --output $@
 

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -14,7 +14,8 @@ SLIDE_ASSETS := \
 	$(LOCAL_ROOT_REPORT_GEN)/fig_direct_p1_base.pdf \
 	$(LOCAL_ROOT_REPORT_GEN)/fig_spider_exp1_families.pdf \
 	$(LOCAL_ROOT_REPORT_GEN)/fig_capability_timeline.pdf \
-	$(LOCAL_ROOT_REPORT_GEN)/fig_exp2_arms_comparison.pdf \
+	$(LOCAL_ROOT_REPORT_GEN)/fig_exp2_coverage.pdf \
+	$(LOCAL_ROOT_REPORT_GEN)/fig_exp2_cost.pdf \
 	$(LOCAL_ROOT_REPORT_GEN)/fig_exp2_coverage_certainty.pdf \
 	$(GENERATED)/regimes.csv \
 	$(GENERATED)/fig_method_convergence.pdf \
@@ -68,7 +69,8 @@ $(LOCAL_ROOT_REPORT_GEN)/macros_p1_base.tex: ; $(MAKE) -C .. $(ROOT_REPORT_GEN)/
 $(LOCAL_ROOT_REPORT_GEN)/cost_quality.csv: ; $(MAKE) -C .. $(ROOT_REPORT_GEN)/cost_quality.csv
 $(LOCAL_ROOT_REPORT_GEN)/fig_capability_timeline.pdf: ; $(MAKE) -C .. $(ROOT_REPORT_GEN)/fig_capability_timeline.pdf
 $(LOCAL_ROOT_REPORT_GEN)/fig_capability_dag.pdf: ; $(MAKE) -C .. $(ROOT_REPORT_GEN)/fig_capability_dag.pdf
-$(LOCAL_ROOT_REPORT_GEN)/fig_exp2_arms_comparison.pdf: ; $(MAKE) -C .. $(ROOT_REPORT_GEN)/fig_exp2_arms_comparison.pdf
+$(LOCAL_ROOT_REPORT_GEN)/fig_exp2_coverage.pdf $(LOCAL_ROOT_REPORT_GEN)/fig_exp2_cost.pdf &: ; \
+	$(MAKE) -C .. $(ROOT_REPORT_GEN)/fig_exp2_coverage.pdf
 $(LOCAL_ROOT_REPORT_GEN)/fig_exp2_coverage_certainty.pdf: ; $(MAKE) -C .. $(ROOT_REPORT_GEN)/fig_exp2_coverage_certainty.pdf
 
 clean:

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -275,7 +275,13 @@ LLM \textit{actual competencies: reformulation, translation, comparison, synthes
 % -------------------------------------------------------------------
 \begin{frame}[plain]
 \centering
-\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_exp2_arms_comparison.pdf}
+\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage.pdf}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}[plain]
+\centering
+\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_exp2_cost.pdf}
 \end{frame}
 
 % -------------------------------------------------------------------

--- a/src/aedist/plot_exp2_arms_split.py
+++ b/src/aedist/plot_exp2_arms_split.py
@@ -1,0 +1,362 @@
+"""Coverage and Cost single-panel figures for Exp2, with Exp1 baseline bar.
+
+Each model group shows 5 bars:
+  E1  = Experiment 1 parametric baseline (from cost_quality.csv)
+  1N  = arm1: single-shot, no docs
+  5N  = arm2: multi-turn, no docs
+  1D  = arm3: single-shot, with docs
+  5D  = arm4: multi-turn, with docs
+
+Writes two separate PDF files:
+  --coverage-output  diverging bar: matched assets above 0, hallucinations below 0
+  --cost-output      positive bar: mean API cost per run (USD)
+
+E1 bars use the same family colour as the model with diagonal hatching
+to visually signal that they come from a different experiment.
+
+Usage:
+    python -m aedist.plot_exp2_arms_split \
+        --input report/inputs/generated/tab_exp2_arms_runs.csv \
+        --exp1-input report/inputs/generated/cost_quality.csv \
+        --coverage-output report/inputs/generated/fig_exp2_coverage.pdf \
+        --cost-output report/inputs/generated/fig_exp2_cost.pdf
+"""
+
+import argparse
+import csv
+import json
+import logging
+from pathlib import Path
+
+from .extract import count_best_table_rows
+from .util import (
+    COLOR_HALLUC,
+    COLOR_REFERENCE,
+    SLIDE_FIGSIZE_FULL,
+    model_family_color,
+)
+
+log = logging.getLogger(__name__)
+
+N_REFERENCE_PLANTS = 163
+
+_AGENT_LABELS = {
+    "anthropic": "Anthropic\nOpus 4.6",
+    "mistral": "Mistral\nLarge 2512",
+    "openai": "OpenAI\nGPT-5.5",
+    "qwen": "Qwen3\nMax",
+}
+_AGENT_ORDER = ["anthropic", "mistral", "openai", "qwen"]
+
+_AGENT_MODEL = {
+    "anthropic": "claude-opus-4-6",
+    "mistral": "mistral-large-2512",
+    "openai": "gpt-5.5",
+    "qwen": "qwen3.7-max",
+}
+
+# Exp1 slugs in cost_quality.csv for each agent.
+_AGENT_EXP1_SLUG = {
+    "anthropic": "claude-opus-4.6",
+    "mistral": "mistral-large-2512",
+    "openai": "gpt-5.5",
+    "qwen": "qwen3.7-max",
+}
+
+# Display order: E1 first, then the four Exp2 arms.
+_CONDITIONS = ["arm1", "arm2", "arm3", "arm4"]
+_CONDITION_LABEL = {"arm1": "1N", "arm2": "5N", "arm3": "1D", "arm4": "5D"}
+
+# 5-bar layout: E1 + arm1..arm4, symmetric around the model centre.
+_BAR_WIDTH = 0.14
+_ALL_KEYS = ["e1", "arm1", "arm2", "arm3", "arm4"]
+_CONDITION_OFFSET = {"e1": -0.36, "arm1": -0.18, "arm2": 0.00, "arm3": +0.18, "arm4": +0.36}
+
+
+def _canonical_arm(raw: str) -> str:
+    if raw == "naive":
+        return "arm1"
+    if raw == "optimised":
+        return "arm2"
+    return raw
+
+
+# ---- data loading ------------------------------------------------------------
+
+
+def _inventory_rows_from_flat(json_path: Path) -> int:
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    for key in ("inventory_rows", "n_rows"):
+        val = payload.get(key)
+        if isinstance(val, int):
+            return val
+    md_path = json_path.with_suffix(".md")
+    if md_path.exists():
+        return count_best_table_rows(md_path.read_text(encoding="utf-8"))
+    return 0
+
+
+def _load_pack_arm_rows(base_dir: Path, arm: str) -> list[dict]:
+    if not base_dir.exists():
+        return []
+    rows: list[dict] = []
+    for json_path in sorted(base_dir.glob("*.json")):
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        agent = str(payload.get("agent") or "").strip()
+        if agent not in _AGENT_ORDER:
+            continue
+        model = str(payload.get("model") or _AGENT_MODEL[agent])
+        run = int(payload.get("run") or 0)
+        classification = str(payload.get("classification") or "report")
+        rows.append(
+            {
+                "arm": arm,
+                "agent": agent,
+                "model": model,
+                "run": run,
+                "classification": classification,
+                "inventory_rows": _inventory_rows_from_flat(json_path),
+                "n_matched": None,
+                "cost_usd": float(payload.get("total_cost_usd", payload.get("cost_usd")) or 0.0),
+                "is_report": classification == "report",
+            }
+        )
+    return rows
+
+
+def load_exp2_rows(path: Path) -> list[dict]:
+    rows = []
+    with path.open(newline="") as fh:
+        for row in csv.DictReader(fh):
+            row["run"] = int(row["run"])
+            raw_rows = row["inventory_rows"]
+            row["inventory_rows"] = int(raw_rows) if raw_rows not in ("", "None") else 0
+            raw_matched = row.get("n_matched", "")
+            row["n_matched"] = int(raw_matched) if raw_matched not in ("", "None") else None
+            row["cost_usd"] = float(row.get("cost_usd") or 0.0)
+            row["arm"] = _canonical_arm(row["arm"])
+            row["is_report"] = row["classification"] == "report"
+            rows.append(row)
+
+    present_arms = {r["arm"] for r in rows}
+    root = path.parents[3]
+    if "arm3" not in present_arms:
+        rows.extend(_load_pack_arm_rows(root / "experiments/derived/arm3_flat", "arm3"))
+    if "arm4" not in present_arms:
+        rows.extend(_load_pack_arm_rows(root / "experiments/derived/arm4_flat", "arm4"))
+    return rows
+
+
+def load_exp1_summary(path: Path) -> dict[str, dict]:
+    """Return {exp1_slug: {median_tp, min_tp, max_tp, mean_cost}} from cost_quality.csv."""
+    summary: dict[str, dict] = {}
+    with path.open(newline="") as fh:
+        for row in csv.DictReader(fh):
+            summary[row["model"]] = {
+                "median_tp": int(row["median_tp"]),
+                "min_tp": int(row["min_tp"]),
+                "max_tp": int(row["max_tp"]),
+                "mean_cost": float(row["mean_cost"]),
+            }
+    return summary
+
+
+# ---- drawing helpers ---------------------------------------------------------
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _draw_whiskers(ax, x_center: float, values: list[float]) -> None:
+    if not values:
+        return
+    seg = _BAR_WIDTH * 0.6
+    ax.vlines(x_center, min(values), max(values), color="black", linewidth=0.7, zorder=5)
+    ax.hlines(
+        values,
+        x_center - seg / 2,
+        x_center + seg / 2,
+        color="black",
+        linewidth=0.8,
+        zorder=5,
+    )
+
+
+def _annotate_bar_labels(ax, include_e1: bool = True) -> None:
+    """Small condition labels (E1/1N/5N/1D/5D) just inside the baseline."""
+    y0 = ax.get_ylim()[0]
+    span = ax.get_ylim()[1] - y0
+    keys = (["e1"] if include_e1 else []) + _CONDITIONS
+    for agent_idx in range(len(_AGENT_ORDER)):
+        for key in keys:
+            label = "E1" if key == "e1" else _CONDITION_LABEL[key]
+            ax.text(
+                agent_idx + _CONDITION_OFFSET[key],
+                y0 + span * 0.015,
+                label,
+                ha="center",
+                va="bottom",
+                fontsize=5.5,
+                color="0.30",
+                zorder=6,
+            )
+
+
+def _style_axis(ax) -> None:
+    ax.set_xticks(range(len(_AGENT_ORDER)))
+    ax.set_xticklabels([_AGENT_LABELS[a] for a in _AGENT_ORDER], fontsize=8)
+    ax.set_xlim(-0.65, len(_AGENT_ORDER) - 0.35)
+    ax.tick_params(axis="y", labelsize=8)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+
+# ---- figure builders ---------------------------------------------------------
+
+
+def make_coverage_figure(
+    exp2_rows: list[dict],
+    exp1_summary: dict[str, dict],
+    output: Path,
+) -> None:
+    import matplotlib.pyplot as plt
+
+    exp2_rows = [r for r in exp2_rows if r["is_report"]]
+
+    fig, ax = plt.subplots(figsize=SLIDE_FIGSIZE_FULL)
+
+    for agent_idx, agent in enumerate(_AGENT_ORDER):
+        color = model_family_color(_AGENT_MODEL[agent])
+
+        # E1 bar
+        exp1_slug = _AGENT_EXP1_SLUG[agent]
+        if exp1_slug in exp1_summary:
+            e1 = exp1_summary[exp1_slug]
+            x = agent_idx + _CONDITION_OFFSET["e1"]
+            ax.bar(x, e1["median_tp"], _BAR_WIDTH, color=color, alpha=0.55, hatch="//", zorder=3)
+            _draw_whiskers(ax, x, [e1["min_tp"], e1["max_tp"]])
+
+        # Exp2 arms
+        for cond in _CONDITIONS:
+            subset = [r for r in exp2_rows if r["agent"] == agent and r["arm"] == cond]
+            if not subset:
+                continue
+            x = agent_idx + _CONDITION_OFFSET[cond]
+            scored = [r for r in subset if r["n_matched"] is not None]
+            if scored:
+                matched_vals = [r["n_matched"] for r in scored]
+                halluc_vals = [max(0, r["inventory_rows"] - r["n_matched"]) for r in scored]
+                mean_matched = _mean(matched_vals)
+                mean_halluc = _mean(halluc_vals)
+                ax.bar(x, mean_matched, _BAR_WIDTH, color=color, alpha=0.85, zorder=3)
+                if mean_halluc > 0:
+                    ax.bar(x, -mean_halluc, _BAR_WIDTH, color=COLOR_HALLUC, alpha=0.9, zorder=3)
+                _draw_whiskers(ax, x, matched_vals)
+            else:
+                inv_vals = [r["inventory_rows"] for r in subset if r["inventory_rows"] > 0]
+                ax.bar(x, _mean(inv_vals), _BAR_WIDTH, color="0.70", alpha=0.85, zorder=3)
+                _draw_whiskers(ax, x, inv_vals)
+
+    ax.axhline(0, color=COLOR_REFERENCE, linewidth=1.4, zorder=2)
+    ax.axhline(N_REFERENCE_PLANTS, color=COLOR_REFERENCE, linestyle="--", linewidth=1.0, zorder=1)
+    ax.yaxis.set_major_formatter(lambda val, pos: str(abs(int(val))))
+    ax.set_ylim(-50, 150)
+    ax.set_yticks([-50, 0, 50, 100, 150])
+    ax.text(-0.55, 150, "163 plants", ha="left", va="bottom", fontsize=8, fontweight="bold")
+    _style_axis(ax)
+    _annotate_bar_labels(ax, include_e1=True)
+    ax.set_title(
+        "Number of assets identified  (hatched = Exp 1 memory-only baseline; red = false positives)",
+        fontsize=10,
+        fontweight="bold",
+        pad=10,
+    )
+    fig.suptitle(
+        "Coverage  ·  E1 = memory only  ·  1N = 1-shot no doc  ·  5N = 5-turn no doc  ·  "
+        "1D = 1-shot + doc  ·  5D = 5-turn + doc",
+        fontsize=8,
+        y=0.02,
+    )
+    fig.tight_layout(rect=(0.0, 0.06, 1.0, 1.0))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    log.info("Wrote %s", output)
+
+
+def make_cost_figure(
+    exp2_rows: list[dict],
+    exp1_summary: dict[str, dict],
+    output: Path,
+) -> None:
+    import matplotlib.pyplot as plt
+
+    exp2_rows = [r for r in exp2_rows if r["is_report"]]
+
+    fig, ax = plt.subplots(figsize=SLIDE_FIGSIZE_FULL)
+
+    for agent_idx, agent in enumerate(_AGENT_ORDER):
+        color = model_family_color(_AGENT_MODEL[agent])
+
+        # E1 bar
+        exp1_slug = _AGENT_EXP1_SLUG[agent]
+        if exp1_slug in exp1_summary:
+            x = agent_idx + _CONDITION_OFFSET["e1"]
+            mean_cost = exp1_summary[exp1_slug]["mean_cost"]
+            ax.bar(x, mean_cost, _BAR_WIDTH, color=color, alpha=0.55, hatch="//", zorder=3)
+
+        # Exp2 arms
+        for cond in _CONDITIONS:
+            subset = [r for r in exp2_rows if r["agent"] == agent and r["arm"] == cond]
+            if not subset:
+                continue
+            x = agent_idx + _CONDITION_OFFSET[cond]
+            cost_vals = [r["cost_usd"] for r in subset]
+            ax.bar(x, _mean(cost_vals), _BAR_WIDTH, color=color, alpha=0.85, zorder=3)
+            _draw_whiskers(ax, x, cost_vals)
+
+    ax.set_ylim(bottom=0)
+    _style_axis(ax)
+    _annotate_bar_labels(ax, include_e1=True)
+    ax.set_title(
+        "API cost per run, USD  (hatched = Exp 1 memory-only baseline)",
+        fontsize=10,
+        fontweight="bold",
+        pad=10,
+    )
+    fig.suptitle(
+        "Cost  ·  E1 = memory only  ·  1N = 1-shot no doc  ·  5N = 5-turn no doc  ·  "
+        "1D = 1-shot + doc  ·  5D = 5-turn + doc",
+        fontsize=8,
+        y=0.02,
+    )
+    fig.tight_layout(rect=(0.0, 0.06, 1.0, 1.0))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    log.info("Wrote %s", output)
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(
+        description="Split Exp2 arms figure into separate coverage and cost panels with Exp1 baseline"
+    )
+    parser.add_argument("--input", required=True, help="Path to tab_exp2_arms_runs.csv")
+    parser.add_argument(
+        "--exp1-input", required=True, help="Path to cost_quality.csv (Exp1 summary)"
+    )
+    parser.add_argument("--coverage-output", required=True, help="Path to write coverage PDF")
+    parser.add_argument("--cost-output", required=True, help="Path to write cost PDF")
+    args = parser.parse_args(argv)
+
+    exp2_rows = load_exp2_rows(Path(args.input))
+    exp1_summary = load_exp1_summary(Path(args.exp1_input))
+
+    make_coverage_figure(exp2_rows, exp1_summary, Path(args.coverage_output))
+    make_cost_figure(exp2_rows, exp1_summary, Path(args.cost_output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Replaces the combined two-panel `fig_exp2_arms_comparison.pdf` with two separate full-slide figures: `fig_exp2_coverage.pdf` and `fig_exp2_cost.pdf`
- Adds an **E1 hatched bar** (Experiment 1 parametric memory-only baseline, from `cost_quality.csv`) as the leftmost bar in each model group — so the progression E1 → no-doc → with-doc is directly readable on both panels
- Model mapping: `claude-opus-4.6` / `gpt-5.5` / `mistral-large-2512` / `qwen3.7-max` from cost_quality.csv to the 4 Exp2 agents
- Adds a Makefile grouped-target rule (`&:`) for the two new figures
- `slides/Makefile` and `slides/slides.tex` updated to use the two new frames

## Test plan

- [x] Script runs cleanly: `uv run python -m aedist.plot_exp2_arms_split ...`
- [x] Both PDFs generated and visually inspected
- [x] Pre-commit hook: 14 tests pass
- [ ] Full `make slides.pdf` (blocked by pre-existing tectonic/logo-cired PDF 1.7 incompatibility, unrelated to this change)

**Ticket:** none (exploratory improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)