### PR TITLE
ticket(0152): close obsolete — talk delivered, slides frozen

### DIFF
--- a/tickets/closed/0152-align-slides-on-argument.erg
+++ b/tickets/closed/0152-align-slides-on-argument.erg
@@ -2,12 +2,14 @@
 Title: Align slides on the argument's three-part structure
 Created: 2026-04-30
 Author: claude
+Closed: obsolete — talk delivered 2026-05-27 at Econom'IA Cergy; slides are frozen post-conference, realigning them now would be destructive
 
 --- log ---
 2026-04-30T19:00Z claude created
 2026-05-21T08:50Z claude note removed Blocked-by 0149 — 0149 superseded (docs/hypotheses.md rewritten on main via 844c3f3/297f2e1/aeb63f1); PR #316 closed
 2026-05-21T09:55Z claude note rebased argument source argument.md -> slides/manuscript/main.md (current working manuscript)
 
+2026-06-04T16:42Z HDMX-coding-agent closed — obsolete — talk delivered 2026-05-27 at Econom'IA Cergy; slides are frozen post-conference, realigning them now would be destructive
 --- body ---
 
 ## Context


### PR DESCRIPTION
Ticket-ref: tickets/closed/0152-align-slides-on-the-argument-s-three-par.erg

Author flag (2026-06-04): 0152 is obsolete AND dangerous — the talk was delivered 2026-05-27; realigning the slide structure now would rewrite a frozen deliverable. Hand-closed in this PR so no autonomous sweep (pick-ticket/raid/nightbeat) can pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)