### PR TITLE
chore(ci): drop redundant fig_capability_dag pre-build in docs-build

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -95,14 +95,8 @@ jobs:
         run: make slides
 
       - name: Build manuscript
-        # Pre-build fig_capability_dag.pdf (root Makefile owns the rule; the
-        # slides sub-make has no rule for it — same recursive-make gap that
-        # makes `make slides` red. Pre-building here lets manuscript pass even
-        # before ticket 0367's fix lands.
         if: needs.changes.outputs.chore != 'true'
-        run: |
-          make report/inputs/generated/fig_capability_dag.pdf
-          make -C slides manuscript/main.pdf
+        run: make -C slides manuscript/main.pdf
 
       - name: Run make check (lint + tests)
         if: needs.changes.outputs.chore != 'true'

--- a/tickets/closed/0376-cleanup-docs-build-fig-capability-dag-workaround.erg
+++ b/tickets/closed/0376-cleanup-docs-build-fig-capability-dag-workaround.erg
@@ -2,10 +2,12 @@
 Title: Cleanup stale fig_capability_dag.pdf workaround in docs-build.yml
 Created: 2026-05-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #660
 
 --- log ---
 2026-05-28T20:00Z HDMX-coding-agent created — PR #640 made fig_capability_dag.pdf a committed handoff artifact; the docs-build.yml pre-build step is now a no-op with a misleading comment
 
+2026-06-03T06:19Z HDMX-coding-agent closed — autoclosed — PR #660
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`docs-build.yml`'s **Build manuscript** step pre-built `report/inputs/generated/fig_capability_dag.pdf` before the slides sub-make, with a comment pointing at ticket 0367 "as if the fix were pending."

After 0367 (#637) and 0370 (#640):
- the figure's rule lives in `experiments/analysis.mk`, not the root Makefile;
- the PDF is a **committed handoff artifact** under `report/inputs/generated/`;
- the root Makefile has **no** `report/inputs/generated/fig_capability_dag.pdf` target, so `make report/inputs/generated/fig_capability_dag.pdf` is a no-op ("Nothing to be done").

So the pre-build line and its comment are both dead weight and misleading.

## Change
- Remove the no-op `make report/...fig_capability_dag.pdf` line and the stale 0367 comment.
- **Kept** "Build slides" and "Build manuscript" as separate steps: slides carries `continue-on-error: true` + `id: slides` that the manuscript step must not inherit, so collapsing them (the ticket's optional step 3) would change failure semantics.

## Verification
- YAML parses (`yaml.safe_load`).
- Committed `fig_capability_dag.pdf` present at checkout.
- `make -C slides -n manuscript/main.pdf` → bare pandoc call resolving the figure from the committed artifact; no missing prerequisite.
- Test: none — CI-config simplification; the docs-build CI pass on this branch is the test.

**Ticket:** tickets/0376-cleanup-docs-build-fig-capability-dag-workaround.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)