### PR TITLE
ci: sync CI.yml chore filter with docs-build.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,10 +5,12 @@ on:
   pull_request:
 jobs:
   # Decide whether the diff touches anything that lint/tests care about.
-  # `chore` is true ONLY when *every* changed file is a ticket or STATE.md
-  # (predicate-quantifier: every). Anything else — code, configs, docs, a
-  # mixed diff, or an empty/errored output — leaves it != 'true', so the
+  # `chore` is true ONLY when *every* changed file matches the chore filter
+  # (predicate-quantifier: every) — ticket-only, STATE, in-repo notes, top-
+  # level READMEs, .claude/** harness files. Anything else — including a
+  # mixed diff or an empty/errored output — leaves it != 'true', so the
   # heavy steps below run. Fail-safe: ambiguity always runs full CI.
+  # Kept in sync with docs-build.yml.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -22,7 +24,15 @@ jobs:
           filters: |
             chore:
               - 'tickets/**'
+              - '.claude/**'
+              - 'docs/**'
               - 'STATE.md'
+              - 'README.md'
+              - 'AGENTS.md'
+              - 'CLAUDE.md'
+              - 'ADR.md'
+              - 'MASTERPLAN.md'
+              - 'PLAN.md'
   lint:
     needs: changes
     if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
- Extend CI.yml's \`chore\` path filter to match docs-build.yml's broader set
- Adds \`docs/**\`, \`.claude/**\`, \`README.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, \`ADR.md\`, \`MASTERPLAN.md\`, \`PLAN.md\` to the filter
- Doc-only and harness-only PRs now short-circuit lint+tests, not just the docs build

## Test plan
- [x] This PR itself touches only \`.github/workflows/\` → NOT chore → CI must run lint+tests (sanity check)
- [ ] A follow-up doc-only PR would now skip lint+tests (would have to verify on the next docs PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)