### PR TITLE
fix(0414): _NEEDS_ENV covers all paid sweeps

### DIFF
--- a/experiments/acquire.mk
+++ b/experiments/acquire.mk
@@ -63,6 +63,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))common.mk
 # missing. Keys themselves are not read into Make variables — uv loads them
 # at child-process spawn time via --env-file.
 _NEEDS_ENV := census census-run regimes regimes-run \
+						 decomposed decomposed-run verification verification-run \
 						 sourced sourced-run frontier frontier-run
 ifneq ($(filter $(_NEEDS_ENV),$(MAKECMDGOALS)),)
   $(if $(wildcard ../.env),,$(error ../.env not found — copy ../.env.example and populate API keys))

--- a/tests/test_acquire_all_phony.py
+++ b/tests/test_acquire_all_phony.py
@@ -113,3 +113,48 @@ def test_no_filesystem_path_targets():
         "target. A path target (especially one escaping experiments/ via '..') "
         "would couple a money-gated re-acquisition to a timestamp rebuild."
     )
+
+
+def _parse_needs_env(text: str) -> set[str]:
+    """Return the set of names declared in the _NEEDS_ENV assignment."""
+    joined = text.replace("\\\n", " ")
+    m = re.search(r"_NEEDS_ENV\s*:=\s*([^\n#]+)", joined)
+    if not m:
+        return set()
+    return set(m.group(1).split())
+
+
+def test_env_file_verbs_covered_by_needs_env():
+    """Every sweep group X (with X-generate and X-run) must have X and X-run in _NEEDS_ENV.
+
+    All sweep groups invoke the manager/worker pipeline via $(MANAGER) / $(OR_DRAIN),
+    which expand through $(UV_RUN) and carry --env-file ../.env.  The _NEEDS_ENV
+    sentinel must cover the top-level verb X and its X-run sub-target so that
+    invoking either without a populated .env fails fast rather than burning API
+    quota mid-run.
+    """
+    text = ACQUIRE_MK.read_text()
+    phony, _ = _phony_names_and_targets(text)
+
+    sweep_groups = sorted(
+        name[: -len("-generate")]
+        for name in phony
+        if name.endswith("-generate")
+        and name[: -len("-generate")] + "-run" in phony
+    )
+
+    needs_env = _parse_needs_env(text)
+
+    missing = []
+    for group in sweep_groups:
+        if group not in needs_env:
+            missing.append(group)
+        if f"{group}-run" not in needs_env:
+            missing.append(f"{group}-run")
+
+    assert not missing, (
+        f"Sweep verbs with --env-file recipes not covered by _NEEDS_ENV: "
+        f"{sorted(missing)}. "
+        "Add them to the _NEEDS_ENV list so `make <verb>` fails fast when "
+        "../.env is absent instead of launching a money-costing API sweep."
+    )

--- a/tickets/closed/0414-needs-env-sweep-coverage.erg
+++ b/tickets/closed/0414-needs-env-sweep-coverage.erg
@@ -2,10 +2,14 @@
 Title: _NEEDS_ENV sentinel covers only 4 of 6 paid sweeps — add decomposed, verification
 Created: 2026-06-04
 Author: claude
+Closed: decomposed+verification covered; guard test enforces --env-file ⊆ _NEEDS_ENV
 
 --- log ---
 2026-06-04T12:40Z claude created — follow-up surfaced by /verify on PR #698 (0411, acquire.mk); pre-existing gap, out of scope there
 
+2026-06-04T12:50Z claude claimed t414 (remote run)
+
+2026-06-04T17:20Z Claude closed — decomposed+verification covered; guard test enforces --env-file ⊆ _NEEDS_ENV
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0414-needs-env-sweep-coverage.erg

## Summary

- `decomposed` and `decomposed-run` added to `_NEEDS_ENV` in `experiments/acquire.mk`
- `verification` and `verification-run` added to `_NEEDS_ENV` in `experiments/acquire.mk`
- New adherence test `test_env_file_verbs_covered_by_needs_env` in `tests/test_acquire_all_phony.py` enforces that every sweep group (X where X-generate and X-run are declared .PHONY) has X and X-run in `_NEEDS_ENV`

## Red-test evidence

Before the fix, the new test failed with:

```
FAILED tests/test_acquire_all_phony.py::test_env_file_verbs_covered_by_needs_env
AssertionError: Sweep verbs with --env-file recipes not covered by _NEEDS_ENV:
['decomposed', 'decomposed-run', 'verification', 'verification-run'].
Add them to the _NEEDS_ENV list so `make <verb>` fails fast when
../.env is absent instead of launching a money-costing API sweep.
```

After the fix: 4/4 tests in `test_acquire_all_phony.py` pass, and `make -C experiments -f acquire.mk -n decomposed` without `.env` fails fast:

```
acquire.mk:69: *** ../.env not found — copy ../.env.example and populate API keys.  Stop.
```

## Test plan

- [x] `make check-fast` green (1850 tests pass)
- [x] `test_env_file_verbs_covered_by_needs_env` RED before fix, GREEN after
- [x] Dry-run sentinel confirmed: `make -C experiments -f acquire.mk -n decomposed` fails fast without `.env`
- [x] Ticket 0414 closed and archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016wvPdv4y8A36LFxc4hZs5R)_