### PR TITLE
slides: align French deck on the revised English deck (land both)

### DIFF
--- a/slides/slides-en.tex
+++ b/slides/slides-en.tex
@@ -252,11 +252,10 @@ Five axes for judging the quality of research statistical data:
 \section{Experiment 2}
 
 % -------------------------------------------------------------------
-\begin{frame}{From Exp 1 to Exp 2: a matter of technique?}
+\begin{frame}{What do we get with a RAG Agentic Architecture ?}
 \begin{itemize}\setlength\itemsep{1.0em}
-  \item \textbf{Exp 1 takeaway.} Are these chatbots' answers to our 84-line prompt\\research-grade data? \textcolor{red}{Non!}.
-
-  \item \textbf{Exp 2 question.} How to do better? Which factors matter: Allow web search? Deepen the dialogue? Provide source documents?
+  \item \textbf{Exp 1 takeaway.} Are these chatbots' answers to our 84-line prompt\\research-grade data? Non.
+  \item \textbf{Exp 2 question.} Which factors matter to do better?\\Allow web search? Deepen the dialogue? Provide source documents?
 \end{itemize}
 
 \bigskip
@@ -268,10 +267,10 @@ Five axes for judging the quality of research statistical data:
 
 
 % -------------------------------------------------------------------
-\begin{frame}[plain]
+\begin{frame}{Features of commercial general AI products, by arrival date}
 \centering
 %\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
-\includegraphics[width=\paperwidth,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
+\includegraphics[height=0.85\textheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
 
 % The figure code itself needed patching; the agent attempted an overlay instead
 % \begin{tikzpicture}[remember picture,overlay]
@@ -286,7 +285,7 @@ Five axes for judging the quality of research statistical data:
 \framesubtitle{Four conditions: 1N (single turn + no docs); 5N; 1D; 5D (multi-turn + with docs)}
 \begin{center}
 \begin{tabular}{@{}l p{8.5cm}@{}}
-\textbf{Architecture}         & One prompt vs. Agentic (3--5 turns) \\
+\textbf{Architecture}         & One prompt (single turn as Exp 1) vs. Agentic (3--5 turns) \\
 \textbf{Documentation}    & None vs. RAG (18 tables, primary sources, Markdown) \\
 \\
 \textbf{Agents  }               & Opus~4.6, GPT-5.5, Mistral Large, Qwen 3.7 max \\
@@ -298,11 +297,10 @@ Five axes for judging the quality of research statistical data:
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{The method --- Multi-turn protocol}
+\begin{frame}{The method --- Agentic architecture condition}
 \begin{description}\setlength\itemsep{8pt}
-  \item[\textbf{Phase A}] Each agent optimizes its own prompt, knowing the protocol.
-  \item[\textbf{Phase B}] Up to 3 research turns + 1 finalization turn.
-  \item[\textbf{Transitions}] Script state machine; DeepSeek V3.2 judges at each turn whether the agent has produced a report or should continue~{\footnotesize (role: judge, not evaluated)}.
+  \item[\textbf{Phase A is reflexive}] Each agent optimizes its own prompt, knowing the protocol.
+  \item[\textbf{Phase B is scripted}] Up to 3 research turns + 1 finalization turn. DeepSeek V3.2 reads the agent's work and replies with Encourage\_Continue or Ask\_Final\_Verify prompts.
 \end{description}
 
 \medskip
@@ -327,20 +325,19 @@ Five axes for judging the quality of research statistical data:
 \section{Results}
 
 % -------------------------------------------------------------------
-\begin{frame}{Providing documents rescues Qwen and Mistral. Multi-turn does not help. Variance and unrecognized assets persist.}
+\begin{frame}{RAG rescues Qwen and Mistral. Multi-turn hurts. Variance still high.}
 \centering\vspace{-0.4em}
 \includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage.pdf}
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Costs remain highly variable across models, runs, and modalities.}
+\begin{frame}{Costs differences++. Multi-turn hurts more. Cost (=effort) variance.}
 \centering\vspace{-0.4em}
 \includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_cost.pdf}
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Documents ease corroboration\\
-when the model's memory (or imagination) is not enough.}
+\begin{frame}{Providing documents ensures sources-citing but are not required:\\model's memory (or imagination) can also provide.}
 \centering\vspace{-0.4em}
 \includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage_certainty.pdf}
 \end{frame}
@@ -374,35 +371,42 @@ when the model's memory (or imagination) is not enough.}
 % -------------------------------------------------------------------
 \begin{frame}[t]{Limitations}
 
-Prompt:
-\begin{description}\setlength\itemsep{4pt}
-  \item[\textbf{Phase-A optimization}]: uncontrolled variance factor.
-  \item[\textbf{Language}]: uncontrolled variance factor.
-  \item[\textbf{Optimality}]: formal quality criteria yet to be developed.
-\end{description}
-
-Experimental:
-\begin{description}\setlength\itemsep{4pt}
-  \item[\textbf{Moving target}]: evolving models, fluctuating providers.
-  \item[\textbf{Small samples}]: 5 runs per condition, 4 models.
-  \item[\textbf{Preregistration, peer review}]: not yet done.
-  \item[\textbf{Sector $\times$ country generalization}] from electricity in Vietnam to hydrocarbons in Indonesia, to water in Thailand.
-\end{description}
+\textbf{Prompt:}
+\begin{itemize}
+  \item Phase-A optimization is an uncontrolled variance factor.
+  \item Language is an uncontrolled variance factor.
+  \item Baseline prompt could be improved (but against which criteria?)
+\end{itemize}
+\medskip
+\textbf{Method:}
+\begin{itemize}
+  \item Moving target: evolving models, fluctuating providers.
+  \item Small sample size: 5 runs per condition, 4 models.
+  \item Preregistration, peer review: not yet done.
+  \item Generalization not proven. From electricity in Vietnam to hydrocarbons in Indonesia, to water in Thailand.
+\end{itemize}
 
 \end{frame}
 
 % -------------------------------------------------------------------
 \begin{frame}{Beyond RAG: toward hybridization with knowledge graphs}
 
-\begin{description}\setlength\itemsep{4pt}
-  \item[\textbf{Source discovery and management}] with human verification.
-  \item[\textbf{Incrementality}] with memory of how hard cases were resolved.
-  \item[\textbf{Verify}] the presence of citations (verifiable) is not enough.
-  \item[\textbf{Detailed attributes}] knowing the asset exists is not enough.
-\end{description}
+Choose 1D, develop towards:
 
-Each table cell is a triple [subject (row), predicate (column), object (value)].
-Each document is a partial knowledge graph: dated, noisy, redundant, contradictory.
+\begin{itemize}
+  \item Source discovery and management with human verification.
+  \item Incrementality with memory of how hard cases were human-resolved.
+  \item Verify the presence of citations (verifiable) is not enough.
+  \item Detailed attributes knowing the asset exists is not enough.
+  \item Coldstart with intermodel, multirun fusion
+\end{itemize}
+
+Why Knowledge Graphs?
+\begin{itemize}
+\item Efficiency and incrementality
+\item Table cells map on KG triples: subject (row), predicate (column), object (value).
+\item Document are knowledge graph: partial, dated, noisy, redundant, less contradictory.
+\end{itemize}
 
 \end{frame}
 

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -96,21 +96,21 @@ Gold standard: liste compilée par l'auteur sur plusieurs années, en ligne.}
 \section{Expérience 1}
 
 % -------------------------------------------------------------------
-\begin{frame}{Expérience 1 : utiliser un générateur de mots aléatoires}
+\begin{frame}{Expérience 1~: interroger un générateur de mots aléatoires}
 
 \smallskip
-\textbf{Tâche~: Donne l'inventaire des centrales thermiques au Vietnam} en prompt de 84 lignes. Connaissance paramétrique uniquement: ni recherche web, ni documents fournis. Effort de raisonnement par défaut. Température = 0.
+\textbf{Tâche~: «~Donne-moi l'inventaire des centrales thermiques au Vietnam~»} (dans un prompt de 84 lignes). Connaissance paramétrique uniquement~: ni recherche web, ni documents fournis. Effort de raisonnement par défaut. Température = 0.
 
 \smallskip
-\textbf{Métrique principale~:} Nombre d'actifs correctement identifiés. Référence~: 163 centrales charbon, gaz, fioul $>30 MWe$
+\textbf{Métrique principale~:} nombre d'actifs correctement identifiés dans la liste de référence de 163.
 
 \smallskip
 \textbf{Résultats \NumCensusModels{} modèles, 5 runs chacun~:}
 \begin{itemize}\setlength\itemsep{0pt}
-  \item Centrales identifiées~: \CensusTPMin{}--\CensusTPMax{} par run
+  \item Centrales identifiées dans la liste~: \CensusTPMin{}--\CensusTPMax{} par run
   \item Centrales non-reconnues~: \CensusFPMin{}--\CensusFPMax{} par run
-  \item Durée par run~: \CensusWallMin{} s --20 min
-  \item Coûts~: \CensusCostTotal{}\,\$ total (\CensusCostMin{}--\CensusCostMax{}\,\$ par run)
+  \item Vitesse de réponse~: \CensusWallMin{} s à 20 min par run
+  \item Coût~: \CensusCostMin{}--\CensusCostMax{}\,\$ par run, \CensusCostTotal{}\,\$ total
 \end{itemize}
 \end{frame}
 
@@ -132,12 +132,12 @@ Non-monotone
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{«~Hallucinant~»~: deux modes récurrents}
+\begin{frame}{Exemples de motifs d'hallucination~: boucles de prédiction du mot suivant}
 
 \begin{columns}[T]
 \column{0.50\textwidth}
-\textbf{Mode 1~: une centrale par province}\\
-{\small Claude Haiku, T$=0$ — les mêmes 15 centrales dans les 5 runs~:}
+\textbf{Une centrale par province}\\
+{\small Claude Haiku, tous les runs~:}
 \begin{itemize}\setlength\itemsep{1pt}
   \item{\small NMĐ Hà Nội}
   \item{\small NMĐ Đà Nẵng}
@@ -148,8 +148,8 @@ Non-monotone
 {\small Aucune n'existe dans le référentiel.}
 
 \column{0.50\textwidth}
-\textbf{Mode 2~: récursion}\\
-{\small GPT OSS 20B — run 3~: 83 lignes, une seule entreprise~:}
+\textbf{Récursion sur le numéro de centrale}\\
+{\small GPT OSS 20B run 3~:}
 \begin{itemize}\setlength\itemsep{1pt}
   \item{\small Trung Nam 1 (charbon, 600 MW)}
   \item{\small Trung Nam 2 (charbon, 600 MW)}
@@ -162,9 +162,9 @@ Non-monotone
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Précision~: actifs non-reconnus, pas nécessairement hallucinés}
+\begin{frame}{Les actifs non-reconnus ne sont pas toujours des hallucinations}
 
-\textbf{Faux positif}~$=$~actif listé par le modèle non-réconcilié.
+Les \textbf{faux positifs} sont des actifs de la liste du modèle que nous n'avons pas pu réconcilier avec la nôtre.
 
 \medskip
 \begin{description}\setlength\itemsep{6pt}
@@ -172,18 +172,16 @@ Non-monotone
         Ex.~: \emph{Nhơn Trạch 3 \& 4} vs \emph{LNG Nhơn Trạch 3} + \emph{4}~;
         \emph{NMĐ Bà Rịa} vs \emph{Bà Rịa GT}~;
         \emph{Vedan} vs \emph{Vedan Vietnam Cogeneration}.
-  \item[\textbf{Limite du référentiel}] Actif réel, absent du référentiel.
-  \item[\textbf{Interrogations statistiques}] Co-génération chaleur-électricité, incinération, taille limite...
+  \item[\textbf{Limite du référentiel}] Actif réel, absent de notre référentiel.
+  \item[\textbf{Interrogations statistiques}] Co-génération chaleur-électricité, incinération, taille limite\ldots
 \end{description}
 
 \medskip
-\small Une table statistique de qualité reconnaît les interrogations.
+\small Une table statistique de qualité reconnaît le flou du monde réel.
 
 \end{frame}
 
-
 % -------------------------------------------------------------------
-% OPTION A — version épurée (Claude, pour choix auteur)
 \begin{frame}{Le prompt en 84 lignes~: trois blocs}
 \begin{columns}[T]
 \column{0.33\textwidth}
@@ -192,10 +190,11 @@ Non-monotone
 \smallskip
 {\small Inventorier les centrales $>30$\,MWe~: statut, carburant, capacité, exploitant, date de mise en service.\\[4pt]
 Citer deux sources indépendantes par valeur.\\[4pt]
-Dater chaque information.}
+Dater chaque information.\\[4pt]
+Répondre en Markdown}
 
 \column{0.33\textwidth}
-\textbf{\# QUALITÉ}
+\textbf{\# DIMENSIONS QUALITÉ}
 
 \smallskip
 {\small Quatre axes notés~: accuracy, cohérence, provenance, temporalité.\\[4pt]
@@ -210,41 +209,10 @@ Vocabulaire de confiance calibré.\\[4pt]
 Règles de saisie par ligne d'actif.}
 \end{columns}
 
-\medskip
-\begin{center}
-{\small\textit{84 lignes d'instructions~; le modèle répond en Markdown.}}
-\end{center}
 \end{frame}
 
-% OPTION B — version originale (verbatim, pour choix auteur)
-%\begin{frame}[fragile]{Structure du prompt}
-%\scriptsize
-%\textbf{\# GOAL}
-%
-%Produce a complete, primary-sourced reference inventory [...] Structure it as follows:
-%- the plant inventory: Name, Province, Fuel, Confidence, Source 1, Source 2, Notes.
-%- per-asset explanatory notes / annotated bibliography
-%Scope includes [...] When uncertain, mark confidence [...] Output format: Markdown.
-%
-%\textbf{\# QUALITY DIMENSIONS} [...voir slide suivante...]
-%
-%\textbf{\# CONTEXT} (\#\# Source quality management / Calibrated confidence vocabulary / Asset-row rules)
-%\end{frame}
-%
-%\begin{frame}{\# Quality dimensions (prompt partie 2)}
-%\small \textit{Your output is judged on four axes:}
-%\begin{enumerate}\setlength\itemsep{4pt}
-%  \item \textit{Accuracy} --- right assets and right attributes. [...]
-%  \item \textit{Coherence} --- internally consistent. [...]
-%  \item \textit{Provenance} --- each value traces to a source that supports it. [...]
-%  \item \textit{Temporality} --- every value carries a best-effort as-of date. [...]
-%\end{enumerate}
-%{\small\textit{We prefer a comprehensive inventory with uncertainty clearly expressed.}}
-%\end{frame}
-
-
 % -------------------------------------------------------------------
-\begin{frame}{84 lignes car la statistique exige plus que les chiffres}
+\begin{frame}{84 lignes car nous exigeons plus que de simples chiffres}
 \begin{center}
 {\small\textit{«~Connaissance~: croyance vraie justifiée.~»}}
 \end{center}
@@ -275,18 +243,19 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
 % -------------------------------------------------------------------
 \begin{frame}{Famille et taille comptent~; description des centrales~: point faible}
 \centering\vspace{-0.4em}
-\includegraphics[width=\textwidth,height=0.82\textheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
+% Crop the baked-in figure title ("Source is the universal failure mode") off
+% the top, then enlarge into the freed space at the bottom of the slide.
+\includegraphics[trim=0 0 0 42bp,clip,width=\textwidth,height=0.98\textheight,keepaspectratio]{../report/inputs/generated/fig_spider_exp1_families.pdf}
 \end{frame}
 
 % ===================================================================
 \section{Expérience 2}
 
 % -------------------------------------------------------------------
-\begin{frame}{De l'Exp 1 à l'Exp 2 : technique~?}
+\begin{frame}{Qu'obtient-on avec une architecture agentique RAG~?}
 \begin{itemize}\setlength\itemsep{1.0em}
-  \item \textbf{Bilan Exp 1.} Les réponses d'un chatbot à un prompt de 84 lignes sont-elles des données de qualité recherche~? Non.
-
-  \item \textbf{Question Exp 2.} Comment faire mieux~? Quels facteurs comptent~: Autoriser la recherche web~? Approfondir le dialogue~? Fournir des documents sources~? Modèle plus puissant~?
+  \item \textbf{Bilan Exp 1.} Les réponses de ces chatbots à notre prompt de 84 lignes sont-elles des données de qualité recherche~? Non.
+  \item \textbf{Question Exp 2.} Quels facteurs comptent pour faire mieux~?\\Autoriser la recherche web~? Approfondir le dialogue~? Fournir des documents sources~?
 \end{itemize}
 
 \bigskip
@@ -298,9 +267,10 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
 
 
 % -------------------------------------------------------------------
-\begin{frame}[plain]
+\begin{frame}{Capacités des produits d'IA générale commerciaux, par date d'arrivée}
 \centering
-\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
+%\includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
+\includegraphics[height=0.85\textheight,keepaspectratio]{../report/inputs/generated/fig_capability_timeline.pdf}
 
 % Il fallait patcher le code la figure, l'agent a tenté un overlay
 % \begin{tikzpicture}[remember picture,overlay]
@@ -311,27 +281,26 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Expérience 2 design : (single turn, multitour) × (no docs, with docs)}
-\framesubtitle{Quatre conditions : 1N (single turn, no docs) ; 5N ; 1D ; 5D (multitour, with docs)}
+\begin{frame}{Expérience 2, plan~: (tour unique, multi-tours) × (sans docs, avec docs)}
+\framesubtitle{Quatre conditions~: 1N (tour unique + sans docs)~; 5N~; 1D~; 5D (multi-tours + avec docs)}
 \begin{center}
 \begin{tabular}{@{}l p{8.5cm}@{}}
-\textbf{Architecture}     & One prompt vs. Agentic (3 - 5 turns) \\
-\textbf{Documentation}    & aucune vs. RAG 18 tables, sources primaires, Markdown \\
+\textbf{Architecture}     & One prompt (single turn as Exp 1) vs. Agentic (3--5 turns) \\
+\textbf{Documentation}    & aucune vs. RAG (18 tables, sources primaires, Markdown) \\
 \\
 \textbf{Agents}           & Opus~4.6, GPT-5.5, Mistral Large, Qwen 3.7 max \\
 \textbf{Répétitions}      & 5 (variabilité modèle) \\
 \textbf{Contrôles}        & default reasoning effort, web search allowed, no tools, no code, direct lab API provider \\
-\textbf{Ressources}      & coût < \$6, longueur < 50\,000 tokens \\
+\textbf{Ressources}      & coût < \$6, longueur < 50\,000 tokens par run\\
 \end{tabular}
 \end{center}
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{La méthode --- Protocole multi-tours}
+\begin{frame}{La méthode --- Condition architecture agentique}
 \begin{description}\setlength\itemsep{8pt}
-  \item[\textbf{Phase A}] Chaque agent optimise son propre prompt connaissant le protocole.
-  \item[\textbf{Phase B}] Jusqu'à 3 tours de recherche + 1 tour de finalisation.
-  \item[\textbf{Transitions}] Script state machine~; DeepSeek V3.2 juge à chaque tour si l'agent a produit un rapport ou doit continuer~{\footnotesize (rôle~: juge, non évalué)}.
+  \item[\textbf{Phase A, réflexive}] Chaque agent optimise son propre prompt, connaissant le protocole.
+  \item[\textbf{Phase B, scriptée}] Jusqu'à 3 tours de recherche + 1 tour de finalisation. DeepSeek V3.2 lit le travail de l'agent et répond par des prompts Encourage\_Continue ou Ask\_Final\_Verify.
 \end{description}
 
 \medskip
@@ -356,20 +325,20 @@ Cinq axes pour juger la qualité des données statistiques de recherche~:
 \section{Résultats}
 
 % -------------------------------------------------------------------
-\begin{frame}{Fournir les documents repêche Qwen et Mistral. Le multi-tour n'aide pas. Variance et actifs non reconnus persistent.}
+\begin{frame}{Le RAG repêche Qwen et Mistral. Le multi-tour nuit. La variance reste élevée.}
 \centering\vspace{-0.4em}
 \includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage.pdf}
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Les coûts restent très variables entre modèles, runs et modalités.}
+\begin{frame}{Différences de coûts++. Le multi-tour nuit davantage. Variance du coût (= effort).}
 \centering\vspace{-0.4em}
 \includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_cost.pdf}
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Les documents facilitent la corroboration\\
-quand la mémoire (ou l'imagination) du modèle ne suffit pas.}
+\begin{frame}{Fournir des documents garantit la citation des sources mais n'est pas requis~:\\
+la mémoire (ou l'imagination) du modèle peut aussi y pourvoir.}
 \centering\vspace{-0.4em}
 \includegraphics[width=\textwidth,keepaspectratio]{../report/inputs/generated/fig_exp2_coverage_certainty.pdf}
 \end{frame}
@@ -402,35 +371,42 @@ quand la mémoire (ou l'imagination) du modèle ne suffit pas.}
 % -------------------------------------------------------------------
 \begin{frame}[t]{Limites}
 
-Prompt:
-\begin{description}\setlength\itemsep{4pt}
-  \item[\textbf{Optimisation en Phase A}]: facteur de variance non contrôlé.
-  \item[\textbf{Langue}]: facteur de variance non contrôlé.
-  \item[\textbf{Optimalité}]: critères formels de qualités à développer.
-\end{description}
-
-Expérimentales:
-\begin{description}\setlength\itemsep{4pt}
-  \item[\textbf{Cible mobile}]: Modèles évolutifs, hébergeurs fluctuants.
-  \item[\textbf{Petits échantillons}]: 5 runs par condition, 4 modèles.
-  \item[\textbf{Préenregistrement, évaluation par les pairs}]: pas encore réalisés.
-  \item[\textbf{Généralisation secteur $\times$ pays}] de l'électricité au Vietnam aux hydrocarbures en Indonésie, à l'eau en Thaïlande.
-\end{description}
+\textbf{Prompt~:}
+\begin{itemize}
+  \item L'optimisation en Phase A est un facteur de variance non contrôlé.
+  \item La langue est un facteur de variance non contrôlé.
+  \item Le prompt de référence pourrait être amélioré (mais selon quels critères~?).
+\end{itemize}
+\medskip
+\textbf{Méthode~:}
+\begin{itemize}
+  \item Cible mobile~: modèles évolutifs, hébergeurs fluctuants.
+  \item Petite taille d'échantillon~: 5 runs par condition, 4 modèles.
+  \item Préenregistrement, évaluation par les pairs~: pas encore réalisés.
+  \item Généralisation non démontrée. De l'électricité au Vietnam aux hydrocarbures en Indonésie, à l'eau en Thaïlande.
+\end{itemize}
 
 \end{frame}
 
 % -------------------------------------------------------------------
-\begin{frame}{Dépasser le RAG: vers l'hybridation avec les graphes de connaissances}
+\begin{frame}{Dépasser le RAG~: vers l'hybridation avec les graphes de connaissances}
 
-\begin{description}\setlength\itemsep{4pt}
-  \item[\textbf{Découverte et gestion des sources}] avec vérification humaine.
-  \item[\textbf{Incrémentalité}] avec mémoire des résolutions des cas difficiles.
-  \item[\textbf{Vérifier}] la présence de citations (vérifiable) ne suffit pas.
-  \item[\textbf{Attributs détaillés}] savoir que l'actif existe ne suffit pas.
-\end{description}
+Choisir 1D, développer vers~:
 
-Chaque cellule d'une table est un triplet [sujet (rangée), prédicat (colonne), objet (valeur)].
-Chaque document est un graphe de connaissances partiel, daté, bruité, redondant, contradictoire.
+\begin{itemize}
+  \item Découverte et gestion des sources avec vérification humaine.
+  \item Incrémentalité avec mémoire de la résolution humaine des cas difficiles.
+  \item Vérifier~: la présence de citations (vérifiable) ne suffit pas.
+  \item Attributs détaillés~: savoir que l'actif existe ne suffit pas.
+  \item Démarrage à froid par fusion inter-modèles et multi-runs.
+\end{itemize}
+
+Pourquoi les graphes de connaissances~?
+\begin{itemize}
+  \item Efficacité et incrémentalité.
+  \item Les cellules d'une table correspondent à des triplets de GC~: sujet (rangée), prédicat (colonne), objet (valeur).
+  \item Un document est un graphe de connaissances~: partiel, daté, bruité, redondant, moins contradictoire.
+\end{itemize}
 
 \end{frame}
 


### PR DESCRIPTION
## What
The author revised the **English** deck (`slides-en.tex`) substantially. This PR:
1. Ports that revision into the **French** `slides.tex` (translated) so the two decks match in structure and content.
2. Lands the author's English edits in the **same** commit — "merge both at once".

Content authored by the author; transcribed and translated to French by the agent.

## French alignment (mirrors the English revision)
- Exp 1 frame retitled ("interroger un générateur de mots aléatoires"); task as a quote; metric simplified to "dans la liste de référence de 163"; results bullets reworded.
- Hallucination frame: "motifs d'hallucination / boucles de prédiction"; "Une centrale par province" / "Récursion sur le numéro de centrale".
- "Les actifs non-reconnus ne sont pas toujours des hallucinations".
- 84-line prompt: "Répondre en Markdown" in GOAL; "# DIMENSIONS QUALITÉ"; dormant OPTION B block removed.
- Family figure: same title crop + enlarge as EN (#621).
- Exp 2 intro "Qu'obtient-on avec une architecture agentique RAG"; capability-timeline frame now titled; Exp 2 design table tweaks.
- Method frame "Condition architecture agentique"; Phase A réflexive / Phase B scriptée.
- Results titles reworded; **Limites** restructured (Prompt/Méthode itemize); **Dépasser le RAG** rebuilt with "Choisir 1D" + "Pourquoi les graphes de connaissances ?".

## Verification
- `make slides.pdf` and `make slides-en.pdf` → exit 0, **32 pages each**.
- FR aspell pass clean; visually spot-checked the two most-restructured FR frames (Limites, Dépasser le RAG) — read as natural French.

🤖 Generated with [Claude Code](https://claude.com/claude-code)