### PR TITLE
fix(makefile): add fig_capability_dag.pdf to slides prereq list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ slides/slides.pdf: slides/slides.tex \
     $(GEN)/fig_spider_exp1_families.pdf \
     $(GEN)/fig_spider_cross_exp.pdf \
     $(GEN)/fig_capability_timeline.pdf \
+    $(GEN)/fig_capability_dag.pdf \
     $(GEN)/fig_exp2_coverage.pdf \
     $(GEN)/fig_exp2_cost.pdf \
     $(GEN)/fig_exp2_coverage_certainty.pdf \

--- a/tests/test_make_slides_prereqs.py
+++ b/tests/test_make_slides_prereqs.py
@@ -1,0 +1,51 @@
+"""Recursive-make visibility guard for `slides/slides.pdf`.
+
+The slides sub-make (`slides/Makefile`) consumes
+`$(LOCAL_ROOT_REPORT_GEN)/fig_capability_dag.pdf`. The recursive sub-make
+cannot resolve that target on its own — root must list it as a prereq of
+the `slides/slides.pdf` rule so the producing recipe (defined at root)
+fires before `$(MAKE) -C slides` runs.
+
+Without this, `make slides` fails with
+`No rule to make target '…fig_capability_dag.pdf'` from the sub-make even
+though a producing rule exists at root.
+
+This is the adherence companion to ticket 0367. It is integration-marked
+because it shells out via `make -n`.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.adherence
+@pytest.mark.integration
+def test_make_slides_lists_fig_capability_dag_as_prereq():
+    """The root `make -n slides` plan must reference fig_capability_dag.pdf.
+
+    "Reference" = the root recipe to (re)build the figure appears in the
+    dry-run plan on stdout. Before ticket 0367's fix, the file was not a
+    prereq of `slides/slides.pdf` so root never planned to build it, and
+    the sub-make failed at runtime. After the fix, root sees it as a
+    prereq and either invokes the producing recipe or treats it as
+    up-to-date — either way it appears on stdout (when missing on disk,
+    as a recipe; when present, the dry-run still surfaces it).
+    """
+    result = subprocess.run(
+        ["make", "-n", "slides"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    # Search stdout only — stderr would catch the sub-make's *failure*
+    # message, which is what we are guarding against, not evidence of success.
+    assert "fig_capability_dag.pdf" in result.stdout, (
+        "Root `make -n slides` does not reference fig_capability_dag.pdf — "
+        "add it to the slides/slides.pdf prereq list in the root Makefile so "
+        "the recursive sub-make can resolve the dependency.\n\n"
+        f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )

--- a/tickets/closed/0367-fix-make-slides-fig-capability-dag-prereq.erg
+++ b/tickets/closed/0367-fix-make-slides-fig-capability-dag-prereq.erg
@@ -2,10 +2,12 @@
 Title: Fix make slides: add fig_capability_dag.pdf to root prereq list
 Created: 2026-05-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #635
 
 --- log ---
 2026-05-28T13:00Z HDMX-coding-agent created — spun off from 0365 as the green-baseline precondition for the docs-build workflow; STATE.md backlog had it as a candidate
 
+2026-05-28T12:52Z HDMX-coding-agent closed — autoclosed — PR #635
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Closes the recursive-make visibility gap in `slides/slides.pdf`. The root rule listed `fig_capability_timeline.pdf` but missed its sibling `fig_capability_dag.pdf`, even though `slides/Makefile` consumes both via `MANUSCRIPT_ASSETS`. Without the prereq, root never plans to build the figure for this path, and the sub-make aborts with `No rule to make target`.

- One-line addition to the root prereq list (`Makefile`).
- New adherence test `tests/test_make_slides_prereqs.py` shells out to `make -n slides` and asserts the figure appears in the root-make plan. Marked `@pytest.mark.integration` because it spawns a subprocess.

The existing DAG guard (`tests/test_makefile_dag.py`) operates on rule parsing across the makefile union, not recursive resolution, so it could not catch this — hence the dedicated integration test.

**Ticket:** tickets/0367-fix-make-slides-fig-capability-dag-prereq.erg

## Test plan

- [x] `uv run pytest tests/test_make_slides_prereqs.py` — passes after the fix, fails when the prereq line is removed (TDD red/green confirmed).
- [x] `make check-fast` green: 1702 passed, 5 skipped, 1 xfailed, ruff clean, ticket structure OK.
- [x] `make -n slides 2>/dev/null | grep -F fig_capability_dag.pdf` shows the root recipe (was zero before the fix).
- [ ] Validated downstream by the docs-build workflow from ticket 0365 (unblocks 0358's required-checks flip).