### PR TITLE
tickets: open 0401 (level schema+reference derivation) + 0402 (model emits level, level-conditioned capacity coherence); fix 0397 capacity bullet (drop wrong flat band)

### DIFF
--- a/tickets/0397-coherence-internal-external-composite.erg
+++ b/tickets/0397-coherence-internal-external-composite.erg
@@ -6,6 +6,7 @@ Blocked-by: 0396
 
 --- log ---
 2026-06-03T00:00Z claude created — Imagine-phase design with the author. Sits ABOVE the per-field coherence indicators (0396 row_atomicity, plus the existing vocab/status/capacity adherence): aggregates them into two reference-free composites, internal (response-only) and external (world-knowledge, not gold), with per-row pass/fail aggregation. Blocked-by 0396 because the internal composite ANDs the per-row atomicity predicate that 0396 introduces.
+2026-06-03T10:00Z claude — Imagine-session verification killed the external [30,1600] band: operating centrales max ≈1500 MW but reference power-centers legitimately reach 6000 MW, so a flat ceiling mislabels ~25% of the gold. Capacity plausibility is level-conditional → spun out the `level` schema (0401) and the level-conditioned capacity coherence check (0402). 0397's external check now keeps only province + capacity≥30-numeric; the upper-plausibility signal lives in 0402.
 
 --- body ---
 ## Context
@@ -49,14 +50,14 @@ they are not mistaken for the per-field numbers.
 **External composite — per-row AND of:**
 - province ∈ gazetteer (reuse `_province_known` from `coherence.py`; promote it
   to a scored column with `_annotation`)
-- capacity ∈ [30, 1600] MW. **Two distinct semantics, document both:**
-  - lower bound 30 = task-scope compliance (the prompt asked for >30 MWe; a
-    sub-30 row is out-of-requested-scope, not implausible).
-  - upper bound 1600 = loose physical plausibility (max nuclear unit, EPR). Real
-    VN thermal max ≈ 600–750 MW/unit — TODO verify and record the real thermal
-    max in the docstring. 1600 is a garbage-catcher (negatives, 5e4), NOT a 1NF
-    detector (two 600 MW units merged = 1200 < 1600); the 1NF regex (0396) owns
-    merged-row detection. Do not tighten the band to chase merged rows.
+- capacity ≥ 30 MWe and numeric. Lower bound 30 = task-scope compliance (the
+  prompt asked for >30 MWe; a sub-30 row is out-of-requested-scope). **No flat
+  upper band.** The Imagine-session verification killed the [30,1600] idea: a
+  flat ceiling is meaningless because capacity plausibility is *level-conditional*
+  (operating centrales max ≈1500 MW, but reference power-centers legitimately
+  reach 6000 MW). The level-conditioned upper-plausibility check is a separate,
+  richer signal that lives in 0402 (needs the `level` schema field from 0401);
+  do not put a flat ceiling here.
 
 Both composites land as per-run scalars in `records_to_metrics()` (ADR-7) and as
 `coherence_*` columns (+ `_annotation`), threaded through scorer → mart → views
@@ -76,8 +77,9 @@ into the other. See docs/inventory-1nf-handoff-exp2.md §Two objectives.
 - `{"name":"Nhơn Trạch 3 & 4","fuel":"gas","status":"operating",
   "capacity_mwe":1200,"province":"Đồng Nai"}` → fails internal (non-atomic),
   passes external.
-- `{"name":"Hà Tĩnh","fuel":"coal","status":"operating","capacity_mwe":12000,
-  "province":"Hà Tĩnh"}` → fails external (out of [30,1600]), passes internal.
+- `{"name":"Hà Tĩnh","fuel":"coal","status":"operating","capacity_mwe":12,
+  "province":"Hà Tĩnh"}` → fails external (below the 30 MWe task scope), passes
+  internal.
 - `{"name":"Hà Tĩnh","fuel":"coal","status":"operating","capacity_mwe":600,
   "province":"Hà Tĩnh"}` → passes both → both composites = 1.0 on a singleton.
 
@@ -86,11 +88,9 @@ into the other. See docs/inventory-1nf-handoff-exp2.md §Two objectives.
       pass/fail fractions, alongside (not replacing) the per-field indicators.
 - [ ] Internal AND includes 0396's per-row atomicity predicate (consumed, not
       re-implemented); external AND includes a new `coherence_province_known`
-      column and the [30,1600] band.
+      column and a capacity ≥30-and-numeric check (no flat upper band).
 - [ ] Both composites in `records_to_metrics()` (ADR-7); per-field breakdown
       retained.
-- [ ] Capacity-band docstring records the verified real VN thermal max and the
-      task-scope (30) vs plausibility (1600) rationale.
 - [ ] `tests/test_score_coherence.py` green; `make check` passes.
 - [ ] Mart/view schema accepts the new columns (defensive `.get` per #651);
       real regen is out of scope → 0387.
@@ -108,6 +108,9 @@ into the other. See docs/inventory-1nf-handoff-exp2.md §Two objectives.
 ## Related
 - 0396 — prerequisite: per-field 1NF row-atomicity indicator (provides the
   per-row predicate the internal composite ANDs)
+- 0401 — `level` schema + reference derivation (foundation for 0402)
+- 0402 — level-conditioned capacity-plausibility coherence; feeds this internal
+  composite (replaces the deleted flat upper band)
 - 0201 — parent: quality composite axis
 - 0387 — downstream: mart regen after coherence-field additions
 - 0393 — reference-based counterpart; opposite 1NF reading (do not conflate)

--- a/tickets/0401-schema-level-enum-and-reference-derivation.erg
+++ b/tickets/0401-schema-level-enum-and-reference-derivation.erg
@@ -1,0 +1,95 @@
+%erg 0.1
+Title: Schema: add `level` enum (Unit/Block/Plant/Complex/Unknown) + derive reference Level + taxonomy audit
+Created: 2026-06-03
+Author: claude
+
+--- log ---
+2026-06-03T00:00Z claude created — Imagine session with the author. The capacity-plausibility paradox (operating centrales max ≈1500 MW yet reference rows reach 6000 MW) turned out to be a MISSING DIMENSION: rows live at different granularities (turbo-set / plant / power-center), and plausibility is level-conditional. A flat capacity band cannot work. The clean fix is to make granularity a first-class schema field. Author decisions: Site = Complex; the MODEL assigns level (answer-side, → 0402); reference level is derived mechanically; plants are conventionally named "Site + number" (so Plant = Site+N, Complex = bare Site).
+
+--- body ---
+## Context
+
+Verified during the Imagine session against `data/reference/`:
+- operating/constructing centrales max = **1500 MW**, none > 1600;
+- the 6000 MW rows are **power centers** (LNG Mỹ Giang/Hà Tĩnh/Cái Mép Hạ),
+  i.e. several plants aggregated into one row;
+- planned single LNG centrales reach ~3200 MW (Bạc Liêu).
+
+So capacity plausibility is meaningless without knowing the row's granularity.
+This ticket adds that granularity as a schema field and proves the taxonomy
+holds on the real reference. The capacity *scoring* that consumes it is 0402.
+
+This is the AGENTS.md "transform a codesmell metric into a design architecture
+improvement" move, and the experiment-design "lead with the generic abstraction"
+rule: `level` is the generic container hierarchy; the first application is the
+VN thermal inventory asked at Plant granularity.
+
+## The enum (author-fixed)
+
+`level ∈ {Unit, Block, Plant, Complex, Unknown}`
+
+| Value | Meaning | Plausibility cap (domain note) |
+|---|---|---|
+| Unit | one turbo-set / tranche (single shaft) | coal ≤1350 (world record), VN typ. 300/600/660; CCGT mono-shaft ≤~900; VN alert >700 |
+| Block | CCGT multi-shaft assembly (2+ GT / 1 ST) — **CCGT only** | >1300 normal; not a single turbo-set |
+| Plant | a centrale = "Site + number" (Vĩnh Tân 2, Vung Ang 1) | ≤~1500 operating, ≤~3200 planned |
+| Complex | a site / power center = bare "Site" (several plants) | >3200, up to 6000+ |
+| Unknown | grain not determinable | no capacity check |
+
+Note the hierarchy is **not** a clean linear order: `Block` is a CCGT-only rung
+between Unit and Plant, and a single-block CCGT is simultaneously a Block and a
+Plant. Rule of assignment: the row's level is the **finest grain it represents**;
+for a single-block CCGT prefer Plant unless the row is explicitly one turbo-set.
+
+## Scope of THIS ticket (offline, mechanical, no model calls)
+
+1. **Schema.** Add `level: Level = Unknown` to `Plant`/`SourcedPlant`
+   (`src/aedist/schema.py`), enum with the five values above.
+2. **Reference derivation.** A function that assigns `level` to every reference
+   row from the unit-level data we already have (`data/reference/gem_units.csv`,
+   `vietnam_thermal_units_v1.csv`) and the `units_included` column of
+   `vietnam_thermal_v1.csv`: bare Site / ≥2 distinct named plants → Complex;
+   "Site + number" with its own units → Plant; a single turbo-set row → Unit;
+   CCGT multi-shaft → Block. Use the "Site + number" naming convention as the
+   primary signal, `units_included` cardinality as the tie-breaker.
+3. **Taxonomy audit (audit-before-instrumenting — this GATES 0402).** Confirm on
+   the real reference that (a) every row receives exactly one non-Unknown level
+   (report the Unknown rate), and (b) the per-level caps actually separate the
+   levels (no operating Plant > 1600, no Unit > 1350, Complexes are the >3200
+   tail). If the taxonomy does NOT partition the reference cleanly, STOP and
+   record the non-finding — do not proceed to 0402's prompt/scoring work.
+
+## First failing test
+`tests/test_level.py` (red→green):
+- `Level` enum importable with the five members; `Plant(level=...)` round-trips.
+- `derive_reference_level`: "Vung Ang" (units_included lists ≥2 plants) → Complex;
+  "Vĩnh Tân 2" (Site+number, own units) → Plant; a bare single turbo-set → Unit.
+- audit assertion: over `vietnam_thermal_v1.csv`, every operating/constructing
+  row classified Plant has capacity ≤ 1600 (catches a broken derivation that
+  labels a 6000 MW Complex as Plant).
+
+## Exit criteria
+- [ ] `Level` enum + `level` field on `Plant`/`SourcedPlant`; ADR-7: when a row
+      carries `level`, it flows into `records_to_metrics()`.
+- [ ] `derive_reference_level` assigns a level to every reference row; Unknown
+      rate reported.
+- [ ] Taxonomy audit passes (clean partition + caps separate levels) OR a
+      documented non-finding closes the ticket without 0402.
+- [ ] `tests/test_level.py` green; `make check` passes.
+
+## Out of scope
+- Model emitting `level` (prompt change, new runs) → 0402.
+- Level-conditioned capacity plausibility *scoring* → 0402.
+- Entity-resolution thresholds and the consensus-fusion objective (handoff §5).
+- Reference de-dup / hygiene that the derivation may surface → 0394/0395.
+
+## Related
+- 0402 — downstream: model emission + level-conditioned capacity coherence
+- 0397 — its external capacity check drops the flat band; level-conditioned
+  plausibility moves to 0402
+- 0396 — verbal 1NF (name "1&2"); complementary — the Level+capacity signal
+  catches power-centers whose NAME has no merge marker (LNG Mỹ Giang 6000)
+- 0201 — the quality composite axis this feeds
+- 0394 / 0395 — reference-v2 hygiene (derivation may surface granularity issues)
+- docs/inventory-1nf-handoff-exp2.md — granularity / 1NF background
+- data/reference/gem_units.csv, vietnam_thermal_units_v1.csv — unit-level source

--- a/tickets/0402-model-emits-level-and-capacity-coherence.erg
+++ b/tickets/0402-model-emits-level-and-capacity-coherence.erg
@@ -1,0 +1,82 @@
+%erg 0.1
+Title: Model emits `level`; level-conditioned capacity-plausibility coherence check
+Created: 2026-06-03
+Author: claude
+Blocked-by: 0401
+
+--- log ---
+2026-06-03T00:00Z claude created — Imagine session. Once `level` exists in the schema and is validated on the reference (0401), the capacity-plausibility check becomes a per-row INTERNAL self-consistency signal: is the capacity plausible *given the level the model declared*, and is the declared level consistent with the name. This replaces the flat [30,1600] band that the verification proved wrong (operating max 1500, but power-centers reach 6000). Author decision: the model assigns level.
+
+--- body ---
+## Context
+
+The flat external capacity band died on contact with the data (0401 context):
+plausibility is level-conditional. With `level` a first-class field, capacity
+becomes an **internal-coherence** signal, and it catches a defect the verbal
+1NF detector (0396) cannot: a power-center row like `LNG Mỹ Giang | 6000` has no
+"1 & 2" in its name, so the name regex passes it — but `level=Plant ∧ 6000 MW`
+is incoherent, and `level=Complex` when the task asked for Plant grain is a
+scope violation. Name-based 1NF and capacity-vs-level are complementary.
+
+## Two pieces
+
+**A. Model emits `level` (answer-side).**
+- Prompt change so each output row declares its granularity
+  (Unit/Block/Plant/Complex/Unknown), per the 0401 enum and the "finest grain
+  represented" rule.
+- **Audit before the full sweep** (.claude/rules): one test call per regime,
+  inspect whether models label grain coherently, BEFORE re-running the batch. If
+  models cannot self-classify grain reliably, fall back to deriving level
+  post-hoc from the emitted name (Site+number→Plant, bare Site→Complex) and
+  record that the "model-assigned" goal was not met — do not silently ship a
+  noisy hallucination axis.
+- New runs carry `level`; existing `measurements.jsonl` rows are backfilled by
+  the same post-hoc name derivation (flagged as derived, not model-emitted).
+
+**B. Level-conditioned capacity coherence (internal).**
+- Per-row predicate `capacity_plausible_for_level`, using the 0401 caps:
+  Unit ≤1350 (coal) / ≤~900 (CCGT); Block >1300 ok; Plant ≤~3200; Complex any;
+  Unknown skipped. Lower bound: ≥30 MWe = task scope (already in 0397's external
+  check; keep it there, it is not level-conditional).
+- Per-row predicate `level_consistent_with_name`: a name with a merge marker
+  (0396's regex) cannot be `Unit`; a bare-Site name is not `Unit`/`Plant`.
+- Both feed the **internal** composite of 0397 (a row passes internal coherence
+  only if its capacity is plausible for its declared level and its level matches
+  its name). Wire as `coherence_*` columns (+ `_annotation`), ADR-7 into
+  `records_to_metrics()`.
+
+## First failing test
+`tests/test_score_coherence_level.py` (red→green):
+- `{name:"Cẩm Phả 1", level:"Plant", fuel:"coal", capacity_mwe:6000}` →
+  `capacity_plausible_for_level` False (Plant ≤3200) → fails internal.
+- `{name:"LNG Mỹ Giang", level:"Complex", capacity_mwe:6000}` → plausible for
+  Complex → passes the capacity predicate (granularity-scope is a separate
+  signal, not this predicate).
+- `{name:"Nhơn Trạch 3 & 4", level:"Unit", capacity_mwe:1500}` →
+  `level_consistent_with_name` False (merge marker can't be a Unit).
+- `{name:"Vinh Tan 2", level:"Unit", fuel:"coal", capacity_mwe:1244}` →
+  fails Unit cap (≤1350 is fine, but 1244 with 2 units → really a Plant); pin
+  the intended verdict so the Unit/Plant boundary is explicit in tests.
+
+## Exit criteria
+- [ ] Prompt emits `level`; one-call-per-regime audit recorded before any batch.
+- [ ] `measurements.jsonl` rows carry `level` (model-emitted on new runs, derived
+      + flagged on existing).
+- [ ] `capacity_plausible_for_level` and `level_consistent_with_name` predicates
+      land with unit tests on the curated fixtures above.
+- [ ] Both feed 0397's internal composite; `coherence_*` columns + ADR-7 wiring.
+- [ ] `make check` passes.
+
+## Out of scope
+- The flat upper capacity band (deleted — superseded by this).
+- Re-running the full Exp2 sweep is gated on the audit verdict; if the model
+  cannot label grain, ship the derived fallback and ticket the sweep separately.
+- Entity resolution / consensus fusion (handoff §5).
+
+## Related
+- 0401 — prerequisite: `level` schema + reference derivation + taxonomy audit
+- 0397 — consumes these predicates in its internal composite; its external
+  check keeps only province + capacity≥30
+- 0396 — verbal 1NF, complementary detector
+- 0201 — quality composite axis
+- docs/inventory-1nf-handoff-exp2.md


### PR DESCRIPTION
Opened via scripts/quickpr.sh.