### PR TITLE
slides(exp2): actionable 1D recommendation frame

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -321,6 +321,28 @@ quand la mémoire (ou l'imagination) du modèle ne suffit pas.}
 \end{frame}
 
 % -------------------------------------------------------------------
+% Préconisation 1D — replaces 2×2 table (ticket 0351)
+\begin{frame}{Préconisation~: 1 tour, avec documents}
+
+\centering
+
+\vspace{1em}
+{\Large\textbf{F1 moyen = 0{,}63}}\\[0.5em]
+{\normalsize contre 0{,}51 sans documents \quad·\quad 0{,}54 multi-tours avec docs \quad·\quad 0{,}44 multi-tours sans docs}
+
+\bigskip
+{\large Meilleure condition pour \textbf{4/4 modèles}}
+
+\bigskip
+{\large Surcoût~: \textbf{$\times$\,1{,}4} en moyenne \quad {\small (multi-tours avec docs~: $\times$\,2{,}2)}}
+
+\vspace{1.5em}
+{\Large\bfseries\textcolor{matched}{$\to$ Fournir les sources~; un seul tour suffit.}}
+
+\end{frame}
+
+% --- Frame commenté (2×2 statistique, réactivable post-conférence) ---
+\iffalse
 \begin{frame}{Effet du RAG > Effet du multitour}
 \centering
 \small
@@ -331,6 +353,7 @@ quand la mémoire (ou l'imagination) du modèle ne suffit pas.}
 \vspace{0.8em}
 {\footnotesize $N=4$ modèles (facteur de blocage), 5 reps/cellule. On rapporte la cohérence directionnelle $k/n$, pas un seuil de significativité : à $n=4$, $p_{\min}=1/2^4=0{,}0625$ est inatteignable.}
 \end{frame}
+\fi
 
 
 


### PR DESCRIPTION
## Summary
- Replace the 2×2 statistical table (slide 19) with an actionable recommendation: "1 tour, avec documents"
- New frame shows verified data: F1=0.63 (1D) dominates all 4 models, costs ×1.4 the naive baseline
- Old frame preserved in `\iffalse` block for post-conference reactivation

**Ticket:** tickets/0351-slide-preconisation-1d.erg

## Data verification
- 1D best for 4/4 models: Claude (0.61), Mistral (0.59), GPT-5.5 (0.72), Qwen (0.60)
- Grand mean F1: 0.63 (1D) vs 0.51 (1N) vs 0.54 (5D) vs 0.44 (5N)
- Cost ratio: ×1.4 average (range: ×0.24 Mistral to ×5.4 Qwen)

## Test plan
- [x] `tectonic slides.tex` compiles without error
- [x] Visual verification: slide 24 (19/23) renders cleanly
- [x] Old frame preserved, not deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)