### PR TITLE
tickets: reference pipeline chain — open 0418+0419, rewire 0413/0395

### DIFF
--- a/tickets/0395-reference-v2-add-verified-holes.erg
+++ b/tickets/0395-reference-v2-add-verified-holes.erg
@@ -3,6 +3,7 @@ Title: Reference v2: add verified missing plants (Kiên Lương, Hòa Phát, Kim
 Created: 2026-06-03
 Author: claude
 Blocked-by: 0394
+Blocked-by: 0416
 Label: needs-human
 
 --- log ---
@@ -11,6 +12,7 @@ Label: needs-human
 
 2026-06-04T11:37Z claude note — FN recount (0394, 80 runs): top-missed reference rows are the LNG-project holes; fix1's merged scope leaves hole-filling entirely to this ticket (FP reference_hole bucket: 99 occ)
 2026-06-04T12:19Z claude note — Blocked-by candidate: 0416 fixes the aggregator that will regenerate plant rows when plants are added; adding via the unfixed aggregator reintroduces duplicate-name collisions
+2026-06-04T12:58Z claude note — Blocked-by 0416 formalized: additions flow through the master ods + validated pipe (0418→0416), not hand-appends to CSVs
 --- body ---
 ## Context
 

--- a/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
+++ b/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
@@ -4,10 +4,12 @@ Created: 2026-06-04
 Author: HDMX-coding-agent
 Blocked-by: 0394
 Blocked-by: 0412
+Blocked-by: 0416
 
 --- log ---
 2026-06-04T11:37Z HDMX-coding-agent created
 
+2026-06-04T12:58Z claude note — pipeline revision (0418/0416/0419): adoption now targets the pipe-produced v2 regenerated from the corrected master; fix1 (PR #699) is the interim integrity patch; Blocked-by 0416 added
 --- body ---
 ## Contexte
 

--- a/tickets/0418-pipeline-r-f-rence-1-3-data-reference-ra.erg
+++ b/tickets/0418-pipeline-r-f-rence-1-3-data-reference-ra.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: Pipeline référence 1/3: data/reference/raw + import.sh + extraction ODS→CSV validée
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T12:56Z HDMX-coding-agent created
+
+--- body ---
+## Contexte
+
+Révision du pipeline de production de la liste de référence (décisions auteur
+2026-06-04). Chaîne actuelle reconstituée : pipeline.ods (maître, projet
+« Market report on Gas to Power », 1 ligne par unité) → export tableur MANUEL
+jamais commité (HDM.csv, perdu) → HDM_aggregate.py (chemins en dur) →
+curation manuelle → data/reference/*.csv. Chaque flèche est manuelle et
+perdue — c'est par là que la coercition `ires_code` (0121→121) est passée.
+Une copie trackée de l'ODS existe déjà : docs/pipeline.ods (26 mai, périmée,
+AUCUN consommateur dans le code — vérifié par grep).
+
+## Quoi faire
+
+1. Créer `data/reference/raw/` :
+   - y DÉPLACER docs/pipeline.ods (git mv) ;
+   - `import.sh` : un cp depuis le maître
+     `~/CNRS/papiers/actif/Market report on Gas to Power/pipeline.ods`
+     (chemin surchargeable par variable d'environnement) ;
+   - `README.md` : ATTENTION NE PAS ÉDITER À LA MAIN — ce répertoire ne
+     contient que des copies importées ; toute correction se fait dans le
+     maître puis ré-import.
+2. `extract_ods.py` (argparse, entrée→sortie) : ODS → CSV unités.
+   Lecture **dtype=str** intégrale (aucune coercition : les zéros de tête
+   survivent par construction) ; la colonne `Level` (à venir dans le maître)
+   traverse telle quelle ; sélection de feuille explicite.
+3. VALIDATION du fichier d'entrée — refus dur, pas de tolérance :
+   - aucun doublon de nom (modulo diacritiques) ;
+   - si le nom contient « Unit » alors `Level` doit valoir unité ;
+   - liste de règles extensible (les invariants Level/nom se complètent ici).
+4. Rôle « Tier-2 oracle Exp 3 » de l'ODS : si une extraction des sources
+   bibliographiques est nécessaire, le fichier intermédiaire vit dans
+   `data/reference/` (PAS raw/) et se gère avec les autres artefacts.
+5. Câblage `acquire.mk`/`paths.mk` : APRÈS l'atterrissage de la refonte
+   Makefile (0406/0411) — ne rien câbler avant.
+
+## Exit criteria
+
+- [ ] `data/reference/raw/{pipeline.ods,import.sh,README.md}` ; docs/ nettoyé
+- [ ] `extract_ods.py` reproductible, dtype=str, Level passthrough
+- [ ] Validation d'entrée : doublon de nom → échec ; « Unit » sans
+      Level=unité → échec ; messages actionnables
+- [ ] Cible make dans acquire.mk (post-0406/0411)
+- [ ] `make check` vert
+
+## Related
+
+- 0416 (2/3, agrégateur — à amender post-merge PR #699 : Blocked-by ce
+  ticket ; VALIDATION DE SORTIE « nom de centrale = clé UNIQUE » ; abandon
+  de la proposition de suffixe extension — on n'invente pas de nom ;
+  propagation Level)
+- 0419 (3/3, consommateurs), 0413 (adoption — ciblera le v2 produit par ce
+  pipe), 0395 (ajouts de centrales via le maître + pipe)
+- `data/reference/PROVENANCE.md`, mémoire feedback « no invented names »

--- a/tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
+++ b/tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
@@ -1,0 +1,47 @@
+%erg 0.1
+Title: Pipeline référence 3/3: un seul chemin de référence côté consommateurs
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T12:56Z HDMX-coding-agent created
+
+--- body ---
+## Contexte
+
+Règle auteur (2026-06-04) : les scripts qui comparent une sortie extraite de
+modèle à une liste de référence prennent les fichiers en ARGUMENTS de ligne
+de commande — pas de chemin de référence en dur.
+
+État : la plupart des entry points ont déjà `--reference`, mais le chemin par
+défaut est dupliqué en ~8 constantes module éparpillées :
+
+- `evaluate.py:_DEFAULT_REF`, `query_fusion.py:_DEFAULT_REF`,
+  `prototype_v1_fusion.py:_DEFAULT_REF`, `verify.py` (copie),
+  `tabulate_verification.py` (copie), `verify_source_grounding.py` (copie),
+  `reconcile.py:_REFERENCE`, `tabulate_reconciliation.py:_EXPERT_REF`
+- Côté make, `score.mk:SCORE_REFERENCE` est déjà le point unique — bien.
+
+## Quoi faire
+
+1. Une seule source du chemin par défaut (petit module/config partagé,
+   cf. règle « No hardcoded paths : defaults from config ») ; les 8
+   constantes dupliquées meurent.
+2. Chaque entry point qui compare sortie-modèle vs référence expose
+   `--reference` (compléter les manquants) et le défaut vient de la config.
+3. Vérifier qu'aucun module n'utilise la constante en interne sans passer
+   par le paramètre (ex. `reconcile.py:_REFERENCE`).
+4. Effet attendu : la bascule v1 → v2-du-pipe (0413) = un changement de
+   variable make + un défaut de config, zéro chasse aux constantes.
+
+## Exit criteria
+
+- [ ] Zéro occurrence de `vietnam_thermal_v1.csv` en dur dans `src/`
+      (hors module de config et docstrings)
+- [ ] Tous les entry points de comparaison acceptent `--reference`
+- [ ] `make check` vert (le DAG score.mk continue de passer `--reference`)
+
+## Related
+
+- 0418 (1/3 extraction), 0416 (2/3 agrégateur), 0413 (adoption — bénéficiaire
+  direct), refonte Makefile 0406 (paths.mk)


### PR DESCRIPTION
Chore: ticket housekeeping for the reference-pipeline revision (author decisions, 2026-06-04).

- **Open 0418** (1/3 extraction): `data/reference/raw/` with the tracked ODS snapshot (moved from `docs/`), `import.sh` (cp from the Market report master), big do-not-hand-edit README; `extract_ods.py` dtype=str + `Level` passthrough; hard input validation (unique names modulo diacritics; "Unit" in name ⇒ Level=unit). Makefile wiring deferred until 0406/0411 land.
- **Open 0419** (3/3 consumers): one source of truth for the default reference path, `--reference` on every model-vs-reference entry point; kills ~8 duplicated constants.
- **0413 + 0395**: `Blocked-by: 0416` — adoption targets the pipe-produced v2 (fix1 = interim); plant additions flow through the master + validated pipe.
- **0416** (2/3 aggregator) amendments — output validation "plant name = unique key", no synthesized names, Level propagation, Blocked-by 0418 — are deferred until PR #699 merges (its branch already modifies `0416.erg`).

`tickets/erg check`: PASS (403 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)