### PR TITLE
Wire orphaned figures into the build DAG + completeness guard test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ EXP1_BATCH2_RECORDS := $(wildcard experiments/outputs/exp1_batch2/*.record.json)
 $(GEN)/fig_direct_p1_base.pdf $(GEN)/macros_p1_base.tex &: $(MEASUREMENTS) $(EXP1_BATCH2_RECORDS)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_method_convergence \
-	    --output $@ --methods direct \
+	    --output $(GEN)/fig_direct_p1_base.pdf --methods direct \
 	    --label-x 100 --label-ha left \
 	    --xlabel "Assets identified (1 dot = 1 power plant / project)" \
 	    --title "How do models recall Vietnam's thermal power assets? Not well." \

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ $(GEN)/fig_census_direct.pdf: $(MEASUREMENTS)
 
 EXP1_BATCH2_RECORDS := $(wildcard experiments/outputs/exp1_batch2/*.record.json)
 
-$(GEN)/fig_direct_p1_base.pdf: $(MEASUREMENTS) $(EXP1_BATCH2_RECORDS)
+$(GEN)/fig_direct_p1_base.pdf $(GEN)/macros_p1_base.tex &: $(MEASUREMENTS) $(EXP1_BATCH2_RECORDS)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_method_convergence \
 	    --output $@ --methods direct \

--- a/experiments/analysis.mk
+++ b/experiments/analysis.mk
@@ -55,6 +55,9 @@ ANALYSIS_EXP2_COVERAGE_SPLIT := $(ANALYSIS_GEN)/fig_exp2_coverage.pdf
 ANALYSIS_EXP2_COST_SPLIT := $(ANALYSIS_GEN)/fig_exp2_cost.pdf
 ANALYSIS_SLIDE_MACROS := $(ANALYSIS_SLIDE_GEN)/macros.tex
 
+ANALYSIS_EXP1_SPIDER_FAMILIES := $(ANALYSIS_GEN)/fig_spider_exp1_families.pdf
+ANALYSIS_EXP1_SPIDER_CLAUDE := $(ANALYSIS_GEN)/fig_spider_exp1_claude.pdf
+
 ANALYSIS_EXP2_OUTLINE_ARTIFACTS := \
 	$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex \
 	$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex \
@@ -264,6 +267,21 @@ $(ANALYSIS_EXP2_SPIRE_FIG): $(ANALYSIS_GEN)/sota_cross_eval_view.csv experiments
 	    --config experiments/quality_spider_config.yaml \
 	    --output $@
 
+# Exp1 quality spiders: one script, two invocations (family 2x2 panels vs a
+# single-model large spider) -> two targets, not a grouped rule.
+$(ANALYSIS_EXP1_SPIDER_FAMILIES): $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval/.done
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_quality_spider_exp1 \
+	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
+	    --output $@
+
+$(ANALYSIS_EXP1_SPIDER_CLAUDE): $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval/.done
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_quality_spider_exp1 \
+	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
+	    --model claude-opus-4.6 \
+	    --output $@
+
 $(ANALYSIS_GEN)/stat_tests_arm1_vs_arm2.txt: $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_stat_tests \
@@ -370,9 +388,11 @@ $(ANALYSIS_SLIDE_MACROS): $(ANALYSIS_GEN)/census_bars.csv $(ANALYSIS_REPO_ROOT)/
 	uv run python -m aedist.tabulate_macros \
 	    --census-csv $(ANALYSIS_GEN)/census_bars.csv --output $@
 
-.PHONY: exp2-analysis-report
+.PHONY: exp2-analysis-report exp1-analysis-figures
 
 exp2-analysis-report: $(ANALYSIS_EXP2_REPORT_TARGETS) \
 	$(ANALYSIS_EXP2_2X2_TEX) $(ANALYSIS_EXP2_2X2_FR_TEX) \
 	$(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) \
 	$(ANALYSIS_SLIDE_MACROS)
+
+exp1-analysis-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES) $(ANALYSIS_EXP1_SPIDER_CLAUDE)

--- a/tests/test_makefile_dag.py
+++ b/tests/test_makefile_dag.py
@@ -1,0 +1,135 @@
+"""Every generated figure/table consumed by the build must have a producer.
+
+The build is split into two workpackages (see slides/Makefile header):
+
+  * analysis  -- experiments/*.mk, run on demand with data/network access,
+                 writes artifacts into report/inputs/generated/ and
+                 slides/inputs/generated/.
+  * writing   -- Makefile + report/Makefile + slides/Makefile, compiles the
+                 PDFs from those artifacts treated as committed inputs.
+
+A producing rule may therefore live in *any* of the makefiles. This test
+takes the UNION of all makefiles, expands variables (analysis.mk names its
+targets through $(ANALYSIS_*) variables, so a literal scan misses them), and
+asserts that every generated .pdf/.tex used as a prerequisite is the target
+of some rule somewhere in that union. Grouped targets (`a b &:`) count as
+producers of each member.
+
+This guards the analysis<->writing seam: an artifact may be committed, but if
+no makefile knows how to (re)build it, it is orphaned from the DAG and silently
+goes stale.
+"""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# A generated artifact lives under <report|slides>/inputs/generated/ and is a
+# figure (.pdf) or a LaTeX include (.tex). CSV data marts are out of scope.
+GEN_RE = re.compile(r"(report|slides)/inputs/generated/([^/\s:*?)]+\.(?:pdf|tex))")
+ASSIGN_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(:=|\?=|\+=|=)\s*(.*)$")
+VAR_REF_RE = re.compile(r"\$\(([A-Za-z_][A-Za-z0-9_]*)\)")
+
+
+def _makefiles() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    files = []
+    for rel in out.split("\0"):
+        if not rel or rel.startswith("tickets/"):
+            continue
+        name = rel.rsplit("/", 1)[-1]
+        if name == "Makefile" or rel.endswith(".mk"):
+            files.append(REPO_ROOT / rel)
+    return files
+
+
+def _logical_lines(path: Path) -> list[str]:
+    return path.read_text().replace("\\\n", " ").splitlines()
+
+
+def _expand(value: str, variables: dict[str, str], _depth: int = 0) -> str:
+    if _depth > 25 or "$(" not in value:
+        return value
+    new = VAR_REF_RE.sub(lambda m: variables.get(m.group(1), ""), value)
+    return new if new == value else _expand(new, variables, _depth + 1)
+
+
+def _key(token: str, mk_dir: Path) -> str | None:
+    norm = os.path.normpath(os.path.join(str(mk_dir), token))
+    m = GEN_RE.search(norm)
+    return f"{m.group(1)}/inputs/generated/{m.group(2)}" if m else None
+
+
+def _parse(path: Path) -> tuple[set[str], dict[str, set[str]]]:
+    """Return (targets, prereq_sources) of generated-artifact keys."""
+    variables: dict[str, str] = {}
+    rules: list[str] = []
+    for raw in _logical_lines(path):
+        if raw.startswith("\t"):  # recipe line
+            continue
+        line = raw.split("#", 1)[0]
+        if not line.strip():
+            continue
+        m = ASSIGN_RE.match(line)
+        if m:
+            name, op, val = m.group(1), m.group(2), m.group(3).strip()
+            if op == "+=":
+                variables[name] = f"{variables.get(name, '')} {val}".strip()
+            elif op == "?=" and name in variables:
+                pass
+            else:
+                variables[name] = val
+            continue
+        if ":" in line:
+            rules.append(line)
+
+    mk_dir = path.parent.relative_to(REPO_ROOT)
+    targets: set[str] = set()
+    prereqs: dict[str, set[str]] = {}
+    rel = str(path.relative_to(REPO_ROOT))
+    for line in rules:
+        lhs, _, rhs = line.partition(":")
+        lhs = lhs.rstrip().rstrip("&").rstrip()  # drop grouped-target marker
+        for tok in _expand(lhs, variables).split():
+            if (key := _key(tok, mk_dir)) is not None:
+                targets.add(key)
+        for tok in _expand(rhs, variables).split():
+            if (key := _key(tok, mk_dir)) is not None:
+                prereqs.setdefault(key, set()).add(rel)
+    return targets, prereqs
+
+
+def test_generated_artifacts_have_a_producer():
+    all_targets: set[str] = set()
+    all_prereqs: dict[str, set[str]] = {}
+    for mk in _makefiles():
+        targets, prereqs = _parse(mk)
+        all_targets |= targets
+        for key, srcs in prereqs.items():
+            all_prereqs.setdefault(key, set()).update(srcs)
+
+    orphans = sorted(k for k in all_prereqs if k not in all_targets)
+    detail = "\n".join(
+        f"  - {k}  (required by: {', '.join(sorted(all_prereqs[k]))})"
+        for k in orphans
+    )
+    assert not orphans, (
+        "Generated artifacts used as prerequisites but produced by no makefile "
+        "rule (orphaned from the build DAG):\n"
+        f"{detail}\n\n"
+        "Add a producing rule (in experiments/analysis.mk for analysis "
+        "artifacts) or, for multi-output scripts, a grouped target `a b &:`."
+    )

--- a/tickets/0354-wire-orphaned-figures-into-dag.erg
+++ b/tickets/0354-wire-orphaned-figures-into-dag.erg
@@ -1,0 +1,65 @@
+%erg 0.1
+Title: Wire orphaned generated figures into the build DAG; add completeness guard
+Created: 2026-05-27
+Author: claude
+
+--- log ---
+2026-05-27T00:00Z claude created — red adherence test committed first (TDD), fix follows
+
+--- body ---
+## Context
+
+A union-aware Makefile DAG-completeness test (`tests/test_makefile_dag.py`,
+`@pytest.mark.adherence`, committed on branch
+`claude/slides-figures-list-3GC71`) asserts that every generated `.pdf`/`.tex`
+consumed as a prerequisite is the target of some rule across the union of all
+makefiles (writing + analysis workpackages), with variable expansion so
+`analysis.mk`'s `$(ANALYSIS_*)` targets are recognised.
+
+It is currently **red**, documenting three artifacts orphaned from the DAG —
+committed, consumed by the build, but produced by no makefile rule:
+
+- `report/inputs/generated/fig_spider_exp1_claude.pdf`
+- `report/inputs/generated/fig_spider_exp1_families.pdf`
+- `report/inputs/generated/macros_p1_base.tex`
+
+This completes the unchecked exit criterion of **0345** ("slides.pdf
+prerequisites match the figures the deck includes — add the 5 missing":
+the two `fig_spider_exp1_*` were among them) and is a slice of **0352**
+(analysis.mk as sole figure producer). Sibling exp1 cross-eval figure
+`fig_spider_cross_exp` and the input variable
+`ANALYSIS_EXP1_CROSS_EVAL_CSV` (analysis.mk:22, declared but unused) confirm
+analysis.mk is the intended home.
+
+## Test
+
+`tests/test_makefile_dag.py::test_generated_artifacts_have_a_producer` —
+red now (3 orphans), green when each has a producing rule. This IS the
+first test.
+
+## Actions
+
+1. `experiments/analysis.mk`: add producers for `fig_spider_exp1_families.pdf`
+   (default) and `fig_spider_exp1_claude.pdf` (`--model claude-opus-4.6`) via
+   `aedist.plot_quality_spider_exp1`, depending on the
+   `exp1_cross_eval/.done` stamp (analysis.mk:85). Two rules, one script, two
+   invocations (not a grouped target). Attach to a phony aggregate.
+2. `Makefile`: declare `macros_p1_base.tex` a grouped co-target of the
+   existing `fig_direct_p1_base.pdf` rule (it is already written via
+   `--output-macros` in the same invocation) — `a b &: deps`. DAG honesty,
+   no new `uv run` leakage. Full migration to analysis.mk stays 0352's scope.
+
+## Definition of done
+
+- `pytest tests/test_makefile_dag.py` is green.
+- `make -n slides` / `make -n report` introduce no NEW `uv run` (clean-room
+  property of 0345 preserved; the writing build still consumes committed
+  PDFs).
+- One real invocation of each new recipe (to a temp output) succeeds against
+  committed `exp1_cross_eval.csv` with slug `claude-opus-4.6`.
+
+## Related
+- 0345 (closed, PR #609): analysis.mk sole producer, writing build from artifacts.
+- 0352 (deferred): report writing build clean-room — full producer migration.
+- 0353 (deferred): adherence guard against `uv run` in the writing build —
+  sibling guard to this DAG-completeness test.


### PR DESCRIPTION
## Summary

- Adds `tests/test_makefile_dag.py` (`@pytest.mark.adherence`): a union-aware DAG-completeness guard. It parses all makefiles (writing + analysis workpackages), expands variables (so `analysis.mk`'s `$(ANALYSIS_*)` targets are recognised), and asserts every generated `.pdf`/`.tex` consumed as a prerequisite is the target of some rule. Grouped targets (`a b &:`) count as producers.
- Wires the three artifacts the guard flagged as orphaned (committed, consumed by the build, produced by no rule):
  - `experiments/analysis.mk` gains producers for `fig_spider_exp1_families.pdf` and `fig_spider_exp1_claude.pdf` (`aedist.plot_quality_spider_exp1`, off the `exp1_cross_eval/.done` stamp), plus a `exp1-analysis-figures` phony. The `ANALYSIS_EXP1_CROSS_EVAL_CSV` variable was already declared for them; this completes 0345's intended shape (analysis.mk as sole producer).
  - `Makefile` declares `macros_p1_base.tex` a grouped co-target of the existing `fig_direct_p1_base.pdf` rule that already writes it via `--output-macros` — DAG honesty, no new `uv run`.
- Adds ticket `0354` documenting the work (TDD: red test committed first, fix follows).

Placement in `analysis.mk` (not the root Makefile) is deliberate and evidence-based: the input variable was pre-wired, 0345 named these figures, and it avoids adding `uv run` to the writing build. Full migration of the remaining root figure rules stays 0352's scope.

## Test plan

- [x] `pytest tests/test_makefile_dag.py` — red on 3 orphans before the fix, green after.
- [x] Both new recipes run successfully against the committed `exp1_cross_eval.csv` (slug `claude-opus-4.6` accepted), verified to a temp output without touching committed PDFs.
- [x] `make -n slides` shows zero `uv run` and does not rebuild the spider figures — 0345's clean-room property preserved.
- [x] `make -n` parses both modified makefiles; root co-target now recognised (`is up to date`, no longer `No rule to make target`).

Related: 0345 (closed, PR #609), 0352 (deferred), 0353 (deferred).

https://claude.ai/code/session_01EfM3C7kdBb5mThT4a1219c

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfM3C7kdBb5mThT4a1219c)_