### PR TITLE
slides: align FR on EN revision (Limitations: generalization not started)

### DIFF
--- a/slides/slides-en.tex
+++ b/slides/slides-en.tex
@@ -383,7 +383,7 @@ Five axes for judging the quality of research statistical data:
   \item Moving target: evolving models, fluctuating providers.
   \item Small sample size: 5 runs per condition, 4 models.
   \item Preregistration, peer review: not yet done.
-  \item Generalization not proven. From electricity in Vietnam to hydrocarbons in Indonesia, to water in Thailand.
+  \item Generalization: not started. From electricity in Vietnam to hydrocarbons in Indonesia, to water in Thailand.
 \end{itemize}
 
 \end{frame}

--- a/slides/slides.tex
+++ b/slides/slides.tex
@@ -383,7 +383,7 @@ la mémoire (ou l'imagination) du modèle peut aussi y pourvoir.}
   \item Cible mobile~: modèles évolutifs, hébergeurs fluctuants.
   \item Petite taille d'échantillon~: 5 runs par condition, 4 modèles.
   \item Préenregistrement, évaluation par les pairs~: pas encore réalisés.
-  \item Généralisation non démontrée. De l'électricité au Vietnam aux hydrocarbures en Indonésie, à l'eau en Thaïlande.
+  \item Généralisation~: non commencée. De l'électricité au Vietnam aux hydrocarbures en Indonésie, à l'eau en Thaïlande.
 \end{itemize}
 
 \end{frame}


### PR DESCRIPTION
Round-three alignment. EN Limitations bullet changed *Generalization not proven* → *Generalization: not started*; mirrored in FR (*Généralisation : non commencée*). Both decks build, 32 pages each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)