### PR TITLE
tickets: open 0422-0424 — 0421 celebrate sweep follow-ups

### DIFF
--- a/tickets/0422-stale-pre-rename-dir-names-in-score-stru.erg
+++ b/tickets/0422-stale-pre-rename-dir-names-in-score-stru.erg
@@ -1,0 +1,40 @@
+%erg 0.1
+Title: Stale pre-rename dir names in SCORE_STRUCTURED_DIRS extract loop
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T15:16Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`SCORE_STRUCTURED_DIRS` (experiments/derived/score.mk:66) lists the dirs
+the `extract` loop scans under `$(SCORE_OUTPUTS)/`:
+
+    census multiturn web rag decomposed decomposed_v2 sourced frontier
+    ablation/direct/p1_base ablation/direct/p1_base.topup
+    ablation/direct/p1_composite exp1_batch2
+
+Several entries are pre-rename names (the 0122 namespace migration,
+026f0e72, renamed e.g. rag -> rag_extract, decomposed -> rag_per_fuel,
+sourced -> rag_cited) and were never updated. The loop silently no-ops
+on missing dirs — no data corruption, but extract has not covered those
+dirs since the rename, and the stale list misleads readers about the P2
+surface. Surfaced by /verify on PR #713 (ticket 0421).
+
+## Actions
+
+1. For each entry, check existence under experiments/outputs/ (live) —
+   map old -> new names via the 026f0e72 rename table.
+2. Decide per entry: rename to the current dir, or drop (raw replies
+   archived per edda724b mean extract has nothing to scan there;
+   exp1_batch2 is the only live-data dir today).
+3. Consider asserting every SCORE_STRUCTURED_DIRS entry exists, so
+   future renames fail loudly instead of no-oping.
+
+## Exit criteria
+
+- Every SCORE_STRUCTURED_DIRS entry points at an existing dir (or the
+  variable is reduced to the dirs extract actually serves)
+- make check green

--- a/tickets/0423-adherence-guard-empty-raw-reply-wildcard.erg
+++ b/tickets/0423-adherence-guard-empty-raw-reply-wildcard.erg
@@ -1,0 +1,38 @@
+%erg 0.1
+Title: Adherence guard: empty raw-reply wildcard with non-empty archive sibling
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T15:16Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Ticket 0421 found three render/score rules whose `$(wildcard ...)` over
+`experiments/outputs/<dir>/` silently expanded to empty after the
+edda724b archive move — the rules then produced empty tables (latent
+0383 hazard: a rebuild clobbers correct committed tables). The 0417
+guard checks rule *existence*, not rule *correctness*: a rule with an
+empty input wildcard passes it. The bug has a class shape: any future
+dir rename or archive sweep recreates it silently.
+
+This was action 4 of 0421, deferred out of its scope.
+
+## First test (the deliverable)
+
+Adherence test (tests/test_makefile_dag.py or a sibling): for every
+`$(wildcard <pattern>)` in the phase makefiles whose pattern points
+under `experiments/outputs/`, if the wildcard expands empty AND the
+matching `experiments/archive/outputs/` sibling pattern is non-empty,
+fail with a "repoint to archive?" message. Reuse the existing makefile
+scanner (`_parse_to_vars_rules`).
+
+Expected green today (0421 repointed all known cases) — the test guards
+the class coming back.
+
+## Exit criteria
+
+- Standing adherence test as above, green on current main
+- Red if any repointed wildcard in render.mk/score.mk is reverted to
+  the live outputs/ path (verify by temporary mutation)

--- a/tickets/0424-restore-tab-decomposition-fix-reproducib.erg
+++ b/tickets/0424-restore-tab-decomposition-fix-reproducib.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: Restore tab_decomposition_fix reproducibility via reconcile-from-archive P2 step
+Created: 2026-06-04
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-04T15:16Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`tab_decomposition_fix.tex` (the 0068 hallucination-fix result,
+report.tex:396) was FROZEN by 0421: its inputs (reconciliation_*.csv in
+rag_per_fuel{,_v2}/) were gitignored (c14136ff) and never archived. The
+committed table is correct but unreproducible — entry documented in
+FROZEN_ALLOWLIST (tests/test_makefile_dag.py).
+
+The raw model JSONs/CSVs ARE in experiments/archive/outputs/
+rag_per_fuel{,_v2}/. Reproducibility needs a P2 step that re-runs
+reconciliation (evaluate.py) on the archived raw replies into a
+derived/ location, then a repointed tabulate_decomposition_fix.
+
+## Risk — 0383
+
+The LP matcher changed since the table was generated (e.g. PR #547
+fixed Mismatched routing, memory: pre-fix metrics inflated). A re-run
+will likely NOT be byte-identical: the regenerated numbers reflect the
+current scorer, not the published ones. The redress must (a) regenerate
+under explicit review, (b) decide whether the paper keeps the frozen
+numbers (with a scorer-version note) or adopts the new ones, with the
+author in the loop. Do NOT auto-commit a changed table.
+
+## Actions
+
+1. Wire a score.mk rule: archive/outputs/rag_per_fuel{,_v2}/*.csv ->
+   derived/decomp_fix/reconciliation_*.csv via evaluate.py reconcile.
+2. Repoint tabulate_decomposition_fix defaults + restore the render.mk
+   rule (preserved in comment at render.mk, near tab_coherence).
+3. Regenerate; diff against the frozen table; surface any drift to the
+   author (0383 review) before committing.
+4. On success, drop the FROZEN_ALLOWLIST entry.
+
+## Exit criteria
+
+- tab_decomposition_fix.tex has a producer rule again; FROZEN_ALLOWLIST
+  entry removed
+- Any numeric drift vs the frozen table explicitly reviewed and decided
+  by the author
+- make check green


### PR DESCRIPTION
Ticket: none

Three follow-up tickets from the 0421 celebrate sweep:
- **0422** — `SCORE_STRUCTURED_DIRS` stale pre-rename dir names (surfaced by /verify on PR #713)
- **0423** — standing adherence guard: empty raw-reply wildcard with non-empty archive sibling (the 0421 class, action 4 deferred)
- **0424** — restore `tab_decomposition_fix` reproducibility (the FROZEN_ALLOWLIST entry referenced this follow-up; it now exists)

Tickets only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)