### PR TITLE
ticket(0409): extract experiments/render.mk — P3 rules out of analysis.mk (0406 S2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,7 @@ tickets/tools/go/erg
 # experiments/outputs/ stay tracked (provenance, cf. exp1_batch2).
 experiments/derived/*.record.json
 experiments/derived/**/*.record.json
+
+# Dual-run mart-parity staging scratch (P2 validation, check-mart-parity).
+# Transient, regenerated; never a tracked handoff artifact (ticket 0409).
+experiments/derived/parity/

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ experiments/models_selected.yaml: $(MEASUREMENTS) experiments/models.yaml
 # tab_comparaison, tab_variance, tab_verification, tab_decomposition_fix,
 # tab_coherence, tab_reconciliation, tab_converter_benchmark) and the
 # intermediate derived/*.json|csv artifacts they consume are produced by the
-# analysis workpackage. To regenerate:
-#     make -f experiments/analysis.mk report-tables
+# render (P3) workpackage. To regenerate:
+#     make -f experiments/render.mk report-tables
 # tab_self_consistency.tex and tab_per_run.tex come from
 # experiments/Makefile `self-consistency` (single producer, 0354).
 
@@ -122,14 +122,15 @@ slides/slides.pdf: slides/slides.tex \
 report: report/report.pdf
 slides: slides/slides.pdf
 # Report-side tables, figures, and slide chart data are produced by the
-# analysis workpackage. tab_self_consistency.tex and tab_per_run.tex live in
-# experiments/Makefile under `self-consistency` (single producer, 0354), so
-# the `tables:` alias chains both to preserve the pre-0352 UX.
+# render (P3) workpackage (experiments/render.mk). tab_self_consistency.tex and
+# tab_per_run.tex live in experiments/Makefile under `self-consistency`
+# (single producer, 0354), so the `tables:` alias chains both to preserve the
+# pre-0352 UX.
 tables:
-	$(MAKE) -f experiments/analysis.mk report-tables
+	$(MAKE) -f experiments/render.mk report-tables
 	$(MAKE) -C experiments self-consistency
 figures:
-	$(MAKE) -f experiments/analysis.mk chart-figures
+	$(MAKE) -f experiments/render.mk chart-figures
 select: experiments/models_selected.yaml
 census:
 	$(MAKE) -C experiments census

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -13,15 +13,17 @@ file is non-precious (regenerable) and is `.gitignore`d.
 | Phase | What it does | Outcome (TRACK) | Non-precious (IGNORE) |
 |-------|--------------|-----------------|-----------------------|
 | **P1 Acquire** | API runs against models (`experiments/Makefile`) | raw model replies: `experiments/outputs/**`, `experiments/archive/**` (incl. extracted `*.md` siblings of tracked `*.json`) | run logs, retries, jobs/, `rag_work/` |
-| **P2 Score & consolidate** | extract → evaluate → assemble (`experiments/Makefile`, mart build in `analysis.mk`) | `measurements.jsonl` (mart v0, transitional until 0297), `experiments/derived/exp2_mart.jsonl` | per-run `experiments/derived/**/*.record.json`, mart→view CSVs |
-| **P3 Analyze & render** | plot/tabulate scripts (`experiments/analysis.mk`) | figures/tables/macros the manuscript or slides include: `report/inputs/generated/` (the single P3 deliverable tree; the slides-side tree was retired, 0408) | plotting intermediates consumed only inside P3 (`census_bars.csv`, view CSVs, unconsumed figs; the report-dir `cost_quality.csv` is a P4 prereq → tracked) |
+| **P2 Score & consolidate** | extract → evaluate → assemble (`experiments/Makefile`, mart build in `experiments/analysis.mk`) | `measurements.jsonl` (mart v0, transitional until 0297), `experiments/derived/exp2_mart.jsonl` | per-run `experiments/derived/**/*.record.json`, mart→view CSVs |
+| **P3 Analyze & render** | plot/tabulate scripts (`experiments/render.mk`, including the mart→view projection) | figures/tables/macros the manuscript or slides include: `report/inputs/generated/` (the single P3 deliverable tree; the slides-side tree was retired, 0408) | plotting intermediates consumed only inside P3 (`census_bars.csv`, view CSVs, unconsumed figs; the report-dir `cost_quality.csv` is a P4 prereq → tracked) |
 | **P4 Write** | tectonic / pandoc (`report/Makefile`, `slides/Makefile`) | — (final PDFs are regenerable) | `report.pdf`, `slides.pdf`, LaTeX aux files |
 
 ## The classification test
 
 For any generated file, find its **producing rule** and its **consuming
 rule(s)** in the Makefile DAG (`Makefile`, `experiments/Makefile`,
-`experiments/analysis.mk`, `report/Makefile`, `slides/Makefile`):
+`experiments/analysis.mk` for P2, `experiments/render.mk` for P3,
+`experiments/paths.mk` for shared variables, `report/Makefile`,
+`slides/Makefile`):
 
 - **Producing phase ≠ consuming phase → boundary outcome → TRACK.**
 - **Same phase, or no consumer at all → intra-phase intermediate → IGNORE**

--- a/experiments/analysis.mk
+++ b/experiments/analysis.mk
@@ -1,28 +1,26 @@
-# Exp2 analysis DAG
+# Exp2 analysis DAG — P2 (score & consolidate) build phase.
 #
-# This file declares the analysis pipeline from run outputs to report-ready
-# artifacts. Override the path variables below to relocate the repository or
-# point at alternate output trees.
+# PHASE: P2 score & consolidate. This file extracts run outputs, scores them,
+# and assembles the canonical mart ($(ANALYSIS_EXP2_MART_JSONL)) and the
+# cross-eval CSVs. The P3 (render) phase that turns these outcomes into
+# figures/tables/macros lives in experiments/render.mk (ticket 0409, tracker
+# 0406 S2) — a figure build can no longer reach back into this scoring DAG.
+#
+# Shared path variables come from experiments/paths.mk. Override the path
+# variables there to relocate the repository or point at alternate output
+# trees. (analysis.mk becomes score.mk in tracker 0406 step S3 — not renamed
+# yet.)
 
-SHELL := /bin/bash
+include $(dir $(lastword $(MAKEFILE_LIST)))paths.mk
 
-ANALYSIS_REPO_ROOT ?= .
-ANALYSIS_EXPERIMENTS_DIR ?= $(ANALYSIS_REPO_ROOT)/experiments
-ANALYSIS_REPORT_DIR ?= $(ANALYSIS_REPO_ROOT)/report
-ANALYSIS_GENERATED_DIR ?= $(ANALYSIS_REPORT_DIR)/inputs/generated
-ANALYSIS_GEN ?= $(ANALYSIS_GENERATED_DIR)
-ANALYSIS_OUTPUTS_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/outputs
-ANALYSIS_DERIVED_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/derived
+# --- P2-local input wildcards -----------------------------------------------
 
 ANALYSIS_EXP2_NAIVE_DIR ?= $(ANALYSIS_DERIVED_DIR)/arm1_flat
 ANALYSIS_EXP2_OPTIMISED_DIR ?= $(ANALYSIS_DERIVED_DIR)/arm2_flat
 ANALYSIS_EXP2_ARM3_DIR ?= $(ANALYSIS_DERIVED_DIR)/arm3_flat
 ANALYSIS_EXP2_ARM4_DIR ?= $(ANALYSIS_DERIVED_DIR)/arm4_flat
-ANALYSIS_EXP2_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/sota_cross_eval.csv
-ANALYSIS_EXP1_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval.csv
 
 ANALYSIS_EXP1_INPUT_CSVS := $(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.csv)
-ANALYSIS_EXP1_BATCH2_RECORDS := $(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json)
 
 ANALYSIS_EXP2_NAIVE_JSONS := $(wildcard $(ANALYSIS_EXP2_NAIVE_DIR)/*.json)
 ANALYSIS_EXP2_OPTIMISED_JSONS := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/*.json)
@@ -34,41 +32,6 @@ ANALYSIS_EXP2_ARM3_MDS := $(wildcard $(ANALYSIS_EXP2_ARM3_DIR)/*.md)
 ANALYSIS_EXP2_ARM4_MDS := $(wildcard $(ANALYSIS_EXP2_ARM4_DIR)/*.md)
 ANALYSIS_EXP2_PROBE_RAWS := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/probes/*/*.raw.json)
 ANALYSIS_EXP2_PROBE_CLSF := $(wildcard $(ANALYSIS_EXP2_OPTIMISED_DIR)/probes/*/*.classification.json)
-
-ANALYSIS_EXP2_MART_JSONL := $(ANALYSIS_DERIVED_DIR)/exp2_mart.jsonl
-ANALYSIS_EXP2_MART_VIEWS := \
-	$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
-	$(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
-	$(ANALYSIS_GEN)/exp2_turn_trajectory_view.csv \
-	$(ANALYSIS_GEN)/sota_cross_eval_view.csv
-
-ANALYSIS_EXP2_ARM_FIG := $(ANALYSIS_GEN)/fig_exp2_arms_comparison.pdf
-ANALYSIS_EXP2_TURN_FIG := $(ANALYSIS_GEN)/fig_exp2_turn_trajectory.pdf
-ANALYSIS_EXP2_BIB_TABLE := $(ANALYSIS_GEN)/tab_exp2_bib_quality.tex
-ANALYSIS_EXP2_COVERAGE_FIG := $(ANALYSIS_GEN)/fig_exp2_coverage_certainty.pdf
-ANALYSIS_EXP2_SPIRE_FIG := $(ANALYSIS_GEN)/fig_quality_spider.pdf
-ANALYSIS_EXP2_2X2_CSV := $(ANALYSIS_DERIVED_DIR)/tab_exp2_2x2.csv
-ANALYSIS_EXP2_2X2_TEX := $(ANALYSIS_GEN)/tab_exp2_2x2.tex
-ANALYSIS_EXP2_2X2_FR_TEX := $(ANALYSIS_GEN)/tab_exp2_2x2_fr.tex
-ANALYSIS_EXP2_COVERAGE_SPLIT := $(ANALYSIS_GEN)/fig_exp2_coverage.pdf
-ANALYSIS_EXP2_COST_SPLIT := $(ANALYSIS_GEN)/fig_exp2_cost.pdf
-ANALYSIS_SLIDE_MACROS := $(ANALYSIS_GEN)/macros_slides.tex
-
-ANALYSIS_EXP1_SPIDER_FAMILIES := $(ANALYSIS_GEN)/fig_spider_exp1_families.pdf
-ANALYSIS_EXP1_SPIDER_CLAUDE := $(ANALYSIS_GEN)/fig_spider_exp1_claude.pdf
-
-ANALYSIS_EXP2_OUTLINE_ARTIFACTS := \
-	$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex \
-	$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_hypotheses_map.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_protocol_fidelity.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_h1.tex \
-	$(ANALYSIS_GEN)/fig_exp2_outline_h2.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_h3.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_h4.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_h5.tex \
-	$(ANALYSIS_GEN)/fig_exp2_outline_h6.tex \
-	$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex
 
 # --- Extraction stamps -------------------------------------------------------
 
@@ -141,7 +104,9 @@ $(ANALYSIS_EXP2_CROSS_EVAL_CSV): $(ANALYSIS_DERIVED_DIR)/arm1_flat/.done \
 		    --output-csv $@ || true; \
 	done
 
-# --- Canonical mart and mart-derived views ---------------------------------
+# --- Canonical mart ---------------------------------------------------------
+# The mart-derived VIEW projections (*_view.csv) are render-time shaping (P3)
+# and live in experiments/render.mk. This file produces only the mart itself.
 
 $(ANALYSIS_EXP2_MART_JSONL): $(ANALYSIS_DERIVED_DIR)/arm1_flat/.done \
 		$(ANALYSIS_DERIVED_DIR)/arm2_flat/.done \
@@ -162,17 +127,14 @@ $(ANALYSIS_EXP2_MART_JSONL): $(ANALYSIS_DERIVED_DIR)/arm1_flat/.done \
 	    --output $@ \
 	    --repo-root $(ANALYSIS_REPO_ROOT)
 
-$(ANALYSIS_EXP2_MART_VIEWS): $(ANALYSIS_EXP2_MART_JSONL)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.build_exp2_mart_views \
-	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
-	    --output-dir $(ANALYSIS_GEN) \
-	    --repo-root $(ANALYSIS_REPO_ROOT)
-
 # --- Dual-run parity staging -------------------------------------------------
+# P2 mart-validation scratch. Staged under the P2-owned derived/ tree (NOT the
+# P3 handoff tree report/inputs/generated/) so this P2 file never writes a
+# render artifact — the analysis.mk/render.mk seam stays clean (ticket 0409).
+# Transient: untracked, consumed only by check-mart-parity below.
 
-ANALYSIS_EXP2_OLD_STAGE := $(ANALYSIS_GEN)/exp2-old-path
-ANALYSIS_EXP2_MART_STAGE := $(ANALYSIS_GEN)/exp2-mart-path
+ANALYSIS_EXP2_OLD_STAGE := $(ANALYSIS_DERIVED_DIR)/parity/exp2-old-path
+ANALYSIS_EXP2_MART_STAGE := $(ANALYSIS_DERIVED_DIR)/parity/exp2-mart-path
 
 $(ANALYSIS_EXP2_OLD_STAGE)/tab_exp2_arms_runs.csv: $(ANALYSIS_EXP2_NAIVE_JSONS) $(ANALYSIS_EXP2_NAIVE_MDS) $(ANALYSIS_EXP2_OPTIMISED_JSONS)
 	@mkdir -p $(dir $@)
@@ -222,342 +184,3 @@ check-mart-parity: exp2-old-path exp2-mart-path
 	uv run python -m aedist.check_exp2_mart_parity \
 	    --left-dir $(ANALYSIS_EXP2_OLD_STAGE) \
 	    --right-dir $(ANALYSIS_EXP2_MART_STAGE)
-
-# --- Tables and figures -----------------------------------------------------
-
-$(ANALYSIS_EXP2_ARM_FIG): $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_arms_comparison \
-	    --input $< \
-	    --output $@
-
-$(ANALYSIS_EXP2_TURN_FIG): $(ANALYSIS_GEN)/exp2_turn_trajectory_view.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_turn_trajectory \
-	    --input $< \
-	    --output $@
-
-$(ANALYSIS_EXP2_BIB_TABLE): $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_bib_quality \
-	    --input $< \
-	    --output $@
-
-$(ANALYSIS_EXP2_COVERAGE_FIG): $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
-		$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_coverage_certainty \
-	    --input $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
-	    --arms-input $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
-	    --output $@
-
-$(ANALYSIS_EXP2_SPIRE_FIG): $(ANALYSIS_GEN)/sota_cross_eval_view.csv experiments/quality_spider_config.yaml
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_quality_spider \
-	    --input $< \
-	    --config experiments/quality_spider_config.yaml \
-	    --output $@
-
-# Exp1 quality spiders: one script, two invocations (family 2x2 panels vs a
-# single-model large spider) -> two targets, not a grouped rule.
-$(ANALYSIS_EXP1_SPIDER_FAMILIES): $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval/.done
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_quality_spider_exp1 \
-	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
-	    --output $@
-
-$(ANALYSIS_EXP1_SPIDER_CLAUDE): $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval/.done
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_quality_spider_exp1 \
-	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
-	    --model claude-opus-4.6 \
-	    --output $@
-
-$(ANALYSIS_GEN)/stat_tests_arm1_vs_arm2.txt: $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_stat_tests \
-	    --input $< \
-	    --output $@
-
-# --- Outline placeholder artifacts (post-conference skeleton) ----------------
-
-$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_dataset --output $@
-
-$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_outline_dataset --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_hypotheses_map.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_hypotheses_map --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_protocol_fidelity.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_protocol_fidelity --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_h1.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_h1 --output $@
-
-$(ANALYSIS_GEN)/fig_exp2_outline_h2.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_outline_h2 --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_h3.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_h3 --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_h4.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_h4 --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_h5.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_h5 --output $@
-
-$(ANALYSIS_GEN)/fig_exp2_outline_h6.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_outline_h6 --output $@
-
-$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex:
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_outline_hypothesis_status --output $@
-
-ANALYSIS_EXP2_REPORT_TARGETS := \
-	$(ANALYSIS_EXP2_MART_VIEWS) \
-	$(ANALYSIS_EXP2_ARM_FIG) \
-	$(ANALYSIS_EXP2_TURN_FIG) \
-	$(ANALYSIS_EXP2_BIB_TABLE) \
-	$(ANALYSIS_EXP2_COVERAGE_FIG) \
-	$(ANALYSIS_EXP2_SPIRE_FIG) \
-	$(ANALYSIS_EXP2_OUTLINE_ARTIFACTS)
-
-# 2x2 factorial table (F1 + cost, query-mode x documents). Co-produces the
-# per-(agent,arm) CSV. Agent is the unit of replication; see the module docstring.
-$(ANALYSIS_EXP2_2X2_TEX): $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
-		$(ANALYSIS_DERIVED_DIR)/arm1_flat/.done \
-		$(ANALYSIS_DERIVED_DIR)/arm2_flat/.done \
-		$(ANALYSIS_DERIVED_DIR)/arm3_flat/.done \
-		$(ANALYSIS_DERIVED_DIR)/arm4_flat/.done
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_2x2 \
-	    --cross-eval-csv $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
-	    --flat-root $(ANALYSIS_DERIVED_DIR) \
-	    --output-csv $(ANALYSIS_EXP2_2X2_CSV) \
-	    --output-tex $@ --lang en
-
-$(ANALYSIS_EXP2_2X2_FR_TEX): $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
-		$(ANALYSIS_DERIVED_DIR)/arm1_flat/.done \
-		$(ANALYSIS_DERIVED_DIR)/arm2_flat/.done \
-		$(ANALYSIS_DERIVED_DIR)/arm3_flat/.done \
-		$(ANALYSIS_DERIVED_DIR)/arm4_flat/.done
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_exp2_2x2 \
-	    --cross-eval-csv $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
-	    --flat-root $(ANALYSIS_DERIVED_DIR) \
-	    --output-csv $(ANALYSIS_EXP2_2X2_CSV) \
-	    --output-tex $@ --lang fr
-
-# --- Coverage/cost split figures (reads from mart views + Exp1 cost CSV) ------
-
-$(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) &: \
-		$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv $(ANALYSIS_GEN)/cost_quality.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_exp2_arms_split \
-	    --input $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
-	    --exp1-input $(ANALYSIS_GEN)/cost_quality.csv \
-	    --coverage-output $(ANALYSIS_EXP2_COVERAGE_SPLIT) \
-	    --cost-output $(ANALYSIS_EXP2_COST_SPLIT)
-
-# --- Slide macros (census + measurements → report/inputs/generated/macros_slides.tex) ---
-
-$(ANALYSIS_SLIDE_MACROS): $(ANALYSIS_GEN)/census_bars.csv $(ANALYSIS_REPO_ROOT)/measurements.jsonl
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_macros \
-	    --census-csv $(ANALYSIS_GEN)/census_bars.csv --output $@
-
-.PHONY: exp2-analysis-report exp1-analysis-figures report-tables report-figures chart-figures
-
-exp2-analysis-report: $(ANALYSIS_EXP2_REPORT_TARGETS) \
-	$(ANALYSIS_EXP2_2X2_TEX) $(ANALYSIS_EXP2_2X2_FR_TEX) \
-	$(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) \
-	$(ANALYSIS_SLIDE_MACROS)
-
-exp1-analysis-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES) $(ANALYSIS_EXP1_SPIDER_CLAUDE)
-
-# --- Report-side tables and figures (migrated from root Makefile by 0352) ---
-# These produce committed handoff artifacts under $(ANALYSIS_GEN). The root
-# Makefile's `report/report.pdf` rule depends on these files but has no
-# recipes — `make report` is a writing-only build (tectonic) consuming
-# committed artifacts. Regenerate them from this file:
-#     make -f experiments/analysis.mk report-tables report-figures
-
-ANALYSIS_MEASUREMENTS ?= $(ANALYSIS_REPO_ROOT)/measurements.jsonl
-
-ANALYSIS_REPORT_DERIVED_DIR ?= $(ANALYSIS_REPO_ROOT)/derived
-ANALYSIS_VARIANCE_JSON := $(ANALYSIS_REPORT_DERIVED_DIR)/variance_decomposition.json
-ANALYSIS_VERIFICATION_DIR := $(ANALYSIS_REPORT_DERIVED_DIR)/verification
-ANALYSIS_VERIFICATION_TRADEOFF := $(ANALYSIS_VERIFICATION_DIR)/tradeoff.csv
-
-ANALYSIS_DECOMP_BEFORE := $(wildcard $(ANALYSIS_OUTPUTS_DIR)/rag_per_fuel/reconciliation_*.csv)
-ANALYSIS_DECOMP_AFTER  := $(wildcard $(ANALYSIS_OUTPUTS_DIR)/rag_per_fuel_v2/reconciliation_*.csv)
-ANALYSIS_RAG_CSVS      := $(wildcard $(ANALYSIS_OUTPUTS_DIR)/rag_extract/*.csv)
-ANALYSIS_EXPERT_REF    := $(ANALYSIS_REPO_ROOT)/data/reference/vietnam_thermal_v1.csv
-ANALYSIS_GEM_REF       := $(ANALYSIS_REPO_ROOT)/data/reference/gem_thermal.csv
-
-ANALYSIS_CONVERTER_TEST := $(ANALYSIS_EXPERIMENTS_DIR)/data/converter_test
-ANALYSIS_CONVERTER_META := $(ANALYSIS_CONVERTER_TEST)/benchmark_meta.yaml
-ANALYSIS_CONVERTER_DOCS := $(wildcard $(ANALYSIS_CONVERTER_TEST)/*/Decision-1509.md)
-
-$(ANALYSIS_GEN)/tab_census.tex: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_census --output $@
-
-$(ANALYSIS_GEN)/macros.tex: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_macros --output $@
-
-# Co-target fig_census_direct.pdf was retired with the ablation thread (0361);
-# the script still requires --output, so the PDF is written to a sentinel path
-# in $(ANALYSIS_REPORT_DERIVED_DIR) and not consumed by any downstream rule.
-$(ANALYSIS_GEN)/macros_census.tex: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@) $(ANALYSIS_REPORT_DERIVED_DIR)
-	uv run python -m aedist.plot_method_convergence \
-	    --output $(ANALYSIS_REPORT_DERIVED_DIR)/_macros_census_unused.pdf \
-	    --methods direct --prompt-version census \
-	    --output-macros $@
-
-$(ANALYSIS_GEN)/tab_relances.tex: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_relances --output $@
-
-$(ANALYSIS_GEN)/tab_comparaison.tex: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_VARIANCE_JSON)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_comparaison --output $@ --variance-json $(ANALYSIS_VARIANCE_JSON)
-
-$(ANALYSIS_GEN)/tab_reconciliation.tex: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_GEM_REF)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_reconciliation --output $@ --expert-ref $(ANALYSIS_EXPERT_REF) --gem-ref $(ANALYSIS_GEM_REF)
-
-$(ANALYSIS_VARIANCE_JSON): $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.variance_decomposition --output $@
-
-$(ANALYSIS_GEN)/tab_variance.tex: $(ANALYSIS_VARIANCE_JSON)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_variance --input $< --output $@
-
-$(ANALYSIS_VERIFICATION_TRADEOFF): $(wildcard $(ANALYSIS_VERIFICATION_DIR)/*-run*.csv)
-	uv run python -m aedist.tabulate_verification \
-	    --input $(ANALYSIS_VERIFICATION_DIR) --output $@
-
-$(ANALYSIS_GEN)/tab_verification.tex: $(ANALYSIS_VERIFICATION_TRADEOFF)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_verification \
-	    --input $(ANALYSIS_VERIFICATION_DIR) --latex $@
-
-$(ANALYSIS_GEN)/tab_decomposition_fix.tex: $(ANALYSIS_DECOMP_BEFORE) $(ANALYSIS_DECOMP_AFTER)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_decomposition_fix --output $@
-
-$(ANALYSIS_GEN)/tab_coherence.tex: $(ANALYSIS_RAG_CSVS) $(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_coherence.py $(ANALYSIS_REPO_ROOT)/src/aedist/coherence.py
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.tabulate_coherence \
-	    --input $(ANALYSIS_OUTPUTS_DIR)/rag_extract --output $@
-
-$(ANALYSIS_GEN)/tab_converter_benchmark.tex: $(ANALYSIS_CONVERTER_META) $(ANALYSIS_CONVERTER_DOCS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.compare_converters \
-	    --input $(ANALYSIS_CONVERTER_TEST) --meta $(ANALYSIS_CONVERTER_META) --output $@
-
-# Grouping targets — drive end-to-end regeneration of report-side handoff
-# artifacts. tab_self_consistency.tex and tab_per_run.tex are produced by the
-# experiments/Makefile self-consistency target (single producer, 0354) and
-# remain committed handoff artifacts without a rule here.
-report-tables: \
-	$(ANALYSIS_GEN)/tab_census.tex \
-	$(ANALYSIS_GEN)/macros.tex \
-	$(ANALYSIS_GEN)/macros_census.tex \
-	$(ANALYSIS_GEN)/tab_relances.tex \
-	$(ANALYSIS_EXP2_2X2_TEX) \
-	$(ANALYSIS_GEN)/tab_comparaison.tex \
-	$(ANALYSIS_GEN)/tab_variance.tex \
-	$(ANALYSIS_GEN)/tab_verification.tex \
-	$(ANALYSIS_GEN)/tab_decomposition_fix.tex \
-	$(ANALYSIS_GEN)/tab_coherence.tex \
-	$(ANALYSIS_GEN)/tab_reconciliation.tex \
-	$(ANALYSIS_GEN)/tab_converter_benchmark.tex
-
-report-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES)
-
-# --- Chart-data figures (migrated from root Makefile by 0370) -----------------
-# These produce committed handoff artifacts consumed by both report and slides.
-# The writing-side `make report` and `make slides` have no recipes for these
-# outputs — they are clean-room builds from committed artifacts only.
-
-$(ANALYSIS_GEN)/census_bars.csv: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_census --output $@
-
-$(ANALYSIS_GEN)/fig_direct_cost_quality.pdf $(ANALYSIS_GEN)/cost_quality.csv &: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_cost_quality \
-	    --output $(ANALYSIS_GEN)/cost_quality.csv --figure $(ANALYSIS_GEN)/fig_direct_cost_quality.pdf
-
-$(ANALYSIS_GEN)/fig_method_convergence.pdf: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_method_convergence \
-	    --output $@ --core-only
-
-$(ANALYSIS_GEN)/fig_direct_p1_base.pdf $(ANALYSIS_GEN)/macros_p1_base.tex &: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_EXP1_BATCH2_RECORDS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_method_convergence \
-	    --output $(ANALYSIS_GEN)/fig_direct_p1_base.pdf --methods direct \
-	    --label-x 100 --label-ha left \
-	    --xlabel "Assets identified (1 dot = 1 power plant / project)" \
-	    --title "How do models recall Vietnam's thermal power assets? Not well." \
-	    --ui-scale 1.35 \
-	    --fig-width 12 --fig-height-min 8 --fig-height-per-run 0.06 --fig-height-per-method 0.35 \
-	    --result-dir $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/ \
-	    --output-macros $(dir $@)macros_p1_base.tex
-
-$(ANALYSIS_GEN)/fig_regimes_scatter.pdf: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_EXPERIMENTS_DIR)/figures.toml
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_regimes_scatter \
-	    --output $@
-
-$(ANALYSIS_GEN)/fig_scaling_curve.pdf: $(ANALYSIS_MEASUREMENTS)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_scaling_curve \
-	    --output $@
-
-$(ANALYSIS_GEN)/fig_capability_timeline.pdf: $(ANALYSIS_REPO_ROOT)/data/capability_timeline.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_capability_timeline \
-	    --input $< --output $@
-
-$(ANALYSIS_GEN)/fig_capability_dag.pdf: $(ANALYSIS_REPO_ROOT)/data/capability_timeline.csv
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_capability_dag \
-	    --input $< --output $@
-
-$(ANALYSIS_GEN)/fig_spider_cross_exp.pdf: $(ANALYSIS_EXP1_CROSS_EVAL_CSV) $(ANALYSIS_EXP2_CROSS_EVAL_CSV)
-	@mkdir -p $(dir $@)
-	uv run python -m aedist.plot_spider_cross_exp \
-	    --exp1 $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
-	    --exp2 $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
-	    --output $@
-
-chart-figures: \
-	$(ANALYSIS_GEN)/census_bars.csv \
-	$(ANALYSIS_GEN)/fig_direct_cost_quality.pdf \
-	$(ANALYSIS_GEN)/fig_direct_p1_base.pdf \
-	$(ANALYSIS_GEN)/fig_capability_timeline.pdf \
-	$(ANALYSIS_GEN)/fig_capability_dag.pdf \
-	$(ANALYSIS_GEN)/fig_spider_cross_exp.pdf \
-	$(ANALYSIS_EXP1_SPIDER_FAMILIES) \
-	$(ANALYSIS_GEN)/fig_method_convergence.pdf \
-	$(ANALYSIS_GEN)/fig_regimes_scatter.pdf \
-	$(ANALYSIS_GEN)/fig_scaling_curve.pdf

--- a/experiments/paths.mk
+++ b/experiments/paths.mk
@@ -1,0 +1,37 @@
+# Shared path/variable definitions for the AEDIST analysis + render phases.
+#
+# VARIABLES ONLY — this file declares zero rules. It is included by both
+# experiments/analysis.mk (P2 score & consolidate) and experiments/render.mk
+# (P3 analyze & render) so the two phases agree on where the repository tree,
+# the derived data, and the P2 outcomes they share live. Override any path
+# below to relocate the repository or point at alternate output trees.
+#
+# Ownership: a variable lives here only if BOTH phases reference it. Variables
+# used by a single phase live in that phase's .mk (kept minimal here on
+# purpose — ticket 0409 / tracker 0406 S2).
+
+SHELL := /bin/bash
+
+ANALYSIS_REPO_ROOT ?= .
+ANALYSIS_EXPERIMENTS_DIR ?= $(ANALYSIS_REPO_ROOT)/experiments
+ANALYSIS_REPORT_DIR ?= $(ANALYSIS_REPO_ROOT)/report
+ANALYSIS_GENERATED_DIR ?= $(ANALYSIS_REPORT_DIR)/inputs/generated
+ANALYSIS_GEN ?= $(ANALYSIS_GENERATED_DIR)
+ANALYSIS_OUTPUTS_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/outputs
+ANALYSIS_DERIVED_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/derived
+
+# Shared P2 outcome paths. analysis.mk owns the rules that PRODUCE these;
+# render.mk references them only as prerequisites (sources). Defining the
+# paths here keeps the producer and the consumer in agreement.
+ANALYSIS_EXP2_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/sota_cross_eval.csv
+ANALYSIS_EXP1_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval.csv
+ANALYSIS_EXP2_MART_JSONL := $(ANALYSIS_DERIVED_DIR)/exp2_mart.jsonl
+
+# Mart → view CSV projections. The PRODUCING rule is P3 (render.mk); the
+# variable is shared because analysis.mk's dual-run parity staging still names
+# the same four view basenames for its left/right comparison.
+ANALYSIS_EXP2_MART_VIEWS := \
+	$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
+	$(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
+	$(ANALYSIS_GEN)/exp2_turn_trajectory_view.csv \
+	$(ANALYSIS_GEN)/sota_cross_eval_view.csv

--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -1,0 +1,408 @@
+# AEDIST P3 (analyze & render) build phase.
+#
+# PHASE: P3 render. This file turns committed P2 outcomes into the
+# figures, tables and macros the manuscript and slides include.
+#
+# SOURCES (consumed, never produced here — they appear only as
+# prerequisites, and render.mk carries NO rule able to rebuild them):
+#   * measurements.jsonl                          (P2 outcome, mart v0)
+#   * experiments/derived/exp2_mart.jsonl         (P2 outcome, consolidated mart)
+#   * experiments/derived/sota_cross_eval.csv     (P2 outcome, Exp2 cross-eval)
+#   * experiments/derived/exp1_cross_eval.csv     (P2 outcome, Exp1 cross-eval)
+#   * experiments/outputs/**                      (P1 raw model replies)
+#   * data/reference/*, data/capability_timeline.csv, experiments/*.toml|yaml
+#
+# OUTCOMES (produced): figures/tables/macros under
+#   report/inputs/generated/  (the single P3 deliverable tree, ticket 0408),
+#   plus P3-internal derived analysis files under derived/ (variance JSON,
+#   verification tradeoff CSV) consumed only by later P3 rules.
+#
+# INVARIANT: render.mk declares NO rule for an upstream (P1/P2) outcome. If a
+#   source is missing, make MUST stop with "No rule to make target" — it must
+#   never fall back to regenerating the mart or cross-eval CSVs (the
+#   2026-06-03 cascade, ticket 0383). Shared path variables come from
+#   experiments/paths.mk; analysis.mk (P2) owns the producing rules.
+#
+# Regenerate (mart-staleness hazard 0383: prefer dry-run for DAG checks):
+#   make -f experiments/render.mk report-tables report-figures chart-figures
+#
+# Tracker 0406 step S2 (ticket 0409) extracted this file from analysis.mk.
+
+include $(dir $(lastword $(MAKEFILE_LIST)))paths.mk
+
+# --- P3 output artifact paths (render-only) ---------------------------------
+
+ANALYSIS_EXP2_ARM_FIG := $(ANALYSIS_GEN)/fig_exp2_arms_comparison.pdf
+ANALYSIS_EXP2_TURN_FIG := $(ANALYSIS_GEN)/fig_exp2_turn_trajectory.pdf
+ANALYSIS_EXP2_BIB_TABLE := $(ANALYSIS_GEN)/tab_exp2_bib_quality.tex
+ANALYSIS_EXP2_COVERAGE_FIG := $(ANALYSIS_GEN)/fig_exp2_coverage_certainty.pdf
+ANALYSIS_EXP2_SPIRE_FIG := $(ANALYSIS_GEN)/fig_quality_spider.pdf
+ANALYSIS_EXP2_2X2_CSV := $(ANALYSIS_DERIVED_DIR)/tab_exp2_2x2.csv
+ANALYSIS_EXP2_2X2_TEX := $(ANALYSIS_GEN)/tab_exp2_2x2.tex
+ANALYSIS_EXP2_2X2_FR_TEX := $(ANALYSIS_GEN)/tab_exp2_2x2_fr.tex
+ANALYSIS_EXP2_COVERAGE_SPLIT := $(ANALYSIS_GEN)/fig_exp2_coverage.pdf
+ANALYSIS_EXP2_COST_SPLIT := $(ANALYSIS_GEN)/fig_exp2_cost.pdf
+ANALYSIS_SLIDE_MACROS := $(ANALYSIS_GEN)/macros_slides.tex
+
+ANALYSIS_EXP1_SPIDER_FAMILIES := $(ANALYSIS_GEN)/fig_spider_exp1_families.pdf
+ANALYSIS_EXP1_SPIDER_CLAUDE := $(ANALYSIS_GEN)/fig_spider_exp1_claude.pdf
+
+ANALYSIS_EXP2_OUTLINE_ARTIFACTS := \
+	$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex \
+	$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_hypotheses_map.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_protocol_fidelity.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h1.tex \
+	$(ANALYSIS_GEN)/fig_exp2_outline_h2.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h3.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h4.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_h5.tex \
+	$(ANALYSIS_GEN)/fig_exp2_outline_h6.tex \
+	$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex
+
+# Report-side (measurements/mart-derived) P3 inputs and intermediates.
+ANALYSIS_MEASUREMENTS ?= $(ANALYSIS_REPO_ROOT)/measurements.jsonl
+ANALYSIS_EXP1_BATCH2_RECORDS := $(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json)
+
+ANALYSIS_REPORT_DERIVED_DIR ?= $(ANALYSIS_REPO_ROOT)/derived
+ANALYSIS_VARIANCE_JSON := $(ANALYSIS_REPORT_DERIVED_DIR)/variance_decomposition.json
+ANALYSIS_VERIFICATION_DIR := $(ANALYSIS_REPORT_DERIVED_DIR)/verification
+ANALYSIS_VERIFICATION_TRADEOFF := $(ANALYSIS_VERIFICATION_DIR)/tradeoff.csv
+
+ANALYSIS_DECOMP_BEFORE := $(wildcard $(ANALYSIS_OUTPUTS_DIR)/rag_per_fuel/reconciliation_*.csv)
+ANALYSIS_DECOMP_AFTER  := $(wildcard $(ANALYSIS_OUTPUTS_DIR)/rag_per_fuel_v2/reconciliation_*.csv)
+ANALYSIS_RAG_CSVS      := $(wildcard $(ANALYSIS_OUTPUTS_DIR)/rag_extract/*.csv)
+ANALYSIS_EXPERT_REF    := $(ANALYSIS_REPO_ROOT)/data/reference/vietnam_thermal_v1.csv
+ANALYSIS_GEM_REF       := $(ANALYSIS_REPO_ROOT)/data/reference/gem_thermal.csv
+
+ANALYSIS_CONVERTER_TEST := $(ANALYSIS_EXPERIMENTS_DIR)/data/converter_test
+ANALYSIS_CONVERTER_META := $(ANALYSIS_CONVERTER_TEST)/benchmark_meta.yaml
+ANALYSIS_CONVERTER_DOCS := $(wildcard $(ANALYSIS_CONVERTER_TEST)/*/Decision-1509.md)
+
+# --- Mart-derived views (P3 render-time projection of the P2 mart) ----------
+# The mart itself ($(ANALYSIS_EXP2_MART_JSONL)) is a P2 outcome with NO rule
+# here — it is a committed source. These views are the render-time shaping of
+# that source and are produced by build_exp2_mart_views (the P3 projection).
+
+$(ANALYSIS_EXP2_MART_VIEWS): $(ANALYSIS_EXP2_MART_JSONL)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.build_exp2_mart_views \
+	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
+	    --output-dir $(ANALYSIS_GEN) \
+	    --repo-root $(ANALYSIS_REPO_ROOT)
+
+# --- Tables and figures -----------------------------------------------------
+
+$(ANALYSIS_EXP2_ARM_FIG): $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_arms_comparison \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_TURN_FIG): $(ANALYSIS_GEN)/exp2_turn_trajectory_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_turn_trajectory \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_BIB_TABLE): $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_bib_quality \
+	    --input $< \
+	    --output $@
+
+$(ANALYSIS_EXP2_COVERAGE_FIG): $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
+		$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_coverage_certainty \
+	    --input $(ANALYSIS_GEN)/tab_exp2_bib_quality_view.csv \
+	    --arms-input $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
+	    --output $@
+
+$(ANALYSIS_EXP2_SPIRE_FIG): $(ANALYSIS_GEN)/sota_cross_eval_view.csv experiments/quality_spider_config.yaml
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_quality_spider \
+	    --input $< \
+	    --config experiments/quality_spider_config.yaml \
+	    --output $@
+
+# Exp1 quality spiders: one script, two invocations (family 2x2 panels vs a
+# single-model large spider) -> two targets, not a grouped rule.
+$(ANALYSIS_EXP1_SPIDER_FAMILIES): $(ANALYSIS_EXP1_CROSS_EVAL_CSV)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_quality_spider_exp1 \
+	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
+	    --output $@
+
+$(ANALYSIS_EXP1_SPIDER_CLAUDE): $(ANALYSIS_EXP1_CROSS_EVAL_CSV)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_quality_spider_exp1 \
+	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
+	    --model claude-opus-4.6 \
+	    --output $@
+
+$(ANALYSIS_GEN)/stat_tests_arm1_vs_arm2.txt: $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_stat_tests \
+	    --input $< \
+	    --output $@
+
+# --- Outline placeholder artifacts (post-conference skeleton) ----------------
+
+$(ANALYSIS_GEN)/tab_exp2_outline_dataset.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_dataset --output $@
+
+$(ANALYSIS_GEN)/fig_exp2_outline_dataset.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_outline_dataset --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_hypotheses_map.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_hypotheses_map --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_protocol_fidelity.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_protocol_fidelity --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h1.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h1 --output $@
+
+$(ANALYSIS_GEN)/fig_exp2_outline_h2.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_outline_h2 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h3.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h3 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h4.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h4 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_h5.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_h5 --output $@
+
+$(ANALYSIS_GEN)/fig_exp2_outline_h6.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_outline_h6 --output $@
+
+$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex:
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_outline_hypothesis_status --output $@
+
+ANALYSIS_EXP2_REPORT_TARGETS := \
+	$(ANALYSIS_EXP2_MART_VIEWS) \
+	$(ANALYSIS_EXP2_ARM_FIG) \
+	$(ANALYSIS_EXP2_TURN_FIG) \
+	$(ANALYSIS_EXP2_BIB_TABLE) \
+	$(ANALYSIS_EXP2_COVERAGE_FIG) \
+	$(ANALYSIS_EXP2_SPIRE_FIG) \
+	$(ANALYSIS_EXP2_OUTLINE_ARTIFACTS)
+
+# 2x2 factorial table (F1 + cost, query-mode x documents). Co-produces the
+# per-(agent,arm) CSV. Agent is the unit of replication; see the module docstring.
+# Reads the committed cross-eval CSV (P2 source) and the flat arm dirs (P1
+# source); produces nothing under P2 outcome paths.
+$(ANALYSIS_EXP2_2X2_TEX): $(ANALYSIS_EXP2_CROSS_EVAL_CSV)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_2x2 \
+	    --cross-eval-csv $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
+	    --flat-root $(ANALYSIS_DERIVED_DIR) \
+	    --output-csv $(ANALYSIS_EXP2_2X2_CSV) \
+	    --output-tex $@ --lang en
+
+$(ANALYSIS_EXP2_2X2_FR_TEX): $(ANALYSIS_EXP2_CROSS_EVAL_CSV)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_exp2_2x2 \
+	    --cross-eval-csv $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
+	    --flat-root $(ANALYSIS_DERIVED_DIR) \
+	    --output-csv $(ANALYSIS_EXP2_2X2_CSV) \
+	    --output-tex $@ --lang fr
+
+# --- Coverage/cost split figures (reads from mart views + Exp1 cost CSV) ------
+
+$(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) &: \
+		$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv $(ANALYSIS_GEN)/cost_quality.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_exp2_arms_split \
+	    --input $(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \
+	    --exp1-input $(ANALYSIS_GEN)/cost_quality.csv \
+	    --coverage-output $(ANALYSIS_EXP2_COVERAGE_SPLIT) \
+	    --cost-output $(ANALYSIS_EXP2_COST_SPLIT)
+
+# --- Slide macros (census + measurements → report/inputs/generated/macros_slides.tex) ---
+
+$(ANALYSIS_SLIDE_MACROS): $(ANALYSIS_GEN)/census_bars.csv $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_macros \
+	    --census-csv $(ANALYSIS_GEN)/census_bars.csv --output $@
+
+.PHONY: exp2-analysis-report exp1-analysis-figures report-tables report-figures chart-figures
+
+exp2-analysis-report: $(ANALYSIS_EXP2_REPORT_TARGETS) \
+	$(ANALYSIS_EXP2_2X2_TEX) $(ANALYSIS_EXP2_2X2_FR_TEX) \
+	$(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) \
+	$(ANALYSIS_SLIDE_MACROS)
+
+exp1-analysis-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES) $(ANALYSIS_EXP1_SPIDER_CLAUDE)
+
+# --- Report-side tables and figures (migrated from root Makefile by 0352) ---
+# These produce committed handoff artifacts under $(ANALYSIS_GEN). The root
+# Makefile's `report/report.pdf` rule depends on these files but has no
+# recipes — `make report` is a writing-only build (tectonic) consuming
+# committed artifacts. Regenerate them from this file:
+#     make -f experiments/render.mk report-tables report-figures
+
+$(ANALYSIS_GEN)/tab_census.tex: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_census --output $@
+
+$(ANALYSIS_GEN)/macros.tex: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_macros --output $@
+
+# Co-target fig_census_direct.pdf was retired with the ablation thread (0361);
+# the script still requires --output, so the PDF is written to a sentinel path
+# in $(ANALYSIS_REPORT_DERIVED_DIR) and not consumed by any downstream rule.
+$(ANALYSIS_GEN)/macros_census.tex: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@) $(ANALYSIS_REPORT_DERIVED_DIR)
+	uv run python -m aedist.plot_method_convergence \
+	    --output $(ANALYSIS_REPORT_DERIVED_DIR)/_macros_census_unused.pdf \
+	    --methods direct --prompt-version census \
+	    --output-macros $@
+
+$(ANALYSIS_GEN)/tab_relances.tex: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_relances --output $@
+
+$(ANALYSIS_GEN)/tab_comparaison.tex: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_VARIANCE_JSON)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_comparaison --output $@ --variance-json $(ANALYSIS_VARIANCE_JSON)
+
+$(ANALYSIS_GEN)/tab_reconciliation.tex: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_GEM_REF)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_reconciliation --output $@ --expert-ref $(ANALYSIS_EXPERT_REF) --gem-ref $(ANALYSIS_GEM_REF)
+
+$(ANALYSIS_VARIANCE_JSON): $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.variance_decomposition --output $@
+
+$(ANALYSIS_GEN)/tab_variance.tex: $(ANALYSIS_VARIANCE_JSON)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_variance --input $< --output $@
+
+$(ANALYSIS_VERIFICATION_TRADEOFF): $(wildcard $(ANALYSIS_VERIFICATION_DIR)/*-run*.csv)
+	uv run python -m aedist.tabulate_verification \
+	    --input $(ANALYSIS_VERIFICATION_DIR) --output $@
+
+$(ANALYSIS_GEN)/tab_verification.tex: $(ANALYSIS_VERIFICATION_TRADEOFF)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_verification \
+	    --input $(ANALYSIS_VERIFICATION_DIR) --latex $@
+
+$(ANALYSIS_GEN)/tab_decomposition_fix.tex: $(ANALYSIS_DECOMP_BEFORE) $(ANALYSIS_DECOMP_AFTER)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_decomposition_fix --output $@
+
+$(ANALYSIS_GEN)/tab_coherence.tex: $(ANALYSIS_RAG_CSVS) $(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_coherence.py $(ANALYSIS_REPO_ROOT)/src/aedist/coherence.py
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.tabulate_coherence \
+	    --input $(ANALYSIS_OUTPUTS_DIR)/rag_extract --output $@
+
+$(ANALYSIS_GEN)/tab_converter_benchmark.tex: $(ANALYSIS_CONVERTER_META) $(ANALYSIS_CONVERTER_DOCS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.compare_converters \
+	    --input $(ANALYSIS_CONVERTER_TEST) --meta $(ANALYSIS_CONVERTER_META) --output $@
+
+# Grouping targets — drive end-to-end regeneration of report-side handoff
+# artifacts. tab_self_consistency.tex and tab_per_run.tex are produced by the
+# experiments/Makefile self-consistency target (single producer, 0354) and
+# remain committed handoff artifacts without a rule here.
+report-tables: \
+	$(ANALYSIS_GEN)/tab_census.tex \
+	$(ANALYSIS_GEN)/macros.tex \
+	$(ANALYSIS_GEN)/macros_census.tex \
+	$(ANALYSIS_GEN)/tab_relances.tex \
+	$(ANALYSIS_EXP2_2X2_TEX) \
+	$(ANALYSIS_GEN)/tab_comparaison.tex \
+	$(ANALYSIS_GEN)/tab_variance.tex \
+	$(ANALYSIS_GEN)/tab_verification.tex \
+	$(ANALYSIS_GEN)/tab_decomposition_fix.tex \
+	$(ANALYSIS_GEN)/tab_coherence.tex \
+	$(ANALYSIS_GEN)/tab_reconciliation.tex \
+	$(ANALYSIS_GEN)/tab_converter_benchmark.tex
+
+report-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES)
+
+# --- Chart-data figures (migrated from root Makefile by 0370) -----------------
+# These produce committed handoff artifacts consumed by both report and slides.
+# The writing-side `make report` and `make slides` have no recipes for these
+# outputs — they are clean-room builds from committed artifacts only.
+
+$(ANALYSIS_GEN)/census_bars.csv: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_census --output $@
+
+$(ANALYSIS_GEN)/fig_direct_cost_quality.pdf $(ANALYSIS_GEN)/cost_quality.csv &: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_cost_quality \
+	    --output $(ANALYSIS_GEN)/cost_quality.csv --figure $(ANALYSIS_GEN)/fig_direct_cost_quality.pdf
+
+$(ANALYSIS_GEN)/fig_method_convergence.pdf: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_method_convergence \
+	    --output $@ --core-only
+
+$(ANALYSIS_GEN)/fig_direct_p1_base.pdf $(ANALYSIS_GEN)/macros_p1_base.tex &: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_EXP1_BATCH2_RECORDS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_method_convergence \
+	    --output $(ANALYSIS_GEN)/fig_direct_p1_base.pdf --methods direct \
+	    --label-x 100 --label-ha left \
+	    --xlabel "Assets identified (1 dot = 1 power plant / project)" \
+	    --title "How do models recall Vietnam's thermal power assets? Not well." \
+	    --ui-scale 1.35 \
+	    --fig-width 12 --fig-height-min 8 --fig-height-per-run 0.06 --fig-height-per-method 0.35 \
+	    --result-dir $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/ \
+	    --output-macros $(dir $@)macros_p1_base.tex
+
+$(ANALYSIS_GEN)/fig_regimes_scatter.pdf: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_EXPERIMENTS_DIR)/figures.toml
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_regimes_scatter \
+	    --output $@
+
+$(ANALYSIS_GEN)/fig_scaling_curve.pdf: $(ANALYSIS_MEASUREMENTS)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_scaling_curve \
+	    --output $@
+
+$(ANALYSIS_GEN)/fig_capability_timeline.pdf: $(ANALYSIS_REPO_ROOT)/data/capability_timeline.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_capability_timeline \
+	    --input $< --output $@
+
+$(ANALYSIS_GEN)/fig_capability_dag.pdf: $(ANALYSIS_REPO_ROOT)/data/capability_timeline.csv
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_capability_dag \
+	    --input $< --output $@
+
+$(ANALYSIS_GEN)/fig_spider_cross_exp.pdf: $(ANALYSIS_EXP1_CROSS_EVAL_CSV) $(ANALYSIS_EXP2_CROSS_EVAL_CSV)
+	@mkdir -p $(dir $@)
+	uv run python -m aedist.plot_spider_cross_exp \
+	    --exp1 $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
+	    --exp2 $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
+	    --output $@
+
+chart-figures: \
+	$(ANALYSIS_GEN)/census_bars.csv \
+	$(ANALYSIS_GEN)/fig_direct_cost_quality.pdf \
+	$(ANALYSIS_GEN)/fig_direct_p1_base.pdf \
+	$(ANALYSIS_GEN)/fig_capability_timeline.pdf \
+	$(ANALYSIS_GEN)/fig_capability_dag.pdf \
+	$(ANALYSIS_GEN)/fig_spider_cross_exp.pdf \
+	$(ANALYSIS_EXP1_SPIDER_FAMILIES) \
+	$(ANALYSIS_GEN)/fig_method_convergence.pdf \
+	$(ANALYSIS_GEN)/fig_regimes_scatter.pdf \
+	$(ANALYSIS_GEN)/fig_scaling_curve.pdf

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -1,8 +1,8 @@
 # Beamer slides and manuscript handout
 #
 # The writing build compiles from committed handoff artifacts only — no uv run,
-# no data access. To regenerate figures/tables, run the analysis workpackage:
-#   make -f experiments/analysis.mk exp2-analysis-report
+# no data access. To regenerate figures/tables, run the render (P3) workpackage:
+#   make -f experiments/render.mk exp2-analysis-report
 
 ROOT_REPORT_GEN := report/inputs/generated
 LOCAL_ROOT_REPORT_GEN := ../report/inputs/generated

--- a/src/aedist/build_exp2_mart_views.py
+++ b/src/aedist/build_exp2_mart_views.py
@@ -1,4 +1,7 @@
-"""Build CSV views from the Exp2 mart JSONL artifact."""
+"""Build CSV views from the Exp2 mart JSONL artifact.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import csv

--- a/src/aedist/compare_converters.py
+++ b/src/aedist/compare_converters.py
@@ -1,5 +1,7 @@
 """Compare PDF converter backends on table extraction quality.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads pre-generated markdown outputs from each backend and produces
 a side-by-side quality report: tables detected, rows, Vietnamese
 diacritics, file size.  When ``--meta`` points to a YAML sidecar the

--- a/src/aedist/plot_capability_dag.py
+++ b/src/aedist/plot_capability_dag.py
@@ -1,5 +1,7 @@
 """Render the empirical capability transition matrix for §3.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 8×8 heatmap: for each ordered pair (i, j) of capability stages, the
 fraction of labs where feature i shipped before feature j (conditional on
 both being present). White = no lab made that transition; green = all

--- a/src/aedist/plot_capability_timeline.py
+++ b/src/aedist/plot_capability_timeline.py
@@ -1,5 +1,7 @@
 """Render the capability-rollout swimlane for §3 of the manuscript.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 For each lab in Experiment 1's panel (Anthropic, OpenAI, Mistral, Alibaba,
 DeepSeek), place a marker at the date the lab first shipped each of the
 eight capability features as a consumer-facing product surface. Rows are

--- a/src/aedist/plot_census.py
+++ b/src/aedist/plot_census.py
@@ -1,5 +1,7 @@
 """Generate census bar-chart CSV from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Writes census_bars.csv with columns: model, f1, n_tp, n_fp, local
 sorted by f1 descending. f1 is median across runs as a decimal 0-1.
 n_tp and n_fp are median matched/hallucinated plant counts (integers).

--- a/src/aedist/plot_cost_quality.py
+++ b/src/aedist/plot_cost_quality.py
@@ -1,5 +1,7 @@
 """Generate cost × quality CSV and scatter PDF from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Scope: **Experiment 1 only** (the parametric baseline sweep,
 ``experiments/outputs/ablation/direct/p1_base/``). Pilot rows under
 ``p1_base.pilot/`` are excluded. The figure is descriptive — no

--- a/src/aedist/plot_exp2_arms_comparison.py
+++ b/src/aedist/plot_exp2_arms_comparison.py
@@ -1,5 +1,7 @@
 """Two-panel comparison figure for Exp2 4-arm design.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.plot_exp2_arms_comparison \
         --input report/inputs/generated/tab_exp2_arms_runs.csv \

--- a/src/aedist/plot_exp2_arms_split.py
+++ b/src/aedist/plot_exp2_arms_split.py
@@ -1,5 +1,7 @@
 """Coverage and Cost single-panel figures for Exp2, with Exp1 baseline bar.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Each model group shows 5 bars:
   E1  = Experiment 1 parametric baseline (from cost_quality.csv)
   1N  = arm1: single-shot, no docs

--- a/src/aedist/plot_exp2_coverage_certainty.py
+++ b/src/aedist/plot_exp2_coverage_certainty.py
@@ -1,5 +1,7 @@
 """Coverage vs. corroboration scatter for all Exp2 runs.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 X = assets correctly identified (``n_matched``, same axis as the coverage
 figure); Y = assets backed by two sources (``src2_present``). One point per
 run; per-model colour; condition (1N/5N/1D/5D) shown by glyph. Individual runs

--- a/src/aedist/plot_exp2_outline_dataset.py
+++ b/src/aedist/plot_exp2_outline_dataset.py
@@ -1,4 +1,7 @@
-"""Generate dataset figure placeholder for Exp2 outline."""
+"""Generate dataset figure placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/plot_exp2_outline_h2.py
+++ b/src/aedist/plot_exp2_outline_h2.py
@@ -1,4 +1,7 @@
-"""Generate H2 figure placeholder for Exp2 outline."""
+"""Generate H2 figure placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/plot_exp2_outline_h6.py
+++ b/src/aedist/plot_exp2_outline_h6.py
@@ -1,4 +1,7 @@
-"""Generate H6 figure placeholder for Exp2 outline."""
+"""Generate H6 figure placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/plot_exp2_turn_trajectory.py
+++ b/src/aedist/plot_exp2_turn_trajectory.py
@@ -1,5 +1,7 @@
 """Turn-by-turn inventory rows for Exp2 Arm 2 (optimised) — Figure 4.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Four panels, one per agent, sharing a common y-axis scale.  Each panel shows
 N=5 runs as connected lines.  Filled dots = turn classified 'report'; open
 circles = 'no_report'.  Colors from the model-family palette.

--- a/src/aedist/plot_method_convergence.py
+++ b/src/aedist/plot_method_convergence.py
@@ -1,5 +1,7 @@
 """Generate method-convergence strip plot from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 For each method (Y axis), plots every run as a horizontal bar.
 Each bar is a row of dots: 1 dot = 1 plant.
 Blue dots = correctly identified (TP). Orange dots = hallucinated (FP).

--- a/src/aedist/plot_quality_spider.py
+++ b/src/aedist/plot_quality_spider.py
@@ -1,5 +1,7 @@
 """Radar/spider figure for Exp2 quality profiles.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.plot_quality_spider \
         --input experiments/derived/sota_cross_eval.csv \

--- a/src/aedist/plot_quality_spider_exp1.py
+++ b/src/aedist/plot_quality_spider_exp1.py
@@ -1,5 +1,7 @@
 """Radar/spider figures for Exp1 quality profiles.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Two modes:
   - Family 2×2 panels (default): one subplot per model family.
   - Single model (--model): one large spider for a single model,

--- a/src/aedist/plot_regimes_scatter.py
+++ b/src/aedist/plot_regimes_scatter.py
@@ -1,5 +1,7 @@
 """Generate regimes scatter plot: 5 models × 3 methods, one dot per TP plant.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Shows how RAG lifts the identification floor across all models.
 Median TP across runs per model-method combo.
 

--- a/src/aedist/plot_scaling_curve.py
+++ b/src/aedist/plot_scaling_curve.py
@@ -1,5 +1,7 @@
 """Scaling curve: F1 vs active parameters under RAG wholesale.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Compares single-shot (parametric knowledge only) vs RAG wholesale
 for two model families (Qwen 3.5, Gemma 4) from edge to cloud.
 X-axis: active parameters (log scale) — relevant for MoE models.

--- a/src/aedist/plot_spider_cross_exp.py
+++ b/src/aedist/plot_spider_cross_exp.py
@@ -1,5 +1,7 @@
 """Cross-experiment spider multiplot: E1 + 4 Exp2 conditions.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Layout (compact GridSpec, 2 rows — no wasted edge cells):
 
    [1N]  [E1]  [5N]      no-docs / baseline / no-docs

--- a/src/aedist/tabulate_census.py
+++ b/src/aedist/tabulate_census.py
@@ -1,5 +1,7 @@
 """Generate census results LaTeX table from measurements.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads per-run metrics, groups by model (stripping -runN suffix),
 computes medians, and emits a longtable sorted by F1 descending.
 Local (Padme) models are marked with (L).

--- a/src/aedist/tabulate_coherence.py
+++ b/src/aedist/tabulate_coherence.py
@@ -1,5 +1,7 @@
 """Generate internal-coherence LaTeX table from RAG extraction CSVs.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.tabulate_coherence \\
         --input experiments/outputs/rag_extract \\

--- a/src/aedist/tabulate_comparaison.py
+++ b/src/aedist/tabulate_comparaison.py
@@ -1,5 +1,7 @@
 """Generate RAG comparison LaTeX table from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.tabulate_comparaison \\
         --measurements measurements.jsonl \\

--- a/src/aedist/tabulate_decomposition_fix.py
+++ b/src/aedist/tabulate_decomposition_fix.py
@@ -1,5 +1,7 @@
 """Generate LaTeX table comparing FP rates before/after decomposition prompt fix.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads reconciliation CSVs directly from rag_per_fuel/ (before) and
 rag_per_fuel_v2/ (after) directories. Computes per-run false-positive rates
 and mean FP rate per model, organized in two panels.

--- a/src/aedist/tabulate_exp2_2x2.py
+++ b/src/aedist/tabulate_exp2_2x2.py
@@ -1,5 +1,7 @@
 """Exp2 2x2 factorial table: F1 and cost across query-mode x documents.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 The four Exp2 arms form a 2x2 factorial:
 
                  | without docs      | with docs

--- a/src/aedist/tabulate_exp2_bib_quality.py
+++ b/src/aedist/tabulate_exp2_bib_quality.py
@@ -1,5 +1,7 @@
 """Render bibliography quality LaTeX table from Exp2 bib quality CSV.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.tabulate_exp2_bib_quality \
         --input report/inputs/generated/tab_exp2_bib_quality_view.csv \

--- a/src/aedist/tabulate_exp2_outline_dataset.py
+++ b/src/aedist/tabulate_exp2_outline_dataset.py
@@ -1,4 +1,7 @@
-"""Generate dataset descriptive table placeholder for Exp2 outline."""
+"""Generate dataset descriptive table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_h1.py
+++ b/src/aedist/tabulate_exp2_outline_h1.py
@@ -1,4 +1,7 @@
-"""Generate H1 table placeholder for Exp2 outline."""
+"""Generate H1 table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_h3.py
+++ b/src/aedist/tabulate_exp2_outline_h3.py
@@ -1,4 +1,7 @@
-"""Generate H3 table placeholder for Exp2 outline."""
+"""Generate H3 table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_h4.py
+++ b/src/aedist/tabulate_exp2_outline_h4.py
@@ -1,4 +1,7 @@
-"""Generate H4 table placeholder for Exp2 outline."""
+"""Generate H4 table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_h5.py
+++ b/src/aedist/tabulate_exp2_outline_h5.py
@@ -1,4 +1,7 @@
-"""Generate H5 table placeholder for Exp2 outline."""
+"""Generate H5 table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_hypotheses_map.py
+++ b/src/aedist/tabulate_exp2_outline_hypotheses_map.py
@@ -1,4 +1,7 @@
-"""Generate hypotheses-to-tests mapping table placeholder for Exp2 outline."""
+"""Generate hypotheses-to-tests mapping table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_hypothesis_status.py
+++ b/src/aedist/tabulate_exp2_outline_hypothesis_status.py
@@ -1,4 +1,7 @@
-"""Generate synthesis hypothesis-status table placeholder for Exp2 outline."""
+"""Generate synthesis hypothesis-status table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_exp2_outline_protocol_fidelity.py
+++ b/src/aedist/tabulate_exp2_outline_protocol_fidelity.py
@@ -1,4 +1,7 @@
-"""Generate protocol-fidelity table placeholder for Exp2 outline."""
+"""Generate protocol-fidelity table placeholder for Exp2 outline.
+
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+"""
 
 import argparse
 import logging

--- a/src/aedist/tabulate_macros.py
+++ b/src/aedist/tabulate_macros.py
@@ -1,5 +1,7 @@
 """Generate LaTeX \\newcommand macros from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads per-run metrics, groups by model slug (stripping -runN suffix
 and directory prefix), computes median F1, and emits macros for
 the report preamble.

--- a/src/aedist/tabulate_reconciliation.py
+++ b/src/aedist/tabulate_reconciliation.py
@@ -1,5 +1,7 @@
 """Three-way reference reconciliation: expert vs GEM vs system.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Ticket 0082 — inter-annotator agreement analysis.
 
 1. Reconciles expert reference against GEM reference using the LP matcher.

--- a/src/aedist/tabulate_relances.py
+++ b/src/aedist/tabulate_relances.py
@@ -1,5 +1,7 @@
 """Generate multi-turn relances LaTeX table from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.tabulate_relances \\
         --measurements measurements.jsonl \\

--- a/src/aedist/tabulate_stat_tests.py
+++ b/src/aedist/tabulate_stat_tests.py
@@ -1,5 +1,7 @@
 """Compute directional statistical tests comparing arm1 (naive) vs arm2 (optimised).
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads tab_exp2_arms_runs_view.csv and produces stat_tests_arm1_vs_arm2.txt with:
 1. Sign test across agents on n_matched (arm2 > arm1 direction)
 2. Effect size on n_matched: median differences per agent and pooled

--- a/src/aedist/tabulate_variance.py
+++ b/src/aedist/tabulate_variance.py
@@ -1,5 +1,7 @@
 """Generate variance decomposition LaTeX table.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads the output of ``variance_decomposition()`` and produces a longtable
 showing SS, df, F, p, eta-squared, and omega-squared for each ANOVA source.
 

--- a/src/aedist/tabulate_verification.py
+++ b/src/aedist/tabulate_verification.py
@@ -1,5 +1,7 @@
 """Generate verification tradeoff table.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Reads annotated verification CSVs from derived/verification/ and produces
 a precision-coverage tradeoff table by sweeping evidence_score thresholds.
 Evaluates each filtered subset against the reference to compute precision,

--- a/src/aedist/variance_decomposition.py
+++ b/src/aedist/variance_decomposition.py
@@ -1,5 +1,7 @@
 """Variance decomposition of F1 scores via two-way ANOVA.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Computes eta-squared and omega-squared for model, method, interaction,
 and residual effects on F1 variance.  Uses only stdlib — no scipy, no numpy.
 

--- a/tests/test_make_slides_prereqs.py
+++ b/tests/test_make_slides_prereqs.py
@@ -4,7 +4,8 @@ The slides sub-make (`slides/Makefile`) consumes
 `$(LOCAL_ROOT_REPORT_GEN)/fig_capability_dag.pdf` as a manuscript prereq.
 After ticket 0370, the writing build is clean-room: no producing recipe
 exists in the writing-side Makefiles. The file must be a committed handoff
-artifact. The producer rule lives in `experiments/analysis.mk`.
+artifact. The producer rule lives in `experiments/render.mk` (the P3 render
+phase, extracted from analysis.mk by ticket 0409).
 
 This is the adherence companion to tickets 0367 and 0370.
 """
@@ -28,6 +29,6 @@ def test_fig_capability_dag_is_committed_artifact():
     )
     assert result.stdout.strip(), (
         "report/inputs/generated/fig_capability_dag.pdf is not tracked by git — "
-        "regenerate via `make -f experiments/analysis.mk chart-figures` "
+        "regenerate via `make -f experiments/render.mk chart-figures` "
         "then `git add -f` and commit."
     )

--- a/tests/test_makefile_dag.py
+++ b/tests/test_makefile_dag.py
@@ -73,6 +73,47 @@ def _key(token: str, mk_dir: Path) -> str | None:
     return f"{m.group(1)}/inputs/generated/{m.group(2)}" if m else None
 
 
+INCLUDE_RE = re.compile(r"^\s*include\s+(.+)$")
+# A sibling makefile name inside an include argument, tolerating a leading
+# `$(dir $(lastword $(MAKEFILE_LIST)))` prefix glued to the basename.
+INCLUDE_MK_RE = re.compile(r"([A-Za-z0-9_.-]+\.mk)\b")
+
+
+def _collect_assignments(path: Path, variables: dict[str, str]) -> None:
+    """Merge variable assignments from `path` (and its includes) into `variables`.
+
+    GNU make's `include` is followed so a producer .mk that factors its shared
+    path variables into a sibling file (e.g. render.mk including paths.mk) still
+    has its $(ANALYSIS_*) target names expand. Only variable definitions are
+    pulled in here; rules are parsed by the caller for the including file.
+    """
+    for raw in _logical_lines(path):
+        if raw.startswith("\t"):
+            continue
+        line = raw.split("#", 1)[0]
+        if not line.strip():
+            continue
+        inc = INCLUDE_RE.match(line)
+        if inc:
+            # The committed convention is
+            # `include $(dir $(lastword $(MAKEFILE_LIST)))paths.mk`; resolve any
+            # sibling .mk basename relative to the including file's directory.
+            for name in INCLUDE_MK_RE.findall(inc.group(1)):
+                sibling = path.parent / name
+                if sibling.is_file():
+                    _collect_assignments(sibling, variables)
+            continue
+        m = ASSIGN_RE.match(line)
+        if m:
+            name, op, val = m.group(1), m.group(2), m.group(3).strip()
+            if op == "+=":
+                variables[name] = f"{variables.get(name, '')} {val}".strip()
+            elif op == "?=" and name in variables:
+                pass
+            else:
+                variables[name] = val
+
+
 def _parse(path: Path) -> tuple[set[str], dict[str, set[str]]]:
     """Return (targets, prereq_sources) of generated-artifact keys."""
     variables: dict[str, str] = {}
@@ -82,6 +123,13 @@ def _parse(path: Path) -> tuple[set[str], dict[str, set[str]]]:
             continue
         line = raw.split("#", 1)[0]
         if not line.strip():
+            continue
+        inc = INCLUDE_RE.match(line)
+        if inc:
+            for name in INCLUDE_MK_RE.findall(inc.group(1)):
+                sibling = path.parent / name
+                if sibling.is_file():
+                    _collect_assignments(sibling, variables)
             continue
         m = ASSIGN_RE.match(line)
         if m:
@@ -129,6 +177,7 @@ def test_generated_artifacts_have_a_producer():
         "Generated artifacts used as prerequisites but produced by no makefile "
         "rule (orphaned from the build DAG):\n"
         f"{detail}\n\n"
-        "Add a producing rule (in experiments/analysis.mk for analysis "
-        "artifacts) or, for multi-output scripts, a grouped target `a b &:`."
+        "Add a producing rule (in experiments/render.mk for P3 render "
+        "artifacts, experiments/analysis.mk for P2 mart/cross-eval) or, for "
+        "multi-output scripts, a grouped target `a b &:`."
     )

--- a/tests/test_render_build_clean_room.py
+++ b/tests/test_render_build_clean_room.py
@@ -1,0 +1,132 @@
+"""`experiments/render.mk` is the P3 (render) phase — it never regenerates P2.
+
+Ticket 0409 (tracker 0406, step S2) split every render rule out of
+`experiments/analysis.mk` into `experiments/render.mk`, so a figure/table/view
+build can no longer trigger the scoring/extraction cascade that produced the
+2026-06-03 mart staleness incident (ticket 0383).
+
+render.mk consumes committed P2 outcomes (``measurements.jsonl``,
+``experiments/derived/exp2_mart.jsonl``, the cross-eval CSVs,
+``experiments/outputs/**``) as *sources* — they appear only as prerequisites,
+never as targets, and render.mk carries no rule able to rebuild them. Their
+absence must be a hard "No rule to make target" error, never a silent rebuild.
+
+This adherence test dry-runs each P3 aggregate target through render.mk and
+asserts the recipe trace contains:
+
+* no P2 scoring/extraction/acquire invocation — ``aedist.build_exp2_mart``
+  (the standalone mart builder, *not* ``build_exp2_mart_views``, which is the
+  P3 projection and is explicitly allowed), ``extract_``, ``evaluate_``,
+  ``score_``, worker drains, or ``query_`` adapters; and
+* no *target* path under a P2 outcome location (``exp2_mart.jsonl``, the
+  cross-eval CSVs, ``experiments/outputs/``).
+
+The needles are deliberately precise: ``aedist.build_exp2_mart `` (with the
+trailing space) matches the mart builder module invocation but not
+``aedist.build_exp2_mart_views``; ``--output .*exp2_mart.jsonl`` catches any
+rule writing the mart.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RENDER_MK = REPO_ROOT / "experiments" / "render.mk"
+
+# P3 aggregate targets that drive the full render surface.
+P3_AGGREGATE_TARGETS = (
+    "exp2-analysis-report",
+    "exp1-analysis-figures",
+    "report-tables",
+    "report-figures",
+    "chart-figures",
+)
+
+# Substrings in a recipe line that prove a P2 (score/extract/acquire) step ran.
+# build_exp2_mart_views is the P3 projection and is explicitly NOT forbidden.
+FORBIDDEN_RECIPE_NEEDLES = (
+    "aedist.build_exp2_mart ",  # trailing space: mart builder, not _views
+    "aedist.extract_",
+    "aedist.evaluate_",
+    "aedist.score_",
+    "aedist.run_worker",
+    "aedist.query_",
+)
+
+# A recipe writing to one of these is regenerating a P2 outcome.
+FORBIDDEN_OUTPUT_RE = re.compile(
+    r"--output\S*\s+\S*(?:exp2_mart\.jsonl|sota_cross_eval\.csv|exp1_cross_eval\.csv)"
+)
+
+# A rule target (left of ':' in `make -p`/`-n` is not exposed; instead we scan
+# the makefile source for targets under P2 outcome paths).
+P2_OUTCOME_TARGET_RE = re.compile(
+    r"^\s*\$\(ANALYSIS_EXP2_MART_JSONL\)\s*:"
+    r"|^\s*\$\(ANALYSIS_EXP2_CROSS_EVAL_CSV\)\s*:"
+    r"|^\s*\$\(ANALYSIS_EXP1_CROSS_EVAL_CSV\)\s*:"
+    r"|experiments/outputs/\S*\s*:"
+    r"|experiments/derived/\S*exp2_mart\.jsonl\s*:",
+    re.MULTILINE,
+)
+
+
+def _dry_run(target: str) -> str:
+    result = subprocess.run(
+        ["make", "-f", str(RENDER_MK), "-n", target],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return result.stdout
+
+
+def test_render_mk_exists():
+    assert RENDER_MK.is_file(), (
+        "experiments/render.mk must exist (P3 render rules extracted from "
+        "analysis.mk by ticket 0409)."
+    )
+
+
+@pytest.mark.parametrize("target", P3_AGGREGATE_TARGETS)
+def test_p3_target_does_not_invoke_p2_scoring(target):
+    trace = _dry_run(target)
+    offending = []
+    for line in trace.splitlines():
+        if "build_exp2_mart_views" in line:
+            continue  # the P3 projection — allowed
+        if any(needle in line for needle in FORBIDDEN_RECIPE_NEEDLES):
+            offending.append(line)
+        if FORBIDDEN_OUTPUT_RE.search(line):
+            offending.append(line)
+    assert not offending, (
+        f"`make -f experiments/render.mk -n {target}` regenerates a P2 outcome "
+        "(scoring/extraction). render.mk must consume committed P2 outcomes as "
+        "sources only.\n" + "\n".join(offending)
+    )
+
+
+def test_render_mk_has_no_p2_outcome_targets():
+    """render.mk may name P2 outcomes only as prerequisites, never as targets."""
+    text = RENDER_MK.read_text()
+    rule_lines = [ln for ln in text.splitlines() if not ln.startswith("\t") and ":" in ln]
+    offending = [ln for ln in rule_lines if P2_OUTCOME_TARGET_RE.search(ln + "\n")]
+    assert not offending, (
+        "render.mk declares a rule whose target is a P2 outcome (mart / "
+        "cross-eval / experiments outputs). Those rules belong in analysis.mk; "
+        "render.mk references them only as prerequisites.\n" + "\n".join(offending)
+    )
+
+
+def test_render_mk_views_rule_is_present():
+    """The mart→view projection (P3) lives in render.mk, not analysis.mk."""
+    text = RENDER_MK.read_text()
+    assert "build_exp2_mart_views" in text, (
+        "render.mk must carry the ANALYSIS_EXP2_MART_VIEWS projection rule "
+        "(views are render-time shaping, P3)."
+    )

--- a/tests/test_report_build_clean_room.py
+++ b/tests/test_report_build_clean_room.py
@@ -6,9 +6,10 @@ Python data pipeline. This test guards that invariant.
 
 The check uses `make -n` (and a force-rebuild variant) on the report target and
 asserts the recipe trace contains no `uv run` invocation. New producer rules
-belong in `experiments/analysis.mk`; the root Makefile's `report/report.pdf`
-rule must depend only on files that either have no recipe in the writing-side
-makefiles or are produced by `$(MAKE) -C report` (i.e. tectonic itself).
+belong in `experiments/render.mk` (the P3 render phase); the root Makefile's
+`report/report.pdf` rule must depend only on files that either have no recipe
+in the writing-side makefiles or are produced by `$(MAKE) -C report` (i.e.
+tectonic itself).
 """
 
 import subprocess
@@ -36,7 +37,7 @@ def _assert_no_uv_run(trace: str, label: str) -> None:
     offending = [line for line in trace.splitlines() if "uv run" in line]
     assert not offending, (
         f"{label} must not invoke `uv run` (writing build = clean-room). "
-        "Move producer rules to experiments/analysis.mk.\n" + "\n".join(offending)
+        "Move producer rules to experiments/render.mk.\n" + "\n".join(offending)
     )
 
 

--- a/tests/test_slides_build_clean_room.py
+++ b/tests/test_slides_build_clean_room.py
@@ -6,7 +6,8 @@ data pipeline. This test guards that invariant.
 
 The check uses `make -n` (and a force-rebuild variant) on the slides target
 and asserts the recipe trace contains no `uv run` invocation. Producer rules
-belong in `experiments/analysis.mk`; the root Makefile's `slides/slides.pdf`
+belong in `experiments/render.mk` (the P3 render phase); the root Makefile's
+`slides/slides.pdf`
 rule must depend only on committed artifacts or targets produced by
 `$(MAKE) -C slides` (i.e. tectonic itself).
 """
@@ -36,7 +37,7 @@ def _assert_no_uv_run(trace: str, label: str) -> None:
     offending = [line for line in trace.splitlines() if "uv run" in line]
     assert not offending, (
         f"{label} must not invoke `uv run` (writing build = clean-room). "
-        "Move producer rules to experiments/analysis.mk.\n" + "\n".join(offending)
+        "Move producer rules to experiments/render.mk.\n" + "\n".join(offending)
     )
 
 

--- a/tickets/0406-build-one-mk-per-phase.erg
+++ b/tickets/0406-build-one-mk-per-phase.erg
@@ -10,6 +10,7 @@ Author: claude
 2026-06-04T08:55Z claude note Author decision: slides/inputs/generated/ is RETIRED — generated-tree unification is now IN scope, no longer optional-later. Inserted as new S1 (retire slides tree, single P3 deliverable home) so render.mk is written once against the final layout; old S1-S4 renumbered to S2-S5.
 2026-06-04T09:05Z claude note Author confirmed destination: report/inputs/generated/ is the single P3 tree. S1 child needs no layout decision — purely mechanical (move slides artifacts, repoint paths, update guards).
 2026-06-04T08:55Z claude note S1 done (PR #692): slides/inputs/generated retired; S2 (render.mk) unblocked.
+2026-06-04T09:44Z claude note S2 done (PR #694): render.mk extracted, cascade dead; S3 (score.mk) unblocked.
 --- body ---
 ## Context
 

--- a/tickets/closed/0409-extract-render-mk.erg
+++ b/tickets/closed/0409-extract-render-mk.erg
@@ -2,10 +2,12 @@
 Title: Extract experiments/render.mk — P3 rules out of analysis.mk (0406 S2)
 Created: 2026-06-04
 Author: claude
+Closed: render.mk extracted; figure builds can no longer regenerate the mart
 
 --- log ---
 2026-06-04T10:05Z claude created — S2 child of tracker 0406; S1 (0408, PR #692) landed, single P3 tree in place
 
+2026-06-04T09:43Z HDMX-coding-agent closed — render.mk extracted; figure builds can no longer regenerate the mart
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0409-extract-render-mk.erg
Tracker: tickets/0406-build-one-mk-per-phase.erg (S2 of 5 — do not close)

## What

Step S2 of tracker 0406. Split every P3 (render) rule out of
`experiments/analysis.mk` into a new `experiments/render.mk`, so a figure /
table / view build can never again regenerate the mart or cross-eval CSVs
(the 2026-06-03 cascade, ticket 0383).

- **`experiments/render.mk`** (P3 analyze & render): the "Tables and figures"
  section plus the `ANALYSIS_EXP2_MART_VIEWS` projection rule (views are
  render-time shaping, ratified P3). Opens with the header contract: phase,
  sources, outcomes, and the invariant "no rules for upstream (P1/P2)
  outcomes". P2 outcomes appear only as prerequisites, never as targets.
- **`experiments/analysis.mk`** (P2 score & consolidate): extraction stamps,
  cross-eval CSV, mart build, dual-run parity. Becomes `score.mk` in S3 — not
  renamed now.
- **`experiments/paths.mk`**: shared path variables (variables only, zero
  rules), `include`d by both phases.

## paths.mk variable ownership

**Shared (both phases → paths.mk):** `ANALYSIS_REPO_ROOT`,
`ANALYSIS_EXPERIMENTS_DIR`, `ANALYSIS_REPORT_DIR`, `ANALYSIS_GENERATED_DIR`,
`ANALYSIS_GEN`, `ANALYSIS_OUTPUTS_DIR`, `ANALYSIS_DERIVED_DIR`,
`ANALYSIS_EXP2_CROSS_EVAL_CSV`, `ANALYSIS_EXP1_CROSS_EVAL_CSV`,
`ANALYSIS_EXP2_MART_JSONL`, `ANALYSIS_EXP2_MART_VIEWS` (P2 outcome paths kept
here so the analysis.mk producer and the render.mk consumer agree; the
producing *rules* stay in their phase).

**P3-only → render.mk:** `ANALYSIS_MEASUREMENTS`, `ANALYSIS_REPORT_DERIVED_DIR`,
`ANALYSIS_VARIANCE_JSON`, the verification/decomp/converter/reference path
vars, `ANALYSIS_EXP1_BATCH2_RECORDS`, and all the EXP2 figure/table output
var defs.

**P2-only → analysis.mk:** arm-dir vars, the `*_JSONS`/`*_MDS`/`PROBE`
wildcards, `ANALYSIS_EXP1_INPUT_CSVS`.

## Cascade-death (the point of S2)

render.mk carries **no recipe** able to produce `exp2_mart.jsonl` or the
cross-eval CSVs — it consumes the committed P2 outcomes as sources. Two prereq
repoints were needed so it reads committed outcomes instead of P2 build stamps:
Exp1 spiders now depend on the committed `$(ANALYSIS_EXP1_CROSS_EVAL_CSV)` (was
the `exp1_cross_eval/.done` stamp); the 2x2 tables drop the four `arm*/.done`
stamp prereqs (the committed cross-eval CSV + committed arm flat `.json` cover
them).

Dual-run parity staging moved out of `report/inputs/generated/` into the
P2-owned `experiments/derived/parity/` (gitignored scratch) so **analysis.mk
writes nothing under the P3 handoff tree**.

## Dry-run evidence

```
$ make -f experiments/render.mk -n exp2-analysis-report report-tables \
      report-figures chart-figures exp1-analysis-figures \
  | grep -E 'build_exp2_mart |extract_|evaluate_|score_|worker|query_|--output.*exp2_mart.jsonl'
>>> NONE — cascade is dead <<<
```

The only mart reference in the trace is `build_exp2_mart_views --mart-jsonl
./experiments/derived/exp2_mart.jsonl` — the mart as a **source**, the P3
projection (`_views`) as the only producer. The standalone `build_exp2_mart`
mart builder, `extract_*`, `score_*` never appear.

## Verification

- New `tests/test_render_build_clean_room.py` (`@pytest.mark.adherence`) green;
  full `make check` green (1843 passed); `pytest -m adherence` 62 passed.
- `make report` (261 KiB PDF) and `make slides` (395 KiB PDF) still build;
  both `make -n` traces have zero `uv run` (clean-room preserved).
- `experiments/analysis.mk` has zero rule targets under
  `report/inputs/generated/` (verified by grep + the DAG test).
- `test_makefile_dag.py` now follows `include` so render.mk's `$(ANALYSIS_*)`
  targets (defined in paths.mk) still expand in the union.
- P3 phase line added to the 40 invoked module docstrings;
  `docs/pipeline-phases.md` P3 section now names render.mk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)