### PR TITLE
tickets: open 0416 — aggregator multi-status groups emit duplicate plant names

### DIFF
--- a/tickets/0395-reference-v2-add-verified-holes.erg
+++ b/tickets/0395-reference-v2-add-verified-holes.erg
@@ -10,6 +10,7 @@ Label: needs-human
 2026-06-03T00:00Z claude note — needs-human: adding plants to the scientific reference requires sourcing each against primary documents and a version bump
 
 2026-06-04T11:37Z claude note — FN recount (0394, 80 runs): top-missed reference rows are the LNG-project holes; fix1's merged scope leaves hole-filling entirely to this ticket (FP reference_hole bucket: 99 occ)
+2026-06-04T12:19Z claude note — Blocked-by candidate: 0416 fixes the aggregator that will regenerate plant rows when plants are added; adding via the unfixed aggregator reintroduces duplicate-name collisions
 --- body ---
 ## Context
 

--- a/tickets/0416-agr-gateur-unit-s-plantes-groupes-multi.erg
+++ b/tickets/0416-agr-gateur-unit-s-plantes-groupes-multi.erg
@@ -1,0 +1,54 @@
+%erg 0.1
+Title: Agrégateur unités→plantes: groupes multi-statuts → noms de plante dupliqués
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T12:18Z HDMX-coding-agent created
+
+--- body ---
+## Contexte
+
+Diagnostic auteur (2026-06-04) : pipeline.ods (maître, une ligne par unité)
+est bon — c'est l'agrégateur qui a fabriqué les défauts corrigés à la main
+par fix1 (ticket 0394, PR #699).
+
+`data/reference/HDM_aggregate.py` groupe par
+`["Normalized Name", "Status", "Province", "Fuel"]` : une centrale dont les
+tranches ont des statuts différents sort en PLUSIEURS lignes plante portant
+le même `Name` (Dong Nai Formosa ×2, Ha Tinh Formosa ×2 — la collision de
+clé exacte de 0394). Et aucun garde-fou : « Quảng Trị 1 Unit 2 » dupliqué en
+entrée a été sommé (660+660=1320) et joint « Unit 2, Unit 2 » sans erreur.
+
+Toute régénération depuis pipeline.ods réintroduirait ces collisions (les
+renames `extension` de fix1 n'existent pas en amont). 0395 (ajout de
+centrales) passera vraisemblablement par ce chemin — corriger AVANT.
+
+## Quoi faire
+
+1. Disambiguïser les groupes multi-statuts d'une même centrale : suffixer le
+   groupe non-dominant selon la convention `extension` du fichier (le groupe
+   *operating* garde le nom nu ; le groupe proposed/announced devient
+   `<Name> extension`) — c'est exactement ce que fix1 a fait à la main.
+2. Garde-fous en sortie : assert « aucun `Name` dupliqué » et « aucune unité
+   répétée dans `Units Included` » — refuser de produire, lister les groupes
+   fautifs pour adjudication.
+3. Brancher les invariants de `tests/test_reference_integrity.py`
+   (fold-uniqueness) sur la sortie de l'agrégateur.
+4. Vérifier que la régénération depuis le fichier unités fix1 reproduit le
+   fichier plantes fix1 (oracle de non-régression).
+
+## Exit criteria
+
+- [ ] Agrégateur : groupes multi-statuts disambiguïsés (convention extension)
+- [ ] Sortie refusée si noms dupliqués ou unités répétées (message actionnable)
+- [ ] Régénération depuis units_v1_fix1 == vietnam_thermal_v1_fix1 (modulo
+      colonnes de classification ajoutées en aval)
+- [ ] `make check` vert
+
+## Related
+
+- 0394 (fix1 — patch des artefacts ; ce ticket répare le générateur)
+- 0395 (ajout de centrales — consommateur direct de ce fix)
+- 0413 (adoption fix1), `data/reference/HDM_aggregate.py`,
+  `tests/test_reference_integrity.py`


### PR DESCRIPTION
Chore: one new ticket.

**0416** — root-cause repair of the unit→plant aggregator (`data/reference/HDM_aggregate.py`): `groupby(name, status, …)` emits duplicate plant `Name` rows for multi-status plants (the exact DNF/HTF key collision hand-patched by fix1 in PR #699), with no output guard (it summed the duplicated `Quảng Trị 1 Unit 2` silently). Fix = extension-convention disambiguation + no-duplicate output asserts + regeneration oracle against the fix1 files. Should land before 0395 adds plants through this path (log note added on 0395).

`tickets/erg check`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)