### PR TITLE
slides: fix line wrap on recommendation frame

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -328,7 +328,7 @@ quand la mémoire (ou l'imagination) du modèle ne suffit pas.}
 
 \vspace{1em}
 {\Large\textbf{F1 moyen = 0{,}63}}\\[0.5em]
-{\normalsize contre 0{,}51 sans documents \quad·\quad 0{,}54 multi-tours avec docs \quad·\quad 0{,}44 multi-tours sans docs}
+{\normalsize contre 0{,}51 (1N) \enspace·\enspace 0{,}54 (5D) \enspace·\enspace 0{,}44 (5N)}
 
 \bigskip
 {\large Meilleure condition pour \textbf{4/4 modèles}}


### PR DESCRIPTION
## Summary
- Use condition abbreviations (1N/5D/5N) to prevent line wrap on the recommendation slide
- Tighter `\enspace` separators replace `\quad` for better fit

## Test plan
- [x] `tectonic slides.tex` compiles
- [x] Visual: comparison line now fits on one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)