### PR TITLE
tickets: refresh 0413 — adopt the pipe-produced v2 (fix1 leapfrogged)

### DIFF
--- a/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
+++ b/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
@@ -1,47 +1,56 @@
 %erg 0.1
-Title: Adopter la référence fix1: figures avant/après puis recâblage
+Title: Adopter la référence v2 (régénérée par le pipe): figures avant/après puis recâblage
 Created: 2026-06-04
 Author: HDMX-coding-agent
 Blocked-by: 0412
 Blocked-by: 0416
+Blocked-by: 0419
 
 --- log ---
 2026-06-04T11:37Z HDMX-coding-agent created
 
 2026-06-04T12:58Z claude note — pipeline revision (0418/0416/0419): adoption now targets the pipe-produced v2 regenerated from the corrected master; fix1 (PR #699) is the interim integrity patch; Blocked-by 0416 added
 2026-06-04T13:37Z HDMX-coding-agent note blocker 0394 closed — Blocked-by removed.
+2026-06-04T13:41Z claude note — refreshed post-leapfrog: adoption targets the v2 produced by the 0420->0416 pipe (fix1 never shipped); delta oracle = PROVENANCE known-defects checklist; Blocked-by 0419 added (single-switch rewiring)
 --- body ---
 ## Contexte
 
-0394 (PR #699) livre la référence fix1 — patch d'intégrité minimal, avec
-non-finding mesuré : FP 399→399, FN 7617→7537 (delta = FN fantômes du doublon
-supprimé). Le v1 gelé reste la référence de scoring tant que ce ticket n'est
-pas passé. Les correctifs matcher 0392/0393 + fix1 peuvent déplacer les
-figures. La refonte Makefile (0406) est en cours : NE RIEN recâbler avant
-qu'elle soit posée.
+fix1 a été leapfroggé (0394, PR #699 : documentation + instrumentation,
+aucun patch livré). Le v1 gelé score Exp1–3 tel quel, avec défauts
+documentés dans `PROVENANCE.md` § « Known defects of v1 ». Le pipe
+0420 (extraction validée) → 0416 (agrégateur, clé unique) régénère la
+référence **v2** depuis le maître corrigé ; 0419 réduit la bascule à un
+changement de variable + un défaut de config.
 
-Séquence imposée par l'auteur : archiver d'abord la version présentée à Cergy
-(0412), puis valider visuellement, et seulement ensuite recâbler.
+Séquence imposée par l'auteur : archiver d'abord la version présentée à
+Cergy (0412), puis valider visuellement, et seulement ensuite recâbler.
 
 ## Étapes
 
-1. Régénérer les figures avec la base v1 puis avec fix1 (matcher courant) ;
-   comparer avant/après ; expliquer chaque delta. Le non-finding 0394 prédit
-   des deltas quasi nuls — toute surprise est un signal.
-2. Si validé : recâbler scoring + Makefile sur fix1 — règle de build pour
-   `experiments/scripts/build_reference_v1_fix1.py`, consommateurs sur
-   `vietnam_thermal_v1_fix1.csv` — en coordination avec la structure 0406.
+1. Régénérer les figures avec v1 puis avec le v2-du-pipe (matcher courant) ;
+   comparer avant/après ; expliquer chaque delta. Oracle : tout delta doit
+   se rattacher à la checklist « Known defects of v1 » de PROVENANCE.md ou
+   à l'évolution documentée du maître — l'inexpliqué bloque. Le non-finding
+   0394 (FP 399→399, FN −80 fantômes) prédit des deltas quasi nuls.
+2. Si validé : basculer scoring + Makefile sur v2 — via le point unique de
+   0419 (`SCORE_REFERENCE` + défaut de config), zéro chasse aux constantes.
 3. Re-score officiel Exp1–3 depuis les sorties existantes ; mart + tables
-   régénérés ; PROVENANCE/docs mis à jour (« v1 reste la référence » → fix1).
+   régénérés ; PROVENANCE/docs mis à jour (clôture de la section « Known
+   defects of v1 » : corrigés en v2 ; v2 devient la référence gelée, avec
+   son entrée de version).
 
 ## Exit criteria
 
-- [ ] Comparaison figures avant/après commitée et expliquée
-- [ ] Scoring + Makefile recâblés sur fix1 (post-0406, DAG propre)
+- [ ] Comparaison figures v1 vs v2 commitée ; chaque delta expliqué par la
+      checklist PROVENANCE ou l'évolution du maître
+- [ ] Scoring + Makefile basculés sur v2 (un seul point de changement)
 - [ ] Exp1–3 re-scorés ; deltas documentés
+- [ ] PROVENANCE : entrée de version v2 ; section défauts v1 close
 - [ ] `make check` vert
 
 ## Related
 
-- 0394 (livre fix1), 0412 (archive Cergy — prérequis), 0406 (refonte Makefile)
-- `data/reference/PROVENANCE.md` §fix1
+- 0420 → 0416 → 0419 (le pipe qui produit v2), 0412 (archive Cergy —
+  prérequis), 0395 (ajouts de centrales — après ce ticket ou avec)
+- `data/reference/PROVENANCE.md` § Known defects of v1 (la checklist)
+- 0394 (clos — adjudications, mesures, leapfrog)


### PR DESCRIPTION
Chore: one ticket refresh.

**0413** retitled « Adopter la référence v2 (régénérée par le pipe) » — fix1 was leapfrogged (0394 closed via PR #699 with documentation only), so adoption targets the v2 regenerated by 0420→0416 from the corrected master. Delta-validation oracle = `PROVENANCE.md` § Known defects of v1. `Blocked-by: 0419` added (the rewiring is a single switch once consumers are deduplicated). Stale fix1/0406 references removed.

`tickets/erg check`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)