### PR TITLE
Add tickets 0354 (Makefile consolidation) and 0355 (git-erg skill removal)

### DIFF
--- a/tickets/0354-makefile-cross-file-duplication.erg
+++ b/tickets/0354-makefile-cross-file-duplication.erg
@@ -1,0 +1,86 @@
+%erg 0.1
+Title: Consolidate Makefile cross-file duplication and divergence (shared common.mk)
+Created: 2026-05-27
+Author: claude
+
+--- log ---
+2026-05-27T00:00Z claude created — modularity audit of the 7 makefiles found duplicate producers, 4 divergent UV_RUN definitions, a 6x copy-pasted drain recipe, and an env-policy violation in experiment1.mk
+
+--- body ---
+## Context
+
+Audit of the 7 makefiles (`Makefile`, `experiments/Makefile`,
+`experiments/{analysis,experiment1,experiment2}.mk`, `report/Makefile`,
+`slides/Makefile`). The directory split (experiments = data/analysis,
+report/slides = writing) is sound, and the analysis-vs-writing workpackage
+split (analysis.mk produces handoff artifacts, the writing build only
+compiles) is **intentional** — established by ticket 0345 / PR #609, and
+documented in `slides/Makefile` lines 2-6. This ticket does NOT relitigate
+that split.
+
+What it targets is cross-file duplication and divergence that no longer has a
+reason to exist:
+
+1. **Duplicate self-consistency producer.** `tab_self_consistency.tex` +
+   `tab_per_run.tex` are produced by TWO rules: root `Makefile:80-84` and
+   `experiments/Makefile:213-216` (via `SC_TEX`/`SC_PERRUN`). Same outputs, two
+   recipes — exactly the duplicate-producer anti-pattern 0345 removed for the
+   2x2 table. Whichever fires depends on which makefile is invoked.
+
+2. **Four divergent `UV_RUN` definitions** for the same operation:
+   - `experiments/Makefile:48` — `uv run --project .. --env-file ../.env` (the
+     documented-policy form)
+   - `experiment2.mk:20` — `PYTHONPATH=.. uv run --project .. --env-file ../.env`
+   - `experiment1.mk:10` — `env PYTHONPATH=.. uv run --env-file $(HOME)/.claude/.env --project ..`
+   - `analysis.mk` — bare `uv run` (no `--project`, no `--env-file`; cwd-dependent)
+
+3. **`experiment1.mk:10` violates the documented ENV POLICY.**
+   `experiments/Makefile:13-29` makes the project `../.env` the single source of
+   truth and explicitly warns against `~/.claude/.env` (stale-key + `ps -ef`
+   leak history). `experiment1.mk` uses `--env-file $(HOME)/.claude/.env`.
+
+4. **Drain recipe copy-pasted 6x.** `census-run`, `regimes-run`,
+   `decomposed-run`, `verification-run`, `sourced-run`, `frontier-run` in
+   `experiments/Makefile` are byte-identical
+   (`for i in $$(seq 1 $(OR_JOBS)); do $(WORKER) openrouter --drain & done; wait`).
+   The matching `*-generate` targets differ only by `--sweep` name.
+
+Out of scope (note for a possible follow-up tracking ticket): the root
+`Makefile` is itself an undocumented analysis producer — ~20 `uv run` rules
+writing into `report/inputs/generated/` — parallel to `analysis.mk`. Folding
+the whole presentation layer into the analysis workpackage is a larger
+architecture change; this ticket only removes the clear duplication above.
+
+## Actions
+1. Add `experiments/common.mk` defining `UV_RUN`, `WORKER`, `MANAGER`,
+   `OR_*`, and a canned drain recipe (`define drain ... endef`). `include` it
+   from `experiments/Makefile` and the three `.mk` files. Keep `analysis.mk`'s
+   overridable `?=` path-var style.
+2. Replace the 6 `*-run` recipes with the shared drain define; collapse the
+   near-identical `*-generate` targets where it does not hurt readability.
+3. Remove the duplicate self-consistency rule from the root `Makefile`
+   (keep the `experiments/Makefile` producer, since measurements live there).
+4. Point `experiment1.mk` at `../.env`, matching the ENV POLICY.
+5. Verify the full DAG still resolves: `make report`, `make slides`,
+   `make -f experiments/analysis.mk exp2-analysis-report`,
+   `make -C experiments rebuild-measurements` (dry-run `-n` is enough for the
+   long data targets).
+
+## Test
+First (red) test — an adherence check in `tests/` (pytest, `@pytest.mark.adherence`)
+asserting the de-duplication holds, so regressions are caught:
+- no makefile under the repo contains the literal `$(HOME)/.claude/.env`;
+- the drain loop literal `openrouter --drain & done` appears in at most one
+  recipe location (i.e. in the `common.mk` define, not 6 inline copies);
+- `tabulate_self_consistency` is invoked by exactly one makefile recipe.
+Plus a build smoke test: `make -n report` and `make -n slides` exit 0 with no
+"No rule to make target" error.
+
+## Exit criteria
+- [ ] One `experiments/common.mk` is the single definition of `UV_RUN`/`WORKER`/
+      `MANAGER`/drain; the four makefiles include it, no local redefinitions.
+- [ ] The 6 `*-run` recipes share the drain define (no copy-paste).
+- [ ] Exactly one producer of `tab_self_consistency.tex` / `tab_per_run.tex`.
+- [ ] No makefile references `$(HOME)/.claude/.env`.
+- [ ] `make -n report` and `make -n slides` resolve with no missing-rule error.
+- [ ] New adherence test added and `make check` passes.

--- a/tickets/0355-git-erg-deprecate-and-remove-vendored-ti.erg
+++ b/tickets/0355-git-erg-deprecate-and-remove-vendored-ti.erg
@@ -2,10 +2,13 @@
 Title: git-erg: deprecate and remove vendored ticket-* skills, standardise on erg verbs
 Created: 2026-05-27
 Author: Claude
+Tag: needs-human
 
 --- log ---
 2026-05-27T06:57Z Claude created
 
+2026-05-27T06:59Z Claude tag needs-human
+2026-05-27T06:59Z tagged needs-human — reminder: file upstream in git-erg; agent has no access to that repo
 --- body ---
 ## Upstream ticket — for git-erg, not this repo
 

--- a/tickets/0355-git-erg-deprecate-and-remove-vendored-ti.erg
+++ b/tickets/0355-git-erg-deprecate-and-remove-vendored-ti.erg
@@ -1,0 +1,76 @@
+%erg 0.1
+Title: git-erg: deprecate and remove vendored ticket-* skills, standardise on erg verbs
+Created: 2026-05-27
+Author: Claude
+
+--- log ---
+2026-05-27T06:57Z Claude created
+
+--- body ---
+## Upstream ticket — for git-erg, not this repo
+
+Filed locally because this container has no checkout of, and no write access
+to, the git-erg / ImperialDragonHarness repo. **Transcribe to git-erg's own
+issue tracker**, then close this with a `Closed:` ref to the upstream issue.
+
+## Context
+
+git-erg vendors a bundle into each host repo via `erg init` (the installer):
+a managed `# --- git-erg --- begin/end` block in `.claude/CLAUDE.md`, the five
+`.claude/skills/ticket-{new,claim,close,ready,release}/` skills, the spec, and
+the binary. In aedist this landed via PR #570 (2026-05-25).
+
+Two problems:
+
+1. **The skills are obsolete wrappers.** The `erg` CLI already exposes the full
+   verb set — `new`, `ready`, `close`, `log`, `tag`, `untag`, `archive`,
+   `next-id`, `validate`, `check`. The `ticket-new`/`ticket-ready`/`ticket-close`
+   skills just reimplement `erg new` / `erg ready` / `erg close` in prose. The
+   workflow is now "`erg <verb>`"; the skills add a parallel, drift-prone path.
+
+2. **The vendored prose is stale and contradicts the shipped spec/binary**, so
+   following the skill produces invalid tickets:
+   - `ticket-new/SKILL.md` and the CLAUDE.md block say `%erg v1`; spec + binary
+     are `%erg 0.1` (MAJOR.MINOR, no `v` prefix).
+   - The skill writes a `Status: open` header and lists a "Closed header set"
+     including `Status`. The validator rejects it: rule 3 — *"Status: is unknown;
+     run 'erg migrate' to convert it"*. Open is the absence of a `Closed:` header.
+   - CLAUDE.md says "no CLI needed" and points the validator at
+     `tickets/tools/go/`; the actual interface is the `tickets/erg` binary and
+     that directory does not exist.
+
+   Version skew is concrete: the binary was built 2026-05-12 (rev f2a97e1) at
+   spec 0.1, yet the skills vendored 2026-05-25 still describe the pre-0.1 draft.
+   The human-readable bundle lags the machine-checked spec/binary.
+
+## Actions (in git-erg)
+1. Delete the `ticket-*` skills from the git-erg source bundle. Document in the
+   integration notes that the canonical interface is `erg <verb>` (and direct
+   `.erg` text editing per the spec), not skills.
+2. Make `erg update` (the autoupdater) **remove** any `.claude/skills/ticket-*`
+   it previously installed in the host repo — not merely stop shipping them.
+   Detect git-erg-managed skill dirs (e.g. a provenance marker written at init,
+   analogous to the `# --- git-erg --- begin/end` CLAUDE.md fences) and prune
+   them, so existing installs converge on update instead of leaving orphans.
+3. Update the managed `.claude/CLAUDE.md` block to: drop "no CLI needed",
+   reference `erg <verb>`, fix the spec version to `%erg 0.1`, and point at the
+   `erg` binary rather than `tickets/tools/go/`.
+4. Optional: have `erg init` / `erg update` emit the obsolescence warning when it
+   finds vendored skills it is about to remove.
+
+## Test
+First (red) test in git-erg's suite: install the old bundle (with the
+`ticket-*` skills present) into a scratch repo, run `erg update`, assert the
+`.claude/skills/ticket-*` directories are gone and the CLAUDE.md managed block
+no longer mentions skills or `%erg v1`. Re-running `erg update` is idempotent.
+
+## Exit criteria
+- [ ] Upstream issue filed in git-erg; this ticket carries a `Closed:` ref to it.
+- [ ] git-erg no longer ships the `ticket-*` skills.
+- [ ] `erg update` removes previously-installed `ticket-*` skills from a host
+      repo (verified on a scratch install of the old bundle).
+- [ ] The managed CLAUDE.md block references `erg <verb>` and `%erg 0.1`, with no
+      "no CLI needed" / `tickets/tools/go/` claims.
+- [ ] Local follow-up: after the fix ships, run `erg update` in aedist and
+      confirm `.claude/skills/ticket-*` are removed (do NOT hand-delete now —
+      the point is that the autoupdater does it).


### PR DESCRIPTION
## Summary
- **0354** — Makefile modularity audit findings: duplicate self-consistency producer (root + experiments), four divergent `UV_RUN` definitions, 6x copy-pasted drain recipe, and `experiment1.mk` env-policy violation. Scopes a shared `experiments/common.mk` consolidation; leaves the intentional analysis/writing workpackage split (#609) alone.
- **0355** — upstream request for git-erg: the vendored `ticket-*` skills are redundant wrappers around existing `erg` verbs, and their prose (`%erg v1`, `Status:` header) contradicts the shipped 0.1 spec/binary. Tagged `needs-human` to file in the git-erg repo (agent has no access).

Ticket files only — no code changes.

https://claude.ai/code/session_01J8qgojPrJAyotGjqzJ66rm

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qgojPrJAyotGjqzJ66rm)_