### PR TITLE
fix(0418): run erg check in CI lint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,8 @@ jobs:
               - 'ADR.md'
               - 'MASTERPLAN.md'
               - 'PLAN.md'
+      - name: Check ticket corpus integrity
+        run: tickets/erg check tickets/
   lint:
     needs: changes
     if: ${{ !cancelled() }}

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ coverage:
 lint:
 	uv run ruff check src/ tests/ scripts/
 	uv run python scripts/check_ticket_structure.py
+	tickets/erg check tickets/
 
 check-fast: test-fast lint
 

--- a/tickets/0418-erg-check-in-ci.erg
+++ b/tickets/0418-erg-check-in-ci.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-06-04T14:55Z claude created — raid 405-406 celebrate sweep; the 0412 ID collision (fixed by PR #701) sat on main with erg check FAILED and no CI signal
 
 2026-06-04T13:20Z claude note — live instance for this ticket: 0418-pipeline-reference collided with this very ID from a sibling branch (both erg-new allocations passed locally); renumbered to 0420
+2026-06-04T16:43Z claude claimed t418 (remote run)
 --- body ---
 ## Context
 

--- a/tickets/closed/0418-erg-check-in-ci.erg
+++ b/tickets/closed/0418-erg-check-in-ci.erg
@@ -2,12 +2,14 @@
 Title: Run erg check in CI lint — duplicate ticket IDs reached main undetected
 Created: 2026-06-04
 Author: claude
+Closed: erg check wired into lint + CI path filter
 
 --- log ---
 2026-06-04T14:55Z claude created — raid 405-406 celebrate sweep; the 0412 ID collision (fixed by PR #701) sat on main with erg check FAILED and no CI signal
 
 2026-06-04T13:20Z claude note — live instance for this ticket: 0418-pipeline-reference collided with this very ID from a sibling branch (both erg-new allocations passed locally); renumbered to 0420
 2026-06-04T16:43Z claude claimed t418 (remote run)
+2026-06-04T16:44Z Claude closed — erg check wired into lint + CI path filter
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0418-erg-check-in-ci.erg

## Summary

- Added `tickets/erg check tickets/` to the Makefile `lint:` target so `make lint` and `make check-fast` catch duplicate IDs, dangling `Blocked-by` refs, and closed-not-archived files locally.
- Added a `Check ticket corpus integrity` step directly in the `changes` job of `.github/workflows/CI.yml`. Because the `changes` job already runs on every PR (no `if:` guard), this guarantees `erg check` executes even for ticket-only diffs that would otherwise trigger the chore-bypass and skip the heavy `lint` / `tests` jobs.

## Path-filter reasoning

The `changes` job uses `dorny/paths-filter` with `predicate-quantifier: every` to set `chore: true` when all changed files are tickets, docs, or harness files. Downstream jobs (`lint`, `tests`) skip their expensive steps when `chore == 'true'`. This bypass is intentional — ticket-only PRs shouldn't rebuild PDFs or run the full test suite. However, ticket-only PRs are **exactly** the commits that can introduce duplicate IDs (two parallel sessions calling `erg new` both get the same ID). Inserting `erg check` as a step inside `changes` — before any `if:` guard — ensures it runs on every PR regardless of the chore flag, while keeping the bypass benefit for the heavy pipeline.

## Red-test evidence

Duplicate-ID file created → `make lint` fails:

```
tickets/erg check tickets/
erg: branch t418 (tickets)
ERG CHECK FAILED (1 error):
  VIOLATION duplicate ID '0418' in: 0418-duplicate-test.erg, 0418-erg-check-in-ci.erg
make: *** [Makefile:73: lint] Error 1
EXIT CODE: 2
```

Clean run → `make check-fast` passes in 25.98 s (< 30 s limit):

```
tickets/erg check tickets/
erg: branch t418 (tickets)
ERG CHECK: PASS (411 tickets)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdF8GXgetDHoBGrm5GtRZq)_