### PR TITLE
ticket(0410): carve experiments/derived/score.mk — P2 consolidated, P3 strays to render.mk (0406 S3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ show-prompts:
 #   3. Assembling record JSONs into measurements.jsonl (evaluate.py assemble)
 
 $(MEASUREMENTS): $(wildcard experiments/outputs/*/*.json) $(wildcard experiments/outputs/*/*.csv)
-	$(MAKE) -C experiments ../measurements.jsonl
+	$(MAKE) -f experiments/derived/score.mk measurements.jsonl
 
 .PHONY: measurements
 measurements: $(MEASUREMENTS)
@@ -84,7 +84,8 @@ experiments/models_selected.yaml: $(MEASUREMENTS) experiments/models.yaml
 # render (P3) workpackage. To regenerate:
 #     make -f experiments/render.mk report-tables
 # tab_self_consistency.tex and tab_per_run.tex come from
-# experiments/Makefile `self-consistency` (single producer, 0354).
+# experiments/render.mk `self-consistency` (single producer, 0354 →
+# migrated from experiments/Makefile by 0410).
 
 # --- Publications -------------------------------------------------------------
 
@@ -123,12 +124,12 @@ report: report/report.pdf
 slides: slides/slides.pdf
 # Report-side tables, figures, and slide chart data are produced by the
 # render (P3) workpackage (experiments/render.mk). tab_self_consistency.tex and
-# tab_per_run.tex live in experiments/Makefile under `self-consistency`
-# (single producer, 0354), so the `tables:` alias chains both to preserve the
-# pre-0352 UX.
+# tab_per_run.tex live in experiments/render.mk under `self-consistency`
+# (single producer, 0354 → migrated from experiments/Makefile by 0410), so the
+# `tables:` alias chains both to preserve the pre-0352 UX.
 tables:
 	$(MAKE) -f experiments/render.mk report-tables
-	$(MAKE) -C experiments self-consistency
+	$(MAKE) -f experiments/render.mk self-consistency
 figures:
 	$(MAKE) -f experiments/render.mk chart-figures
 select: experiments/models_selected.yaml

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -13,15 +13,15 @@ file is non-precious (regenerable) and is `.gitignore`d.
 | Phase | What it does | Outcome (TRACK) | Non-precious (IGNORE) |
 |-------|--------------|-----------------|-----------------------|
 | **P1 Acquire** | API runs against models (`experiments/Makefile`) | raw model replies: `experiments/outputs/**`, `experiments/archive/**` (incl. extracted `*.md` siblings of tracked `*.json`) | run logs, retries, jobs/, `rag_work/` |
-| **P2 Score & consolidate** | extract → evaluate → assemble (`experiments/Makefile`, mart build in `experiments/analysis.mk`) | `measurements.jsonl` (mart v0, transitional until 0297), `experiments/derived/exp2_mart.jsonl` | per-run `experiments/derived/**/*.record.json`, mart→view CSVs |
+| **P2 Score & consolidate** | extract → evaluate → assemble (all P2 verbs + the mart build in `experiments/derived/score.mk`, invoked from the repo root) | `measurements.jsonl` (mart v0, transitional until 0297), `experiments/derived/exp2_mart.jsonl` | per-run `experiments/derived/**/*.record.json`, mart→view CSVs |
 | **P3 Analyze & render** | plot/tabulate scripts (`experiments/render.mk`, including the mart→view projection) | figures/tables/macros the manuscript or slides include: `report/inputs/generated/` (the single P3 deliverable tree; the slides-side tree was retired, 0408) | plotting intermediates consumed only inside P3 (`census_bars.csv`, view CSVs, unconsumed figs; the report-dir `cost_quality.csv` is a P4 prereq → tracked) |
 | **P4 Write** | tectonic / pandoc (`report/Makefile`, `slides/Makefile`) | — (final PDFs are regenerable) | `report.pdf`, `slides.pdf`, LaTeX aux files |
 
 ## The classification test
 
 For any generated file, find its **producing rule** and its **consuming
-rule(s)** in the Makefile DAG (`Makefile`, `experiments/Makefile`,
-`experiments/analysis.mk` for P2, `experiments/render.mk` for P3,
+rule(s)** in the Makefile DAG (`Makefile`, `experiments/Makefile` for P1,
+`experiments/derived/score.mk` for P2, `experiments/render.mk` for P3,
 `experiments/paths.mk` for shared variables, `report/Makefile`,
 `slides/Makefile`):
 

--- a/experiments/Makefile
+++ b/experiments/Makefile
@@ -34,7 +34,9 @@ include common.mk
 # Targets in this list will fail fast with a readable message if .env is
 # missing. Keys themselves are not read into Make variables — uv loads them
 # at child-process spawn time via --env-file.
-_NEEDS_ENV := census census-run census-summary regimes regimes-run \
+# census-summary delegates to the P2 scorer (experiments/derived/score.mk), a
+# pure offline rebuild — no API keys — so it is NOT in this list (ticket 0410).
+_NEEDS_ENV := census census-run regimes regimes-run \
 						 sourced sourced-run frontier frontier-run
 ifneq ($(filter $(_NEEDS_ENV),$(MAKECMDGOALS)),)
   $(if $(wildcard ../.env),,$(error ../.env not found — copy ../.env.example and populate API keys))
@@ -61,7 +63,11 @@ census-generate:
 census-run:
 	$(OR_DRAIN); $(WORKER) padme --drain & wait
 
-census-summary: rebuild-measurements
+# Score & consolidate (P2) now lives in experiments/derived/score.mk, invoked
+# from the repo root. Delegate there (-C .. so cwd = repo root, which score.mk's
+# paths.mk-anchored paths assume).
+census-summary:
+	$(MAKE) -C .. -f experiments/derived/score.mk rebuild-measurements
 
 # --- Regimes: information regimes ---------------------------------------------
 
@@ -127,98 +133,16 @@ frontier-generate:
 frontier-run:
 	$(OR_DRAIN); wait
 
-# --- Rebuild measurements (materialized view of all outputs) -----------------
-
-EVAL      := $(UV_RUN) python -m aedist.evaluate
-REFERENCE := ../data/reference/vietnam_thermal_v1.csv
-
-STRUCTURED_DIRS := census multiturn web rag \
-                   decomposed decomposed_v2 sourced frontier \
-                   ablation/direct/p1_base ablation/direct/p1_base.topup \
-                   ablation/direct/p1_composite \
-                   exp1_batch2
-
-OUTPUT_FILES := $(filter-out %.record.json derived/rag_consistency/%,$(wildcard outputs/*/*.json) $(wildcard derived/*/*.json)) \
-				$(filter-out derived/rag_consistency/%,$(wildcard outputs/*/*.csv) $(wildcard derived/*/*.csv))
-
-# Extract structured outputs from LLM JSON responses into CSVs.
-.PHONY: extract
-extract:
-	@for dir in $(STRUCTURED_DIRS); do \
-	    $(UV_RUN) python -m aedist.extract \
-	        --input outputs/$$dir --output outputs/$$dir; \
-	done
-
-.PRECIOUS: outputs/%.record.json derived/%.record.json
-outputs/%.record.json: outputs/%.csv $(REFERENCE)
-	@$(EVAL) evaluate $< --reference $(REFERENCE) --output $(dir $<)
-derived/%.record.json: derived/%.csv $(REFERENCE)
-	@$(EVAL) evaluate $< --reference $(REFERENCE) --output $(dir $<)
-
-# Recursive Make: extract may create CSVs, so the second invocation must
-# re-scan to find them.  Orphan JSONs (qualitative, no CSV) need nullglob.
-../measurements.jsonl: $(OUTPUT_FILES)
-	@$(MAKE) --no-print-directory extract
-	@$(MAKE) --no-print-directory evaluate-all-records
-	@$(EVAL) assemble $$(find outputs derived -name '*.record.json' ! -path '*/_extracted/*' | sort) --output $@
-
-.PHONY: evaluate-all-records
-evaluate-all-records:
-	@$(MAKE) --no-print-directory -j$$(nproc) \
-	    $$(find outputs derived -name '*.csv' ! -name 'reconciliation_*' ! -name '*_audit.csv' ! -path '*/_extracted/*' | sed 's/\.csv$$/.record.json/')
-	@shopt -s nullglob; \
-	for f in outputs/*/*-run*.json outputs/*/*/*-run*.json derived/*/*-run*.json; do \
-	    [[ "$$f" == *.record.json ]] && continue; \
-	    [ -f "$${f%.json}.csv" ] && continue; \
-	    rec="$${f%.json}.record.json"; \
-	    [ -f "$$rec" ] && [ "$$rec" -nt "$$f" ] && continue; \
-	    $(EVAL) evaluate "$$f" --output "$$(dirname $$f)"; \
-	done
-
-.PHONY: rebuild-measurements
-rebuild-measurements:
-	find outputs derived -name '*.record.json' ! -path '*/_extracted/*' -delete
-	$(MAKE) --no-print-directory ../measurements.jsonl
-
-# --- Analysis: self-consistency -----------------------------------------------
-
-SC_INPUT  := outputs/rag
-SC_OUTPUT := derived/rag_consistency
-SC_JSON   := $(SC_OUTPUT)/self_consistency_summary.json
-SC_TEX    := ../report/inputs/generated/tab_self_consistency.tex
-SC_PERRUN := ../report/inputs/generated/tab_per_run.tex
-
-.PHONY: self-consistency
-
-$(SC_JSON): $(wildcard $(SC_INPUT)/*.json) ../src/aedist/self_consistency.py
-	$(UV_RUN) python -m aedist.self_consistency \
-	    --input $(SC_INPUT) --output $(SC_OUTPUT) --measurements ../measurements.jsonl
-
-$(SC_TEX) $(SC_PERRUN) &: ../measurements.jsonl ../src/aedist/tabulate_self_consistency.py
-	$(UV_RUN) python -m aedist.tabulate_self_consistency \
-	    --output $(SC_TEX) --per-run-output $(SC_PERRUN)
-
-self-consistency: $(SC_TEX) $(SC_PERRUN)
-
-# --- Experiment 1 cost summary ----------------------------------------------
-
-EXP1_COST_TEX := ../report/inputs/generated/tab_exp1_cost_summary.tex
-
-$(EXP1_COST_TEX): ../measurements.jsonl ../src/aedist/tabulate_exp1_cost_summary.py
-	$(UV_RUN) python -m aedist.tabulate_exp1_cost_summary \
-	    --measurements ../measurements.jsonl --output $(EXP1_COST_TEX)
-
-.PHONY: exp1-cost-summary
-exp1-cost-summary: $(EXP1_COST_TEX)
-
-EXP1_TOPUP_TEX := ../report/inputs/generated/tab_exp1_reasoning_topup.tex
-
-$(EXP1_TOPUP_TEX): ../measurements.jsonl ../src/aedist/tabulate_exp1_reasoning_topup.py
-	$(UV_RUN) python -m aedist.tabulate_exp1_reasoning_topup \
-	    --measurements ../measurements.jsonl --output $(EXP1_TOPUP_TEX)
-
-.PHONY: exp1-reasoning-topup
-exp1-reasoning-topup: $(EXP1_TOPUP_TEX)
+# --- Score & consolidate (P2) and render (P3) now live elsewhere -------------
+# extract / evaluate / measurements.jsonl / rebuild-measurements / the
+# self-consistency scorer (the P2 score & consolidate phase) moved to
+# experiments/derived/score.mk (tracker 0406 S3, ticket 0410). The
+# self-consistency / exp1-cost-summary / exp1-reasoning-topup LaTeX tables (the
+# P3 render half) moved to experiments/render.mk. Both are invoked from the
+# repo root:
+#     make -f experiments/derived/score.mk rebuild-measurements
+#     make -f experiments/render.mk self-consistency
+# This Makefile is now pure P1 acquire (sweeps) + corpus utilities.
 
 # --- Utility -----------------------------------------------------------------
 
@@ -316,8 +240,11 @@ help:
 	@echo "  make verification         Generate + run verification sweep"
 	@echo "  make sourced              Generate + run sourced extraction sweep"
 	@echo "  make frontier             Generate + run frontier deep-research (3 prompts)"
-	@echo "  make rebuild-measurements Extract + evaluate all outputs → measurements.jsonl"
-	@echo "  make self-consistency     Majority/union vote analysis + LaTeX tables"
+	@echo "  make census-summary       Score & consolidate all outputs → measurements.jsonl"
+	@echo ""
+	@echo "Score & render (run from repo root):"
+	@echo "  make -f experiments/derived/score.mk rebuild-measurements  Extract + evaluate → measurements.jsonl (P2)"
+	@echo "  make -f experiments/render.mk self-consistency             Majority/union vote LaTeX tables (P3)"
 	@echo ""
 	@echo "Tools:"
 	@echo "  make pdf2md PDF=file.pdf  Convert PDF to Markdown (for RAG corpus)"

--- a/experiments/derived/score.mk
+++ b/experiments/derived/score.mk
@@ -1,17 +1,139 @@
-# Exp2 analysis DAG — P2 (score & consolidate) build phase.
+# AEDIST P2 (score & consolidate) build phase.
 #
-# PHASE: P2 score & consolidate. This file extracts run outputs, scores them,
-# and assembles the canonical mart ($(ANALYSIS_EXP2_MART_JSONL)) and the
-# cross-eval CSVs. The P3 (render) phase that turns these outcomes into
-# figures/tables/macros lives in experiments/render.mk (ticket 0409, tracker
-# 0406 S2) — a figure build can no longer reach back into this scoring DAG.
+# PHASE: P2 score & consolidate. This file extracts run outputs, scores them
+# against the reference, and assembles the canonical outcomes: the mart v0
+# (measurements.jsonl), the consolidated Exp2 mart (exp2_mart.jsonl), and the
+# cross-eval CSVs. It lives in experiments/derived/ — next to the P2 derived
+# data it produces. The P3 (render) phase that turns these outcomes into
+# figures/tables/macros lives in experiments/render.mk (tracker 0406 S2); a
+# figure build can no longer reach back into this scoring DAG. The P1 (acquire)
+# sweeps that produce the raw model replies this file consumes live in
+# experiments/Makefile.
 #
-# Shared path variables come from experiments/paths.mk. Override the path
-# variables there to relocate the repository or point at alternate output
-# trees. (analysis.mk becomes score.mk in tracker 0406 step S3 — not renamed
-# yet.)
+# SOURCES (consumed, never produced here — they appear only as prerequisites,
+# and score.mk carries NO rule able to (re)acquire them):
+#   * experiments/outputs/**           (P1 raw model replies + flat arm dirs)
+#   * data/reference/vietnam_thermal_v1.csv  (expert reference)
+#
+# OUTCOMES (produced):
+#   * measurements.jsonl               (mart v0 — do NOT move or rename it,
+#                                        transitional until ticket 0297)
+#   * experiments/derived/exp2_mart.jsonl    (consolidated Exp2 mart)
+#   * experiments/derived/sota_cross_eval.csv, .../exp1_cross_eval.csv
+#                                            (per-run cross-eval CSVs)
+#   * experiments/derived/rag_consistency/self_consistency_summary.json
+#   * the *.record.json evaluation siblings under outputs/** and derived/**
+#     (P2 scoring artifacts, NOT re-acquired raw replies)
+#
+# INVARIANT: score.mk declares NO rule for an upstream (P1) outcome. It never
+#   fans out a worker/manager drain, runs a sweep, or calls an LLM adapter —
+#   the only way to (re)acquire raw replies is experiments/Makefile's P1 sweep
+#   verbs (which cost money). If a P1 source is missing, make MUST stop with
+#   "No rule to make target", never silently re-acquire. Guarded by
+#   tests/test_score_build_no_acquire.py.
+#
+# Path discipline: this file is invoked from the repo ROOT
+#   (`make -f experiments/derived/score.mk <verb>`), so cwd = repo root, NOT
+#   experiments/. Every path is anchored via the shared experiments/paths.mk
+#   variables ($(ANALYSIS_*)) — no fragile cwd-relative `outputs/` or
+#   `../measurements.jsonl`. Recursive `$(MAKE)` calls re-invoke THIS file by
+#   absolute self-path so the default makefile (root ./Makefile) is never hit.
+#
+# Tracker 0406 step S3 (ticket 0410) consolidated the former P2 score makefile
+# plus the P2 verbs from experiments/Makefile into this file.
 
-include $(dir $(lastword $(MAKEFILE_LIST)))paths.mk
+# Self-path for recursive $(MAKE): captured BEFORE the include extends
+# MAKEFILE_LIST, so it always points at this score.mk regardless of cwd.
+SCORE_MK_SELF := $(abspath $(lastword $(MAKEFILE_LIST)))
+
+include $(dir $(lastword $(MAKEFILE_LIST)))../paths.mk
+
+# --- P2-local tooling -------------------------------------------------------
+# Bare `uv run` (no --env-file): P2 scoring makes no API calls, so it needs no
+# secrets. This mirrors the former P2 score makefile's convention and keeps
+# the acquire-only ENV policy in experiments/common.mk.
+
+SCORE_EVAL      := uv run python -m aedist.evaluate
+SCORE_REFERENCE := $(ANALYSIS_REPO_ROOT)/data/reference/vietnam_thermal_v1.csv
+SCORE_SRC       := $(ANALYSIS_REPO_ROOT)/src/aedist
+SCORE_OUTPUTS   := $(ANALYSIS_OUTPUTS_DIR)
+SCORE_DERIVED   := $(ANALYSIS_DERIVED_DIR)
+
+# === measurements.jsonl: materialized view of all outputs ===================
+# (migrated from experiments/Makefile, tracker 0406 S3)
+
+SCORE_STRUCTURED_DIRS := census multiturn web rag \
+                   decomposed decomposed_v2 sourced frontier \
+                   ablation/direct/p1_base ablation/direct/p1_base.topup \
+                   ablation/direct/p1_composite \
+                   exp1_batch2
+
+SCORE_OUTPUT_FILES := $(filter-out %.record.json $(SCORE_DERIVED)/rag_consistency/%,\
+                   $(wildcard $(SCORE_OUTPUTS)/*/*.json) $(wildcard $(SCORE_DERIVED)/*/*.json)) \
+                $(filter-out $(SCORE_DERIVED)/rag_consistency/%,\
+                   $(wildcard $(SCORE_OUTPUTS)/*/*.csv) $(wildcard $(SCORE_DERIVED)/*/*.csv))
+
+# Extract structured outputs from LLM JSON responses into CSVs.
+.PHONY: extract
+extract:
+	@for dir in $(SCORE_STRUCTURED_DIRS); do \
+	    uv run python -m aedist.extract \
+	        --input $(SCORE_OUTPUTS)/$$dir --output $(SCORE_OUTPUTS)/$$dir; \
+	done
+
+.PRECIOUS: $(SCORE_OUTPUTS)/%.record.json $(SCORE_DERIVED)/%.record.json
+$(SCORE_OUTPUTS)/%.record.json: $(SCORE_OUTPUTS)/%.csv $(SCORE_REFERENCE)
+	@$(SCORE_EVAL) evaluate $< --reference $(SCORE_REFERENCE) --output $(dir $<)
+$(SCORE_DERIVED)/%.record.json: $(SCORE_DERIVED)/%.csv $(SCORE_REFERENCE)
+	@$(SCORE_EVAL) evaluate $< --reference $(SCORE_REFERENCE) --output $(dir $<)
+
+# Recursive Make: extract may create CSVs, so the second invocation must
+# re-scan to find them.  Orphan JSONs (qualitative, no CSV) need nullglob.
+# Recurse re-invokes THIS file by absolute self-path (cwd is repo root, so a
+# bare `$(MAKE) extract` would hit root ./Makefile and fail).
+$(ANALYSIS_MEASUREMENTS): $(SCORE_OUTPUT_FILES)
+	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) extract
+	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) evaluate-all-records
+	@$(SCORE_EVAL) assemble $$(find $(SCORE_OUTPUTS) $(SCORE_DERIVED) -name '*.record.json' ! -path '*/_extracted/*' | sort) --output $@
+
+.PHONY: evaluate-all-records
+evaluate-all-records:
+	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) -j$$(nproc) \
+	    $$(find $(SCORE_OUTPUTS) $(SCORE_DERIVED) -name '*.csv' ! -name 'reconciliation_*' ! -name '*_audit.csv' ! -path '*/_extracted/*' | sed 's/\.csv$$/.record.json/')
+	@shopt -s nullglob; \
+	for f in $(SCORE_OUTPUTS)/*/*-run*.json $(SCORE_OUTPUTS)/*/*/*-run*.json $(SCORE_DERIVED)/*/*-run*.json; do \
+	    [[ "$$f" == *.record.json ]] && continue; \
+	    [ -f "$${f%.json}.csv" ] && continue; \
+	    rec="$${f%.json}.record.json"; \
+	    [ -f "$$rec" ] && [ "$$rec" -nt "$$f" ] && continue; \
+	    $(SCORE_EVAL) evaluate "$$f" --output "$$(dirname $$f)"; \
+	done
+
+# rebuild-measurements is a DELIBERATE, REVIEWED destructive protocol (0383
+# mart-staleness lesson): it DELETES every committed *.record.json under
+# outputs/ and derived/, then re-evaluates from scratch. ALWAYS review the
+# resulting `git diff` on measurements.jsonl before committing — a silent
+# re-score with a changed scorer or a missing input would corrupt the mart.
+# Never run as a side effect; run it intentionally and inspect the diff.
+.PHONY: rebuild-measurements
+rebuild-measurements:
+	find $(SCORE_OUTPUTS) $(SCORE_DERIVED) -name '*.record.json' ! -path '*/_extracted/*' -delete
+	$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(ANALYSIS_MEASUREMENTS)
+
+# === Self-consistency scorer (outputs/rag → derived/rag_consistency) ========
+# (migrated from experiments/Makefile, tracker 0406 S3 — P2 score half only;
+#  the tabulate→report/inputs/generated/ render half is in render.mk.)
+
+SCORE_SC_INPUT  := $(SCORE_OUTPUTS)/rag
+SCORE_SC_OUTPUT := $(SCORE_DERIVED)/rag_consistency
+SCORE_SC_JSON   := $(SCORE_SC_OUTPUT)/self_consistency_summary.json
+
+$(SCORE_SC_JSON): $(wildcard $(SCORE_SC_INPUT)/*.json) $(SCORE_SRC)/self_consistency.py
+	uv run python -m aedist.self_consistency \
+	    --input $(SCORE_SC_INPUT) --output $(SCORE_SC_OUTPUT) --measurements $(ANALYSIS_MEASUREMENTS)
+
+# === Exp2 analysis DAG (consolidated into this P2 score makefile) ===========
+# extract → score → assemble the Exp2 mart and cross-eval CSVs.
 
 # --- P2-local input wildcards -----------------------------------------------
 
@@ -130,7 +252,7 @@ $(ANALYSIS_EXP2_MART_JSONL): $(ANALYSIS_DERIVED_DIR)/arm1_flat/.done \
 # --- Dual-run parity staging -------------------------------------------------
 # P2 mart-validation scratch. Staged under the P2-owned derived/ tree (NOT the
 # P3 handoff tree report/inputs/generated/) so this P2 file never writes a
-# render artifact — the analysis.mk/render.mk seam stays clean (ticket 0409).
+# render artifact — the score.mk/render.mk seam stays clean (ticket 0409).
 # Transient: untracked, consumed only by check-mart-parity below.
 
 ANALYSIS_EXP2_OLD_STAGE := $(ANALYSIS_DERIVED_DIR)/parity/exp2-old-path

--- a/experiments/paths.mk
+++ b/experiments/paths.mk
@@ -1,10 +1,18 @@
 # Shared path/variable definitions for the AEDIST analysis + render phases.
 #
 # VARIABLES ONLY — this file declares zero rules. It is included by both
-# experiments/analysis.mk (P2 score & consolidate) and experiments/render.mk
-# (P3 analyze & render) so the two phases agree on where the repository tree,
-# the derived data, and the P2 outcomes they share live. Override any path
-# below to relocate the repository or point at alternate output trees.
+# experiments/derived/score.mk (P2 score & consolidate) and
+# experiments/render.mk (P3 analyze & render) so the two phases agree on where
+# the repository tree, the derived data, and the P2 outcomes they share live.
+# Override any path below to relocate the repository or point at alternate
+# output trees.
+#
+# NOTE on include depth: score.mk lives one directory deeper
+# (experiments/derived/) so it includes this file as `../paths.mk`; render.mk
+# (a sibling) includes it as `paths.mk`. The path variables
+# below are resolved relative to $(ANALYSIS_REPO_ROOT) (default `.`, i.e. the
+# directory `make` runs in), NOT relative to this file — both phases are
+# invoked from the repo root via `make -f <phase>.mk`.
 #
 # Ownership: a variable lives here only if BOTH phases reference it. Variables
 # used by a single phase live in that phase's .mk (kept minimal here on
@@ -20,15 +28,20 @@ ANALYSIS_GEN ?= $(ANALYSIS_GENERATED_DIR)
 ANALYSIS_OUTPUTS_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/outputs
 ANALYSIS_DERIVED_DIR ?= $(ANALYSIS_EXPERIMENTS_DIR)/derived
 
-# Shared P2 outcome paths. analysis.mk owns the rules that PRODUCE these;
+# Shared P2 outcome paths. score.mk owns the rules that PRODUCE these;
 # render.mk references them only as prerequisites (sources). Defining the
 # paths here keeps the producer and the consumer in agreement.
 ANALYSIS_EXP2_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/sota_cross_eval.csv
 ANALYSIS_EXP1_CROSS_EVAL_CSV ?= $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval.csv
 ANALYSIS_EXP2_MART_JSONL := $(ANALYSIS_DERIVED_DIR)/exp2_mart.jsonl
 
+# measurements.jsonl is mart v0 (a P2 outcome, transitional until 0297). Its
+# rule lives in score.mk; render.mk consumes it as a source. Shared here
+# because both phases name it. Do NOT move or rename the file.
+ANALYSIS_MEASUREMENTS ?= $(ANALYSIS_REPO_ROOT)/measurements.jsonl
+
 # Mart → view CSV projections. The PRODUCING rule is P3 (render.mk); the
-# variable is shared because analysis.mk's dual-run parity staging still names
+# variable is shared because score.mk's dual-run parity staging still names
 # the same four view basenames for its left/right comparison.
 ANALYSIS_EXP2_MART_VIEWS := \
 	$(ANALYSIS_GEN)/tab_exp2_arms_runs_view.csv \

--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -21,12 +21,14 @@
 #   source is missing, make MUST stop with "No rule to make target" — it must
 #   never fall back to regenerating the mart or cross-eval CSVs (the
 #   2026-06-03 cascade, ticket 0383). Shared path variables come from
-#   experiments/paths.mk; analysis.mk (P2) owns the producing rules.
+#   experiments/paths.mk; experiments/derived/score.mk (P2) owns the producing
+#   rules.
 #
 # Regenerate (mart-staleness hazard 0383: prefer dry-run for DAG checks):
 #   make -f experiments/render.mk report-tables report-figures chart-figures
 #
-# Tracker 0406 step S2 (ticket 0409) extracted this file from analysis.mk.
+# Tracker 0406 step S2 (ticket 0409) extracted this file from the former P2
+# score makefile (since consolidated into experiments/derived/score.mk, S3).
 
 include $(dir $(lastword $(MAKEFILE_LIST)))paths.mk
 
@@ -61,7 +63,8 @@ ANALYSIS_EXP2_OUTLINE_ARTIFACTS := \
 	$(ANALYSIS_GEN)/tab_exp2_outline_hypothesis_status.tex
 
 # Report-side (measurements/mart-derived) P3 inputs and intermediates.
-ANALYSIS_MEASUREMENTS ?= $(ANALYSIS_REPO_ROOT)/measurements.jsonl
+# ANALYSIS_MEASUREMENTS is defined in paths.mk (shared P2 outcome, now produced
+# by score.mk and consumed here as a source).
 ANALYSIS_EXP1_BATCH2_RECORDS := $(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json)
 
 ANALYSIS_REPORT_DERIVED_DIR ?= $(ANALYSIS_REPO_ROOT)/derived
@@ -317,10 +320,48 @@ $(ANALYSIS_GEN)/tab_converter_benchmark.tex: $(ANALYSIS_CONVERTER_META) $(ANALYS
 	uv run python -m aedist.compare_converters \
 	    --input $(ANALYSIS_CONVERTER_TEST) --meta $(ANALYSIS_CONVERTER_META) --output $@
 
+# --- Self-consistency tables (render half; migrated from experiments/Makefile
+#     by ticket 0410, tracker 0406 S3) --------------------------------------
+# The P2 score half ($(SCORE_SC_JSON): outputs/rag → derived/rag_consistency)
+# lives in experiments/derived/score.mk. This render half tabulates the mart
+# into the committed LaTeX handoff artifacts. Reads only measurements.jsonl (a
+# P2 source) — writes nothing under a P2 outcome path.
+
+ANALYSIS_SC_TEX    := $(ANALYSIS_GEN)/tab_self_consistency.tex
+ANALYSIS_SC_PERRUN := $(ANALYSIS_GEN)/tab_per_run.tex
+
+$(ANALYSIS_SC_TEX) $(ANALYSIS_SC_PERRUN) &: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_self_consistency.py
+	uv run python -m aedist.tabulate_self_consistency \
+	    --output $(ANALYSIS_SC_TEX) --per-run-output $(ANALYSIS_SC_PERRUN)
+
+.PHONY: self-consistency
+self-consistency: $(ANALYSIS_SC_TEX) $(ANALYSIS_SC_PERRUN)
+
+# --- Experiment 1 cost summary (migrated from experiments/Makefile, 0410) ---
+
+ANALYSIS_EXP1_COST_TEX := $(ANALYSIS_GEN)/tab_exp1_cost_summary.tex
+
+$(ANALYSIS_EXP1_COST_TEX): $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_exp1_cost_summary.py
+	uv run python -m aedist.tabulate_exp1_cost_summary \
+	    --measurements $(ANALYSIS_MEASUREMENTS) --output $(ANALYSIS_EXP1_COST_TEX)
+
+.PHONY: exp1-cost-summary
+exp1-cost-summary: $(ANALYSIS_EXP1_COST_TEX)
+
+# --- Experiment 1 reasoning top-up (migrated from experiments/Makefile, 0410)
+
+ANALYSIS_EXP1_TOPUP_TEX := $(ANALYSIS_GEN)/tab_exp1_reasoning_topup.tex
+
+$(ANALYSIS_EXP1_TOPUP_TEX): $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_exp1_reasoning_topup.py
+	uv run python -m aedist.tabulate_exp1_reasoning_topup \
+	    --measurements $(ANALYSIS_MEASUREMENTS) --output $(ANALYSIS_EXP1_TOPUP_TEX)
+
+.PHONY: exp1-reasoning-topup
+exp1-reasoning-topup: $(ANALYSIS_EXP1_TOPUP_TEX)
+
 # Grouping targets — drive end-to-end regeneration of report-side handoff
 # artifacts. tab_self_consistency.tex and tab_per_run.tex are produced by the
-# experiments/Makefile self-consistency target (single producer, 0354) and
-# remain committed handoff artifacts without a rule here.
+# `self-consistency` verb above (single producer, 0354 → migrated here 0410).
 report-tables: \
 	$(ANALYSIS_GEN)/tab_census.tex \
 	$(ANALYSIS_GEN)/macros.tex \

--- a/src/aedist/build_exp2_mart.py
+++ b/src/aedist/build_exp2_mart.py
@@ -1,4 +1,7 @@
-"""Build the Exp2 mart JSONL artifact from immutable run outputs."""
+"""Build the Exp2 mart JSONL artifact from immutable run outputs.
+
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+"""
 
 import argparse
 import csv

--- a/src/aedist/check_exp2_mart_parity.py
+++ b/src/aedist/check_exp2_mart_parity.py
@@ -1,5 +1,7 @@
 """Compare legacy Exp2 CSV intermediates against mart-derived views.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Tolerance policy:
 - row counts must match exactly
 - column sets must match exactly
@@ -52,7 +54,9 @@ def _compare_csvs(left: Path, right: Path, key_fields: list[str], name: str) -> 
     right_rows = _load_csv(right)
 
     if len(left_rows) != len(right_rows):
-        return ParityResult(name, False, f"row-count mismatch: {len(left_rows)} != {len(right_rows)}")
+        return ParityResult(
+            name, False, f"row-count mismatch: {len(left_rows)} != {len(right_rows)}"
+        )
 
     if not left_rows and not right_rows:
         return ParityResult(name, True, "empty")
@@ -60,12 +64,16 @@ def _compare_csvs(left: Path, right: Path, key_fields: list[str], name: str) -> 
     left_fields = set(left_rows[0].keys())
     right_fields = set(right_rows[0].keys())
     if left_fields != right_fields:
-        return ParityResult(name, False, f"column-set mismatch: {sorted(left_fields)} != {sorted(right_fields)}")
+        return ParityResult(
+            name, False, f"column-set mismatch: {sorted(left_fields)} != {sorted(right_fields)}"
+        )
 
     left_rows = sorted(left_rows, key=lambda row: tuple(row[field] for field in key_fields))
     right_rows = sorted(right_rows, key=lambda row: tuple(row[field] for field in key_fields))
 
-    for index, (left_row, right_row) in enumerate(zip(left_rows, right_rows, strict=True), start=1):
+    for index, (left_row, right_row) in enumerate(
+        zip(left_rows, right_rows, strict=True), start=1
+    ):
         for field in left_fields:
             if not _compare_cells(left_row[field], right_row[field]):
                 return ParityResult(
@@ -79,7 +87,12 @@ def _compare_csvs(left: Path, right: Path, key_fields: list[str], name: str) -> 
 
 def check_parity(left_dir: Path, right_dir: Path) -> list[ParityResult]:
     specs = [
-        ("tab_exp2_arms_runs", "tab_exp2_arms_runs.csv", "tab_exp2_arms_runs_view.csv", ["agent", "arm", "model", "run"]),
+        (
+            "tab_exp2_arms_runs",
+            "tab_exp2_arms_runs.csv",
+            "tab_exp2_arms_runs_view.csv",
+            ["agent", "arm", "model", "run"],
+        ),
         (
             "tab_exp2_bib_quality",
             "tab_exp2_bib_quality.csv",
@@ -116,8 +129,12 @@ def check_parity(left_dir: Path, right_dir: Path) -> list[ParityResult]:
 
 def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    parser = argparse.ArgumentParser(description="Compare legacy Exp2 CSV intermediates against mart views")
-    parser.add_argument("--left-dir", required=True, help="Directory with legacy CSV intermediates")
+    parser = argparse.ArgumentParser(
+        description="Compare legacy Exp2 CSV intermediates against mart views"
+    )
+    parser.add_argument(
+        "--left-dir", required=True, help="Directory with legacy CSV intermediates"
+    )
     parser.add_argument("--right-dir", required=True, help="Directory with mart-derived view CSVs")
     args = parser.parse_args(argv)
 

--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -1,5 +1,7 @@
 """Command-line tools for the aedist benchmark.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Usage:
     aedist evaluate <system_file> [--reference <ref_csv>] [--output <dir>]
     aedist assemble <record_files>... --output <measurements.jsonl>
@@ -7,7 +9,7 @@ Usage:
 The ``evaluate`` command scores a single system output (CSV or qualitative
 JSON) against the reference and writes a ``.record.json`` RunRecord plus a
 reconciliation CSV.  Batch scheduling belongs in Make; see
-``experiments/Makefile`` for the pattern-rule orchestration.
+``experiments/derived/score.mk`` for the pattern-rule orchestration.
 
 The ``assemble`` command concatenates record JSON files into a single
 ``measurements.jsonl``.

--- a/src/aedist/export_exp2_turn_trajectory_csv.py
+++ b/src/aedist/export_exp2_turn_trajectory_csv.py
@@ -1,4 +1,7 @@
-"""Export the legacy Exp2 turn-trajectory CSV from raw probe artifacts."""
+"""Export the legacy Exp2 turn-trajectory CSV from raw probe artifacts.
+
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+"""
 
 import argparse
 import csv

--- a/src/aedist/extract.py
+++ b/src/aedist/extract.py
@@ -1,5 +1,7 @@
 """Extract CSV tables from LLM JSON responses.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Each JSON file contains raw assistant text which usually embeds a CSV inside
 Markdown code fences.  This script extracts that CSV, canonicalizes the
 columns, and writes a clean comma-delimited CSV so it can be evaluated.

--- a/src/aedist/extract_arm_multi_turn.py
+++ b/src/aedist/extract_arm_multi_turn.py
@@ -1,5 +1,7 @@
 """CLI module to extract multi-turn arm2 outputs into flat files.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Walks an input directory shaped like::
 
     sota_exp3_arm2_batch1/

--- a/src/aedist/extract_arm_single_turn.py
+++ b/src/aedist/extract_arm_single_turn.py
@@ -1,4 +1,7 @@
-"""Flatten single-turn arm outputs into Exp2-mart-compatible per-run artifacts."""
+"""Flatten single-turn arm outputs into Exp2-mart-compatible per-run artifacts.
+
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+"""
 
 import argparse
 import json

--- a/src/aedist/extract_exp2_bib.py
+++ b/src/aedist/extract_exp2_bib.py
@@ -1,5 +1,7 @@
 """Extract bibliography quality metrics from Exp2 markdown narratives.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Usage:
     python -m aedist.extract_exp2_bib \
         --naive-dir experiments/outputs/sota_exp2_naive_arm \

--- a/src/aedist/score_exp1.py
+++ b/src/aedist/score_exp1.py
@@ -1,5 +1,7 @@
 """Score Exp1 flat CSV outputs across quality axes.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Reads canonical CSV outputs from Exp1 batch runs, computes quality metrics
 using score_mechanical helpers, and appends one row per run to a cross-eval CSV.
 """

--- a/src/aedist/score_mechanical.py
+++ b/src/aedist/score_mechanical.py
@@ -1,5 +1,7 @@
 """Mechanical scoring helpers for Exp2 outputs.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Consumes canonical rows (from score_ingest), computes five scoring dimensions,
 and appends one row to experiments/derived/sota_cross_eval.csv.
 """

--- a/src/aedist/self_consistency.py
+++ b/src/aedist/self_consistency.py
@@ -1,5 +1,7 @@
 """Self-consistency evaluation for rag outputs.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 For each model with 3 runs, merge them by majority vote (plant kept if it
 appears in 2+ of 3 runs), evaluate the consolidated result, and compare
 against the single-run median F1.

--- a/src/aedist/tabulate_exp1_cost_summary.py
+++ b/src/aedist/tabulate_exp1_cost_summary.py
@@ -1,5 +1,7 @@
 """Generate Experiment 1 cost summary LaTeX table from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Per-model totals for the parametric baseline sweep
 (``experiments/outputs/ablation/direct/p1_base/``): how many reps succeeded,
 how many refused, how many tokens in / out the sweep cost, and total
@@ -29,7 +31,11 @@ P1_PILOT_MARKER = "/p1_base.pilot/"
 
 
 def _is_p1_base_row(result_file: str) -> bool:
-    return isinstance(result_file, str) and result_file.startswith(P1_BASE_PATH_PREFIX) and P1_PILOT_MARKER not in result_file
+    return (
+        isinstance(result_file, str)
+        and result_file.startswith(P1_BASE_PATH_PREFIX)
+        and P1_PILOT_MARKER not in result_file
+    )
 
 
 def aggregate_per_model(records: list[dict]) -> list[dict]:

--- a/src/aedist/tabulate_exp1_reasoning_topup.py
+++ b/src/aedist/tabulate_exp1_reasoning_topup.py
@@ -1,5 +1,7 @@
 """Generate Annex A reasoning-tokens + interday-variability table.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Joins two cohorts of Experiment 1 runs:
 - baseline: ``outputs/ablation/direct/p1_base/``  (2026-05-20, N=5)
 - topup:    ``outputs/ablation/direct/p1_base.topup/``  (2026-05-21, N≤3)

--- a/src/aedist/tabulate_exp2_arms_runs.py
+++ b/src/aedist/tabulate_exp2_arms_runs.py
@@ -1,5 +1,7 @@
 """Produce a flat per-run CSV for Exp2 naive vs optimised arms.
 
+Pipeline phase: P2 (score & consolidate) — invoked by experiments/derived/score.mk.
+
 Usage:
     python -m aedist.tabulate_exp2_arms_runs --output report/inputs/generated/tab_exp2_arms_runs.csv
 

--- a/src/aedist/tabulate_self_consistency.py
+++ b/src/aedist/tabulate_self_consistency.py
@@ -1,5 +1,7 @@
 """Generate self-consistency LaTeX table from measurements.jsonl.
 
+Pipeline phase: P3 (analyze & render) — invoked by experiments/render.mk.
+
 Usage:
     python -m aedist.tabulate_self_consistency \\
         --measurements measurements.jsonl \\

--- a/tests/test_make_slides_prereqs.py
+++ b/tests/test_make_slides_prereqs.py
@@ -5,7 +5,7 @@ The slides sub-make (`slides/Makefile`) consumes
 After ticket 0370, the writing build is clean-room: no producing recipe
 exists in the writing-side Makefiles. The file must be a committed handoff
 artifact. The producer rule lives in `experiments/render.mk` (the P3 render
-phase, extracted from analysis.mk by ticket 0409).
+phase, split out by ticket 0409).
 
 This is the adherence companion to tickets 0367 and 0370.
 """

--- a/tests/test_makefile_dag.py
+++ b/tests/test_makefile_dag.py
@@ -9,8 +9,9 @@ The build is split into two workpackages (see slides/Makefile header):
                  PDFs from those artifacts treated as committed inputs.
 
 A producing rule may therefore live in *any* of the makefiles. This test
-takes the UNION of all makefiles, expands variables (analysis.mk names its
-targets through $(ANALYSIS_*) variables, so a literal scan misses them), and
+takes the UNION of all makefiles, expands variables (score.mk and render.mk
+name their targets through $(ANALYSIS_*) variables, so a literal scan misses
+them), and
 asserts that every generated .pdf/.tex used as a prerequisite is the target
 of some rule somewhere in that union. Grouped targets (`a b &:`) count as
 producers of each member.
@@ -178,6 +179,6 @@ def test_generated_artifacts_have_a_producer():
         "rule (orphaned from the build DAG):\n"
         f"{detail}\n\n"
         "Add a producing rule (in experiments/render.mk for P3 render "
-        "artifacts, experiments/analysis.mk for P2 mart/cross-eval) or, for "
-        "multi-output scripts, a grouped target `a b &:`."
+        "artifacts, experiments/derived/score.mk for P2 mart/cross-eval) or, "
+        "for multi-output scripts, a grouped target `a b &:`."
     )

--- a/tests/test_render_build_clean_room.py
+++ b/tests/test_render_build_clean_room.py
@@ -1,9 +1,10 @@
 """`experiments/render.mk` is the P3 (render) phase — it never regenerates P2.
 
-Ticket 0409 (tracker 0406, step S2) split every render rule out of
-`experiments/analysis.mk` into `experiments/render.mk`, so a figure/table/view
-build can no longer trigger the scoring/extraction cascade that produced the
-2026-06-03 mart staleness incident (ticket 0383).
+Ticket 0409 (tracker 0406, step S2) split every render rule out of the P2
+score makefile into `experiments/render.mk`, so a figure/table/view build can
+no longer trigger the scoring/extraction cascade that produced the 2026-06-03
+mart staleness incident (ticket 0383). The P2 score makefile was itself
+consolidated into `experiments/derived/score.mk` by S3 (ticket 0410).
 
 render.mk consumes committed P2 outcomes (``measurements.jsonl``,
 ``experiments/derived/exp2_mart.jsonl``, the cross-eval CSVs,
@@ -88,8 +89,8 @@ def _dry_run(target: str) -> str:
 
 def test_render_mk_exists():
     assert RENDER_MK.is_file(), (
-        "experiments/render.mk must exist (P3 render rules extracted from "
-        "analysis.mk by ticket 0409)."
+        "experiments/render.mk must exist (P3 render rules extracted from the "
+        "P2 score makefile by ticket 0409)."
     )
 
 
@@ -118,13 +119,14 @@ def test_render_mk_has_no_p2_outcome_targets():
     offending = [ln for ln in rule_lines if P2_OUTCOME_TARGET_RE.search(ln + "\n")]
     assert not offending, (
         "render.mk declares a rule whose target is a P2 outcome (mart / "
-        "cross-eval / experiments outputs). Those rules belong in analysis.mk; "
-        "render.mk references them only as prerequisites.\n" + "\n".join(offending)
+        "cross-eval / experiments outputs). Those rules belong in "
+        "experiments/derived/score.mk; render.mk references them only as "
+        "prerequisites.\n" + "\n".join(offending)
     )
 
 
 def test_render_mk_views_rule_is_present():
-    """The mart→view projection (P3) lives in render.mk, not analysis.mk."""
+    """The mart→view projection (P3) lives in render.mk, not the P2 score makefile."""
     text = RENDER_MK.read_text()
     assert "build_exp2_mart_views" in text, (
         "render.mk must carry the ANALYSIS_EXP2_MART_VIEWS projection rule "

--- a/tests/test_score_build_no_acquire.py
+++ b/tests/test_score_build_no_acquire.py
@@ -1,0 +1,153 @@
+"""`experiments/derived/score.mk` is the P2 (score & consolidate) phase.
+
+Ticket 0410 (tracker 0406, step S3) consolidated all P2 scoring/extraction
+into `experiments/derived/score.mk` (folding in the former P2 score makefile
+and pulling the P2 verbs out of `experiments/Makefile`), leaving the P3 strays
+in `experiments/render.mk`. score.mk is the *consumer* of P1 outcomes
+(`experiments/outputs/**`, the raw model replies) and the *producer* of the P2
+outcomes (`measurements.jsonl`, `exp2_mart.jsonl`, the cross-eval CSVs).
+
+The invariant this guard enforces is the OTHER seam: score.mk must never reach
+DOWN into P1 (acquire). A P2 scoring/extraction dry-run must not fan out
+manager/worker drains, run a sweep, or call an LLM adapter — the only way to
+(re)acquire raw replies is `experiments/Makefile`'s P1 sweep verbs, which cost
+money and rewrite `experiments/outputs/**`. score.mk reads those outputs as
+committed sources; it carries no rule able to rebuild them.
+
+Mirrors the structure of ``tests/test_render_build_clean_room.py`` (S2's guard
+for the P2↔P3 seam) but inverts the forbidden set: render forbids P2 verbs
+because render is P3; score.mk *is* P2 and legitimately calls
+``aedist.extract``, ``aedist.evaluate``, ``aedist.score_exp1``,
+``aedist.score_mechanical`` etc. — so the forbidden needles here are the
+ACQUIRE-side scripts only (worker, manager, run_sweep, census/regimes drains,
+``query_`` adapters).
+
+CAUTION (0383 mart staleness): these verbs must NEVER be run for real — a real
+``rebuild-measurements`` destroys every ``.record.json`` and rewrites the
+committed mart. This test uses ``make -n`` (dry-run) exclusively. The .PHONY
+verbs wrap ``$(MAKE) -f $(THIS_MK) ...``; recursive make propagates ``-n`` to
+the inner invocation, so the trace stays a dry-run end to end.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCORE_MK = REPO_ROOT / "experiments" / "derived" / "score.mk"
+
+# P2 verbs that drive the full score surface. Dry-running each must not reach
+# down into P1 acquire.
+P2_VERBS = (
+    "extract",
+    "evaluate-all-records",
+    "measurements.jsonl",
+    "rebuild-measurements",
+)
+
+# Substrings in a recipe line that prove a P1 ACQUIRE step ran: manager/worker
+# drains, sweep dispatch, the census/regimes/etc. sweep modules, or an LLM
+# query adapter. score.mk (P2) must never invoke any of these.
+FORBIDDEN_RECIPE_NEEDLES = (
+    "aedist.worker",
+    "aedist.manager",
+    "aedist.run_sweep",
+    "aedist.query_",
+    "OR_DRAIN",
+    "--drain",
+    "--sweep",
+    "census-run",
+    "census-generate",
+    "regimes-run",
+    "sourced-run",
+    "frontier-run",
+)
+
+# A rule whose TARGET is a path under experiments/outputs/ would mean score.mk
+# claims it can rebuild a P1 raw reply (re-acquisition). The P2 pattern rules
+# write ``*.record.json`` SIBLINGS next to those replies — a legitimate P2
+# evaluation artifact, not a re-acquisition — so .record.json targets are
+# exempt. Targets are written through path variables ($(SCORE_OUTPUTS), the
+# shared $(ANALYSIS_OUTPUTS_DIR)) or as literal experiments/outputs/ paths;
+# match all three forms. (Mirrors render's
+# test_render_mk_has_no_p2_outcome_targets — a SOURCE scan of rule-target
+# lines, not a recipe-write trace, which is the ticket's wording: "no TARGET
+# under experiments/outputs/".)
+OUTPUTS_TARGET_RE = re.compile(
+    r"\$\(SCORE_OUTPUTS\)/\S+"
+    r"|\$\(ANALYSIS_OUTPUTS_DIR\)/\S+"
+    r"|(?:experiments/)?outputs/\S+"
+)
+
+
+def _dry_run(target: str) -> str:
+    # -B forces every prerequisite stale so file targets (measurements.jsonl)
+    # expand their full recipe — otherwise an up-to-date mart yields an empty
+    # "est à jour" trace and the scan runs over nothing (a vacuous pass), and
+    # measurements.jsonl is the verb most likely to pull in scoring. -n keeps
+    # it a dry-run; -Bn descends the recursive sub-makes but executes nothing
+    # (0383 mart-staleness: NEVER run these verbs for real).
+    result = subprocess.run(
+        ["make", "-f", str(SCORE_MK), "-Bn", target],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return result.stdout
+
+
+def test_score_mk_exists():
+    assert SCORE_MK.is_file(), (
+        "experiments/derived/score.mk must exist (P2 score rules consolidated "
+        "from the former P2 score makefile + experiments/Makefile by ticket "
+        "0410, tracker 0406 step S3)."
+    )
+
+
+@pytest.mark.parametrize("target", P2_VERBS)
+def test_p2_verb_does_not_invoke_acquire(target):
+    trace = _dry_run(target)
+    offending = [
+        line
+        for line in trace.splitlines()
+        if any(needle in line for needle in FORBIDDEN_RECIPE_NEEDLES)
+    ]
+    assert not offending, (
+        f"`make -f experiments/derived/score.mk -n {target}` invokes a P1 "
+        "acquire step (worker/manager/sweep/query). score.mk (P2) consumes "
+        "experiments/outputs/** as committed sources only — re-acquisition "
+        "lives in experiments/Makefile.\n" + "\n".join(offending)
+    )
+
+
+def test_score_mk_has_no_outputs_rule_target():
+    """score.mk may name `experiments/outputs/` paths only as prerequisites.
+
+    A rule whose TARGET is under outputs/ would claim score.mk can re-acquire a
+    P1 raw reply. The only legitimate outputs/ targets are the `.record.json`
+    evaluation siblings (P2 scoring artifacts) — those are exempt. This is a
+    SOURCE scan of the makefile's rule-target lines (the ticket's wording: "no
+    TARGET under experiments/outputs/"), mirroring render's
+    test_render_mk_has_no_p2_outcome_targets.
+    """
+    text = SCORE_MK.read_text()
+    offending = []
+    for ln in text.splitlines():
+        if ln.startswith("\t") or ":" not in ln:
+            continue  # recipe line or non-rule
+        lhs = ln.split(":", 1)[0]
+        for m in OUTPUTS_TARGET_RE.finditer(lhs):
+            if m.group(0).endswith(".record.json"):
+                continue  # P2 evaluation sibling — legitimate
+            offending.append(ln.rstrip())
+    assert not offending, (
+        "score.mk declares a rule whose TARGET is an experiments/outputs/ path "
+        "other than a `.record.json` sibling — that is P1 territory (raw "
+        "replies). score.mk produces P2 outcomes only (measurements.jsonl, "
+        "derived/**) and reads outputs/ as committed sources.\n" + "\n".join(offending)
+    )

--- a/tickets/0406-build-one-mk-per-phase.erg
+++ b/tickets/0406-build-one-mk-per-phase.erg
@@ -11,6 +11,7 @@ Author: claude
 2026-06-04T09:05Z claude note Author confirmed destination: report/inputs/generated/ is the single P3 tree. S1 child needs no layout decision — purely mechanical (move slides artifacts, repoint paths, update guards).
 2026-06-04T08:55Z claude note S1 done (PR #692): slides/inputs/generated retired; S2 (render.mk) unblocked.
 2026-06-04T09:44Z claude note S2 done (PR #694): render.mk extracted, cascade dead; S3 (score.mk) unblocked.
+2026-06-04T10:36Z claude note S3 done (PR #696): score.mk carved, analysis.mk dissolved, P3 strays relocated; S4 (acquire.mk) unblocked.
 --- body ---
 ## Context
 

--- a/tickets/closed/0410-carve-score-mk.erg
+++ b/tickets/closed/0410-carve-score-mk.erg
@@ -2,10 +2,12 @@
 Title: Carve experiments/derived/score.mk — P2 consolidated, P3 strays to render.mk (0406 S3)
 Created: 2026-06-04
 Author: claude
+Closed: score.mk carved; experiments/Makefile is pure P1; P3 strays in render.mk
 
 --- log ---
 2026-06-04T10:50Z claude created — S3 child of tracker 0406; S2 (0409, PR #694) landed: render.mk exists, analysis.mk is P2-only
 
+2026-06-04T10:36Z HDMX-coding-agent closed — score.mk carved; experiments/Makefile is pure P1; P3 strays in render.mk
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0410-carve-score-mk.erg
Tracker: tickets/0406-build-one-mk-per-phase.erg (S3 of 5 — do not close)

## What this does

Tracker 0406 step S3. Consolidates all P2 (score & consolidate) build rules into a single makefile, `experiments/derived/score.mk` (it lives next to the P2 derived data it produces), and relocates the three P3 stray rule groups from `experiments/Makefile` into `experiments/render.mk`. After this step `experiments/Makefile` is pure P1 acquire (sweeps) + corpus utilities — ready for S4 (acquire.mk).

## Classification evidence (what went where)

**Into `experiments/derived/score.mk` (P2):**
- All of the former `experiments/analysis.mk` (Exp2 extraction stamps, cross-eval CSV, mart rule, dual-run parity staging) — file then deleted.
- From `experiments/Makefile`: `extract`; the `outputs/%.record.json` / `derived/%.record.json` pattern rules + `.PRECIOUS`; the `measurements.jsonl` rule; `evaluate-all-records`; `rebuild-measurements`; the `$(SC_JSON)` self-consistency scorer (`outputs/rag → derived/rag_consistency`).

**Into `experiments/render.mk` (P3 — three former strays):**
- `$(SC_TEX) $(SC_PERRUN)` grouped rule + `self-consistency` verb (tabulate → `report/inputs/generated/`).
- `exp1-cost-summary` + `$(EXP1_COST_TEX)`.
- `exp1-reasoning-topup` + `$(EXP1_TOPUP_TEX)`.

**Stays in `experiments/Makefile` (P1 + utils):** census/regimes/decomposed/verification/sourced/frontier sweeps; pdf2md/build-corpus/preflight/help; Zotero/corpus config.

## Path-anchoring decisions

score.mk is invoked from the repo **root** (`make -f experiments/derived/score.mk <verb>`), so every path anchors via the shared `experiments/paths.mk` `$(ANALYSIS_*)` variables — no fragile cwd-relative paths:
- Bare `uv run` (not `$(UV_RUN) = uv run --project .. --env-file ../.env`): P2 scoring makes **no** API calls, so it needs no `.env`. Follows the dissolved analysis.mk convention.
- `outputs/` → `$(ANALYSIS_OUTPUTS_DIR)`, `derived/` → `$(ANALYSIS_DERIVED_DIR)`, `../measurements.jsonl` → `$(ANALYSIS_MEASUREMENTS)` (moved into paths.mk — now shared by both phases), `../data/reference/...` → `$(ANALYSIS_REPO_ROOT)/...`.
- **Recursive `$(MAKE)`** re-invokes the file by absolute self-path: `SCORE_MK_SELF := $(abspath $(lastword $(MAKEFILE_LIST)))` captured **before** the include, so a bare `$(MAKE) extract` never falls through to root `./Makefile`.
- paths.mk include resolved as `../paths.mk` (score.mk is one directory deeper than render.mk).

Repointed delegations: root Makefile `$(MEASUREMENTS)` → score.mk; `tables` alias `self-consistency` → render.mk; `experiments/Makefile census-summary` delegates to score.mk from repo root (`-C ..`) and is dropped from `_NEEDS_ENV` (offline rebuild, no keys).

## Dry-run proof (NEVER run for real — 0383 mart staleness)

```
$ make -f experiments/derived/score.mk -n rebuild-measurements
find ./experiments/outputs ./experiments/derived -name '*.record.json' ! -path '*/_extracted/*' -delete
/usr/bin/make --no-print-directory -f <abs>/experiments/derived/score.mk ./measurements.jsonl

$ make -f experiments/derived/score.mk -Bn measurements.jsonl   # forced, full recipe
... uv run python -m aedist.extract --input ./experiments/outputs/$dir --output ./experiments/outputs/$dir
... uv run python -m aedist.evaluate evaluate experiments/outputs/exp1_batch2/...csv --reference ./data/reference/vietnam_thermal_v1.csv --output experiments/outputs/exp1_batch2/
```
Paths anchor to `./experiments/...` / `./data/...`, bare `uv run`, zero worker/manager/sweep/query invocations.

## Verification gates (all green)

- New guard `tests/test_score_build_no_acquire.py` (`@adherence`) + `test_render_build_clean_room` + `test_makefile_dag` + both P4 clean-room tests + `test_no_tracked_ignored_files` — **68 adherence pass**.
- `grep -rn "analysis.mk" --include="*.mk" --include="Makefile" --include="*.py" --include="*.yml" --include="*.yaml"` → **zero hits** (only historical mentions remain in docs/tickets).
- `make check` green; `make report` and `make slides` build; no committed data artifacts (measurements.jsonl, CSVs, record.json) changed.

## Reviewer note (for S4)

`census-summary` is the one P2-touching verb left in `experiments/Makefile` — it now delegates to score.mk (documented alias, kept for UX). The "pure P1" enumeration (pdf2md/build-corpus/preflight/help) omits it; S4 (acquire.mk) can decide whether to drop the alias or relocate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
