### PR TITLE
tickets: rename 0366→0368, 0367→0369 (resolve post-merge ID collisions)

### DIFF
--- a/tickets/0368-simple-harness-framing-for-arm2-arm4.erg
+++ b/tickets/0368-simple-harness-framing-for-arm2-arm4.erg
@@ -97,7 +97,7 @@ harness only forwards calls and budget-caps the loop.
   to DeepSeek every turn. The current classifier sees ONLY the latest
   assistant turn (~1–4 KTok). A tool-use orchestrator pays for the full
   conversation in DeepSeek tokens *too*, doubling the multi-turn cost
-  footprint just when ticket 0367 is asking why multi-turn is already
+  footprint just when ticket 0369 is asking why multi-turn is already
   expensive.
 - **Scope creep.** Changing the orchestration shape mid-paper invalidates
   prior arm-4 measurements; the rerun cost is material (Anthropic in
@@ -141,7 +141,7 @@ If the design alternative is pursued (NOT recommended for this paper):
 ## Related
 
 - 0364 — arms vocabulary 2×2 rename (presentation layer).
-- 0367 — RAG-cell caching audit (multi-turn cost driver this ticket touches
+- 0369 — RAG-cell caching audit (multi-turn cost driver this ticket touches
   in the "Cons → Cost overhead" bullet).
 - `experiments/sota/exp2_interactive_smoke.py` — the loop and reply slots.
 - `experiments/sota/dialogue_classifier.py` — the DeepSeek orchestrator.

--- a/tickets/0369-rag-cell-cost-audit-claude-cache-breakpoints.erg
+++ b/tickets/0369-rag-cell-cost-audit-claude-cache-breakpoints.erg
@@ -271,7 +271,7 @@ Instrumentation-phase test (only if audit confirms):
 ## Out of scope
 
 - Mistral / Qwen cost reduction (no client-side cache lever).
-- Changing the orchestration shape (see ticket 0366 — alternative
+- Changing the orchestration shape (see ticket 0368 — alternative
   designs would themselves change the cost profile and the protocol).
 - Cross-rep cache TTL extensions beyond what Anthropic exposes (no
   client-side knob).
@@ -285,7 +285,7 @@ Instrumentation-phase test (only if audit confirms):
   path; the cache_control wiring lives here, not in `query_anthropic.py`.
 - `src/aedist/query_anthropic.py:257-296` — cost breakdown computation;
   source of the audit inputs.
-- 0366 — Simple-harness framing; the "Cons → Cost overhead" bullet there
+- 0368 — Simple-harness framing; the "Cons → Cost overhead" bullet there
   pointed at this ticket as the place where the actual cost numbers live.
 - `.claude/rules/workflow.md` — "Audit before instrumenting" rule that
   governs the two-phase structure above.


### PR DESCRIPTION
## Summary

PR #633 (Simple-harness framing + RAG-cell cost audit) merged into `main` alongside another PR that had taken the same IDs 0366 and 0367. The %erg validator should have rejected the second-to-land file at pre-commit time but did not — both pairs of files coexisted on `main` after the fast-forward, and `./tickets/erg check tickets/` errored with two `duplicate ID` violations.

Renames the newer pair (mine — created with filename collision after the other PR had branched but before it merged) to 0368 and 0369. Internal cross-references between the two tickets updated.

## Verification

- `./tickets/erg check tickets/` → `PASS (353 tickets)`
- `./tickets/erg validate tickets/0368-*.erg tickets/0369-*.erg` → `PASS (2 files)`
- No content changes; only filename + 4 internal ID cross-refs.

## Follow-up (not in this PR)

The pre-commit validator did not block the racing merge, which is the root cause. Worth a follow-up ticket: either make the duplicate-ID check a required CI gate, or document that filename-collision races are an accepted risk and renames are the remediation.

---
_Generated by [Claude Code](https://claude.ai/code/session_012w4LXkPzL6AYnZsjDqfi3D)_