### PR TITLE
ticket(0427): design revision — reservation moves to ticket-new skill

### DIFF
--- a/tickets/0427-adopt-erg-cross-session-id-reservation-g.erg
+++ b/tickets/0427-adopt-erg-cross-session-id-reservation-g.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-04T16:26Z HDMX-coding-agent created
+2026-06-04T16:40Z HDMX-coding-agent note design revised on author review — binary stays network-free; push orchestration moves to the ticket-new skill; upstream scope reduced to an --id/--min-id flag (git-erg#282 comment)
 
 --- body ---
 ## Context
@@ -15,35 +16,54 @@ sessions each scan their own checkout, so `erg new`'s O_EXCL retry loop
 (same-checkout races only) cannot see a sibling branch's allocation.
 The collision surfaces at merge.
 
-Author ratified the prevention approach ("push immédiat"): reserve the
-ID on the remote at allocation time. Upstream feature request filed as
-git-erg#282 — atomic reservation via `git push origin
-HEAD:refs/erg-ids/NNNN` (server-side ref creation fails if the ref
-exists → retry next ID; offline → warn + fall back to current
-behavior).
+Author ratified prevention by remote reservation, then refined the
+design: a network side effect inside the `erg` binary is too dangerous
+(untimely push, credentials-less CI, read-only remotes, agent guard
+bypass). Ratified split (git-erg#282, revision comment):
+
+- **`erg` binary: pure local, zero network.** Upstream scope reduced to
+  an escape hatch: `erg new --id NNNN` (or `--min-id`) accepting an
+  externally-arbitrated ID.
+- **`ticket-new` skill drives the reservation**: fetch → scan
+  origin/main + `refs/erg-ids/*` → `git push origin
+  main:refs/erg-ids/NNNN` (atomic server-side; ref only, never a
+  branch, no checkout switch, no CI trigger) → on ref-exists rejection
+  retry next ID → `erg new --id NNNN`. Offline: skip reservation, fall
+  back to plain `erg new`.
 
 Detection-side complement: 0418 (erg check in CI) — both layers wanted;
 this ticket is the prevention layer.
 
 ## Blocked on upstream
 
-git-erg#282 must land and a release build published. Until then the
-interim discipline stands: fetch + scan origin/main before `erg new`
-(memory: ticket-id-collision-check), CI gate per 0418.
+git-erg#282 (`--id`/`--min-id` flag) must land and a release build
+published; the skill update ships with the git-erg-distributed
+`ticket-new` skill. Until then the interim discipline stands: fetch +
+scan origin/main before `erg new` (memory: ticket-id-collision-check),
+CI gate per 0418.
 
 ## Actions (once upstream lands)
 
 1. Refresh `tickets/erg` from the git-erg release (same flow as 0407:
-   binary + provenance `.erg-assets` rev bump, atomic).
-2. Verify reservation round-trip against this repo's origin: two
-   concurrent `erg new` from separate worktrees must yield distinct IDs.
+   binary + provenance `.erg-assets` rev bump, atomic) and take the
+   updated `ticket-new` skill.
+2. Verify the skill-level reservation round-trip against this repo's
+   origin: two concurrent allocations from separate worktrees must
+   yield distinct IDs, with the reservation push visible in each
+   transcript.
 3. Prune any stale `refs/erg-ids/*` whose ticket is on main (upstream
    may ship the prune verb; otherwise document the one-liner).
 4. Drop/soften the interim fetch-first rule in memory once verified.
 
+## Invariants
+
+- `erg` binary makes no network calls and never switches branches
+- The skill pushes only under `refs/erg-ids/*` — never a branch ref
+
 ## Exit criteria
 
-- `tickets/erg` at a rev including git-erg#282
+- `tickets/erg` at a rev including git-erg#282; `ticket-new` skill does
+  the reservation
 - Two-worktree concurrent allocation test yields distinct IDs
 - Reservation refs visible on origin during allocation, pruned after
   the tickets land on main


### PR DESCRIPTION
Ticket-ref: tickets/0427-adopt-erg-cross-session-id-reservation-g.erg

Race repair: PR #716 auto-merged while the design-revision commit was in flight; the amendment landed on the recreated quickpr branch after the merge. This PR carries that single commit.

Content: author flagged the side-effect hazard of a push inside `erg new` (untimely push / branch switch). The atomic arbiter is unchanged (`refs/erg-ids/*` server-side ref creation); its **driver moves to the ticket-new skill** — explicit, permission-gated, auditable. Upstream git-erg#282 scope reduced to an `--id`/`--min-id` flag; binary stays network-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)