### PR TITLE
slides(fr): land post-conference revisions + spelling fixes

### DIFF
--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -53,8 +53,14 @@
 \begin{frame}{}
 \begin{center}
 {\small\textit{LLM actual competencies: reformulation, translation, comparison, synthesis, or controlled hybridization of textual corpora. Such operations may be mobilized through short prompts, or integrated into hybrid processing loops combining scripts, applications, or agents programmed in Python.}}\\[0.5em]
-{\footnotesize --- Las Vergnas et Jeunesse, Econom'IA 2026}
+{\footnotesize Las Vergnas et Jeunesse, Econom'IA 2026}
 \end{center}
+
+\bigskip
+\begin{center}
+\textbf{Cela suffit-il à produire des données statistiques de qualité recherche à partir de sources ouvertes~?}\\
+\end{center}
+
 \end{frame}
 
 % ===================================================================
@@ -126,7 +132,7 @@ Non-monotone
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{«~Hallucinant~»~: deux modes récurrents (Exp 1, sans documents)}
+\begin{frame}{«~Hallucinant~»~: deux modes récurrents}
 
 \begin{columns}[T]
 \column{0.50\textwidth}
@@ -154,6 +160,27 @@ Non-monotone
 \end{columns}
 
 \end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Précision~: actifs non-reconnus, pas nécessairement hallucinés}
+
+\textbf{Faux positif}~$=$~actif listé par le modèle non-réconcilié.
+
+\medskip
+\begin{description}\setlength\itemsep{6pt}
+  \item[\textbf{Limite du matcher}] Actif réel, nom divergent.
+        Ex.~: \emph{Nhơn Trạch 3 \& 4} vs \emph{LNG Nhơn Trạch 3} + \emph{4}~;
+        \emph{NMĐ Bà Rịa} vs \emph{Bà Rịa GT}~;
+        \emph{Vedan} vs \emph{Vedan Vietnam Cogeneration}.
+  \item[\textbf{Limite du référentiel}] Actif réel, absent du référentiel.
+  \item[\textbf{Interrogations statistiques}] Co-génération chaleur-électricité, incinération, taille limite...
+\end{description}
+
+\medskip
+\small Une table statistique de qualité reconnaît les interrogations.
+
+\end{frame}
+
 
 % -------------------------------------------------------------------
 % OPTION A — version épurée (Claude, pour choix auteur)
@@ -262,6 +289,11 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
   \item \textbf{Question Exp 2.} Comment faire mieux~? Quels facteurs comptent~: Autoriser la recherche web~? Approfondir le dialogue~? Fournir des documents sources~? Modèle plus puissant~?
 \end{itemize}
 
+\bigskip
+\begin{center}
+\textbf{Architecture expérimentale simple 2x2:\\agentique (ou non), avec documents (ou sans)}\\
+\end{center}
+
 \end{frame}
 
 
@@ -269,20 +301,23 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
 \begin{frame}[plain]
 \centering
 \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
-\begin{tikzpicture}[remember picture,overlay]
-  \node[anchor=north east,font=\small\bfseries,text=matched] at ([xshift=-2em,yshift=-2em]current page.north east)
-    {4. Files upload (RAG)};
-\end{tikzpicture}
+
+% Il fallait patcher le code la figure, l'agent a tenté un overlay
+% \begin{tikzpicture}[remember picture,overlay]
+%  \node[anchor=north east,font=\small\bfseries,text=matched] at ([xshift=-2em,yshift=-2em]current page.north east)
+%    {4. Files upload (RAG)};
+%\end{tikzpicture}
+
 \end{frame}
 
 % -------------------------------------------------------------------
 \begin{frame}{Expérience 2 design : (single turn, multitour) × (no docs, with docs)}
 \framesubtitle{Quatre conditions : 1N (single turn, no docs) ; 5N ; 1D ; 5D (multitour, with docs)}
 \begin{center}
-\small
 \begin{tabular}{@{}l p{8.5cm}@{}}
-\textbf{Nombre de tours}  & question unique (prompt Exp 1) / multi-tours (3 à 5) \\
-\textbf{Documentation}    & aucune / RAG 18 tables, sources primaires, Markdown \\
+\textbf{Architecture}     & One prompt vs. Agentic (3 - 5 turns) \\
+\textbf{Documentation}    & aucune vs. RAG 18 tables, sources primaires, Markdown \\
+\\
 \textbf{Agents}           & Opus~4.6, GPT-5.5, Mistral Large, Qwen 3.7 max \\
 \textbf{Répétitions}      & 5 (variabilité modèle) \\
 \textbf{Contrôles}        & default reasoning effort, web search allowed, no tools, no code, direct lab API provider \\
@@ -370,7 +405,7 @@ quand la mémoire (ou l'imagination) du modèle ne suffit pas.}
 Prompt:
 \begin{description}\setlength\itemsep{4pt}
   \item[\textbf{Optimisation en Phase A}]: facteur de variance non contrôlé.
-  \item[\textbf{Language}]: facteur de variance non contrôlé.
+  \item[\textbf{Langue}]: facteur de variance non contrôlé.
   \item[\textbf{Optimalité}]: critères formels de qualités à développer.
 \end{description}
 
@@ -378,44 +413,20 @@ Expérimentales:
 \begin{description}\setlength\itemsep{4pt}
   \item[\textbf{Cible mobile}]: Modèles évolutifs, hébergeurs fluctuants.
   \item[\textbf{Petits échantillons}]: 5 runs par condition, 4 modèles.
-  \item[\textbf{Préregistration, évaluation par les pairs}]: pas encore réalisés.
+  \item[\textbf{Préenregistrement, évaluation par les pairs}]: pas encore réalisés.
   \item[\textbf{Généralisation secteur $\times$ pays}] de l'électricité au Vietnam aux hydrocarbures en Indonésie, à l'eau en Thaïlande.
 \end{description}
 
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Précision~: actifs non-reconnus, pas nécessairement hallucinés}
-
-\textbf{Faux positif}~$=$~actif listé par le modèle que le LP ne parvient pas à réconcilier.
-Trois causes distinctes~:
-
-\medskip
-\begin{description}\setlength\itemsep{6pt}
-  \item[\textbf{Limite du LP}] Actif réel, nom divergent.
-        Ex.~: \emph{Nhơn Trạch 3 \& 4} (agrégé) vs \emph{LNG Nhơn Trạch 3} + \emph{4} (référence)~;
-        \emph{NMĐ Bà Rịa} vs \emph{Bà Rịa GT}~;
-        \emph{Vedan} vs \emph{Vedan Vietnam Cogeneration}.
-  \item[\textbf{Hors périmètre}] Actif réel, absent du référentiel~:
-        extensions (\emph{Mở Rộng}), centrales CHP industrielles (\emph{Đồng Phát}),
-        projets planifiés non encore intégrés.
-  \item[\textbf{Référence inexacte}] Projets annulés ou reportés connus de la mémoire paramétrique~:
-        \emph{Kiên Lương} charbon, \emph{Rạng Đông}, \emph{Bình Định} charbon.
-\end{description}
-
-\medskip
-\small Améliorer la précision exige à la fois un meilleur matching \emph{et} un meilleur ancrage aux sources.
-
-\end{frame}
-
-% -------------------------------------------------------------------
-\begin{frame}{Directions futures: vers l'hybridation avec les graphes de connaissances}
+\begin{frame}{Dépasser le RAG: vers l'hybridation avec les graphes de connaissances}
 
 \begin{description}\setlength\itemsep{4pt}
   \item[\textbf{Découverte et gestion des sources}] avec vérification humaine.
   \item[\textbf{Incrémentalité}] avec mémoire des résolutions des cas difficiles.
-  \item[\textbf{Vérifié $>$ vérifiable}] la présence de citation ne suffit pas.
-  \item[\textbf{Valeurs des attributs $>$ lignes d'actifs}]
+  \item[\textbf{Vérifier}] la présence de citations (vérifiable) ne suffit pas.
+  \item[\textbf{Attributs détaillés}] savoir que l'actif existe ne suffit pas.
 \end{description}
 
 Chaque cellule d'une table est un triplet [sujet (rangée), prédicat (colonne), objet (valeur)].
@@ -428,22 +439,18 @@ Chaque document est un graphe de connaissances partiel, daté, bruité, redondan
 \section{Conclusions}
 
 % -------------------------------------------------------------------
-\begin{frame}{Messages clés}
-\begin{enumerate}\setlength\itemsep{1.2em}
-  \item \textbf{Multi-tour inutile.}\\
-        {\small L'ajout de tours conversationnels n'explique qu'une fraction du gain.}
-
-  \item \textbf{Fournir les sources aide certains modèles.}\\
-        {\small Le RAG massif est l'intervention dominante~; la méthode domine le modèle.}
-
-  \item \textbf{Coût~: de quelques centimes à quelques euros par requête.}
-
-  \item \textbf{L'IA produit-elle des données de qualité recherche~?}
-\end{enumerate}
+\begin{frame}{Conclusions}
+\begin{itemize}\setlength\itemsep{1.2em}
+  \item \textbf{+ De semaines de veille intelligente à quelques euros de requête.}
+  \item \textbf{+ Fournir les sources économise et améliore.}\\
+  \item \textbf{- Mais assurer la qualité demande plus.}\\
+  \item \textbf{- Multi-tour peu convaincant: vérificateur externe.}\\
+\end{itemize}
 
 \bigskip
 \begin{center}
-\Large\textcolor{red}{\textbf{Pas encore vérifié.}}
+\textbf{L'IA produit-elle des données de qualité recherche~?}\\
+\Large\textcolor{red}{\textbf{Pas encore. Il faut dépasser le RAG.}}
 \end{center}
 \end{frame}
 


### PR DESCRIPTION
## What

Lands the author's uncommitted post-conference French slide revisions (the working-tree state on local `main`) plus three orthographic fixes from a French aspell pass.

### Spelling fixes (agent)
| Before | After | Rationale |
|--------|-------|-----------|
| `nom divergent .` | `nom divergent.` | stray space before period |
| `Préregistration` | `Préenregistrement` | anglicism → standard FR term (aspell flags the welded compound — false positive) |
| `Language` | `Langue` | anglicism in the FR *Limites* list (siblings *Optimisation*/*Optimalité*); **judgment call — revert if "Language" was intended** |

### Author revisions carried unchanged (WIP from local main)
- Precision / false-positive frame moved ahead of the prompt block
- Exp 2 design table reframed around the 2×2 architecture × documentation axes
- Conclusions frame rewritten
- Knowledge-graph frame retitled *Dépasser le RAG*

## Verification
- `tectonic slides.tex` → builds clean (exit 0), `slides.pdf` 386 KB, only benign overfull-box warnings.

## Deferred (typography, not spelling — separate pass if wanted)
- Inconsistent French colon spacing (`X:` vs `X~:`)
- `...` vs `\ldots`
- `multitour` / `multi-tour` / `multi-tours` hyphenation

🤖 Generated with [Claude Code](https://claude.com/claude-code)