### PR TITLE
tickets: renumber pipeline 1/3 0418 -> 0420 (ID collision)

### DIFF
--- a/tickets/0418-erg-check-in-ci.erg
+++ b/tickets/0418-erg-check-in-ci.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-06-04T14:55Z claude created — raid 405-406 celebrate sweep; the 0412 ID collision (fixed by PR #701) sat on main with erg check FAILED and no CI signal
 
+2026-06-04T13:20Z claude note — live instance for this ticket: 0418-pipeline-reference collided with this very ID from a sibling branch (both erg-new allocations passed locally); renumbered to 0420
 --- body ---
 ## Context
 

--- a/tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
+++ b/tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
@@ -43,5 +43,5 @@ défaut est dupliqué en ~8 constantes module éparpillées :
 
 ## Related
 
-- 0418 (1/3 extraction), 0416 (2/3 agrégateur), 0413 (adoption — bénéficiaire
+- 0420 (1/3 extraction), 0416 (2/3 agrégateur), 0413 (adoption — bénéficiaire
   direct), refonte Makefile 0406 (paths.mk)

--- a/tickets/0420-pipeline-r-f-rence-1-3-data-reference-ra.erg
+++ b/tickets/0420-pipeline-r-f-rence-1-3-data-reference-ra.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-06-04T12:56Z HDMX-coding-agent created
 
+2026-06-04T13:20Z claude note — renumbered 0418 -> 0420: ID collision on main with 0418-erg-check-in-ci (landed 60s earlier from a parallel branch; erg new's atomic scan cannot see sibling branches — live evidence for the CI erg-check ticket)
 --- body ---
 ## Contexte
 


### PR DESCRIPTION
Chore: `0418-pipeline-r-f-rence-1-3` → `0420-…` — collided with `0418-erg-check-in-ci`, which landed on main 60 s earlier from a sibling branch (both `erg new` allocations passed their local post-check; the optimistic scan cannot see unmerged branches). Newcomer renumbers, per the 0396→0398 precedent. Renumber logged on both tickets — live evidence for the erg-check-in-CI ticket. Reference in 0419 updated.

`tickets/erg check`: PASS (404 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)