### PR TITLE
slides(exp1): hallucination examples slide — Haiku province pattern + gpt-oss-20b recursion

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -118,6 +118,36 @@ Non-monotone
 \end{frame}
 
 % -------------------------------------------------------------------
+\begin{frame}{«~Hallucinant~»~: deux modes récurrents (Exp 1, sans documents)}
+
+\begin{columns}[T]
+\column{0.50\textwidth}
+\textbf{Mode 1~: une centrale par province}\\
+{\small Claude Haiku, T$=0$ — les mêmes 15 centrales dans les 5 runs~:}
+\begin{itemize}\setlength\itemsep{1pt}
+  \item{\small NMĐ Hà Nội}
+  \item{\small NMĐ Đà Nẵng}
+  \item{\small NMĐ Khánh Hòa}
+  \item{\small NMĐ Tiền Giang}
+  \item{\small NMĐ Vĩnh Long \ldots}
+\end{itemize}
+{\small Aucune n'existe dans le référentiel.}
+
+\column{0.50\textwidth}
+\textbf{Mode 2~: récursion}\\
+{\small GPT OSS 20B — run 3~: 83 lignes, une seule entreprise~:}
+\begin{itemize}\setlength\itemsep{1pt}
+  \item{\small Trung Nam 1 (charbon, 600 MW)}
+  \item{\small Trung Nam 2 (charbon, 600 MW)}
+  \item{\small \ldots}
+  \item{\small Trung Nam 83 (charbon, 600 MW)}
+\end{itemize}
+{\small Run 4~: même patron, 100 lignes, province différente.}
+\end{columns}
+
+\end{frame}
+
+% -------------------------------------------------------------------
 % OPTION A — version épurée (Claude, pour choix auteur)
 \begin{frame}{Le prompt en 84 lignes~: trois blocs}
 \begin{columns}[T]


### PR DESCRIPTION
## Summary

Adds a slide right after the Récalcitrant/Incomplet/**Hallucinant** overlay, illustrating two vivid hallucination modes found in Exp 1 small-model runs:

- **Claude Haiku** (T=0): generates one plant per Vietnamese province ("NMĐ Hà Nội", "NMĐ Đà Nẵng" …) — same 15 invented plants in all 5 runs, none in the reference
- **gpt-oss-20b**: runaway counter — run 3: 83 rows all "Trung Nam 1…83" (coal, 600 MW); run 4: 100 rows, same pattern, different province