### PR TITLE
slides(en): crop title and enlarge the Family/size spider figure

### DIFF
--- a/slides/slides-en.tex
+++ b/slides/slides-en.tex
@@ -275,7 +275,9 @@ Five axes for judging the quality of research statistical data:
 % -------------------------------------------------------------------
 \begin{frame}{Family and size matter; describing the plants is the weak point}
 \centering\vspace{-0.4em}
-\includegraphics[width=\textwidth,height=0.82\textheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
+% Crop the baked-in figure title ("Source is the universal failure mode") off
+% the top, then enlarge into the freed space at the bottom of the slide.
+\includegraphics[trim=0 0 0 42bp,clip,width=\textwidth,height=0.98\textheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
 \end{frame}
 
 % ===================================================================


### PR DESCRIPTION
## What
On the **"Family and size matter"** frame of `slides-en.tex`, `fig_spider_exp1_families.pdf` has a baked-in figure title (*"Source is the universal failure mode"*) that duplicates the frame title and wastes vertical space.

- Crop it off: `trim=0 0 0 42bp,clip`
- Enlarge into the freed bottom space: height `0.82` → `0.98\textheight`

`slides-en.tex` only — French deck untouched.

## Verification
Rebuilt and visually checked page 14: title band gone, top labels (*Date COD plausible / Temporalité / Exactitude*) intact under the frame title bar, bottom *Cohérence* labels reach the slide bottom, no overflow. Author confirmed the size.

## Note
Cosmetic presentation fix. The cleaner fix (regenerate the figure without a title / in English) remains tracked in **ticket 0356**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)