### PR TITLE
tickets: open 0372–0375 (status fig, Exp 1 matrix, Exp 3 triage, aggregation sweep)

### DIFF
--- a/tickets/0372-status-distribution-gold-vs-best-llm.erg
+++ b/tickets/0372-status-distribution-gold-vs-best-llm.erg
@@ -1,0 +1,56 @@
+%erg 0.1
+Title: Présenter la distribution par status sur la gold list vs. best LLM
+Created: 2026-05-28
+Author: minh
+
+--- log ---
+2026-05-28T19:45Z minh created — illustrate task difficulty by comparing the status mix of the reference list against the best LLM's recall
+
+--- body ---
+## Context
+
+The "Vietnam thermal" benchmark is hard not just because LLMs miss assets but
+because the gold list itself spans many lifecycle statuses (operating,
+construction, planned, retired, cancelled, mothballed, …). A single figure
+contrasting the *status distribution* of the gold list against the best LLM's
+recall (per status bin) would make the difficulty concrete: models tend to
+recall famous operating plants and miss everything else.
+
+This is a presentation/figure ticket — the data already lives in
+`measurements.jsonl` and the reference CSV (`data/reference/vietnam_thermal_v1.csv`).
+
+## Relevant files
+- `data/reference/vietnam_thermal_v1.csv` — gold list with status column
+- `measurements.jsonl` — per-(model, run, plant) hits
+- `src/aedist/plot_*.py` — existing plot modules (pick the closest pattern, e.g. `plot_census.py`)
+- `experiments/analysis.mk` — add the new figure as a chart-figures target
+- `report/report.tex` and/or `slides/slides.tex` — where the figure is included
+
+## Actions
+1. Pick the "best LLM" definition (top-F1 single model on Exp 1? on direct
+   prompt? clarify in the ticket discussion before implementing).
+2. Write `src/aedist/plot_status_distribution.py` that produces a grouped or
+   stacked bar chart: x-axis = status category, y-axis = count, two series
+   (gold list, best LLM recall).
+3. Wire as a `chart-figures` target in `experiments/analysis.mk`.
+4. Include in the report (and/or slides) with a caption that names the model.
+5. Commit the generated PDF as a handoff artifact.
+
+## Test
+`tests/test_plot_status_distribution.py` — golden test on a small synthetic
+fixture verifying the script produces a non-empty PDF and the underlying
+counts match expected bins.
+
+## Verification
+- [ ] Figure renders without warnings
+- [ ] Counts in figure match a hand-computed pivot on the fixture
+- [ ] Best-LLM choice is documented in the figure caption and the ticket log
+- [ ] `make check` passes
+
+## Invariants
+- Clean-room writing build — no `uv run` in `make report` / `make slides`
+  (rule lives in analysis.mk)
+
+## Exit criteria
+- New figure committed and included in the report (or slides), showing the
+  status-distribution gap that makes the benchmark hard

--- a/tickets/0373-exp1-figure-align-plants-vertically.erg
+++ b/tickets/0373-exp1-figure-align-plants-vertically.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: Aligner verticalement les plants sur la liste de référence dans la figure Exp 1
+Created: 2026-05-28
+Author: minh
+
+--- log ---
+2026-05-28T19:46Z minh created — current Exp 1 figure left-packs each row's recalled plants, hiding which gold-list plants each model missed
+
+--- body ---
+## Context
+
+The current Exp 1 figure (`fig_direct_p1_base.pdf`, produced by
+`aedist.plot_method_convergence` with `--methods direct`) packs each
+model's recalled plants to the left of its row. Two models recalling the
+same number of plants look identical even when they recall *different*
+plants. The reader cannot tell which gold-list assets each model misses.
+
+Replace the left-packed dots with a boolean matrix: rows = (model, run),
+columns = gold-list plants in a fixed order (e.g. by status × capacity).
+A filled cell means "this model recalled this plant"; an empty cell means
+"miss". The vertical alignment makes coverage patterns immediately legible
+— famous plants form dense columns; obscure plants form sparse ones.
+
+## Relevant files
+- `src/aedist/plot_method_convergence.py` — current figure producer
+- `data/reference/vietnam_thermal_v1.csv` — gold list ordering source
+- `experiments/outputs/exp1_batch2/*.record.json` — per-run hits
+- `report/inputs/generated/fig_direct_p1_base.pdf` — committed handoff artifact
+
+## Actions
+1. Decide whether to extend `plot_method_convergence.py` with a new mode
+   (`--layout matrix`) or write a sibling script (`plot_exp1_matrix.py`).
+   Sibling is likely cleaner — different visual primitive.
+2. Define column ordering. Options: by status group then by capacity, by
+   famousness proxy (recall frequency across all models), or alphabetical.
+   Order will significantly shape the reader's takeaway — pick deliberately.
+3. Implement and wire as an analysis.mk chart-figures target.
+4. Swap `\includegraphics{fig_direct_p1_base.pdf}` in the report (and slides
+   if applicable) to the new figure, or use as a companion.
+5. Commit the generated PDF as a handoff artifact.
+
+## Test
+`tests/test_plot_exp1_matrix.py` — golden test on synthetic fixture:
+- N models × M plants matrix, half hit half miss
+- Verify the script produces a non-empty PDF
+- Verify (via the script's CSV side-output, if any) that the boolean
+  matrix matches the input hits
+
+## Verification
+- [ ] Figure produces a boolean matrix with plants aligned vertically
+- [ ] Column ordering documented in caption and ticket log
+- [ ] Generated PDF committed as handoff artifact
+- [ ] `make check` passes
+
+## Invariants
+- Clean-room writing build — no `uv run` in `make report` / `make slides`
+- Existing `fig_direct_p1_base.pdf` not silently removed without a
+  replacement decision (keep both or swap explicitly)
+
+## Exit criteria
+- New Exp 1 figure aligns plants vertically on the reference list
+- Committed in `report/inputs/generated/` and included in the report

--- a/tickets/0374-exp3-false-negatives-triage.erg
+++ b/tickets/0374-exp3-false-negatives-triage.erg
@@ -1,0 +1,69 @@
+%erg 0.1
+Title: Trier les faux négatifs de l'exp 3 (comparateur, liste, définition, résidu)
+Created: 2026-05-28
+Author: minh
+
+--- log ---
+2026-05-28T19:47Z minh created — Exp 3 false negatives currently lumped together; need to know how much of the gap is real model failure vs. evaluation artifact
+
+--- body ---
+## Context
+
+Exp 3 false negatives (gold-list plants the model failed to recall) are
+counted in the aggregate but never triaged. The headline "low coverage"
+number conflates four distinct causes:
+
+1. **Comparator limit** — the matching/scoring code failed to recognize
+   that the model *did* mention the plant (alias, typo, partial name).
+   Fix: improve `score_mechanical` / fuzzy matcher.
+2. **List limit** — the model named something real and arguably valid
+   that the gold list does not contain (so it's actually a miss against
+   our reference, not against reality). Fix: expand/audit gold list.
+3. **Definition limit** — disagreement about what counts (e.g. >30 MW
+   threshold edge cases, "thermal" vs. "fossil", project-vs-plant
+   granularity). Fix: clarify scope in protocol; possibly reclassify.
+4. **Residual** — genuine recall failure. Nothing to fix on our side;
+   this is the real benchmark signal.
+
+Without this triage, we can't tell readers what fraction of the reported
+gap is the model's failing vs. our evaluation's.
+
+## Relevant files
+- `experiments/outputs/sota_exp3_*/` — Exp 3 raw outputs and probes
+- `experiments/derived/sota_cross_eval.csv` — current scoring
+- `src/aedist/score_mechanical.py` — comparator
+- `data/reference/vietnam_thermal_v1.csv` — gold list
+- `src/aedist/coherence.py` and friends — alias handling
+
+## Actions
+1. Sample the false negatives from the best-performing Exp 3 arm
+   (deliberately, not random — focus on the highest-recall model so the
+   residual category is small and the triage is informative). Target n=50
+   to keep manual review tractable.
+2. For each false negative, classify into the 4 buckets above. Record in
+   a triage CSV (`experiments/derived/exp3_fn_triage.csv`).
+3. Write `src/aedist/tabulate_exp3_fn_triage.py` to produce a summary
+   table from the CSV (counts and percentages per bucket, per arm).
+4. Wire as a report-tables target in `experiments/analysis.mk`.
+5. Include in the report Discussion section, with a paragraph explaining
+   what we found (and what we'd fix next).
+
+## Test
+`tests/test_tabulate_exp3_fn_triage.py` — fixture CSV with known bucket
+counts, verify the tabulate script produces the expected LaTeX table.
+
+## Verification
+- [ ] Triage CSV exists with ≥50 manually classified rows
+- [ ] Summary table generated and committed
+- [ ] Report discusses the four buckets explicitly, with numbers
+- [ ] `make check` passes
+
+## Invariants
+- Triage is human-judged — do not script the classification. Manual
+  decisions go in the CSV with a "rationale" column.
+- Clean-room writing build (no `uv run` in `make report`)
+
+## Exit criteria
+- Exp 3 false negatives are categorized into the four buckets with
+  concrete counts; the residual ("real failure") number is reported as
+  the headline benchmark signal

--- a/tickets/0375-aggregative-methods-sweep.erg
+++ b/tickets/0375-aggregative-methods-sweep.erg
@@ -1,0 +1,85 @@
+%erg 0.1
+Title: Tester les méthodes d'agrégation (merge × pool size × diversity rule)
+Created: 2026-05-28
+Author: minh
+
+--- log ---
+2026-05-28T19:48Z minh created — single-run recall is the floor; aggregating runs is the cheapest path to a higher coverage number, but the optimal recipe is unknown
+
+--- body ---
+## Context
+
+Single LLM runs leave coverage on the table. Aggregating multiple runs
+("self-ensembling") is well-known to raise recall. The open question for
+AEDIST: which aggregation recipe is best?
+
+Three orthogonal dimensions:
+
+1. **Merging method**
+   - Union (any run mentioned the plant → include)
+   - Majority (≥k of n runs)
+   - Confidence-weighted (sum/avg per-run confidence, threshold)
+2. **Pool size**: 2, 3, 4 runs
+3. **Diversity rule** (how to compose the pool)
+   - One model, n runs (intra-model variance)
+   - n different models, one run each from smallest-budget runs
+   - n different models, one run each from largest-budget runs
+   - Mixed (some same-model reruns, some different-model)
+
+Full factorial: 3 × 3 × 4 = 36 cells. Some are degenerate (e.g. union on
+pool size 1) but a clean factorial design is worth the budget.
+
+Output: a table showing recall (and cost) for each cell, and a recommended
+aggregation recipe to use as the "AEDIST default" headline number.
+
+## Relevant files
+- `experiments/outputs/exp1_batch2/*.record.json` — per-run hits (already
+  have n>1 runs per model for many models, no new API calls needed)
+- `experiments/outputs/sota_exp3_*/` — Exp 3 multi-run data
+- `src/aedist/score_mechanical.py` — comparator (reuse for evaluating
+  aggregated lists)
+- `experiments/derived/*` — derived CSVs go here
+
+## Actions
+1. Inventory existing data: which models have ≥4 runs available for free
+   re-aggregation? Likely covers pool sizes 2–4 for one-model recipes.
+   Cross-model recipes need only 1 run per model — already have those.
+2. Write `src/aedist/aggregate_runs.py` with three merge primitives
+   (union, majority, confidence-weighted) and a CLI taking a JSONL of
+   per-run record paths plus a merge method.
+3. Write `src/aedist/sweep_aggregations.py` that generates all 36 cells
+   from committed per-run records (no new API spend) and writes a
+   results CSV (`experiments/derived/aggregation_sweep.csv`) with columns:
+   merge_method, pool_size, diversity_rule, mean_F1, mean_cost, n_pools.
+4. Tabulate (and figure?) the sweep results in `experiments/analysis.mk`.
+5. Include in the report — likely a new section "Run aggregation as a
+   coverage lever" with the recommended recipe.
+
+## Test
+`tests/test_aggregate_runs.py` — fixture with 3 synthetic runs over
+4 plants:
+- Run 1: {A, B}
+- Run 2: {B, C}
+- Run 3: {B, D}
+Verify union = {A, B, C, D}; majority(k=2) = {B}; confidence-weighted
+behaves per spec.
+
+## Verification
+- [ ] All 36 cells (or documented subset with rationale) populated
+- [ ] No new API calls — only aggregation over committed run records
+- [ ] Recommended recipe documented with the F1/cost trade-off it implies
+- [ ] `make check` passes
+
+## Invariants
+- Read-only over experiment outputs; no new sweep launches without
+  explicit scope expansion
+- Clean-room writing build (rule lives in analysis.mk)
+- Confidence-weighted aggregation needs a per-plant confidence number
+  from each run — if records lack it, mark that cell as N/A rather
+  than fabricating confidence
+
+## Exit criteria
+- Aggregation sweep results table in the report
+- A recommended (merge, pool, diversity) recipe with F1 and cost numbers
+- The headline coverage number for AEDIST is updated (or argued not to
+  be updated) based on the best aggregation recipe


### PR DESCRIPTION
## Summary
Four new tickets dictated by the author:

- **0372** — Présenter la distribution par status sur la gold list vs. best LLM (figure de difficulté)
- **0373** — Aligner verticalement les plants sur la liste de référence dans la figure Exp 1 (boolean matrix)
- **0374** — Trier les faux négatifs de l'exp 3 (comparateur / liste / définition / résidu)
- **0375** — Tester les méthodes d'agrégation (merge × pool size × diversity rule)

All four pass \`erg validate\` and the corpus \`erg check\`.

## Test plan
- [x] Each ticket has Context, Actions, Test, Verification, Invariants, Exit criteria
- [x] \`tickets/erg validate\` passes on all 4
- [x] \`tickets/erg check tickets/\` passes (one pre-existing warning about closed 0370's Blocked-by 0352, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)