### PR TITLE
ticket(0353): close as already-done — uv-run guard delivered by 0352 + 0370

### DIFF
--- a/tickets/0353-writing-build-no-uvrun-guard.erg
+++ b/tickets/0353-writing-build-no-uvrun-guard.erg
@@ -2,6 +2,7 @@
 Title: Add adherence test guarding the writing build against uv run leakage
 Created: 2026-05-26
 Author: HDMX-coding-agent
+Closed: already-done: uv-run writing-build guard delivered by 0352 (test_report_build_clean_room) + 0370 (test_slides_build_clean_room); recursion case moot — sub-Makefiles have no $(MAKE) calls and -B -n trace covers it
 
 --- log ---
 2026-05-26T21:46Z HDMX-coding-agent created — class regression guard after 0345 + 0352 sweep found two instances
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 2026-05-26T21:50Z HDMX-coding-agent tag deferred
 2026-05-27T20:59Z Claude untag deferred
 2026-05-28T12:54Z HDMX-coding-agent note blocker 0352 closed — Blocked-by removed.
+2026-06-03T07:22Z HDMX-coding-agent closed — already-done: uv-run writing-build guard delivered by 0352 (test_report_build_clean_room) + 0370 (test_slides_build_clean_room); recursion case moot — sub-Makefiles have no $(MAKE) calls and -B -n trace covers it
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

0353 asked for an adherence test asserting the writing build (`make slides` / `make report`) never invokes `uv run`. **That guard already exists and is green** — delivered as a side effect of the workpackage split:

- `tests/test_report_build_clean_room.py` (from 0352) — `make -n report` + `make -B -n report`, asserts no `uv run` in the recipe trace.
- `tests/test_slides_build_clean_room.py` (from 0370) — same for `slides`.

Both assert over the **dry-run recipe trace** (not a hardcoded rule list), so they catch the *class* — satisfying 0353's stated invariant. `pytest -m adherence` runs them in **0.09s**. All three exit criteria are met on current main.

## Why no new test (and no action #2)

Writing a third test would duplicate existing coverage. Action #2 (a static grep guarding sub-Makefiles against `$(MAKE) -C ..` re-entering root analysis rules) is **deliberately skipped**:

- the sub-Makefiles contain **zero `$(MAKE)` calls**, so the recursive-trigger case is structurally absent;
- recursive `make` propagates `-n`, so the existing `-B -n` trace already surfaces any `uv run` reached through recursion;
- a static recursion grep would fire on *non-violating* upward recursion (recursion ≠ `uv run`) — speculative tooling with no signal.

Skipped by design, not overlooked.

## Change
Ticket-only: adds the `Closed:` header to `tickets/0353-…erg`. No code.

This is a chore-only diff (ticket archival) — it'll hit the chore-bypass path with no reported checks; merge via auto-merge.