### PR TITLE
fix(ci): docs-build always runs on PRs, chore-gated internally

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,45 +2,70 @@ name: docs-build
 
 on:
   pull_request:
-    paths:
-      - 'report/**'
-      - 'slides/**'
-      - 'Makefile'
-      - 'experiments/analysis.mk'
-      - 'src/aedist/**'
-      - 'tests/**'
-      - 'data/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/docs-build.yml'
   push:
     branches: [main]
   workflow_dispatch:
 
 jobs:
+  # Decide whether the diff touches anything the docs-build cares about.
+  # `chore` is true ONLY when *every* changed file matches the chore filter
+  # (predicate-quantifier: every) — ticket-only, STATE, in-repo notes, top-
+  # level READMEs, .claude/** harness files. Anything else — including a
+  # mixed diff or an empty/errored output — leaves it != 'true', so the
+  # heavy build steps below run. Fail-safe: ambiguity always builds.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      chore: ${{ steps.filter.outputs.chore }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            chore:
+              - 'tickets/**'
+              - '.claude/**'
+              - 'docs/**'
+              - 'STATE.md'
+              - 'README.md'
+              - 'AGENTS.md'
+              - 'CLAUDE.md'
+              - 'ADR.md'
+              - 'MASTERPLAN.md'
+              - 'PLAN.md'
+
   build:
+    needs: changes
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     env:
       TECTONIC_VERSION: '0.15.0'
     steps:
       - name: Checkout
+        if: needs.changes.outputs.chore != 'true'
         uses: actions/checkout@v4
 
       - name: Setup uv (respects uv.lock)
+        if: needs.changes.outputs.chore != 'true'
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
 
       - name: uv sync (dev group for make check)
+        if: needs.changes.outputs.chore != 'true'
         run: uv sync --group dev
 
       - name: Cache Tectonic bundle
+        if: needs.changes.outputs.chore != 'true'
         uses: actions/cache@v4
         with:
           path: ~/.cache/Tectonic
           key: tectonic-0.15.0-${{ runner.os }}
 
       - name: Install Tectonic 0.15.0 (static musl binary)
+        if: needs.changes.outputs.chore != 'true'
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.local/bin"
@@ -52,6 +77,7 @@ jobs:
           "$HOME/.local/bin/tectonic" --version
 
       - name: Install pandoc
+        if: needs.changes.outputs.chore != 'true'
         run: |
           set -euo pipefail
           sudo apt-get update -qq
@@ -59,10 +85,12 @@ jobs:
           pandoc --version | head -n1
 
       - name: Build report
+        if: needs.changes.outputs.chore != 'true'
         run: make report
 
       - name: Build slides
         id: slides
+        if: needs.changes.outputs.chore != 'true'
         continue-on-error: true
         run: make slides
 
@@ -71,15 +99,17 @@ jobs:
         # slides sub-make has no rule for it — same recursive-make gap that
         # makes `make slides` red. Pre-building here lets manuscript pass even
         # before ticket 0367's fix lands.
+        if: needs.changes.outputs.chore != 'true'
         run: |
           make report/inputs/generated/fig_capability_dag.pdf
           make -C slides manuscript/main.pdf
 
       - name: Run make check (lint + tests)
+        if: needs.changes.outputs.chore != 'true'
         run: make check
 
       - name: Upload PDF artifacts
-        if: success() || failure()
+        if: needs.changes.outputs.chore != 'true' && (success() || failure())
         uses: actions/upload-artifact@v4
         with:
           name: docs-pdfs
@@ -92,7 +122,7 @@ jobs:
           retention-days: 14
 
       - name: Upload build logs on failure
-        if: failure()
+        if: needs.changes.outputs.chore != 'true' && failure()
         uses: actions/upload-artifact@v4
         with:
           name: build-logs

--- a/tests/test_docs_build_workflow.py
+++ b/tests/test_docs_build_workflow.py
@@ -21,35 +21,88 @@ def _load() -> dict:
     return yaml.safe_load(WORKFLOW.read_text())
 
 
+def _triggers(wf: dict) -> dict:
+    # YAML's `on:` key is sometimes parsed as the boolean True by PyYAML.
+    triggers = wf.get("on") or wf.get(True)
+    assert triggers, "no triggers defined"
+    return triggers
+
+
 def test_workflow_file_exists():
     assert WORKFLOW.exists(), f"missing workflow file: {WORKFLOW}"
 
 
-def test_pull_request_paths_cover_build_inputs():
+def test_docs_build_runs_on_all_pull_requests():
+    """The workflow must run on every PR for the required-check gate to clear.
+
+    A `pull_request.paths` filter would skip chore-only PRs and leave the
+    required `build` check pending forever. Heavy work is gated inside the
+    `build` job via the `changes` job's `chore` output instead.
+    """
     wf = _load()
-    # YAML's `on:` key is sometimes parsed as the boolean True by PyYAML.
-    triggers = wf.get("on") or wf.get(True)
-    assert triggers, "no triggers defined"
-    pr = triggers.get("pull_request")
-    assert pr, "pull_request trigger missing"
-    paths = pr.get("paths") or []
-    required = {"report/**", "slides/**", "Makefile"}
-    missing = required - set(paths)
-    assert not missing, f"pull_request.paths missing entries: {missing}"
+    triggers = _triggers(wf)
+    assert "pull_request" in triggers, "pull_request trigger missing"
+    pr = triggers["pull_request"]
+    # pull_request without a paths filter — None (bare `pull_request:`) or a
+    # dict that does not key `paths`.
+    assert pr is None or (isinstance(pr, dict) and "paths" not in pr), (
+        "docs-build.yml must run on every PR for the required-check gate; "
+        "use the internal `changes` job to skip heavy work on chore diffs."
+    )
 
 
 def test_push_main_and_dispatch_triggers():
     wf = _load()
-    triggers = wf.get("on") or wf.get(True)
+    triggers = _triggers(wf)
     push = triggers.get("push") or {}
     assert "main" in (push.get("branches") or []), "push trigger must target main"
     assert "workflow_dispatch" in triggers, "workflow_dispatch trigger missing"
 
 
-def test_build_job_present():
+def test_changes_and_build_jobs_present():
     wf = _load()
     jobs = wf.get("jobs") or {}
+    assert "changes" in jobs, "job named 'changes' is required (chore detector)"
     assert "build" in jobs, "job named 'build' is required (required-check id)"
+
+
+def test_changes_job_uses_paths_filter():
+    wf = _load()
+    changes = wf["jobs"]["changes"]
+    steps = changes.get("steps") or []
+    uses = [s.get("uses", "") for s in steps]
+    assert any("dorny/paths-filter" in u for u in uses), (
+        "changes job must use dorny/paths-filter to compute chore output"
+    )
+    outputs = changes.get("outputs") or {}
+    assert "chore" in outputs, "changes job must expose `chore` output"
+
+
+def test_build_depends_on_changes():
+    wf = _load()
+    build = wf["jobs"]["build"]
+    needs = build.get("needs")
+    assert needs == "changes" or (isinstance(needs, list) and "changes" in needs), (
+        "build job must declare `needs: changes`"
+    )
+    # `!cancelled()` so build still runs (as a no-op) when `changes` returns
+    # chore=true; without it, a skipped dependency would skip `build` too.
+    assert "cancelled()" in str(build.get("if", "")), (
+        "build job must guard with `if: !cancelled()` so it always reports a status"
+    )
+
+
+def test_build_steps_gated_on_chore_flag():
+    """Every concrete step in `build` must skip when the diff is chore-only."""
+    wf = _load()
+    steps = wf["jobs"]["build"].get("steps") or []
+    assert steps, "build job has no steps"
+    ungated = [
+        s.get("name") or s.get("uses") or "<unnamed>"
+        for s in steps
+        if "needs.changes.outputs.chore" not in str(s.get("if", ""))
+    ]
+    assert not ungated, f"every build step must gate on the chore flag; ungated: {ungated}"
 
 
 def test_slides_step_has_continue_on_error():
@@ -85,3 +138,10 @@ def test_tectonic_cache_key():
 def test_setup_uv_action_used():
     text = WORKFLOW.read_text()
     assert "astral-sh/setup-uv@v4" in text, "uv setup action must be pinned to v4"
+
+
+def test_build_runner_pinned():
+    wf = _load()
+    assert wf["jobs"]["build"].get("runs-on") == "ubuntu-24.04", (
+        "build job must pin runner to ubuntu-24.04 for reproducibility"
+    )

--- a/tickets/closed/0371-docs-build-always-run-with-chore-filter.erg
+++ b/tickets/closed/0371-docs-build-always-run-with-chore-filter.erg
@@ -2,10 +2,12 @@
 Title: Refactor docs-build workflow to always-run with internal chore-filter
 Created: 2026-05-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #639
 
 --- log ---
 2026-05-28T13:30Z HDMX-coding-agent created — surfaced by 0358 raid: GitHub branch protection requires the `build` status to report on every PR, but the current `pull_request.paths` trigger skips PRs that don't touch build inputs (STATE.md, ticket-only PRs, .claude/** edits). Required-check + skipped workflow = unmergeable PR.
 
+2026-05-28T14:04Z HDMX-coding-agent closed — autoclosed — PR #639
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Drop `pull_request.paths` filter on `docs-build.yml` so the workflow runs on every PR. This unblocks adding `build` to required status checks (ticket 0358) — chore-only PRs (STATE, tickets, .claude/**) previously skipped the workflow entirely, leaving the required check pending forever.
- Add a top-level `changes` job mirroring `CI.yml`: dorny/paths-filter@v3 with `predicate-quantifier: every` computes a `chore` boolean. The chore list is permissive (tickets/**, .claude/**, docs/**, STATE.md, READMEs, AGENTS.md, CLAUDE.md, ADR.md, MASTERPLAN.md, PLAN.md) — when ambiguous, the full build still runs.
- `build` now has `needs: changes` and `if: !cancelled()`. Every concrete step gates on `needs.changes.outputs.chore != 'true'`, so the job reports SUCCESS as a no-op on chore-only PRs while still doing the full pipeline on build-touching PRs.
- Adherence test re-aimed at the new shape (PR trigger has no paths; `changes`+`build` jobs present; `build` needs `changes` with `!cancelled()`; every build step gated; slides continue-on-error / tectonic 0.15.0 / ubuntu-24.04 invariants preserved). New `test_docs_build_runs_on_all_pull_requests` asserts the load-bearing invariant for the required-check gate.

**Ticket:** tickets/0371-docs-build-always-run-with-chore-filter.erg

## Test plan

- [x] Pre-refactor: new test red, refactor turns it green.
- [x] `uv run pytest tests/test_docs_build_workflow.py` — 12 passed.
- [x] `make check-fast` — only an unrelated, pre-existing flake in `test_manager.py::test_idempotency_across_dirs` (test-ordering-dependent; passes in isolation on both this branch and unmodified main).
- [ ] This PR itself touches `.github/workflows/docs-build.yml`, so its `docs-build` run exercises the full pipeline (not a chore diff) — expect green build PDFs.
- [ ] Follow-up after merge (ticket 0358's scope): demonstrate a STATE-only or ticket-only PR where `docs-build / build` reports SUCCESS as a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)