### PR TITLE
ticket(0419): single reference path for all consumers

### DIFF
--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -301,14 +301,16 @@ $(ANALYSIS_GEN)/tab_variance.tex: $(ANALYSIS_VARIANCE_JSON)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_variance --input $< --output $@
 
-$(ANALYSIS_VERIFICATION_TRADEOFF): $(wildcard $(ANALYSIS_VERIFICATION_DIR)/*-run*.csv)
+$(ANALYSIS_VERIFICATION_TRADEOFF): $(wildcard $(ANALYSIS_VERIFICATION_DIR)/*-run*.csv) $(ANALYSIS_EXPERT_REF)
 	uv run python -m aedist.tabulate_verification \
-	    --input $(ANALYSIS_VERIFICATION_DIR) --output $@
+	    --input $(ANALYSIS_VERIFICATION_DIR) --output $@ \
+	    --reference $(ANALYSIS_EXPERT_REF)
 
 $(ANALYSIS_GEN)/tab_verification.tex: $(ANALYSIS_VERIFICATION_TRADEOFF)
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_verification \
-	    --input $(ANALYSIS_VERIFICATION_DIR) --latex $@
+	    --input $(ANALYSIS_VERIFICATION_DIR) --latex $@ \
+	    --reference $(ANALYSIS_EXPERT_REF)
 
 # tab_decomposition_fix.tex: FROZEN — reconciliation_*.csv inputs were
 # gitignored (c14136ff) and never archived. The committed table is correct

--- a/experiments/scripts/fp_audit_exp2.py
+++ b/experiments/scripts/fp_audit_exp2.py
@@ -43,7 +43,8 @@ from pathlib import Path
 from rapidfuzz import fuzz, process
 
 from aedist.cleaner import PowerPlantDataframeCleaner
-from aedist.evaluate import _DEFAULT_REF, load_plants_csv, plants_from_dicts
+from aedist.config import DEFAULT_REFERENCE
+from aedist.evaluate import load_plants_csv, plants_from_dicts
 from aedist.extract import _extract_pipe_tables, parse_and_canonicalize, score_csv_like_block
 from aedist.reconcile import reconcile
 from aedist.schema import MatchType
@@ -169,7 +170,7 @@ def main() -> None:
     ap.add_argument(
         "--reference",
         type=Path,
-        default=_DEFAULT_REF,
+        default=DEFAULT_REFERENCE,
         help="reference CSV to reconcile against (default: frozen v1)",
     )
     ap.add_argument(

--- a/scripts/audit_lp_mismatched.py
+++ b/scripts/audit_lp_mismatched.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from aedist.config import DEFAULT_REFERENCE
 from aedist.evaluate import load_plants_csv
 from aedist.matching.lp import reconcile as reconcile_lp
 from aedist.reconcile import plants_to_dataframe
@@ -31,7 +32,6 @@ from aedist.reconcile import plants_to_dataframe
 log = logging.getLogger(__name__)
 
 _REPO = Path(__file__).parent.parent
-_REF_CSV = _REPO / "data" / "reference" / "vietnam_thermal_v1.csv"
 _EXP1_DIR = _REPO / "experiments" / "outputs" / "exp1_batch2"
 _DEFAULT_OUT = _REPO / "experiments" / "derived" / "exp1_mismatched_audit.csv"
 
@@ -159,7 +159,7 @@ def _print_summary(rows: list[dict]) -> None:
 def main(argv=None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--ref", default=str(_REF_CSV), help="Reference CSV path")
+    p.add_argument("--ref", default=str(DEFAULT_REFERENCE), help="Reference CSV path")
     p.add_argument("--exp1-dir", default=str(_EXP1_DIR), help="exp1_batch2 output directory")
     p.add_argument("--output", default=str(_DEFAULT_OUT), help="Output audit CSV path")
     args = p.parse_args(argv)

--- a/scripts/verify/incrementality_method.py
+++ b/scripts/verify/incrementality_method.py
@@ -25,6 +25,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
+from aedist.config import DEFAULT_REFERENCE
 from aedist.evaluate import load_plants_csv
 from aedist.harness import make_client
 from aedist.prototype_v1_fusion import (
@@ -41,7 +42,6 @@ log = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
 _DEFAULT_CORPUS = _PROJECT_ROOT / "data" / "rag_corpus"
-_DEFAULT_REF = _PROJECT_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"
 _DEFAULT_OUTPUT = _PROJECT_ROOT / "derived" / "fusion_proto"
 _DEFAULT_MODEL = "openai/gpt-4o-mini"
 
@@ -254,9 +254,9 @@ def main(argv: list[str] | None = None) -> None:
     p.add_argument(
         "--reference",
         type=Path,
-        default=_DEFAULT_REF,
+        default=DEFAULT_REFERENCE,
         metavar="FILE",
-        help=f"Reference CSV file (default: {_DEFAULT_REF})",
+        help=f"Reference CSV file (default: {DEFAULT_REFERENCE})",
     )
     p.add_argument("--verbose", action="store_true")
     args = p.parse_args(argv)

--- a/src/aedist/config.py
+++ b/src/aedist/config.py
@@ -1,0 +1,15 @@
+"""Path constants for the AEDIST pipeline.
+
+Single source of truth for default file locations. Deliberately not a
+config *system* (no TOML, env loading, or classes) — just the few path
+constants that multiple modules would otherwise duplicate. YAGNI.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Default reference list of plants (the "expert" / ground-truth CSV) that
+# comparison entry points score model output against. Override per invocation
+# with the `--reference` CLI flag or the `reference_path` parameter.
+DEFAULT_REFERENCE = _REPO_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"

--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+from .config import DEFAULT_REFERENCE
 from .metrics import BenchmarkMetrics, compute_metrics, format_metrics
 from .reconcile import reconcile
 from .schema import (
@@ -156,12 +157,8 @@ def plants_from_dicts(rows: list[dict]) -> list[Plant]:
 
 
 # ---------------------------------------------------------------------------
-# Default reference path and project root
+# Project root
 # ---------------------------------------------------------------------------
-
-_DEFAULT_REF = (
-    Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
-)
 
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
 
@@ -322,7 +319,7 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
     reconciliation CSV.
     """
     system_path = Path(args.system_file)
-    ref_path = Path(args.reference) if args.reference else _DEFAULT_REF
+    ref_path = Path(args.reference) if args.reference else DEFAULT_REFERENCE
 
     if system_path.suffix == ".json":
         _evaluate_qualitative(system_path, args)

--- a/src/aedist/prototype_v1_fusion.py
+++ b/src/aedist/prototype_v1_fusion.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from rapidfuzz import fuzz
 
+from .config import DEFAULT_REFERENCE
 from .evaluate import load_plants_csv
 from .extract import extract_fenced_blocks, fallback_extract_inline_csv, parse_and_canonicalize
 from .harness import load_experiments, make_client, query_model
@@ -48,7 +49,6 @@ log = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
 _DEFAULT_CORPUS = _PROJECT_ROOT / "data" / "rag_corpus"
-_DEFAULT_REF = _PROJECT_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"
 _DEFAULT_OUTPUT = _PROJECT_ROOT / "derived" / "fusion_proto"
 _PROMPT_DIR = _PROJECT_ROOT / "experiments" / "prompts"
 
@@ -730,7 +730,7 @@ def main(argv: list[str] | None = None) -> None:
         help="[md] Prompt for each incremental md fusion step. Default: built-in.",
     )
     p.add_argument("--corpus", type=Path, default=_DEFAULT_CORPUS)
-    p.add_argument("--reference", type=Path, default=_DEFAULT_REF)
+    p.add_argument("--reference", type=Path, default=DEFAULT_REFERENCE)
     p.add_argument("--output", type=Path, default=_DEFAULT_OUTPUT)
     p.add_argument(
         "--seed",

--- a/src/aedist/query_fusion.py
+++ b/src/aedist/query_fusion.py
@@ -23,6 +23,7 @@ import logging
 import time
 from pathlib import Path
 
+from .config import DEFAULT_REFERENCE
 from .evaluate import load_plants_csv
 from .harness import load_experiments, make_client
 from .prototype_v1_fusion import (
@@ -46,7 +47,6 @@ from .prototype_v1_fusion import (
 log = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
-_DEFAULT_REF = _PROJECT_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"
 _DEFAULT_CORPUS = _PROJECT_ROOT / "data" / "rag_corpus"
 
 # Keys in experiments.toml [sweeps.fusion*] that query_fusion.py reads.
@@ -98,7 +98,7 @@ def run_fusion(
     provider:
         Pin OpenRouter provider, e.g. ``"Alibaba"`` for DeepSeek.
     reference:
-        Path to reference CSV for F1 scoring (defaults to vietnam_thermal_v1.csv).
+        Path to reference CSV for F1 scoring (defaults to config.DEFAULT_REFERENCE).
 
     Returns
     -------
@@ -107,7 +107,7 @@ def run_fusion(
         ``n_fragments``, ``wall_seconds``.
     """
     if reference is None:
-        reference = _DEFAULT_REF
+        reference = DEFAULT_REFERENCE
 
     sequence = DEFAULT_SEQUENCE
     if fragments is not None:
@@ -260,7 +260,7 @@ def main(argv: list[str] | None = None) -> None:
     fragments = args.fragments or sweep_cfg.get("fragments")
     output_dir = Path(args.output or sweep_cfg.get("output", "derived/fusion_proto"))
     corpus_dir = Path(sweep_cfg.get("corpus", str(_DEFAULT_CORPUS)))
-    reference = Path(sweep_cfg.get("reference", str(_DEFAULT_REF)))
+    reference = Path(sweep_cfg.get("reference", str(DEFAULT_REFERENCE)))
     seed = sweep_cfg.get("seed")
     provider = sweep_cfg.get("provider")
 

--- a/src/aedist/query_verification.py
+++ b/src/aedist/query_verification.py
@@ -19,13 +19,13 @@ from pathlib import Path
 
 import yaml
 
+from .config import DEFAULT_REFERENCE
 from .evaluate import load_plants_csv
 from .harness import BudgetTracker
 from .metrics import compute_metrics
 from .reconcile import reconcile
 from .schema import Method, MethodParams, ResourceUse, ResultSummary, RunRecord
 from .verify import (
-    _DEFAULT_REF,
     extract_csv_rows,
     extract_response_text,
     filter_by_score,
@@ -381,7 +381,7 @@ def main():
     cross_verifier = config.get("cross_verifier")
     verifier_panel = config.get("verifier_panel")
     ref_path_str = config.get("reference")
-    reference_path = Path(ref_path_str) if ref_path_str else _DEFAULT_REF
+    reference_path = Path(ref_path_str) if ref_path_str else DEFAULT_REFERENCE
 
     tavily_key = os.environ.get("TAVILY_API_KEY")
 

--- a/src/aedist/reconcile.py
+++ b/src/aedist/reconcile.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pandas as pd
 
 from .cleaner import PowerPlantDataframeCleaner
+from .config import DEFAULT_REFERENCE
 from .matching.lp import reconcile as reconcile_lp
 from .schema import MatchType, Plant, ReconciliationEntry
 
@@ -22,7 +23,6 @@ from .schema import MatchType, Plant, ReconciliationEntry
 # ---------------------------------------------------------------------------
 
 _CLEANER_CONFIG = Path(__file__).parent / "cleaner" / "config.json"
-_REFERENCE = Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
 
 # Strips any trailing digit block (used for base computation only).
 _UNIT_SUFFIX = re.compile(r"\s+\d+$")
@@ -30,16 +30,20 @@ _UNIT_SUFFIX = re.compile(r"\s+\d+$")
 _FIRST_UNIT_SUFFIX = re.compile(r"\s+1$")
 
 
-def _build_single_unit_names() -> frozenset[str]:
+def _build_single_unit_names(reference_path: Path | None = None) -> frozenset[str]:
     """Names of plants that are the sole unit under their base name (from the fixed reference).
 
     Rule: name must end in " 1" AND no sibling unit exists in the reference.
     "An Khanh 1" qualifies; "Na Duong 1" does not (Na Duong 2 exists).
+
+    The reference defaults to ``config.DEFAULT_REFERENCE`` but may be overridden
+    (e.g. when switching the pipeline to a regenerated reference table).
     """
-    if not _REFERENCE.exists():
+    ref = reference_path or DEFAULT_REFERENCE
+    if not ref.exists():
         return frozenset()
     cleaner = PowerPlantDataframeCleaner(config_path=str(_CLEANER_CONFIG))
-    raw_names = pd.read_csv(_REFERENCE)["name"].dropna()
+    raw_names = pd.read_csv(ref)["name"].dropna()
     cleaned = raw_names.apply(cleaner.clean_name)
     bases = cleaned.apply(lambda s: _UNIT_SUFFIX.sub("", s))
     base_counts = bases.value_counts()

--- a/src/aedist/score_exp1.py
+++ b/src/aedist/score_exp1.py
@@ -12,7 +12,7 @@ import logging
 import re
 from pathlib import Path
 
-from .evaluate import _DEFAULT_REF
+from .config import DEFAULT_REFERENCE
 from .score_mechanical import (
     score_accuracy,
     score_coherence,
@@ -262,7 +262,7 @@ def main(argv: list[str] | None = None) -> None:
         default=Path("experiments/derived/exp1_cross_eval.csv"),
         help="CSV to append one scored row per run",
     )
-    parser.add_argument("--reference", type=Path, default=_DEFAULT_REF)
+    parser.add_argument("--reference", type=Path, default=DEFAULT_REFERENCE)
     parser.add_argument("--prompt-version", default="exp1")
     args = parser.parse_args(argv)
 

--- a/src/aedist/score_mechanical.py
+++ b/src/aedist/score_mechanical.py
@@ -13,7 +13,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from .evaluate import _DEFAULT_REF, load_plants_csv, plants_from_dicts
+from .config import DEFAULT_REFERENCE
+from .evaluate import load_plants_csv, plants_from_dicts
 from .metrics import compute_metrics
 from .reconcile import reconcile
 from .score_ingest import RunLocator, ingest_run
@@ -417,7 +418,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--model", required=True)
     parser.add_argument("--run", required=True, type=int)
     parser.add_argument("--prompt-version", default="exp2")
-    parser.add_argument("--reference", type=Path, default=_DEFAULT_REF)
+    parser.add_argument("--reference", type=Path, default=DEFAULT_REFERENCE)
     parser.add_argument(
         "--output-csv",
         type=Path,

--- a/src/aedist/self_consistency.py
+++ b/src/aedist/self_consistency.py
@@ -22,7 +22,8 @@ import unicodedata
 from collections import defaultdict
 from pathlib import Path
 
-from .evaluate import _DEFAULT_REF, load_plants_csv
+from .config import DEFAULT_REFERENCE
+from .evaluate import load_plants_csv
 from .extract import extract_one
 from .metrics import BenchmarkMetrics, compute_metrics
 from .reconcile import reconcile
@@ -455,7 +456,9 @@ def main() -> None:
         "--output", required=True, help="Output directory for consolidated CSVs and results"
     )
     p.add_argument(
-        "--reference", default=None, help="Path to reference CSV (default: vietnam_thermal_v1.csv)"
+        "--reference",
+        default=None,
+        help="Path to reference CSV (default: config.DEFAULT_REFERENCE)",
     )
     p.add_argument(
         "--measurements", default=None, help="Path to measurements.jsonl (updates per-run records)"
@@ -464,7 +467,7 @@ def main() -> None:
 
     input_dir = Path(args.input)
     output_dir = Path(args.output)
-    ref_path = Path(args.reference) if args.reference else _DEFAULT_REF
+    ref_path = Path(args.reference) if args.reference else DEFAULT_REFERENCE
 
     if not input_dir.exists():
         raise SystemExit(f"Input dir not found: {input_dir}")

--- a/src/aedist/tabulate_reconciliation.py
+++ b/src/aedist/tabulate_reconciliation.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 from scipy import stats as scipy_stats
 
+from .config import DEFAULT_REFERENCE
 from .evaluate import load_plants_csv
 from .measurements import SYNTHETIC_SUFFIXES, load, load_metrics
 from .metrics import compute_metrics
@@ -32,7 +33,6 @@ from .tabulate_utils import strip_label
 log = logging.getLogger(__name__)
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
-_EXPERT_REF = _REPO_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"
 _GEM_REF = _REPO_ROOT / "data" / "reference" / "gem_thermal.csv"
 
 _MATCHED_TYPES = {
@@ -49,7 +49,7 @@ _MATCHED_TYPES = {
 
 
 def reconcile_references(
-    expert_path: Path = _EXPERT_REF,
+    expert_path: Path = DEFAULT_REFERENCE,
     gem_path: Path = _GEM_REF,
 ) -> dict:
     """Reconcile expert and GEM references, return agreement summary."""
@@ -285,7 +285,7 @@ def main(argv: list[str] | None = None):
     parser.add_argument(
         "--expert-ref",
         type=Path,
-        default=_EXPERT_REF,
+        default=DEFAULT_REFERENCE,
         help="Path to expert reference CSV (default: %(default)s)",
     )
     parser.add_argument(

--- a/src/aedist/tabulate_verification.py
+++ b/src/aedist/tabulate_verification.py
@@ -22,15 +22,12 @@ import re
 from collections import defaultdict
 from pathlib import Path
 
+from .config import DEFAULT_REFERENCE
 from .evaluate import load_plants_csv, plants_from_dicts
 from .metrics import compute_metrics
 from .reconcile import reconcile
 
 log = logging.getLogger(__name__)
-
-_DEFAULT_REF = (
-    Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
-)
 
 # Pattern: {model}-{mode}-run{N}.csv (not *_filtered.csv)
 _CSV_PATTERN = re.compile(r"^(.+)-(\w+)-run(\d+)\.csv$")
@@ -96,7 +93,7 @@ def compute_tradeoff(verification_dir: Path, reference: Path | None = None) -> l
 
     Returns list of dicts ready for CSV output.
     """
-    ref_path = reference or _DEFAULT_REF
+    ref_path = reference or DEFAULT_REFERENCE
     ref_plants = load_plants_csv(ref_path)
 
     by_mode = _load_annotated_csvs(verification_dir)
@@ -127,17 +124,19 @@ def compute_tradeoff(verification_dir: Path, reference: Path | None = None) -> l
             avg_total = n_total_sum / n_runs
             retention = (avg_retained / avg_total * 100) if avg_total > 0 else 0.0
 
-            results.append({
-                "mode": mode,
-                "threshold": threshold,
-                "n_retained": round(avg_retained),
-                "n_total": round(avg_total),
-                "retention_pct": round(retention, 1),
-                "precision": round(precision_sum / n_runs, 4),
-                "coverage": round(coverage_sum / n_runs, 4),
-                "f1": round(f1_sum / n_runs, 4),
-                "n_runs": n_runs,
-            })
+            results.append(
+                {
+                    "mode": mode,
+                    "threshold": threshold,
+                    "n_retained": round(avg_retained),
+                    "n_total": round(avg_total),
+                    "retention_pct": round(retention, 1),
+                    "precision": round(precision_sum / n_runs, 4),
+                    "coverage": round(coverage_sum / n_runs, 4),
+                    "f1": round(f1_sum / n_runs, 4),
+                    "n_runs": n_runs,
+                }
+            )
 
     return results
 
@@ -212,12 +211,18 @@ def main():
         help="Output CSV path",
     )
     parser.add_argument("--latex", help="Optional LaTeX output path")
+    parser.add_argument(
+        "--reference",
+        type=Path,
+        default=DEFAULT_REFERENCE,
+        help="Reference CSV path",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     vdir = Path(args.input)
-    rows = compute_tradeoff(vdir)
+    rows = compute_tradeoff(vdir, Path(args.reference))
     if not rows:
         log.warning("No verification data found in %s", vdir)
         return

--- a/src/aedist/verify.py
+++ b/src/aedist/verify.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from rapidfuzz import fuzz
 
+from .config import DEFAULT_REFERENCE
 from .evaluate import load_plants_csv, plants_from_dicts
 from .extract import (
     extract_fenced_blocks,
@@ -48,10 +49,6 @@ _MATCHED_TYPES = frozenset(
 )
 
 log = logging.getLogger(__name__)
-
-_DEFAULT_REF = (
-    Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
-)
 
 # Default subject for LLM verification prompts (configurable for other domains)
 DEFAULT_VERIFICATION_SUBJECT = "thermal power plants in Vietnam"
@@ -723,7 +720,7 @@ def main():
     if args.mode == "unverified":
         annotated, summary = verify_unverified(rows)
     elif args.mode == "tool":
-        ref_path = Path(args.reference) if args.reference else _DEFAULT_REF
+        ref_path = Path(args.reference) if args.reference else DEFAULT_REFERENCE
         annotated, summary = verify_tool(rows, ref_path)
     elif args.mode == "self":
         model_id = record.get("model")

--- a/src/aedist/verify_source_grounding.py
+++ b/src/aedist/verify_source_grounding.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 from rapidfuzz import fuzz
 
+from .config import DEFAULT_REFERENCE
+
 log = logging.getLogger(__name__)
 
 # Minimum fuzzy-match score for citation -> corpus filename
@@ -164,11 +166,6 @@ def _name_in_reference(
     return False
 
 
-_DEFAULT_REFERENCE_PATH = (
-    Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
-)
-
-
 def verify_source_grounding(
     rows: list[dict],
     corpus_dir: Path,
@@ -186,7 +183,7 @@ def verify_source_grounding(
         Directory containing the .md corpus files.
     reference_path : Path | None
         Path to the reference CSV with a ``name`` column.  Defaults to
-        ``data/reference/vietnam_thermal_v1.csv`` relative to the project root.
+        ``config.DEFAULT_REFERENCE``.
 
     Returns
     -------
@@ -198,7 +195,7 @@ def verify_source_grounding(
         and a 2x2 counts table.
     """
     if reference_path is None:
-        reference_path = _DEFAULT_REFERENCE_PATH
+        reference_path = DEFAULT_REFERENCE
 
     # Load reference names
     if reference_path.is_file():

--- a/tests/test_no_hardcoded_reference_path.py
+++ b/tests/test_no_hardcoded_reference_path.py
@@ -1,0 +1,89 @@
+"""No hardcoded 'vietnam_thermal_v1.csv' outside config.py, docstrings, comments.
+
+Exit criterion 1 of ticket 0419: a single source of truth for the default
+reference path. The literal filename may only live in ``src/aedist/config.py``;
+everywhere else modules import ``config.DEFAULT_REFERENCE``.
+
+The filename can only appear inside a Python string literal, so exempting all
+string literals would make this check vacuous. Instead we exempt only
+*docstrings* (the first ``Expr``-wrapped string statement of a module, class, or
+function) and ``#`` comments. Ordinary string literals — including path-building
+expressions and ``help=`` strings — are checked.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src" / "aedist"
+CONFIG_MODULE = SRC_DIR / "config.py"
+TARGET = "vietnam_thermal_v1.csv"
+
+
+def _docstring_lines(tree: ast.Module) -> set[int]:
+    """Line numbers spanned by docstrings (module/class/function level)."""
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+        ):
+            continue
+        body = getattr(node, "body", [])
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            start = first.value.lineno
+            end = first.value.end_lineno or start
+            lines.update(range(start, end + 1))
+    return lines
+
+
+def _code_lines(path: Path) -> list[tuple[int, str]]:
+    """Return (lineno, line) for lines that are neither comments nor docstrings."""
+    source = path.read_text()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    docstring_lines = _docstring_lines(tree)
+    result: list[tuple[int, str]] = []
+    for i, line in enumerate(source.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue  # comment line — allowed
+        if i in docstring_lines:
+            continue  # inside a docstring — allowed
+        result.append((i, line))
+    return result
+
+
+def test_no_hardcoded_reference_path():
+    """TARGET must not appear in code lines of any src/aedist/*.py except config.py."""
+    violations = []
+    for py_file in sorted(SRC_DIR.glob("*.py")):
+        if py_file == CONFIG_MODULE:
+            continue  # config.py is the single allowed home
+        for lineno, line in _code_lines(py_file):
+            if TARGET in line:
+                violations.append(f"{py_file.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+    assert not violations, (
+        f"{len(violations)} hardcoded reference path(s) outside config.py:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_config_default_reference_exists():
+    """config.DEFAULT_REFERENCE must point to an existing file."""
+    from aedist.config import DEFAULT_REFERENCE  # noqa: PLC0415
+
+    assert DEFAULT_REFERENCE.exists(), (
+        f"config.DEFAULT_REFERENCE points to a non-existent file: {DEFAULT_REFERENCE}"
+    )

--- a/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
+++ b/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
@@ -3,7 +3,6 @@ Title: Adopter la référence v2 (régénérée par le pipe): figures avant/apr�
 Created: 2026-06-04
 Author: HDMX-coding-agent
 Blocked-by: 0416
-Blocked-by: 0419
 
 --- log ---
 2026-06-04T11:37Z HDMX-coding-agent created
@@ -12,6 +11,7 @@ Blocked-by: 0419
 2026-06-04T13:37Z HDMX-coding-agent note blocker 0394 closed — Blocked-by removed.
 2026-06-04T13:41Z claude note — refreshed post-leapfrog: adoption targets the v2 produced by the 0420->0416 pipe (fix1 never shipped); delta oracle = PROVENANCE known-defects checklist; Blocked-by 0419 added (single-switch rewiring)
 2026-06-04T20:09Z HDMX-coding-agent note blocker 0412 closed — Blocked-by removed.
+2026-06-04T20:12Z HDMX-coding-agent note blocker 0419 closed — Blocked-by removed.
 --- body ---
 ## Contexte
 

--- a/tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
+++ b/tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
@@ -6,6 +6,10 @@ Author: HDMX-coding-agent
 --- log ---
 2026-06-04T12:56Z HDMX-coding-agent created
 
+2026-06-04T14:10Z claude reimagine raid 419-420 — drift guard PASS; refinements appended to body §Notes Imagine; Blocked-by 0420/0416 suggested by agent REJECTED (exit criteria verifiable today; v1→v2 switch is 0413's payoff)
+
+2026-06-04T14:30Z claude plan raid — actions + first test + deps; tautology scan done
+2026-06-04T14:45Z claude feasibility PASS — render.mk:78 ANALYSIS_EXPERT_REF in scope for the two tabulate_verification rules (no SCORE_REFERENCE import needed); file sets disjoint from 0420
 --- body ---
 ## Contexte
 
@@ -40,6 +44,239 @@ défaut est dupliqué en ~8 constantes module éparpillées :
       (hors module de config et docstrings)
 - [ ] Tous les entry points de comparaison acceptent `--reference`
 - [ ] `make check` vert (le DAG score.mk continue de passer `--reference`)
+
+## Notes Imagine (raid 2026-06-04)
+
+- Chemin le plus simple : déplacer `_DEFAULT_REF` d'`evaluate.py` vers un
+  petit `src/aedist/config.py` (~3 lignes, constantes de chemin uniquement).
+  Pas de système de config (TOML/env/classes) — YAGNI.
+- TROIS modules importent déjà `from .evaluate import _DEFAULT_REF` :
+  `score_exp1.py`, `score_mechanical.py`, `self_consistency.py` — à
+  re-pointer dans le MÊME commit atomique (piège ruff : retrait
+  d'evaluate.py + ajout config.py + re-pointage en un seul lot d'édits).
+- `reconcile.py` est une BIBLIOTHÈQUE (pas d'entry point) : `_REFERENCE`
+  sert à construire `_SINGLE_UNIT_NAMES` au chargement. Fix : paramètre de
+  chemin optionnel sur `_build_single_unit_names()` avec défaut config —
+  pas d'argparse à y ajouter.
+- Lacune réelle : `tabulate_verification.py` n'expose PAS `--reference`
+  (la signature `compute_tradeoff(reference=...)` existe déjà) ET la règle
+  Makefile ne le passe pas — câbler les deux (argparse + analysis.mk).
+- Critère 1 vérifiable dès aujourd'hui (grep) — indépendant de 0420/0416.
+
+## Plan (raid 2026-06-04)
+
+### Actions (ordered)
+
+All paths relative to repo root. Verification of assumptions documented inline.
+
+**Step 1 — Create `src/aedist/config.py`** (new file; does NOT exist yet — confirmed)
+
+```python
+# src/aedist/config.py — path constants only; no config system (YAGNI)
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+DEFAULT_REFERENCE = _REPO_ROOT / "data" / "reference" / "vietnam_thermal_v1.csv"
+```
+
+One public name (`DEFAULT_REFERENCE`), nothing else.
+
+**Step 2 — Atomic ruff-safe batch: remove `_DEFAULT_REF` from `evaluate.py` + re-point 3 importers**
+
+This must be ONE atomic edit batch (ruff fires after every Edit and strips unused
+imports between Edits — trap documented in project rules):
+
+- `evaluate.py:162-164`: remove the `_DEFAULT_REF` block (confirmed: 3-line block at
+  lines 162-164 — `_DEFAULT_REF = (` on 162, filename on 163, `)` on 164).
+  Keep `_PROJECT_ROOT` at line 166 (other consumers exist, e.g. line 325
+  `ref_path = Path(args.reference) if args.reference else _DEFAULT_REF` — update that too).
+- `score_exp1.py:15`: `from .evaluate import _DEFAULT_REF` → `from .config import DEFAULT_REFERENCE`
+  and update argparse default at line 265 to `DEFAULT_REFERENCE`.
+- `score_mechanical.py:16`: `from .evaluate import _DEFAULT_REF, load_plants_csv, plants_from_dicts`
+  → `from .evaluate import load_plants_csv, plants_from_dicts` + add
+  `from .config import DEFAULT_REFERENCE`; update argparse default at line 420.
+- `self_consistency.py:25`: `from .evaluate import _DEFAULT_REF, load_plants_csv` →
+  `from .evaluate import load_plants_csv` + add `from .config import DEFAULT_REFERENCE`;
+  update ref_path fallback at line 467.
+
+**Step 3 — Replace `_DEFAULT_REF` in `verify.py`** (confirmed: lines 52-54)
+
+- Remove `_DEFAULT_REF` block at lines 52-54; add `from .config import DEFAULT_REFERENCE`.
+- Line 726: `_DEFAULT_REF` → `DEFAULT_REFERENCE`.
+- Line 13 (module docstring usage example): no code change needed — it's a
+  CLI example showing a concrete path, acceptable in a docstring.
+- Line 262 (docstring body): acceptable — describes the file semantically; the
+  ratchet test will exclude docstrings/comments.
+
+**Step 4 — Replace `_DEFAULT_REF` in `tabulate_verification.py`** (confirmed: lines 31-33)
+
+- Remove `_DEFAULT_REF` block; add `from .config import DEFAULT_REFERENCE`.
+- Line 99: `ref_path = reference or _DEFAULT_REF` → `ref_path = reference or DEFAULT_REFERENCE`.
+- Add `--reference` argument to argparse in `main()` (after line 214):
+  ```python
+  parser.add_argument("--reference", type=Path, default=DEFAULT_REFERENCE,
+                      help="Reference CSV path")
+  ```
+- Update the `main()` body at line 220:
+  `rows = compute_tradeoff(vdir)` → `rows = compute_tradeoff(vdir, Path(args.reference))`.
+
+**Step 5 — Wire `--reference` in `render.mk` for `tabulate_verification`** (confirmed: 2 rules at lines 300-307)
+
+Both rules invoke `tabulate_verification` without `--reference`.
+`SCORE_REFERENCE` is defined in `score.mk:58` but is NOT in scope in `render.mk`
+(different makefile). Check what reference variable `render.mk` uses:
+
+  - If `render.mk` includes `score.mk` or defines its own `SCORE_REFERENCE`, use it.
+  - If not, add `RENDER_REFERENCE ?= $(ANALYSIS_REPO_ROOT)/data/reference/vietnam_thermal_v1.csv`
+    near the top of `render.mk` and thread it through both rules.
+  - Both rules get `--reference $(RENDER_REFERENCE)` appended.
+
+Note: the execute agent must verify `render.mk` variable scope before writing.
+
+**Step 6 — Replace `_DEFAULT_REF`/`_EXPERT_REF` in `prototype_v1_fusion.py` and `query_fusion.py`**
+
+- `prototype_v1_fusion.py:51`: `_DEFAULT_REF = _PROJECT_ROOT / ...` → remove;
+  add `from .config import DEFAULT_REFERENCE`; update argparse at line 733.
+- `query_fusion.py:49`: same pattern; update line 110 (`reference = _DEFAULT_REF`
+  → `reference = DEFAULT_REFERENCE`) and line 263 (`str(_DEFAULT_REF)` →
+  `str(DEFAULT_REFERENCE)`).
+- `query_fusion.py:101` (docstring): update to `(defaults to DEFAULT_REFERENCE)`.
+
+**Step 7 — Replace `_DEFAULT_REF`/`_DEFAULT_REFERENCE_PATH` in `verify_source_grounding.py`** (confirmed: lines 167-169)
+
+- Remove `_DEFAULT_REFERENCE_PATH` block; add `from .config import DEFAULT_REFERENCE`.
+- Line 200: `reference_path = _DEFAULT_REFERENCE_PATH` → `reference_path = DEFAULT_REFERENCE`.
+- Line 189 (docstring): update to `Defaults to ``config.DEFAULT_REFERENCE```.
+
+**Step 8 — Fix `reconcile.py`** (confirmed: `_REFERENCE` at line 25, used in `_build_single_unit_names()` at line 42, frozen to module-level set at line 54)
+
+The function is called at import time (`_SINGLE_UNIT_NAMES = _build_single_unit_names()`).
+Fix: add optional `reference_path` parameter to `_build_single_unit_names()` with
+default from config; call with default at module level.
+
+```python
+# Before:
+_REFERENCE = Path(__file__).parent.parent.parent / "data" / "reference" / "vietnam_thermal_v1.csv"
+def _build_single_unit_names() -> frozenset[str]:
+    ...uses _REFERENCE...
+_SINGLE_UNIT_NAMES: frozenset[str] = _build_single_unit_names()
+
+# After:
+from .config import DEFAULT_REFERENCE
+def _build_single_unit_names(reference_path: Path | None = None) -> frozenset[str]:
+    ref = reference_path or DEFAULT_REFERENCE
+    ...uses ref...
+_SINGLE_UNIT_NAMES: frozenset[str] = _build_single_unit_names()
+```
+
+No argparse change needed (reconcile.py is a library, not an entry point).
+
+**Step 9 — Replace `_EXPERT_REF` in `tabulate_reconciliation.py`** (confirmed: line 35)
+
+- Remove `_EXPERT_REF = _REPO_ROOT / ...`; add `from .config import DEFAULT_REFERENCE`.
+- Line 52 default: `expert_path: Path = _EXPERT_REF` → `expert_path: Path = DEFAULT_REFERENCE`.
+- Line 288 argparse default: same substitution.
+
+**Step 10 — Run `make check` to validate the full DAG**
+
+`score.mk:SCORE_REFERENCE` already passes the explicit path to `evaluate`. The
+migrated modules get their default from `config.DEFAULT_REFERENCE`. No functional
+change to the build — this is a constant consolidation only.
+
+### First test (TDD-first)
+
+File: `tests/test_no_hardcoded_reference_path.py`
+
+```python
+"""No hardcoded 'vietnam_thermal_v1.csv' outside config.py and comments/docstrings.
+
+Exit criterion 1 of ticket 0419: single source of truth for the reference path.
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src" / "aedist"
+CONFIG_MODULE = SRC_DIR / "config.py"
+TARGET = "vietnam_thermal_v1.csv"
+
+
+def _source_lines(path: Path) -> list[tuple[int, str]]:
+    """Return (lineno, line) pairs that are NOT inside string literals or comments."""
+    source = path.read_text()
+    # Walk AST to collect line ranges of string nodes (docstrings + string literals)
+    string_lines: set[int] = set()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            # ast gives lineno/end_lineno for the string span
+            for ln in range(node.lineno, (node.end_lineno or node.lineno) + 1):
+                string_lines.add(ln)
+    result = []
+    for i, line in enumerate(source.splitlines(), 1):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue  # comment line — allowed
+        if i in string_lines:
+            continue  # inside a string literal / docstring — allowed
+        result.append((i, line))
+    return result
+
+
+def test_no_hardcoded_reference_path():
+    """TARGET must not appear in code lines of any src/aedist/*.py except config.py."""
+    violations = []
+    for py_file in sorted(SRC_DIR.glob("*.py")):
+        if py_file == CONFIG_MODULE:
+            continue  # config.py is the allowed home
+        for lineno, line in _source_lines(py_file):
+            if TARGET in line:
+                violations.append(f"{py_file.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+    assert not violations, (
+        f"{len(violations)} hardcoded reference path(s) outside config.py:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_config_default_reference_exists():
+    """config.DEFAULT_REFERENCE must point to an existing file."""
+    from aedist.config import DEFAULT_REFERENCE  # noqa: PLC0415
+
+    assert DEFAULT_REFERENCE.exists(), (
+        f"config.DEFAULT_REFERENCE points to a non-existent file: {DEFAULT_REFERENCE}"
+    )
+```
+
+The AST-based approach skips docstrings and string literals, so the
+`verify.py:262` docstring mention and `verify.py:13` usage example are
+automatically excluded. No manual exception list needed.
+
+### Dependencies
+
+- **0420** (1/3 — raw data pipeline): touches `data/reference/raw/`, `docs/pipeline.ods`,
+  new `extract_ods.py`. Fully disjoint from `src/aedist/` changes here. No conflict.
+- **0416** (2/3 — aggregator): not yet planned; disjoint from constants-migration.
+- **0413** (adoption, beneficiary): blocked on this ticket; no shared files.
+- **0406** (paths.mk): closed; `score.mk:SCORE_REFERENCE` already correct.
+- No other blockers identified.
+
+### Tautological-test scan
+
+| Test | Catches wrong impl? |
+|------|---------------------|
+| `test_no_hardcoded_reference_path` — grep for `vietnam_thermal_v1.csv` in non-comment, non-docstring code lines | YES: if any constant is not removed (e.g. developer leaves `_DEFAULT_REF` in one file), test fails on that line. Does NOT catch wrong path in config.py (acceptable — config.py is the single allowed location). |
+| `test_config_default_reference_exists` — asserts `DEFAULT_REFERENCE.exists()` | YES: catches a typo'd path or wrong filename in config.py. Fails if the file doesn't exist on disk at test time (expected: data/reference/vietnam_thermal_v1.csv is tracked). Does NOT catch a semantically wrong path that happens to exist — unlikely given the specific filename. |
+
+Both tests are non-tautological and complementary: one enforces zero duplication
+outside config.py, the other enforces config.py correctness.
 
 ## Related
 

--- a/tickets/closed/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
+++ b/tickets/closed/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg
@@ -2,6 +2,7 @@
 Title: Pipeline référence 3/3: un seul chemin de référence côté consommateurs
 Created: 2026-06-04
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #712
 
 --- log ---
 2026-06-04T12:56Z HDMX-coding-agent created
@@ -10,6 +11,7 @@ Author: HDMX-coding-agent
 
 2026-06-04T14:30Z claude plan raid — actions + first test + deps; tautology scan done
 2026-06-04T14:45Z claude feasibility PASS — render.mk:78 ANALYSIS_EXPERT_REF in scope for the two tabulate_verification rules (no SCORE_REFERENCE import needed); file sets disjoint from 0420
+2026-06-04T20:12Z HDMX-coding-agent closed — autoclosed — PR #712
 --- body ---
 ## Contexte
 


### PR DESCRIPTION
**Ticket:** tickets/0419-pipeline-r-f-rence-3-3-un-seul-chemin-de.erg

## What

One source of truth for the default reference list path. Previously
`data/reference/vietnam_thermal_v1.csv` was re-derived from `__file__` in
eight module-level constants across `src/aedist/` (plus three more consumers
in `experiments/scripts/` and `scripts/`). The v1→v2 pipeline switch
(ticket 0413) now flips one config line + one make variable instead of
chasing scattered constants.

## Design choices

- **`src/aedist/config.py` — one constant, nothing else.** No TOML, no env
  loading, no classes. Every consumer needs the same default path and
  nothing more (YAGNI). One public name: `DEFAULT_REFERENCE`.
- **`reconcile.py` is a library**, not an entry point. Its `_REFERENCE`
  fed a module-level frozenset at import time. Fixed by giving
  `_build_single_unit_names()` an optional `reference_path` parameter
  defaulting to config; the import-time call uses the default, so behaviour
  is byte-for-byte unchanged. No argparse added.
- **`tabulate_verification.py`**: closed the genuine gap — added the missing
  `--reference` argparse option (the `compute_tradeoff(reference=...)`
  signature already accepted it) and wired it into the `main()` call site.
- **`experiments/render.mk`**: both `tabulate_verification` rules now pass
  `--reference $(ANALYSIS_EXPERT_REF)` (the variable was already defined at
  render.mk:78). Deliberate DAG-correctness addition: the reference file is
  now also listed as a prerequisite of the tradeoff CSV, since the script
  reads it. Not scope creep — it satisfies the project's Makefile-DAG rule.
- **`score.mk`** already passed `--reference $(SCORE_REFERENCE)` — verified,
  unchanged.
- **Wider sweep**: a grep outside `src/` found three more consumers.
  `fp_audit_exp2.py` imported the removed `aedist.evaluate._DEFAULT_REF`
  (a real breakage); `incrementality_method.py` and `audit_lp_mismatched.py`
  had their own duplicate constants. All three re-pointed to
  `config.DEFAULT_REFERENCE`; their CLI `--reference`/`--ref` overrides kept.

## Tests (TDD-first)

`tests/test_no_hardcoded_reference_path.py` (`@pytest.mark.adherence`):
- A ratchet test that AST-parses every `src/aedist/*.py` and asserts the
  literal filename appears in **no code line** outside `config.py`. The AST
  helper exempts only docstrings and `#` comments — **not** all string
  literals (the filename can only live in a string literal, so exempting
  all literals would make the check vacuous; verified it went RED with 9
  violations on the unmodified tree before any edit).
- A unit test asserting `config.DEFAULT_REFERENCE` points at an existing file.

`make check` green (1850 tests, coverage ≥70%, ruff clean). Default
resolution is identical to before — this is a constant-consolidation
refactor with no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)