### PR TITLE
ticket(0411): experiments/Makefile → acquire.mk, pure P1 all-.PHONY guarded (0406 S4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 MEASUREMENTS := measurements.jsonl
 GEN          := report/inputs/generated
 
-.PHONY: test test-fast test-slow coverage lint check-fast check census census-summary show-prompts
+.PHONY: test test-fast test-slow coverage lint check-fast check census show-prompts
 
 # --- Tests --------------------------------------------------------------------
 
@@ -85,7 +85,7 @@ experiments/models_selected.yaml: $(MEASUREMENTS) experiments/models.yaml
 #     make -f experiments/render.mk report-tables
 # tab_self_consistency.tex and tab_per_run.tex come from
 # experiments/render.mk `self-consistency` (single producer, 0354 →
-# migrated from experiments/Makefile by 0410).
+# migrated from the P1 makefile, now experiments/acquire.mk, by 0410).
 
 # --- Publications -------------------------------------------------------------
 
@@ -125,13 +125,20 @@ slides: slides/slides.pdf
 # Report-side tables, figures, and slide chart data are produced by the
 # render (P3) workpackage (experiments/render.mk). tab_self_consistency.tex and
 # tab_per_run.tex live in experiments/render.mk under `self-consistency`
-# (single producer, 0354 → migrated from experiments/Makefile by 0410), so the
-# `tables:` alias chains both to preserve the pre-0352 UX.
+# (single producer, 0354 → migrated from the P1 makefile, now
+# experiments/acquire.mk, by 0410), so the `tables:` alias chains both to
+# preserve the pre-0352 UX.
 tables:
 	$(MAKE) -f experiments/render.mk report-tables
 	$(MAKE) -f experiments/render.mk self-consistency
 figures:
 	$(MAKE) -f experiments/render.mk chart-figures
 select: experiments/models_selected.yaml
+# P1 acquire (money-gated sweeps) lives in experiments/acquire.mk (0411). Use
+# -C experiments so the sweep recipes inherit cwd=experiments/ — the env
+# contract (../.env, UV_RUN's --env-file ../.env), experiments.toml, and the
+# jobs/ board are all resolved relative to experiments/. `-f acquire.mk` then
+# resolves against that cwd. A bare `-f experiments/acquire.mk` from repo root
+# would break every one of those relative paths.
 census:
-	$(MAKE) -C experiments census
+	$(MAKE) -C experiments -f acquire.mk census

--- a/PLAN.md
+++ b/PLAN.md
@@ -85,8 +85,8 @@ heuristics or keyword lists needed.
      - JSON with multiturn format, no table → status="refusal"
 
 4. **Rebuild measurements**
-   - `make -C experiments rebuild-measurements` to regenerate all
-     `.record.json` and `measurements.jsonl`.
+   - `make -f experiments/derived/score.mk rebuild-measurements` (from the repo
+     root) to regenerate all `.record.json` and `measurements.jsonl`.
    - Expected outcome: 27 former "qualitative" records become "ok"
      (they now have CSVs), ~5 become "refusal", ~6 become "error",
      0 remain "qualitative".

--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ make report            # Build report/report.pdf
 make slides            # Build slides/slides.pdf
 make tables            # Generate LaTeX tables from experiment results
 
-# Experiments (from experiments/ directory):
-cd experiments
-make -j8 census        # Census: all models × 3 runs (parallel)
-make rebuild-measurements  # Extract → evaluate all outputs → measurements.jsonl
+# Experiments (from the repo root):
+make census            # P1 acquire: census sweep, all models (delegates to experiments/acquire.mk)
+make -f experiments/derived/score.mk rebuild-measurements  # P2: extract → evaluate all outputs → measurements.jsonl
 ```
 
 ## License

--- a/data/README.md
+++ b/data/README.md
@@ -57,5 +57,5 @@ reports, and government studies/decisions. Each file contains markdown
 tables preserving the original document structure.
 
 Referenced by `experiments/experiments.toml` (`sweeps.rag.corpus`) and
-`experiments/Makefile` (`CORPUS_OUTPUT`). To rebuild the corpus, run
-`make build-corpus` from `experiments/`.
+`experiments/acquire.mk` (`CORPUS_OUTPUT`). To rebuild the corpus, run
+`make -f acquire.mk build-corpus` from `experiments/`.

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -12,7 +12,7 @@ file is non-precious (regenerable) and is `.gitignore`d.
 
 | Phase | What it does | Outcome (TRACK) | Non-precious (IGNORE) |
 |-------|--------------|-----------------|-----------------------|
-| **P1 Acquire** | API runs against models (`experiments/Makefile`) | raw model replies: `experiments/outputs/**`, `experiments/archive/**` (incl. extracted `*.md` siblings of tracked `*.json`) | run logs, retries, jobs/, `rag_work/` |
+| **P1 Acquire** | API runs against models (`experiments/acquire.mk`) | raw model replies: `experiments/outputs/**`, `experiments/archive/**` (incl. extracted `*.md` siblings of tracked `*.json`) | run logs, retries, jobs/, `rag_work/` |
 | **P2 Score & consolidate** | extract → evaluate → assemble (all P2 verbs + the mart build in `experiments/derived/score.mk`, invoked from the repo root) | `measurements.jsonl` (mart v0, transitional until 0297), `experiments/derived/exp2_mart.jsonl` | per-run `experiments/derived/**/*.record.json`, mart→view CSVs |
 | **P3 Analyze & render** | plot/tabulate scripts (`experiments/render.mk`, including the mart→view projection) | figures/tables/macros the manuscript or slides include: `report/inputs/generated/` (the single P3 deliverable tree; the slides-side tree was retired, 0408) | plotting intermediates consumed only inside P3 (`census_bars.csv`, view CSVs, unconsumed figs; the report-dir `cost_quality.csv` is a P4 prereq → tracked) |
 | **P4 Write** | tectonic / pandoc (`report/Makefile`, `slides/Makefile`) | — (final PDFs are regenerable) | `report.pdf`, `slides.pdf`, LaTeX aux files |
@@ -20,7 +20,7 @@ file is non-precious (regenerable) and is `.gitignore`d.
 ## The classification test
 
 For any generated file, find its **producing rule** and its **consuming
-rule(s)** in the Makefile DAG (`Makefile`, `experiments/Makefile` for P1,
+rule(s)** in the Makefile DAG (`Makefile`, `experiments/acquire.mk` for P1,
 `experiments/derived/score.mk` for P2, `experiments/render.mk` for P3,
 `experiments/paths.mk` for shared variables, `report/Makefile`,
 `slides/Makefile`):

--- a/experiments/acquire.mk
+++ b/experiments/acquire.mk
@@ -1,17 +1,42 @@
-# aedist/Makefile — Reproducible experiment pipeline
+# experiments/acquire.mk — P1 ACQUIRE phase (tracker 0406, step S4 / ticket 0411)
+#
+# Phase:    P1 acquire. Run API sweeps against models; (re)acquire raw replies.
+# Sources:  experiments.toml ([sweeps.*] sections), the RAG corpus, models.yaml.
+# Outcomes: raw model replies under experiments/outputs/**, experiments/archive/**
+#           (tracked by the 0405 policy). The worker pipeline writes these; they
+#           are NOT make file targets.
+# Invariant: EVERY target is .PHONY. P1 produces no file a downstream phase may
+#           depend on — nothing in score.mk (P2) or render.mk (P3) may depend on
+#           a P1 target as a file, or an ordinary timestamp rebuild could trigger
+#           a money-costing re-acquisition. Enforced by
+#           tests/test_acquire_all_phony.py.
+#
+# MONEY GATE: the sweep verbs below (census, regimes, decomposed, verification,
+#   sourced, frontier) make real, paid OpenRouter API calls. NEVER run them on a
+#   hunch. Test one before blasting: dry-run
+#   (`make -C experiments -f acquire.mk -n census`) to inspect prompt assembly,
+#   then one real call per regime, inspect tokens/cost/quality, then launch the
+#   full batch. (The `-C experiments` is mandatory — the env contract resolves
+#   ../.env / experiments.toml / jobs/ relative to experiments/; a bare
+#   `-f experiments/acquire.mk` from repo root trips the .env sentinel.)
 #
 # Sweep configs live in [sweeps.*] sections of experiments.toml.
 # Job dispatch is handled by the manager + worker pipeline:
 #   1. `make census-generate`  — fan out sweep config into per-model jobs
 #   2. `make census-run`       — start workers to execute the jobs
-#   3. `make census-summary`   — extract → evaluate → summarize
 #
 # Or simply: `make census` to generate + run in one step.
+# Score & consolidate (P2) is a separate phase — see experiments/derived/score.mk.
+#
+# Invocation: per-phase .mks are the dev path. From the repo root, preserve the
+# experiments/ cwd (the env/relative-path contract: ../.env, experiments.toml,
+# jobs/) with `make -C experiments -f acquire.mk <sweep>`. After this rename,
+# `make -C experiments` finds no default Makefile — that is intended.
 #
 # Adding a model to models.yaml → re-run generate (idempotent) + run.
 #
 # --- ENV POLICY ---------------------------------------------------------------
-# All API keys live in the PROJECT .env (../.env relative to this Makefile),
+# All API keys live in the PROJECT .env (../.env relative to acquire.mk),
 # not in ~/.claude/.env. Decision 2026-04-30:
 #   - Project .env is the single source of truth for OPENROUTER_API_KEY,
 #     TAVILY_API_KEY, HF_TOKEN, ZENODO_TOKEN, HAL_*, etc.
@@ -24,18 +49,19 @@
 #     because doing so leaked all keys via `ps -ef`.
 # Loading mechanism: every `uv run` goes through $(UV_RUN), which uses
 # `--env-file ../.env` so uv populates the env from the file directly.
-# Do NOT `export KEY := $(shell grep ...)` from the Makefile — that puts
+# Do NOT `export KEY := $(shell grep ...)` from acquire.mk — that puts
 # values onto Make's command line and on into spawned process arguments,
 # the same leak path we just closed.
 
-include common.mk
+# cwd-independent include: resolve common.mk relative to THIS makefile, not the
+# caller's cwd, so the clean-room gate (`make -f experiments/acquire.mk -n ...`
+# from repo root) parses without a "no such file" error.
+include $(dir $(lastword $(MAKEFILE_LIST)))common.mk
 
 # --- Sentinel: project .env exists for targets that need API keys -------------
 # Targets in this list will fail fast with a readable message if .env is
 # missing. Keys themselves are not read into Make variables — uv loads them
 # at child-process spawn time via --env-file.
-# census-summary delegates to the P2 scorer (experiments/derived/score.mk), a
-# pure offline rebuild — no API keys — so it is NOT in this list (ticket 0410).
 _NEEDS_ENV := census census-run regimes regimes-run \
 						 sourced sourced-run frontier frontier-run
 ifneq ($(filter $(_NEEDS_ENV),$(MAKECMDGOALS)),)
@@ -52,7 +78,7 @@ cfg = $(shell python3 -c "import tomllib; c=tomllib.load(open('experiments.toml'
 
 # --- Census: model census -----------------------------------------------------
 
-.PHONY: census census-generate census-run census-summary
+.PHONY: census census-generate census-run
 
 census: census-generate census-run
 
@@ -63,11 +89,10 @@ census-generate:
 census-run:
 	$(OR_DRAIN); $(WORKER) padme --drain & wait
 
-# Score & consolidate (P2) now lives in experiments/derived/score.mk, invoked
-# from the repo root. Delegate there (-C .. so cwd = repo root, which score.mk's
-# paths.mk-anchored paths assume).
-census-summary:
-	$(MAKE) -C .. -f experiments/derived/score.mk rebuild-measurements
+# Score & consolidate (P2) lives in experiments/derived/score.mk, invoked from
+# the repo root: `make -f experiments/derived/score.mk rebuild-measurements`.
+# (The former `census-summary` alias that delegated there was dropped in S4 /
+# ticket 0411 — P1 acquire may not carry a cross-phase delegation edge.)
 
 # --- Regimes: information regimes ---------------------------------------------
 
@@ -142,7 +167,7 @@ frontier-run:
 # repo root:
 #     make -f experiments/derived/score.mk rebuild-measurements
 #     make -f experiments/render.mk self-consistency
-# This Makefile is now pure P1 acquire (sweeps) + corpus utilities.
+# acquire.mk is now pure P1 acquire (sweeps) + corpus utilities.
 
 # --- Utility -----------------------------------------------------------------
 
@@ -240,7 +265,6 @@ help:
 	@echo "  make verification         Generate + run verification sweep"
 	@echo "  make sourced              Generate + run sourced extraction sweep"
 	@echo "  make frontier             Generate + run frontier deep-research (3 prompts)"
-	@echo "  make census-summary       Score & consolidate all outputs → measurements.jsonl"
 	@echo ""
 	@echo "Score & render (run from repo root):"
 	@echo "  make -f experiments/derived/score.mk rebuild-measurements  Extract + evaluate → measurements.jsonl (P2)"

--- a/experiments/common.mk
+++ b/experiments/common.mk
@@ -2,9 +2,9 @@
 #
 # Single source of truth for the canonical uv invocation, the manager/worker
 # entry points, OpenRouter concurrency, and the worker-drain loop. Included by
-# experiments/Makefile and the experiment*.mk runners so they cannot drift.
+# experiments/acquire.mk and the experiment*.mk runners so they cannot drift.
 #
-# ENV POLICY (see experiments/Makefile header): the project ../.env is the only
+# ENV POLICY (see experiments/acquire.mk header): the project ../.env is the only
 # source of API keys; never ~/.claude/.env. UV_RUN injects it via --env-file at
 # child-process spawn time, so no secret transits a Make variable or argv.
 

--- a/experiments/derived/score.mk
+++ b/experiments/derived/score.mk
@@ -8,7 +8,7 @@
 # figures/tables/macros lives in experiments/render.mk (tracker 0406 S2); a
 # figure build can no longer reach back into this scoring DAG. The P1 (acquire)
 # sweeps that produce the raw model replies this file consumes live in
-# experiments/Makefile.
+# experiments/acquire.mk.
 #
 # SOURCES (consumed, never produced here — they appear only as prerequisites,
 # and score.mk carries NO rule able to (re)acquire them):
@@ -27,7 +27,7 @@
 #
 # INVARIANT: score.mk declares NO rule for an upstream (P1) outcome. It never
 #   fans out a worker/manager drain, runs a sweep, or calls an LLM adapter —
-#   the only way to (re)acquire raw replies is experiments/Makefile's P1 sweep
+#   the only way to (re)acquire raw replies is experiments/acquire.mk's P1 sweep
 #   verbs (which cost money). If a P1 source is missing, make MUST stop with
 #   "No rule to make target", never silently re-acquire. Guarded by
 #   tests/test_score_build_no_acquire.py.
@@ -40,7 +40,8 @@
 #   absolute self-path so the default makefile (root ./Makefile) is never hit.
 #
 # Tracker 0406 step S3 (ticket 0410) consolidated the former P2 score makefile
-# plus the P2 verbs from experiments/Makefile into this file.
+# plus the P2 verbs from the P1 makefile (now experiments/acquire.mk) into this
+# file.
 
 # Self-path for recursive $(MAKE): captured BEFORE the include extends
 # MAKEFILE_LIST, so it always points at this score.mk regardless of cwd.
@@ -60,7 +61,7 @@ SCORE_OUTPUTS   := $(ANALYSIS_OUTPUTS_DIR)
 SCORE_DERIVED   := $(ANALYSIS_DERIVED_DIR)
 
 # === measurements.jsonl: materialized view of all outputs ===================
-# (migrated from experiments/Makefile, tracker 0406 S3)
+# (migrated from the P1 makefile (now experiments/acquire.mk), tracker 0406 S3)
 
 SCORE_STRUCTURED_DIRS := census multiturn web rag \
                    decomposed decomposed_v2 sourced frontier \
@@ -121,8 +122,9 @@ rebuild-measurements:
 	$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(ANALYSIS_MEASUREMENTS)
 
 # === Self-consistency scorer (outputs/rag → derived/rag_consistency) ========
-# (migrated from experiments/Makefile, tracker 0406 S3 — P2 score half only;
-#  the tabulate→report/inputs/generated/ render half is in render.mk.)
+# (migrated from the P1 makefile (now experiments/acquire.mk), tracker 0406 S3
+#  — P2 score half only; the tabulate→report/inputs/generated/ render half is in
+#  render.mk.)
 
 SCORE_SC_INPUT  := $(SCORE_OUTPUTS)/rag
 SCORE_SC_OUTPUT := $(SCORE_DERIVED)/rag_consistency

--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -320,8 +320,8 @@ $(ANALYSIS_GEN)/tab_converter_benchmark.tex: $(ANALYSIS_CONVERTER_META) $(ANALYS
 	uv run python -m aedist.compare_converters \
 	    --input $(ANALYSIS_CONVERTER_TEST) --meta $(ANALYSIS_CONVERTER_META) --output $@
 
-# --- Self-consistency tables (render half; migrated from experiments/Makefile
-#     by ticket 0410, tracker 0406 S3) --------------------------------------
+# --- Self-consistency tables (render half; migrated from the P1 makefile (now
+#     experiments/acquire.mk) by ticket 0410, tracker 0406 S3) ----------------
 # The P2 score half ($(SCORE_SC_JSON): outputs/rag → derived/rag_consistency)
 # lives in experiments/derived/score.mk. This render half tabulates the mart
 # into the committed LaTeX handoff artifacts. Reads only measurements.jsonl (a
@@ -337,7 +337,7 @@ $(ANALYSIS_SC_TEX) $(ANALYSIS_SC_PERRUN) &: $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_
 .PHONY: self-consistency
 self-consistency: $(ANALYSIS_SC_TEX) $(ANALYSIS_SC_PERRUN)
 
-# --- Experiment 1 cost summary (migrated from experiments/Makefile, 0410) ---
+# --- Experiment 1 cost summary (migrated from the P1 makefile, now acquire.mk, 0410) ---
 
 ANALYSIS_EXP1_COST_TEX := $(ANALYSIS_GEN)/tab_exp1_cost_summary.tex
 
@@ -348,7 +348,7 @@ $(ANALYSIS_EXP1_COST_TEX): $(ANALYSIS_MEASUREMENTS) $(ANALYSIS_REPO_ROOT)/src/ae
 .PHONY: exp1-cost-summary
 exp1-cost-summary: $(ANALYSIS_EXP1_COST_TEX)
 
-# --- Experiment 1 reasoning top-up (migrated from experiments/Makefile, 0410)
+# --- Experiment 1 reasoning top-up (migrated from the P1 makefile, now acquire.mk, 0410)
 
 ANALYSIS_EXP1_TOPUP_TEX := $(ANALYSIS_GEN)/tab_exp1_reasoning_topup.tex
 

--- a/src/aedist/worker.py
+++ b/src/aedist/worker.py
@@ -181,7 +181,7 @@ class Worker:
         """
         client = self.make_client()
         if job.prompt_modules is not None:
-            # Default resolves relative to cwd; the experiments/Makefile sets
+            # Default resolves relative to cwd; experiments/acquire.mk sets
             # cwd=experiments/ before invoking the worker (see UV_RUN macro),
             # so "prompts/modules" finds experiments/prompts/modules/*.txt.
             modules_dir = Path(job.modules_dir) if job.modules_dir else Path("prompts/modules")

--- a/tests/test_acquire_all_phony.py
+++ b/tests/test_acquire_all_phony.py
@@ -1,0 +1,115 @@
+"""`experiments/acquire.mk` is the P1 (acquire) phase — every target is .PHONY.
+
+Tracker 0406, step S4 (ticket 0411) renamed the P1 experiments makefile to
+`experiments/acquire.mk` and made the P1 invariant mechanical: acquire.mk holds
+only manually-invoked, money-gated sweep verbs (census, regimes, decomposed,
+verification, sourced, frontier — each fans out the manager/worker pipeline and
+costs API dollars) plus corpus utilities (pdf2md, build-corpus, preflight,
+help). None of these produce a file a downstream phase may depend on, so EVERY
+rule target must be declared `.PHONY`. A file target here would let score.mk
+(P2) or render.mk (P3) silently trigger a money-costing re-acquisition through
+an ordinary timestamp-driven rebuild — exactly the seam this guard closes.
+
+The two invariants enforced:
+
+  1. Every rule target in acquire.mk is named in a `.PHONY:` line.
+  2. No rule target is a filesystem path (no `/`) and none escapes the
+     experiments/ tree (no `..`) — acquire.mk writes raw replies under
+     experiments/outputs/** through the worker pipeline, never as a make file
+     target.
+
+Mirrors the structure of ``tests/test_render_build_clean_room.py`` (S2's P3
+guard) and ``tests/test_score_build_no_acquire.py`` (S3's P2 guard), but this
+one is a pure SOURCE scan: P1 has no file targets to dry-run, so the invariant
+is "the target set equals the .PHONY set."
+
+Parsing note: acquire.mk carries make assignments (``UV_RUN :=``, ``MODEL ?=``,
+``_NEEDS_ENV :=``, ``ZOTERO_API_KEY :=``) whose left-hand side would be misread
+as a rule target by a naive ``":" in line`` split. We strip assignments
+(mirroring test_makefile_dag.py's ASSIGN_RE), conditional/include/export
+directives, and ``.``-prefixed special targets (``.PHONY``) before collecting
+rule targets. ``experiments/common.mk`` (the sole include) holds zero rules, so
+scanning acquire.mk alone is sufficient.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ACQUIRE_MK = REPO_ROOT / "experiments" / "acquire.mk"
+
+# A variable assignment, not a rule (matches test_makefile_dag.py's ASSIGN_RE).
+ASSIGN_RE = re.compile(r"^\s*[A-Za-z_][A-Za-z0-9_]*\s*(:=|\?=|\+=|=)")
+# Make directives whose line may contain a ':' but is not a rule.
+DIRECTIVE_RE = re.compile(
+    r"^\s*(ifeq|ifneq|ifdef|ifndef|else|endif|include|-include|export|unexport)\b"
+)
+
+
+def _phony_names_and_targets(text: str) -> tuple[set[str], list[str]]:
+    """Return (declared .PHONY names, list of rule-target tokens)."""
+    phony: set[str] = set()
+    targets: list[str] = []
+    for raw in text.replace("\\\n", " ").splitlines():
+        if raw.startswith("\t"):
+            continue  # recipe line
+        line = raw.split("#", 1)[0]
+        if not line.strip():
+            continue
+        if DIRECTIVE_RE.match(line):
+            continue
+        if ASSIGN_RE.match(line):
+            continue
+        if ":" not in line:
+            continue
+        lhs = line.split(":", 1)[0].rstrip().rstrip("&").rstrip()
+        toks = lhs.split()
+        if not toks:
+            continue
+        if toks[0] == ".PHONY":
+            # `.PHONY: a b c` — collect the declared names (rhs of the colon).
+            phony.update(line.split(":", 1)[1].split())
+            continue
+        for tok in toks:
+            if tok.startswith("."):
+                continue  # other special target (.SHELLFLAGS handled by ASSIGN)
+            targets.append(tok)
+    return phony, targets
+
+
+def test_acquire_mk_exists():
+    assert ACQUIRE_MK.is_file(), (
+        "experiments/acquire.mk must exist (P1 acquire phase; renamed from the "
+        "P1 experiments makefile by ticket 0411, tracker 0406 step S4)."
+    )
+
+
+def test_every_target_is_phony():
+    """Every rule target in acquire.mk is declared .PHONY (the P1 invariant)."""
+    phony, targets = _phony_names_and_targets(ACQUIRE_MK.read_text())
+    missing = sorted({t for t in targets if t not in phony})
+    assert not missing, (
+        "acquire.mk declares rule target(s) not in any `.PHONY:` line: "
+        f"{missing}. P1 acquire is all-.PHONY by invariant — every sweep verb "
+        "and corpus utility is manually invoked and money-gated; nothing "
+        "downstream may depend on a P1 target as a file. Either declare the "
+        "target .PHONY (if it is a P1 verb) or relocate it to the right phase "
+        ".mk (score.mk / render.mk)."
+    )
+
+
+def test_no_filesystem_path_targets():
+    """No rule target is a filesystem path, and none escapes experiments/."""
+    _, targets = _phony_names_and_targets(ACQUIRE_MK.read_text())
+    offending = sorted({t for t in targets if "/" in t or ".." in t})
+    assert not offending, (
+        "acquire.mk declares a rule whose TARGET is a filesystem path: "
+        f"{offending}. P1 has no file targets — raw replies are written under "
+        "experiments/outputs/** by the worker pipeline, never as a make file "
+        "target. A path target (especially one escaping experiments/ via '..') "
+        "would couple a money-gated re-acquisition to a timestamp rebuild."
+    )

--- a/tests/test_score_build_no_acquire.py
+++ b/tests/test_score_build_no_acquire.py
@@ -2,15 +2,16 @@
 
 Ticket 0410 (tracker 0406, step S3) consolidated all P2 scoring/extraction
 into `experiments/derived/score.mk` (folding in the former P2 score makefile
-and pulling the P2 verbs out of `experiments/Makefile`), leaving the P3 strays
-in `experiments/render.mk`. score.mk is the *consumer* of P1 outcomes
+and pulling the P2 verbs out of the P1 makefile, now `experiments/acquire.mk`),
+leaving the P3 strays in `experiments/render.mk`. score.mk is the *consumer* of
+P1 outcomes
 (`experiments/outputs/**`, the raw model replies) and the *producer* of the P2
 outcomes (`measurements.jsonl`, `exp2_mart.jsonl`, the cross-eval CSVs).
 
 The invariant this guard enforces is the OTHER seam: score.mk must never reach
 DOWN into P1 (acquire). A P2 scoring/extraction dry-run must not fan out
 manager/worker drains, run a sweep, or call an LLM adapter — the only way to
-(re)acquire raw replies is `experiments/Makefile`'s P1 sweep verbs, which cost
+(re)acquire raw replies is `experiments/acquire.mk`'s P1 sweep verbs, which cost
 money and rewrite `experiments/outputs/**`. score.mk reads those outputs as
 committed sources; it carries no rule able to rebuild them.
 
@@ -104,8 +105,8 @@ def _dry_run(target: str) -> str:
 def test_score_mk_exists():
     assert SCORE_MK.is_file(), (
         "experiments/derived/score.mk must exist (P2 score rules consolidated "
-        "from the former P2 score makefile + experiments/Makefile by ticket "
-        "0410, tracker 0406 step S3)."
+        "from the former P2 score makefile + the P1 makefile (now "
+        "experiments/acquire.mk) by ticket 0410, tracker 0406 step S3)."
     )
 
 
@@ -121,7 +122,7 @@ def test_p2_verb_does_not_invoke_acquire(target):
         f"`make -f experiments/derived/score.mk -n {target}` invokes a P1 "
         "acquire step (worker/manager/sweep/query). score.mk (P2) consumes "
         "experiments/outputs/** as committed sources only — re-acquisition "
-        "lives in experiments/Makefile.\n" + "\n".join(offending)
+        "lives in experiments/acquire.mk.\n" + "\n".join(offending)
     )
 
 

--- a/tickets/0406-build-one-mk-per-phase.erg
+++ b/tickets/0406-build-one-mk-per-phase.erg
@@ -12,6 +12,7 @@ Author: claude
 2026-06-04T08:55Z claude note S1 done (PR #692): slides/inputs/generated retired; S2 (render.mk) unblocked.
 2026-06-04T09:44Z claude note S2 done (PR #694): render.mk extracted, cascade dead; S3 (score.mk) unblocked.
 2026-06-04T10:36Z claude note S3 done (PR #696): score.mk carved, analysis.mk dissolved, P3 strays relocated; S4 (acquire.mk) unblocked.
+2026-06-04T11:15Z claude note S4 done (PR #698): acquire.mk pure P1 all-.PHONY; census-summary dropped; S5 (root rewrite) unblocked.
 --- body ---
 ## Context
 

--- a/tickets/0412-needs-env-sweep-coverage.erg
+++ b/tickets/0412-needs-env-sweep-coverage.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: _NEEDS_ENV sentinel covers only 4 of 6 paid sweeps — add decomposed, verification
+Created: 2026-06-04
+Author: claude
+
+--- log ---
+2026-06-04T12:40Z claude created — follow-up surfaced by /verify on PR #698 (0411, acquire.mk); pre-existing gap, out of scope there
+
+--- body ---
+## Context
+
+`experiments/acquire.mk` guards paid sweeps with a `_NEEDS_ENV`
+sentinel (fails fast when `.env`/API keys are absent instead of
+launching a sweep that errors mid-run). The /verify pass on PR #698
+found the sentinel list covers only 4 of the 6 paid sweeps:
+`decomposed` and `verification` are omitted. Pre-existing gap (predates
+the acquire.mk rename), non-blocking for S4, ticketed for follow-up.
+
+## Relevant files
+
+- `experiments/acquire.mk` — `_NEEDS_ENV` definition and the six sweep
+  verb groups (census, regimes, decomposed, verification, sourced,
+  frontier)
+
+## Actions
+
+1. Add `decomposed` and `verification` (and their -generate/-run
+   variants as appropriate — mirror how the four covered sweeps are
+   listed) to `_NEEDS_ENV`.
+2. Audit while there: any other money-gated verb missing from the
+   sentinel (grep for worker/manager invocations with --env-file).
+
+## Test
+
+Extend the existing acquire guard test (or add a small adherence case):
+every acquire.mk verb whose recipe passes `--env-file` appears in
+`_NEEDS_ENV`. Red today (2 missing), green after action 1.
+
+## Verification
+
+- [ ] Guard/adherence test green
+- [ ] `make -C experiments -f acquire.mk -n decomposed` without .env
+      fails fast at the sentinel (manual check note: do NOT run real)
+
+## Invariants
+
+- No sweep is ever run for real (money gate); dry-run only
+
+## Exit criteria
+
+- All paid sweeps covered by _NEEDS_ENV, enforced by a test

--- a/tickets/closed/0411-acquire-mk-pure-p1.erg
+++ b/tickets/closed/0411-acquire-mk-pure-p1.erg
@@ -2,10 +2,12 @@
 Title: experiments/Makefile → acquire.mk, pure P1 with all-.PHONY guard (0406 S4)
 Created: 2026-06-04
 Author: claude
+Closed: acquire.mk pure P1, all-.PHONY guarded; census-summary alias dropped
 
 --- log ---
 2026-06-04T11:45Z claude created — S4 child of tracker 0406; S3 (0410, PR #696) landed: experiments/Makefile is already P1+utils only
 
+2026-06-04T11:13Z HDMX-coding-agent closed — acquire.mk pure P1, all-.PHONY guarded; census-summary alias dropped
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Tracker 0406 step S4. Renames the P1 experiments makefile `experiments/Makefile` → `experiments/acquire.mk` (git mv, history preserved at R079), applies the phase header contract, and adds a mechanical guard for the P1 invariant.

**Ticket:** tickets/0411-acquire-mk-pure-p1.erg
Tracker: tickets/0406-build-one-mk-per-phase.erg (S4 of 5 — do not close)

## What changed

- **`experiments/acquire.mk`** — header contract added: phase (P1 acquire), sources (experiments.toml, RAG corpus, models.yaml), outcomes (raw replies under `experiments/outputs/**`, `archive/**` — worker-pipeline writes, not make file targets), invariant (every target `.PHONY`; nothing downstream may depend on a P1 target as a file), and the money-gate warning (test-one-before-blasting).
- **`tests/test_acquire_all_phony.py`** (new, `@pytest.mark.adherence`) — source-scan guard: every rule target is declared `.PHONY`; no filesystem-path targets; none escape `experiments/` (no `..`). Excludes `:=`/`?=`/`+=` assignments, `if*/else/endif/include/export` directives, and `.`-prefixed special targets (mirrors test_makefile_dag's ASSIGN_RE). Teeth-checked: a dummy non-`.PHONY` rule and a path target each turn it red.

## census-summary disposition

**Dropped.** It was two dead things: (1) a root `Makefile` `.PHONY` name with **no rule** (`make census-summary` always errored), and (2) an acquire.mk alias delegating to `score.mk rebuild-measurements` — a cross-phase (P1→P2) edge P1 may not carry. Both removed (acquire.mk rule + `.PHONY` + help line; root `.PHONY` name). Dev path is now `make -f experiments/derived/score.mk rebuild-measurements`.

## No target reclassifications

Every P1 verb in the file was already `.PHONY`. The rename surfaced no stray file targets — nothing to relocate.

## Deliberate deviation — root delegation form

The ticket text said repoint to "`-f experiments/acquire.mk` form". I used **`$(MAKE) -C experiments -f acquire.mk census`** instead. Every sweep recipe resolves `../.env` (via `$(UV_RUN) --env-file ../.env`), `experiments.toml`, and the `jobs/` board **relative to `cwd=experiments/`**. `-C experiments` sets that cwd before `-f acquire.mk` loads, preserving the env/relative-path contract (the ticket's own "verify the sweeps still receive their .env/UV_RUN environment" flag). A bare repo-root `-f experiments/acquire.mk` would break all of those paths and trip the `_NEEDS_ENV` sentinel. Advisor-endorsed.

Relatedly, the bare `include common.mk` is switched to the cwd-independent `include $(dir $(lastword $(MAKEFILE_LIST)))common.mk` form (mirrors render.mk / score.mk) so the clean-room dry-run parses from any cwd.

## Exit-criterion 4 note (canonical dry-run)

The ticket's literal gate `make -f experiments/acquire.mk -n census` trips the `_NEEDS_ENV` sentinel in **any** checkout — from `cwd=repo-root`, `../.env` resolves *above* the repo, which never exists. That is structural, not a defect: the env contract is `cwd=experiments`-relative. The **canonical dry-run** is `make -C experiments -f acquire.mk -n census`, which resolves the full recipe with `repo-root/.env` present (verified: emits the correct `--env-file ../.env … --sweep census` manager/worker lines). Parse-correctness of the bare form is shown via `make -f experiments/acquire.mk -n help` (clean expansion, no error). All six sweeps (census/regimes/decomposed/verification/sourced/frontier) dry-run-resolve via the `-C experiments` form.

## References repointed (zero `experiments/Makefile` hits in Makefiles/tests/CI/docs)

root `Makefile`, `experiments/common.mk`, `score.mk`, `render.mk`, `src/aedist/worker.py` (comment), `tests/test_score_build_no_acquire.py`, `docs/pipeline-phases.md`, `data/README.md`. Bonus: `PLAN.md` stale `make -C experiments rebuild-measurements` (0410 drift — verb moved to score.mk) corrected to the current root-invoked form.

## Verification

- New guard green; `test_score_build_no_acquire` + `test_render_build_clean_room` + `test_makefile_dag` + `test_report_build_clean_room` + `test_slides_build_clean_room` + `test_no_tracked_ignored_files` all green
- `make check` exit 0; `make report` and `make slides` build (exit 0); `make lint` exit 0
- `grep -rn "experiments/Makefile" --exclude-dir=.git .` → only append-only `tickets/` history (exempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
