### PR TITLE
slides(en): English translation of the Econom'IA deck

### DIFF
--- a/slides/Makefile
+++ b/slides/Makefile
@@ -33,9 +33,14 @@ MANUSCRIPT_ASSETS := \
 
 .PHONY: all clean manuscript
 
-all: slides.pdf manuscript/main.pdf
+all: slides.pdf slides-en.pdf manuscript/main.pdf
 
 slides.pdf: slides.tex $(SLIDE_ASSETS)
+	tectonic $<
+
+# English deck. Shares all SLIDE_ASSETS; figures keep their generated-language
+# labels (regenerating figures in English is a separate analysis-side task).
+slides-en.pdf: slides-en.tex $(SLIDE_ASSETS)
 	tectonic $<
 
 manuscript: manuscript/main.pdf
@@ -49,4 +54,4 @@ manuscript/main.pdf: manuscript/main.md $(MANUSCRIPT_ASSETS) ../report/refs.bib
 		--bibliography=../report/refs.bib
 
 clean:
-	rm -f slides.pdf manuscript/main.pdf *.aux *.log *.nav *.out *.snm *.toc
+	rm -f slides.pdf slides-en.pdf manuscript/main.pdf *.aux *.log *.nav *.out *.snm *.toc

--- a/slides/slides-en.tex
+++ b/slides/slides-en.tex
@@ -1,0 +1,501 @@
+\documentclass[aspectratio=169]{beamer}
+\usepackage{booktabs}
+\usepackage{colortbl}
+\usepackage{xcolor}
+\usepackage{tikz}
+\usepackage{pgfplots}
+\pgfplotsset{compat=1.18}
+\usepackage{pgfplotstable}
+\usepackage[normalem]{ulem}
+
+\useinnertheme{metropolis}
+\useoutertheme{metropolis}
+\usecolortheme{metropolis}
+\setbeamertemplate{frame numbering}[fraction]
+
+\InputIfFileExists{inputs/generated/macros}{}{}
+\InputIfFileExists{../report/inputs/generated/macros_p1_base}{}{}
+
+\definecolor{matched}{HTML}{2E86AB}
+\definecolor{missed}{HTML}{E8505B}
+\definecolor{halluc}{HTML}{F5A623}
+\definecolor{goodf1}{HTML}{2E86AB}
+\definecolor{medf1}{HTML}{F5A623}
+\definecolor{lowf1}{HTML}{E8505B}
+% Quality ladder colors
+\definecolor{qualred}{HTML}{E74C3C}
+\definecolor{qualgray}{HTML}{BBBBBB}
+\definecolor{qualyellow}{HTML}{F1C40F}
+\definecolor{qualorange}{HTML}{E67E22}
+\definecolor{qualgreen}{HTML}{27AE60}
+\definecolor{qualblue}{HTML}{2E86AB}
+
+\title{Beyond RAG}
+\subtitle{Architectures for Reliable Economic Statistics with Agentic Systems}
+\author{Dr. Minh Ha-Duong}
+\institute{CIRED, CNRS}
+\date{Econom'IA 2026 --- Thema, Cergy --- May 27, 2026}
+
+\begin{document}
+
+% ===================================================================
+\begin{frame}
+\titlepage
+\begin{tikzpicture}[remember picture,overlay]
+  \node[anchor=north east,inner sep=6pt] at (current page.north east)
+    {\includegraphics[height=1.4cm]{inputs/logo-cired.pdf}};
+  \node[anchor=south,inner sep=6pt] at (current page.south)
+    {\includegraphics[width=0.7\paperwidth]{inputs/Bandeau5Tutelles_2024.png}};
+\end{tikzpicture}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{}
+\begin{center}
+{\small\textit{LLM actual competencies: reformulation, translation, comparison, synthesis, or controlled hybridization of textual corpora. Such operations may be mobilized through short prompts, or integrated into hybrid processing loops combining scripts, applications, or agents programmed in Python.}}\\[0.5em]
+{\footnotesize Las Vergnas and Jeunesse, Econom'IA 2026}
+\end{center}
+
+\bigskip
+\begin{center}
+\textbf{Is this enough to produce research-grade statistical data from open sources?}\\
+\end{center}
+
+\end{frame}
+
+% ===================================================================
+\section{Problem}
+
+% -------------------------------------------------------------------
+\begin{frame}{Can AI produce research-grade data?}
+\begin{columns}[T]
+\column{0.55\textwidth}
+\textbf{Models need reliable data.}
+
+\smallskip
+Example: an ASEAN power-system model requires power-plant inventories.
+
+\smallskip
+In countries with weak statistical agencies, such data are hard to access.
+
+\column{0.42\textwidth}
+\textbf{Difficulties:}
+\begin{itemize}\setlength\itemsep{1pt}
+  \item \textbf{Multilingual}
+  \item \textbf{Rapid transition}
+  \item \textbf{Scattered sources}
+\end{itemize}
+
+\medskip
+{\small Pilot task: inventory of thermal power plants in Vietnam.\\
+Gold standard: a list compiled by the author over several years, published online.}
+\end{columns}
+\end{frame}
+
+% ===================================================================
+\section{Experiment 1}
+
+% -------------------------------------------------------------------
+\begin{frame}{Experiment 1: using a random word generator}
+
+\smallskip
+\textbf{Task: Give the inventory of thermal power plants in Vietnam} via an 84-line prompt. Parametric knowledge only: no web search, no documents provided. Default reasoning effort. Temperature = 0.
+
+\smallskip
+\textbf{Primary metric:} number of assets correctly identified. Reference: 163 coal, gas, and oil plants $>30$\,MWe
+
+\smallskip
+\textbf{Results, \NumCensusModels{} models, 5 runs each:}
+\begin{itemize}\setlength\itemsep{0pt}
+  \item Plants identified: \CensusTPMin{}--\CensusTPMax{} per run
+  \item Plants not recognized: \CensusFPMin{}--\CensusFPMax{} per run
+  \item Time per run: \CensusWallMin{} s --20 min
+  \item Cost: \CensusCostTotal{}\,\$ total (\CensusCostMin{}--\CensusCostMax{}\,\$ per run)
+\end{itemize}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}[plain]
+\noindent
+\includegraphics[height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_direct_p1_base.pdf}
+\begin{tikzpicture}[remember picture,overlay]
+\only<2->{%
+\node[anchor=east,align=right,font=\bfseries\small] at ([xshift=-1em]current page.east) {
+\sout{Recalcitrant}\\
+Incomplete\\
+Hallucinating\\
+Non-deterministic\\
+Non-monotonic
+};
+}
+\end{tikzpicture}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{``Hallucinating'': two recurring modes}
+
+\begin{columns}[T]
+\column{0.50\textwidth}
+\textbf{Mode 1: one plant per province}\\
+{\small Claude Haiku, T$=0$ --- the same 15 plants across all 5 runs:}
+\begin{itemize}\setlength\itemsep{1pt}
+  \item{\small NMĐ Hà Nội}
+  \item{\small NMĐ Đà Nẵng}
+  \item{\small NMĐ Khánh Hòa}
+  \item{\small NMĐ Tiền Giang}
+  \item{\small NMĐ Vĩnh Long \ldots}
+\end{itemize}
+{\small None exist in the reference list.}
+
+\column{0.50\textwidth}
+\textbf{Mode 2: recursion}\\
+{\small GPT OSS 20B --- run 3: 83 rows, a single company:}
+\begin{itemize}\setlength\itemsep{1pt}
+  \item{\small Trung Nam 1 (coal, 600 MW)}
+  \item{\small Trung Nam 2 (coal, 600 MW)}
+  \item{\small \ldots}
+  \item{\small Trung Nam 83 (coal, 600 MW)}
+\end{itemize}
+{\small Run 4: same pattern, 100 rows, different province.}
+\end{columns}
+
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Precision: unrecognized assets, not necessarily hallucinated}
+
+\textbf{False positive}~$=$~an asset listed by the model that could not be reconciled.
+
+\medskip
+\begin{description}\setlength\itemsep{6pt}
+  \item[\textbf{Matcher limitation}] Real asset, divergent name.
+        E.g.: \emph{Nhơn Trạch 3 \& 4} vs \emph{LNG Nhơn Trạch 3} + \emph{4};
+        \emph{NMĐ Bà Rịa} vs \emph{Bà Rịa GT};
+        \emph{Vedan} vs \emph{Vedan Vietnam Cogeneration}.
+  \item[\textbf{Reference limitation}] Real asset, absent from the reference list.
+  \item[\textbf{Statistical judgment calls}] Combined heat and power, incineration, size cutoff\ldots
+\end{description}
+
+\medskip
+\small A quality statistical table acknowledges the judgment calls.
+
+\end{frame}
+
+
+% -------------------------------------------------------------------
+% OPTION A — streamlined version (Claude, for author's choice)
+\begin{frame}{The 84-line prompt: three blocks}
+\begin{columns}[T]
+\column{0.33\textwidth}
+\textbf{\# GOAL}
+
+\smallskip
+{\small Inventory plants $>30$\,MWe: status, fuel, capacity, operator, commissioning date.\\[4pt]
+Cite two independent sources per value.\\[4pt]
+Date every piece of information.}
+
+\column{0.33\textwidth}
+\textbf{\# QUALITY}
+
+\smallskip
+{\small Four scored axes: accuracy, coherence, provenance, temporality.\\[4pt]
+\textit{``Prefer a comprehensive inventory with explicit uncertainty over a short, well-known list.''}}
+
+\column{0.33\textwidth}
+\textbf{\# CONTEXT}
+
+\smallskip
+{\small Source management: primary, regulatory, secondary.\\[4pt]
+Calibrated confidence vocabulary.\\[4pt]
+Per-asset-row entry rules.}
+\end{columns}
+
+\medskip
+\begin{center}
+{\small\textit{84 lines of instructions; the model responds in Markdown.}}
+\end{center}
+\end{frame}
+
+% OPTION B — original version (verbatim, for author's choice)
+%\begin{frame}[fragile]{Structure du prompt}
+%\scriptsize
+%\textbf{\# GOAL}
+%
+%Produce a complete, primary-sourced reference inventory [...] Structure it as follows:
+%- the plant inventory: Name, Province, Fuel, Confidence, Source 1, Source 2, Notes.
+%- per-asset explanatory notes / annotated bibliography
+%Scope includes [...] When uncertain, mark confidence [...] Output format: Markdown.
+%
+%\textbf{\# QUALITY DIMENSIONS} [...see next slide...]
+%
+%\textbf{\# CONTEXT} (\#\# Source quality management / Calibrated confidence vocabulary / Asset-row rules)
+%\end{frame}
+%
+%\begin{frame}{\# Quality dimensions (prompt part 2)}
+%\small \textit{Your output is judged on four axes:}
+%\begin{enumerate}\setlength\itemsep{4pt}
+%  \item \textit{Accuracy} --- right assets and right attributes. [...]
+%  \item \textit{Coherence} --- internally consistent. [...]
+%  \item \textit{Provenance} --- each value traces to a source that supports it. [...]
+%  \item \textit{Temporality} --- every value carries a best-effort as-of date. [...]
+%\end{enumerate}
+%{\small\textit{We prefer a comprehensive inventory with uncertainty clearly expressed.}}
+%\end{frame}
+
+
+% -------------------------------------------------------------------
+\begin{frame}{84 lines, because statistics demand more than numbers}
+\begin{center}
+{\small\textit{``Knowledge: justified true belief.''}}
+\end{center}
+
+\medskip
+\small
+Five axes for judging the quality of research statistical data:
+\begin{enumerate}\setlength\itemsep{4pt}
+  \item \textbf{Accuracy} --- all the assets, only the assets.
+  \item \textbf{Coherence} --- reconciled totals, plausible values, conflicts arbitrated.
+  \item \textbf{Provenance} --- statements corroborated by two serious, independent sources.
+  \item \textbf{Temporality} --- statements dated; status changes flagged.
+      \item \textbf{Fitness for use} --- appropriate level of detail.
+\end{enumerate}
+
+\bigskip
+\begin{center}
+\small\textbf{$\to$ Multi-axis scoring grid, 2 scores per axis.}
+\end{center}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}[plain]
+\centering
+\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_claude.pdf}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Family and size matter; describing the plants is the weak point}
+\centering\vspace{-0.4em}
+\includegraphics[width=\textwidth,height=0.82\textheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
+\end{frame}
+
+% ===================================================================
+\section{Experiment 2}
+
+% -------------------------------------------------------------------
+\begin{frame}{From Exp 1 to Exp 2: a matter of technique?}
+\begin{itemize}\setlength\itemsep{1.0em}
+  \item \textbf{Exp 1 takeaway.} Are a chatbot's answers to an 84-line prompt research-grade data? No.
+
+  \item \textbf{Exp 2 question.} How to do better? Which factors matter: Allow web search? Deepen the dialogue? Provide source documents? A more powerful model?
+\end{itemize}
+
+\bigskip
+\begin{center}
+\textbf{A simple 2x2 experimental design:\\agentic (or not), with documents (or without)}\\
+\end{center}
+
+\end{frame}
+
+
+% -------------------------------------------------------------------
+\begin{frame}[plain]
+\centering
+\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
+
+% The figure code itself needed patching; the agent attempted an overlay instead
+% \begin{tikzpicture}[remember picture,overlay]
+%  \node[anchor=north east,font=\small\bfseries,text=matched] at ([xshift=-2em,yshift=-2em]current page.north east)
+%    {4. Files upload (RAG)};
+%\end{tikzpicture}
+
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Experiment 2 design: (single turn, multi-turn) × (no docs, with docs)}
+\framesubtitle{Four conditions: 1N (single turn, no docs); 5N; 1D; 5D (multi-turn, with docs)}
+\begin{center}
+\begin{tabular}{@{}l p{8.5cm}@{}}
+\textbf{Architecture}     & One prompt vs. Agentic (3--5 turns) \\
+\textbf{Documentation}    & none vs. RAG: 18 tables, primary sources, Markdown \\
+\\
+\textbf{Agents}           & Opus~4.6, GPT-5.5, Mistral Large, Qwen 3.7 max \\
+\textbf{Repetitions}      & 5 (model variability) \\
+\textbf{Controls}         & default reasoning effort, web search allowed, no tools, no code, direct lab API provider \\
+\textbf{Resources}        & cost < \$6, length < 50\,000 tokens \\
+\end{tabular}
+\end{center}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{The method --- Multi-turn protocol}
+\begin{description}\setlength\itemsep{8pt}
+  \item[\textbf{Phase A}] Each agent optimizes its own prompt, knowing the protocol.
+  \item[\textbf{Phase B}] Up to 3 research turns + 1 finalization turn.
+  \item[\textbf{Transitions}] Script state machine; DeepSeek V3.2 judges at each turn whether the agent has produced a report or should continue~{\footnotesize (role: judge, not evaluated)}.
+\end{description}
+
+\medskip
+\begin{center}
+{\small\textit{It's LLMs all the way down --- but Knowledge Graphs are not dead.}}
+\end{center}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{The method --- Infrastructure}
+\begin{itemize}\setlength\itemsep{6pt}
+  \item \textbf{git-erg}: local ticket management, agent-friendly\\
+        {\small Versioned text format; agents read and close tickets like humans.}
+  \item \textbf{Imperial Dragon Harness}: an agent-agnostic development harness\\
+        {\small 5 claws: Imagine, Plan, Execute, Verify, Celebrate.}
+  \item \textbf{Protocol co-developed, reviewed, and validated by the LLMs themselves}\\
+        {\small Agents consulted: 2 endorsed without reservation, 2 with reservations.}
+\end{itemize}
+\end{frame}
+
+% ===================================================================
+\section{Results}
+
+% -------------------------------------------------------------------
+\begin{frame}{Providing documents rescues Qwen and Mistral. Multi-turn does not help. Variance and unrecognized assets persist.}
+\centering\vspace{-0.4em}
+\includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage.pdf}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Costs remain highly variable across models, runs, and modalities.}
+\centering\vspace{-0.4em}
+\includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_cost.pdf}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Documents ease corroboration\\
+when the model's memory (or imagination) is not enough.}
+\centering\vspace{-0.4em}
+\includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage_certainty.pdf}
+\end{frame}
+
+% -------------------------------------------------------------------
+\iffalse
+\begin{frame}{RAG effect > multi-turn effect}
+\centering
+\small
+
+% Data-driven: regenerated from sota_cross_eval.csv by aedist.tabulate_exp2_2x2.
+% NOTE: tab_exp2_2x2.tex is currently generated with --lang fr; regenerate with --lang en for an English render.
+\input{inputs/generated/tab_exp2_2x2.tex}
+
+\vspace{0.8em}
+{\footnotesize $N=4$ models (blocking factor), 5 reps/cell. We report directional consistency $k/n$, not a significance threshold: at $n=4$, $p_{\min}=1/2^4=0.0625$ is unreachable.}
+\end{frame}
+\fi
+
+
+
+% -------------------------------------------------------------------
+\begin{frame}[plain]
+\centering
+\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_spider_cross_exp.pdf}
+\end{frame}
+
+% ===================================================================
+\section{Discussion}
+
+% -------------------------------------------------------------------
+\begin{frame}[t]{Limitations}
+
+Prompt:
+\begin{description}\setlength\itemsep{4pt}
+  \item[\textbf{Phase-A optimization}]: uncontrolled variance factor.
+  \item[\textbf{Language}]: uncontrolled variance factor.
+  \item[\textbf{Optimality}]: formal quality criteria yet to be developed.
+\end{description}
+
+Experimental:
+\begin{description}\setlength\itemsep{4pt}
+  \item[\textbf{Moving target}]: evolving models, fluctuating providers.
+  \item[\textbf{Small samples}]: 5 runs per condition, 4 models.
+  \item[\textbf{Preregistration, peer review}]: not yet done.
+  \item[\textbf{Sector $\times$ country generalization}] from electricity in Vietnam to hydrocarbons in Indonesia, to water in Thailand.
+\end{description}
+
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{Beyond RAG: toward hybridization with knowledge graphs}
+
+\begin{description}\setlength\itemsep{4pt}
+  \item[\textbf{Source discovery and management}] with human verification.
+  \item[\textbf{Incrementality}] with memory of how hard cases were resolved.
+  \item[\textbf{Verify}] the presence of citations (verifiable) is not enough.
+  \item[\textbf{Detailed attributes}] knowing the asset exists is not enough.
+\end{description}
+
+Each table cell is a triple [subject (row), predicate (column), object (value)].
+Each document is a partial knowledge graph: dated, noisy, redundant, contradictory.
+
+\end{frame}
+
+
+% ===================================================================
+\section{Conclusions}
+
+% -------------------------------------------------------------------
+\begin{frame}{Conclusions}
+\begin{itemize}\setlength\itemsep{1.2em}
+  \item \textbf{+ From weeks of expert monitoring to a few euros per query.}
+  \item \textbf{+ Providing sources saves money and improves results.}\\
+  \item \textbf{- But ensuring quality demands more.}\\
+  \item \textbf{- Multi-turn unconvincing: an external verifier is needed.}\\
+\end{itemize}
+
+\bigskip
+\begin{center}
+\textbf{Does AI produce research-grade data?}\\
+\Large\textcolor{red}{\textbf{Not yet. We must go beyond RAG.}}
+\end{center}
+\end{frame}
+
+% -------------------------------------------------------------------
+\begin{frame}{}
+\begin{center}
+\large\textbf{Thank you!}
+
+\medskip
+\normalsize
+Code \& data: \href{https://github.com/minhhaduong/aedist-technical-report}{\texttt{github.com/minhhaduong/aedist-technical-report}}
+
+\medskip
+\includegraphics[width=0.28\paperwidth]{inputs/QR-aedist.png}
+\end{center}
+\end{frame}
+
+% ===================================================================
+% APPENDIX — Q&A slides
+% ===================================================================
+
+\appendix
+
+\begin{frame}{Scoring grid: 5 axes $\times$ 2 indicators}
+\small
+\begin{tabular}{@{}l l l@{}}
+\toprule
+\textbf{Dimension} & \textbf{Indicator 1} & \textbf{Indicator 2} \\
+\midrule
+Accuracy    & Assets found (recall)       & Assets correct (precision) \\
+Content     & Correct fuel                & Correct status \\
+Coherence   & Correct province            & Vocabulary respected \\
+Provenance  & Source diversity            & Source distribution \\
+Temporality & Plausible as-of date        & Plausible COD date \\
+\bottomrule
+\end{tabular}
+
+\bigskip
+\begin{itemize}\setlength\itemsep{0.6em}
+  \item All axes: $0 =$ null, $1 =$ perfect.
+  \item Provenance: diversity $= \min(n_{\text{distinct sources}}/20,\; 1)$;
+        distribution $= 1 - \text{top-1 concentration}$.
+  \item Temporality: collapses to $0$ if all dates are identical (hallucination signal).
+\end{itemize}
+\end{frame}
+
+\end{document}


### PR DESCRIPTION
## What

Econom'IA prefers English slides. Adds `slides/slides-en.tex` — a faithful English translation of the French `slides/slides.tex` (post-#619 state) — plus a `slides-en.pdf` Makefile target.

## Translation scope
- All French prose, frame titles, section names, and the **in-`.tex` figure overlay labels** (`Recalcitrant`/`Incomplete`/`Hallucinating`/…) translated.
- French typography (`~:`, `~?`) converted to English punctuation.
- Already-English content kept verbatim: title *Beyond RAG*, the Las Vergnas & Jeunesse epigraph, model names, the *"LLMs all the way down"* quote, the technical *Controls* cell.
- Macros (`\NumCensusModels`, `\Census*`) and `\includegraphics` paths are **identical** to the FR deck — both decks resolve the same shared assets, no duplication.

## ⚠️ Known limitation — figures keep French labels
The spider / coverage / cost figure PDFs (`fig_spider_*`, `fig_exp2_*`) were rendered French-side and embed French text. Regenerating them in English requires the **analysis workpackage** (`make -f experiments/analysis.mk …`, needs data/`uv`) and is a **separable follow-up**, deliberately out of scope for this writing-side PR. The disabled (`\iffalse`) 2×2-table frame carries an inline note that `tab_exp2_2x2.tex` is `--lang fr`.

## Verification
- `make slides-en.pdf` → exit 0, **32 pages** (parity with the FR deck), no undefined macros.
- English aspell pass: no typos (only neologisms / proper nouns / LaTeX tokens flagged).
- `slides-en.pdf` is gitignored (regenerable); the new `slides-en.pdf` target is wired into `all` and `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)