### PR TITLE
fix(measurements): project verification scalars from justification (ADR-7)

### DIFF
--- a/src/aedist/measurements.py
+++ b/src/aedist/measurements.py
@@ -95,6 +95,13 @@ def records_to_metrics(records: list[RunRecord]) -> list[dict]:
     reasoning_summary, thinking_tokens, cost_breakdown, tool_calls_cost_usd
     are surfaced when the underlying RunRecord field is non-None. Lists
     are projected as counts; the raw lists stay in the RunRecord.
+
+    Verification scalars from ``justification`` (source-grounding pipeline):
+    verification_mode, mean_evidence_score, verification_cost_usd are
+    projected when the justification dict carries them (omit-when-absent).
+    Nested structures (score_distribution, filtered_metrics) and the
+    adapter's {"output_text": ...} narrative shape are not projected; they
+    remain in the RunRecord.
     """
     result = []
     for r in records:
@@ -207,6 +214,21 @@ def records_to_metrics(records: list[RunRecord]) -> list[dict]:
             d["thinking_tokens"] = r.resource_use.thinking_tokens
         if r.resource_use.cost_breakdown is not None:
             d["cost_breakdown"] = r.resource_use.cost_breakdown
+
+        # --- verification scalars from justification (source-grounding) ------
+        # justification is a free-form dict whose verification-mode shape
+        # (query_verification.py) carries scientific scalars. Project those so
+        # ADR-7 holds without re-reading raw JSON; omit-when-absent. Nested
+        # structures (score_distribution, filtered_metrics) and the adapter's
+        # {"output_text": ...} narrative shape stay in the RunRecord.
+        if isinstance(r.justification, dict):
+            for src_key, out_key in (
+                ("verification_mode", "verification_mode"),
+                ("mean_evidence_score", "mean_evidence_score"),
+                ("verification_cost_usd", "verification_cost_usd"),
+            ):
+                if r.justification.get(src_key) is not None:
+                    d[out_key] = r.justification[src_key]
 
         result.append(d)
     return result

--- a/tests/test_measurements_agent_fields.py
+++ b/tests/test_measurements_agent_fields.py
@@ -272,6 +272,45 @@ def test_records_to_metrics_includes_error_when_set():
     assert m["retry_count"] == 3
 
 
+def test_records_to_metrics_projects_verification_scalars_from_justification():
+    """Per ADR-7: verification scalars in justification flow through metrics."""
+    record = RunRecord(
+        method=Method.DIRECT,
+        method_params=MethodParams(model="gpt-5.5"),
+        justification={
+            "verification_mode": "source_grounding",
+            "mean_evidence_score": 0.82,
+            "verification_cost_usd": 0.0123,
+            # nested structures must NOT be projected
+            "score_distribution": {"high": 10, "low": 2},
+            "filtered_metrics": {"f1": 0.7},
+        },
+    )
+    [m] = records_to_metrics([record])
+    assert m["verification_mode"] == "source_grounding"
+    assert m["mean_evidence_score"] == 0.82
+    assert m["verification_cost_usd"] == 0.0123
+    assert "score_distribution" not in m
+    assert "filtered_metrics" not in m
+
+
+def test_records_to_metrics_omits_verification_scalars_when_no_justification():
+    """Omit-when-absent: no justification dict means no verification columns.
+
+    Also covers the adapter's {"output_text": ...} shape, which carries no
+    verification scalars and must not leak narrative text into metrics."""
+    record = RunRecord(
+        method=Method.DIRECT,
+        method_params=MethodParams(model="gpt-5.5"),
+        justification={"output_text": "some narrative"},
+    )
+    [m] = records_to_metrics([record])
+    assert "verification_mode" not in m
+    assert "mean_evidence_score" not in m
+    assert "verification_cost_usd" not in m
+    assert "output_text" not in m
+
+
 def test_fixture_line_32_is_byte_identical_to_source():
     """Sanity: the inlined fixture is valid JSON and has the expected run_id.
 


### PR DESCRIPTION
## Summary

ADR-7 gap surfaced by a class-shape bug sweep. `RunRecord.justification` is a free-form dict that, in its source-grounding shape (written by `query_verification.py`), carries real scientific scalars — `verification_mode`, `mean_evidence_score`, `verification_cost_usd` — plus nested structures (`score_distribution`, `filtered_metrics`). None of these reached `records_to_metrics()`, the single source of truth for the scientific record per ADR-7, so they were only recoverable by re-reading raw JSON.

(The adapter also writes a different `justification` shape — `{"output_text": narrative}` — which carries no metrics.)

## Fix

In `records_to_metrics()`, project the three verification **scalars** when the justification dict carries them (omit-when-absent, matching the existing agent-mode field pattern). Deliberately **not** projected:
- nested structures (`score_distribution`, `filtered_metrics`) — stay in the RunRecord
- the adapter's `output_text` narrative — must not leak into metrics

Docstring updated to document the new projected fields.

## Tests

- `test_records_to_metrics_projects_verification_scalars_from_justification` — scalars flow through, nested dicts do not.
- `test_records_to_metrics_omits_verification_scalars_when_no_justification` — omit-when-absent, and the adapter narrative shape leaks nothing.
- Verified red without the fix.

Full fast suite green; ruff clean.

🤖 Found via a class-shape bug sweep over `src/aedist`.

https://claude.ai/code/session_016y3oDdebaw5is3pTq29Eeb

---
_Generated by [Claude Code](https://claude.ai/code/session_016y3oDdebaw5is3pTq29Eeb)_