### PR TITLE
ticket(0383): log mart-staleness evidence from PR #678 — DAG rebuild changes committed scores

### DIFF
--- a/tickets/0383-mart-audit-redress-layer2-drift-from-0322.erg
+++ b/tickets/0383-mart-audit-redress-layer2-drift-from-0322.erg
@@ -5,6 +5,7 @@ Author: Claude
 
 --- log ---
 2026-05-29T00:00Z Claude created — mart building audit ("columns really feed on what they say they encode"); tracking ticket for redress course
+2026-06-04T05:55Z claude note Staleness evidence from PR #678 (0349 figure work): running the analysis DAG regenerates the COMMITTED exp2_mart.jsonl and sota_cross_eval.csv with materially different scores — e.g. arm3/claude run01 coverage 0.2883->0.3006, precision 0.9216->0.9608, f1 0.4393->0.4579 — plus a new coherence field capacity_nonnegative and status_vocab_adherence flips (1.0->0.0 on some records). Cause: the committed mart predates the post-0392 matcher fixes and the coherence-split/ADR-7 scorer changes now on main. Consequence: any DAG run silently rewrites paper numbers; PR #678 deliberately restored the data files and built its figure from the committed mart via build_exp2_mart_views directly. The deliberate "rebuild the mart with current scorers and re-baseline downstream artifacts" decision belongs here.
 
 --- body ---
 ## Context


### PR DESCRIPTION
Opened via scripts/quickpr.sh.