### PR TITLE
slides: title Exp1 families spider — "Source is the universal failure mode"

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -208,9 +208,9 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}[plain]
-\centering
-\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
+\begin{frame}{Source is the universal failure mode}
+\centering\vspace{-0.4em}
+\includegraphics[width=\textwidth,height=0.82\textheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
 \end{frame}
 
 % ===================================================================


### PR DESCRIPTION
## Summary

- Converts the `[plain]` full-bleed frame for `fig_spider_exp1_families.pdf` to a titled frame
- Title: **Source is the universal failure mode**
- Adds `height=0.82\textheight` constraint so the 2×2 figure doesn't overflow the content area below the title bar (was 129pt overfull without it)

## Test plan

- [x] `tectonic slides.tex` compiles clean (no new errors or warnings at that frame)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)