### PR TITLE
ci: add docs-build workflow for PR-time PDF compilation (0365)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,103 @@
+name: docs-build
+
+on:
+  pull_request:
+    paths:
+      - 'report/**'
+      - 'slides/**'
+      - 'Makefile'
+      - 'experiments/analysis.mk'
+      - 'src/aedist/**'
+      - 'tests/**'
+      - 'data/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/docs-build.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    env:
+      TECTONIC_VERSION: '0.15.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv (respects uv.lock)
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: uv sync (dev group for make check)
+        run: uv sync --group dev
+
+      - name: Cache Tectonic bundle
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-0.15.0-${{ runner.os }}
+
+      - name: Install Tectonic 0.15.0 (static musl binary)
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o /tmp/tectonic.tar.gz \
+            "https://github.com/tectonic-typesetting/tectonic/releases/download/tectonic@${TECTONIC_VERSION}/tectonic-${TECTONIC_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/tectonic.tar.gz -C "$HOME/.local/bin"
+          chmod +x "$HOME/.local/bin/tectonic"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/tectonic" --version
+
+      - name: Verify pandoc available (Ubuntu 24.04 preinstalled)
+        run: pandoc --version | head -n1
+
+      - name: Build report
+        run: make report
+
+      - name: Build slides
+        id: slides
+        continue-on-error: true
+        run: make slides
+
+      - name: Build manuscript
+        # Pre-build fig_capability_dag.pdf (root Makefile owns the rule; the
+        # slides sub-make has no rule for it — same recursive-make gap that
+        # makes `make slides` red. Pre-building here lets manuscript pass even
+        # before ticket 0367's fix lands.
+        run: |
+          make report/inputs/generated/fig_capability_dag.pdf
+          make -C slides manuscript/main.pdf
+
+      - name: Run make check (lint + tests)
+        run: make check
+
+      - name: Upload PDF artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-pdfs
+          path: |
+            report/report.pdf
+            slides/slides.pdf
+            slides/slides-en.pdf
+            slides/manuscript/main.pdf
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            report/*.log
+            report/*.aux
+            slides/*.log
+            slides/*.aux
+            slides/*.snm
+            slides/*.toc
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -51,8 +51,12 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/tectonic" --version
 
-      - name: Verify pandoc available (Ubuntu 24.04 preinstalled)
-        run: pandoc --version | head -n1
+      - name: Install pandoc
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq pandoc
+          pandoc --version | head -n1
 
       - name: Build report
         run: make report

--- a/report/inputs/verification_methods.tex
+++ b/report/inputs/verification_methods.tex
@@ -90,7 +90,7 @@ vérifiée contre quatre oracles, dans l'ordre~:
 \begin{enumerate}
 \item Bibliographie sourcée de l'auteur (\texttt{docs/pipeline.ods},
   feuilles \emph{References}, \emph{Power plants}, \emph{Terminals})~;
-\item Corpus RAG local (\texttt{data/rag_corpus/}, extraits markdown des
+\item Corpus RAG local (\texttt{data/rag\_corpus/}, extraits markdown des
   annexes PDP7/7A/8 et rapports annuels EVN)~;
 \item Bibliothèque Zotero de l'auteur (vérification par API)~;
 \item Liste de domaines de confiance~: \texttt{gem.wiki} (Global Energy

--- a/tests/test_docs_build_workflow.py
+++ b/tests/test_docs_build_workflow.py
@@ -1,0 +1,87 @@
+"""Structural adherence test for the docs-build GHA workflow.
+
+The actual end-to-end test is the workflow itself running on a PR. This
+adherence test guards the load-bearing pieces of the YAML — anything a
+casual edit could break without notice.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-build.yml"
+
+
+def _load() -> dict:
+    assert WORKFLOW.exists(), f"missing workflow file: {WORKFLOW}"
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def test_workflow_file_exists():
+    assert WORKFLOW.exists(), f"missing workflow file: {WORKFLOW}"
+
+
+def test_pull_request_paths_cover_build_inputs():
+    wf = _load()
+    # YAML's `on:` key is sometimes parsed as the boolean True by PyYAML.
+    triggers = wf.get("on") or wf.get(True)
+    assert triggers, "no triggers defined"
+    pr = triggers.get("pull_request")
+    assert pr, "pull_request trigger missing"
+    paths = pr.get("paths") or []
+    required = {"report/**", "slides/**", "Makefile"}
+    missing = required - set(paths)
+    assert not missing, f"pull_request.paths missing entries: {missing}"
+
+
+def test_push_main_and_dispatch_triggers():
+    wf = _load()
+    triggers = wf.get("on") or wf.get(True)
+    push = triggers.get("push") or {}
+    assert "main" in (push.get("branches") or []), "push trigger must target main"
+    assert "workflow_dispatch" in triggers, "workflow_dispatch trigger missing"
+
+
+def test_build_job_present():
+    wf = _load()
+    jobs = wf.get("jobs") or {}
+    assert "build" in jobs, "job named 'build' is required (required-check id)"
+
+
+def test_slides_step_has_continue_on_error():
+    wf = _load()
+    job = wf["jobs"]["build"]
+    steps = job.get("steps") or []
+    slides_steps = [
+        s
+        for s in steps
+        if "slides" in (s.get("name") or "").lower()
+        and "manuscript" not in (s.get("name") or "").lower()
+    ]
+    assert slides_steps, "no step named for slides"
+    for s in slides_steps:
+        assert s.get("continue-on-error") is True, (
+            f"slides step '{s.get('name')}' must have continue-on-error: true "
+            f"until fig_capability_dag precondition (ticket 0367) is fixed"
+        )
+
+
+def test_tectonic_version_pinned():
+    text = WORKFLOW.read_text()
+    assert "0.15.0" in text, "tectonic version must be pinned to 0.15.0"
+
+
+def test_tectonic_cache_key():
+    text = WORKFLOW.read_text()
+    assert "tectonic-0.15.0-" in text, (
+        "tectonic cache key must include version 0.15.0 for invalidation on bump"
+    )
+
+
+def test_setup_uv_action_used():
+    text = WORKFLOW.read_text()
+    assert "astral-sh/setup-uv@v4" in text, "uv setup action must be pinned to v4"

--- a/tests/test_make_slides_prereqs.py
+++ b/tests/test_make_slides_prereqs.py
@@ -35,8 +35,11 @@ def test_make_slides_lists_fig_capability_dag_as_prereq():
     up-to-date — either way it appears on stdout (when missing on disk,
     as a recipe; when present, the dry-run still surfaces it).
     """
+    # -B forces make to plan every recipe regardless of file mtimes. Without
+    # it, after a successful `make slides` the targets are up-to-date and
+    # `make -n` emits only "Nothing to be done", hiding what we're guarding.
     result = subprocess.run(
-        ["make", "-n", "slides"],
+        ["make", "-B", "-n", "slides"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tickets/closed/0365-gha-docs-build-workflow.erg
+++ b/tickets/closed/0365-gha-docs-build-workflow.erg
@@ -2,10 +2,12 @@
 Title: Add GHA docs-build workflow — compile report/slides/manuscript on every PR
 Created: 2026-05-28
 Author: claude
+Closed: autoclosed — PR #636
 
 --- log ---
 2026-05-28T00:00Z claude created — closes the merge-time verification gap that PR #630 exposed (Copilot reverts went green on lint/tests/changes because no check compiles the PDFs); also the only path to in-env build verification for 0352/0353 that does not require relaxing the Claude Code cloud env's network policy
 
+2026-05-28T13:23Z HDMX-coding-agent closed — autoclosed — PR #636
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docs-build.yml`: compiles `report.pdf`, `slides.pdf`, `slides-en.pdf`, and `slides/manuscript/main.pdf`, then runs `make check`, on every PR that touches build inputs (and on push-to-main / workflow_dispatch).
- Pinned engines: tectonic 0.15.0 (static musl from GitHub release, cached as `~/.cache/Tectonic` keyed `tectonic-0.15.0-${{ runner.os }}`), pandoc from Ubuntu 24.04 apt, `uv` via `astral-sh/setup-uv@v4`.
- Slides step has `continue-on-error: true` per design — there's a pre-existing recursive-make mismatch (`fig_capability_dag` vs `fig_capability_timeline`) being fixed separately in ticket 0367. The manuscript step pre-builds the dag PDF from the root Makefile (where the rule lives) so it stays green even before 0367 lands.
- Adds `tests/test_docs_build_workflow.py` (`@pytest.mark.adherence`) guarding the load-bearing YAML pieces.
- `CI.yml` is untouched.

Closes the verification gap behind merged-with-build-unverified tickets 0361 and 0362 (see ticket body for full reasoning).

**Ticket:** tickets/0365-gha-docs-build-workflow.erg

## Expected first-run outcome on this PR

This PR's own `docs-build` run is the first real end-to-end test:
- `report` step: PASS (produces report.pdf)
- `slides` step: RED on missing `fig_capability_dag.pdf` rule — but `continue-on-error: true` keeps the overall job green; `slides.pdf` + `slides-en.pdf` artifacts may or may not exist depending on sub-make ordering
- `manuscript` step: PASS (pre-builds the dag from root, then invokes `make -C slides manuscript/main.pdf`)
- `make check`: PASS
- Existing CI checks (`changes`, `lint`, `tests`): PASS

Required-check enablement (`docs-build / build`) is a manual repo-settings step deferred until 0367 lands a green slides baseline — out of scope here.

## Test plan

- [ ] CI's existing `lint`, `tests`, `changes` checks pass on this PR
- [ ] `docs-build / build` runs on this PR and reports the red-state baseline described above (overall job green, slides step internally red)
- [ ] PDF artifacts uploaded with 14-day retention; report.pdf + manuscript/main.pdf present
- [ ] Adherence test `tests/test_docs_build_workflow.py` passes locally (`uv run pytest tests/test_docs_build_workflow.py`)

Generated with [Claude Code](https://claude.com/claude-code)