### PR TITLE
fix(fusion): propagate fused COD through MasterRecord.to_plant()

### DIFF
--- a/src/aedist/prototype_v1_fusion.py
+++ b/src/aedist/prototype_v1_fusion.py
@@ -163,6 +163,7 @@ class MasterRecord:
             status=status if status is not None else PlantStatus.UNKNOWN,
             capacity_mwe=cap,
             province=self.province.value if self.province else None,
+            cod=self.cod.value if self.cod else None,
         )
 
 

--- a/tests/test_fusion_prototype.py
+++ b/tests/test_fusion_prototype.py
@@ -191,12 +191,23 @@ def test_master_to_plants_converts_records():
         fuel=_sf(FuelType.COAL, tier=3, year=2020),
         capacity_mwe=_sf(400.0, tier=3, year=2020),
         status=_sf(PlantStatus.OPERATIONAL, tier=3, year=2020),
+        province=_sf("Hai Duong", tier=3, year=2020),
+        cod=_sf("1983", tier=3, year=2020),
     )
     plants = master_to_plants([rec])
     assert len(plants) == 1
     assert plants[0].name == "Pha Lai"
     assert plants[0].fuel == FuelType.COAL
     assert plants[0].capacity_mwe == 400.0
+    assert plants[0].province == "Hai Duong"
+    # Regression: to_plant() previously dropped the fused commissioning date.
+    assert plants[0].cod == "1983"
+
+
+def test_master_to_plants_cod_none_when_unset():
+    rec = MasterRecord(name="No COD", fuel=_sf(FuelType.GAS, tier=2, year=2019))
+    plants = master_to_plants([rec])
+    assert plants[0].cod is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Class-shape bug found in the v1 fusion prototype's projection step. `MasterRecord` carries a `cod: SourcedField | None` and the `Plant` schema has a `cod` field, but `MasterRecord.to_plant()` constructed `Plant(...)` **without `cod=`** — so the fused commissioning date was silently dropped on every projection through the live `query-fusion` entrypoint (`master_to_plants` → `to_plant`).

COD is an essential column to propagate and analyze, so this is a real data-loss bug, not cosmetic.

## Fix

One line in `to_plant()`, mirroring the existing `province` handling:
```python
cod=self.cod.value if self.cod else None,
```

## Tests

- Extended `test_master_to_plants_converts_records` to seed and assert `cod` (and `province`, which was also previously unasserted).
- Added `test_master_to_plants_cod_none_when_unset` for the omit case.
- Verified the regression test goes **red** without the fix.

All 27 fusion-prototype tests pass; ruff clean.

🤖 Found via a class-shape bug sweep over `src/aedist`.

https://claude.ai/code/session_016y3oDdebaw5is3pTq29Eeb

---
_Generated by [Claude Code](https://claude.ai/code/session_016y3oDdebaw5is3pTq29Eeb)_