### PR TITLE
tickets: close 0392, open 0412 (archive Cergy) + 0413 (adopt fix1), note 0395

### DIFF
--- a/tickets/0393-matcher-combined-units-and-extension-contention.erg
+++ b/tickets/0393-matcher-combined-units-and-extension-contention.erg
@@ -2,13 +2,13 @@
 Title: Matcher: resolve combined "X & Y" rows and base/extension LP contention
 Created: 2026-06-03
 Author: claude
-Blocked-by: 0392
 
 --- log ---
 2026-06-03T00:00Z claude created — from the Exp2 FP audit: the LP-veto bucket is the single largest, 112 distinct / 276 FP occurrences, where the name already matches a reference row at ≥90 but the global LP leaves it unmatched
 
 2026-06-03T08:09Z scope note: a 1NF handoff (docs/inventory-1nf-handoff-exp2.md) measured merged 'X & Y' rows at 2.6% of rows, 91% self-decomposing across peer runs. KEY DISTINCTION for this ticket: its 'do not decompose' rule is for the REFERENCE-FREE consolidation objective, NOT for 0393. Here the gold reference attests both units, so decomposing 'Cẩm Phả I & II' to match reference 'Cẩm Phả 1'+'Cẩm Phả 2' fabricates nothing and IS the fix. Do not import the reference-free no-decompose rule into the matcher.
 2026-06-03T08:21Z re-baseline (post-0392, on main): lp_veto bucket = 68 distinct / 201 occ. Triage (experiments/derived/exp2_fp_0393_lpveto_triage.csv): (a) GENUINE 0393 combined-units core = 23 distinct / 89 occ (X & Y / và / ranges: Nhơn Trạch 3&4, Cà Mau 1&2, Cẩm Phả I&II, Phả Lại 1&2, Duyên Hải 1&3) — every unit attested in the reference, so split-against-reference fabricates nothing; (b) contention/granularity = 6 distinct / 14 occ (model double-lists one site under two names, e.g. TBK Thủ Đức + NĐ Thủ Đức -> one ref row) — NOT the veto, do not loosen for these; (c) reroute to 0395 (sibling unit not in ref: Sông Hậu 3, Nam Định II, Bình Định I/II) = 38 distinct / 91 occ; (d) reroute to 0394 (model atomized a COMBINED ref row 'TBKHH Kiên Giang I, II') = 1 distinct / 7 occ. NET: 0393's true target is the 89-occ combined-units core, down from the ~276 pre-0392 notional. lp.py change justified for (a) only.
+2026-06-04T11:37Z HDMX-coding-agent note blocker 0392 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0395-reference-v2-add-verified-holes.erg
+++ b/tickets/0395-reference-v2-add-verified-holes.erg
@@ -9,6 +9,7 @@ Label: needs-human
 2026-06-03T00:00Z claude created — from the Exp2 FP audit: 48 distinct / 95 FP occurrences are real Vietnamese plants absent from the 163-row reference under any spelling
 2026-06-03T00:00Z claude note — needs-human: adding plants to the scientific reference requires sourcing each against primary documents and a version bump
 
+2026-06-04T11:37Z claude note — FN recount (0394, 80 runs): top-missed reference rows are the LNG-project holes; fix1's merged scope leaves hole-filling entirely to this ticket (FP reference_hole bucket: 99 occ)
 --- body ---
 ## Context
 

--- a/tickets/0412-archiver-la-communication-econom-ia-cerg.erg
+++ b/tickets/0412-archiver-la-communication-econom-ia-cerg.erg
@@ -1,0 +1,37 @@
+%erg 0.1
+Title: Archiver la communication Econom'IA Cergy: release + tag + HAL + page perso
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T11:37Z HDMX-coding-agent created
+
+--- body ---
+## Contexte
+
+Communication présentée à Econom'IA 2026 (Cergy, 2026-05-27) — slides Beamer
+(EN/FR) construits depuis ce dépôt. Les correctifs matcher (0392/0393) et la
+référence fix1 (0394) vont changer les figures : il faut archiver l'état
+exactement présenté AVANT toute adoption (prérequis de 0413).
+
+## Étapes
+
+1. Identifier le commit correspondant à la version présentée le 2026-05-27 ;
+   créer un tag git (ex. `economia-2026-cergy`) et le pousser.
+2. Créer une release GitHub sur ce tag, avec le PDF des slides présentés en
+   pièce jointe.
+3. Déposer la communication sur HAL — passer par le skill `/update-publist`
+   (Ha-Duong.bib + dépôt SWORD).
+4. Publier le lien/PDF sur la page perso de l'auteur.
+
+## Exit criteria
+
+- [ ] Tag poussé sur le commit de la version présentée
+- [ ] Release GitHub avec le PDF des slides attaché
+- [ ] Notice HAL en ligne
+- [ ] Page perso à jour
+
+## Related
+
+- 0413 (adoption fix1 — bloqué par ce ticket)
+- Slides : cible `slides-en`/`slides-fr` du dépôt

--- a/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
+++ b/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: Adopter la référence fix1: figures avant/après puis recâblage
+Created: 2026-06-04
+Author: HDMX-coding-agent
+Blocked-by: 0394
+Blocked-by: 0412
+
+--- log ---
+2026-06-04T11:37Z HDMX-coding-agent created
+
+--- body ---
+## Contexte
+
+0394 (PR #699) livre la référence fix1 — patch d'intégrité minimal, avec
+non-finding mesuré : FP 399→399, FN 7617→7537 (delta = FN fantômes du doublon
+supprimé). Le v1 gelé reste la référence de scoring tant que ce ticket n'est
+pas passé. Les correctifs matcher 0392/0393 + fix1 peuvent déplacer les
+figures. La refonte Makefile (0406) est en cours : NE RIEN recâbler avant
+qu'elle soit posée.
+
+Séquence imposée par l'auteur : archiver d'abord la version présentée à Cergy
+(0412), puis valider visuellement, et seulement ensuite recâbler.
+
+## Étapes
+
+1. Régénérer les figures avec la base v1 puis avec fix1 (matcher courant) ;
+   comparer avant/après ; expliquer chaque delta. Le non-finding 0394 prédit
+   des deltas quasi nuls — toute surprise est un signal.
+2. Si validé : recâbler scoring + Makefile sur fix1 — règle de build pour
+   `experiments/scripts/build_reference_v1_fix1.py`, consommateurs sur
+   `vietnam_thermal_v1_fix1.csv` — en coordination avec la structure 0406.
+3. Re-score officiel Exp1–3 depuis les sorties existantes ; mart + tables
+   régénérés ; PROVENANCE/docs mis à jour (« v1 reste la référence » → fix1).
+
+## Exit criteria
+
+- [ ] Comparaison figures avant/après commitée et expliquée
+- [ ] Scoring + Makefile recâblés sur fix1 (post-0406, DAG propre)
+- [ ] Exp1–3 re-scorés ; deltas documentés
+- [ ] `make check` vert
+
+## Related
+
+- 0394 (livre fix1), 0412 (archive Cergy — prérequis), 0406 (refonte Makefile)
+- `data/reference/PROVENANCE.md` §fix1

--- a/tickets/closed/0392-matcher-strip-vn-prefixes-unify-extension.erg
+++ b/tickets/closed/0392-matcher-strip-vn-prefixes-unify-extension.erg
@@ -2,11 +2,13 @@
 Title: Matcher: strip missing Vietnamese facility prefixes and unify mở rộng↔extension
 Created: 2026-06-03
 Author: claude
+Closed: implemented and merged: matcher strips VN facility prefixes, unifies mở rộng↔extension (0e32efb + review fix 05f4696); 0393 re-baselined on it (03b330f)
 
 --- log ---
 2026-06-03T00:00Z claude created — from the Exp2 FP audit (docs/fp-audit-exp2.md): name-normalization gap is 57 distinct / 152 FP occurrences, all recover to a real reference row once normalized
 
 2026-06-03T07:28Z executed: added name_drops nhiet dien/nha may/dong phat/tbk/nmn?d + mo rong|mr->extension substitution + empty-name guard. Verified on existing Exp2 outputs: matched(TP) 5182->5423 (+241), FP 640->399 (-241, no TP regression); matcher_fail_normalization occ 152->5 (<=20 criterion). 17 cleaner tests + 1814 fast tests + ruff all green.
+2026-06-04T11:37Z HDMX-coding-agent closed — implemented and merged: matcher strips VN facility prefixes, unifies mở rộng↔extension (0e32efb + review fix 05f4696); 0393 re-baselined on it (03b330f)
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket housekeeping (chore, no code):

- **Close 0392** — matcher work merged (`0e32efb`, `05f4696`); archived to `tickets/closed/`.
- **Open 0412** — archive the Econom'IA Cergy communication: git tag + GitHub release with presented slides PDF + HAL deposit (`/update-publist`) + personal page.
- **Open 0413** — adopt reference fix1 (from PR #699): before/after figure validation first, then rewire scoring+Makefile onto fix1; `Blocked-by: 0394, 0412`; explicitly defers all Makefile changes until the 0406 redesign lands.
- **Note on 0395** — FN recount evidence: the most-missed reference rows are LNG-project holes; filling them stays in 0395.

`tickets/erg check`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)