### PR TITLE
fix(0422): SCORE_STRUCTURED_DIRS — drop/rename stale pre-rename entries + existence guard

### DIFF
--- a/experiments/derived/score.mk
+++ b/experiments/derived/score.mk
@@ -63,11 +63,17 @@ SCORE_DERIVED   := $(ANALYSIS_DERIVED_DIR)
 # === measurements.jsonl: materialized view of all outputs ===================
 # (migrated from the P1 makefile (now experiments/acquire.mk), tracker 0406 S3)
 
-SCORE_STRUCTURED_DIRS := census multiturn web rag \
-                   decomposed decomposed_v2 sourced frontier \
-                   ablation/direct/p1_base ablation/direct/p1_base.topup \
-                   ablation/direct/p1_composite \
-                   exp1_batch2
+# Dropped entries (0422): pre-0122 names and record-only dirs have no
+# extractable JSON/CSV for extract to scan. Raw replies were moved to
+# experiments/archive/outputs/ (edda724b); renamed dirs under
+# $(SCORE_OUTPUTS) hold only .record.json pointers.
+#   census, multiturn, web, frontier: dirs never created post-archive
+#   rag (→ rag_extract): record-only after edda724b
+#   decomposed (→ rag_per_fuel): record-only after edda724b
+#   decomposed_v2 (→ rag_per_fuel_v2): record-only after edda724b
+#   sourced (→ rag_cited): record-only after edda724b
+#   ablation/direct/p1_base, p1_base.topup, p1_composite: record-only
+SCORE_STRUCTURED_DIRS := exp1_batch2
 
 SCORE_OUTPUT_FILES := $(filter-out %.record.json $(SCORE_DERIVED)/rag_consistency/%,\
                    $(wildcard $(SCORE_OUTPUTS)/*/*.json) $(wildcard $(SCORE_DERIVED)/*/*.json)) \

--- a/tests/test_score_structured_dirs.py
+++ b/tests/test_score_structured_dirs.py
@@ -1,0 +1,41 @@
+"""Adherence guard: every SCORE_STRUCTURED_DIRS entry must exist as a directory.
+
+Ticket 0422. RED before the stale pre-rename entries are removed from
+score.mk; GREEN after.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCORE_MK = REPO_ROOT / "experiments" / "derived" / "score.mk"
+OUTPUTS_DIR = REPO_ROOT / "experiments" / "outputs"
+
+
+def _parse_score_structured_dirs() -> list[str]:
+    text = SCORE_MK.read_text()
+    m = re.search(r"SCORE_STRUCTURED_DIRS\s*:=\s*((?:[^\n\\]*\\\n)*[^\n]*)", text)
+    if not m:
+        return []
+    raw = re.sub(r"\\\n\s*", " ", m.group(1))
+    return raw.split()
+
+
+@pytest.mark.parametrize("entry", _parse_score_structured_dirs())
+def test_score_structured_dir_exists(entry):
+    """Every SCORE_STRUCTURED_DIRS entry must be a live directory in outputs/.
+
+    If extract has nothing to scan (record-only or dir was renamed/archived),
+    the entry must be dropped from the list so it does not mislead readers or
+    silently no-op.
+    """
+    d = OUTPUTS_DIR / entry
+    assert d.is_dir(), (
+        f"SCORE_STRUCTURED_DIRS entry '{entry}' does not exist under "
+        f"experiments/outputs/. Rename it to the current dir name (if live "
+        f"data is present) or drop it (if the dir is record-only or archived)."
+    )

--- a/tickets/0422-stale-pre-rename-dir-names-in-score-stru.erg
+++ b/tickets/0422-stale-pre-rename-dir-names-in-score-stru.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-04T15:16Z HDMX-coding-agent created
+2026-06-04T15:30Z claude claimed t422 (remote run)
 
 --- body ---
 ## Context

--- a/tickets/closed/0422-stale-pre-rename-dir-names-in-score-stru.erg
+++ b/tickets/closed/0422-stale-pre-rename-dir-names-in-score-stru.erg
@@ -2,11 +2,13 @@
 Title: Stale pre-rename dir names in SCORE_STRUCTURED_DIRS extract loop
 Created: 2026-06-04
 Author: HDMX-coding-agent
+Closed: stale entries resolved with evidence; existence guard added
 
 --- log ---
 2026-06-04T15:16Z HDMX-coding-agent created
 2026-06-04T15:30Z claude claimed t422 (remote run)
 
+2026-06-04T17:54Z Claude closed — stale entries resolved with evidence; existence guard added
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0422-stale-pre-rename-dir-names-in-score-stru.erg

## Summary

- Drop 11 stale entries from `SCORE_STRUCTURED_DIRS` that have silently no-op'd since the 0122 namespace migration (commit `026f0e72`) and the edda724b archive move. Only `exp1_batch2` survives.
- Add `tests/test_score_structured_dirs.py` (`@adherence`) that asserts every listed entry exists as a directory under `experiments/outputs/`, so future renames fail loudly instead of silently no-oping.

## Per-entry disposition table

| Entry | Renamed to | Lives under outputs/? | Non-record files | Disposition | Evidence |
|-------|-----------|----------------------|-----------------|-------------|---------|
| `census` | — | No | — | **DROP** | dir never created post-archive |
| `multiturn` | — | No | — | **DROP** | dir never created post-archive |
| `web` | — | No | — | **DROP** | dir never created post-archive |
| `rag` | `rag_extract` | Yes | 0 | **DROP** | `rag_extract/` holds 50 `.record.json` only; raw replies in archive (edda724b) |
| `decomposed` | `rag_per_fuel` | Yes | 0 | **DROP** | `rag_per_fuel/` holds 16 `.record.json` only |
| `decomposed_v2` | `rag_per_fuel_v2` | Yes | 0 | **DROP** | `rag_per_fuel_v2/` holds 17 `.record.json` only |
| `sourced` | `rag_cited` | Yes | 0 | **DROP** | `rag_cited/` holds 3 `.record.json` only |
| `frontier` | — | No | — | **DROP** | dir never created post-archive |
| `ablation/direct/p1_base` | — | Yes | 0 | **DROP** | 86 files, all `.record.json` |
| `ablation/direct/p1_base.topup` | — | Yes | 0 | **DROP** | 40 files, all `.record.json` |
| `ablation/direct/p1_composite` | — | Yes | 0 | **DROP** | 4 files, all `.record.json` |
| `exp1_batch2` | — | Yes | 140 | **KEEP** | 70 CSVs + 70 JSONs — live extractable data |

## Red-test run (before fix)

```
collected 12 items

FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[census]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[multiturn]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[web]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[rag]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[decomposed]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[decomposed_v2]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[sourced]
FAILED test_score_structured_dirs.py::test_score_structured_dir_exists[frontier]
PASSED test_score_structured_dir_exists[ablation/direct/p1_base]
PASSED test_score_structured_dir_exists[ablation/direct/p1_base.topup]
PASSED test_score_structured_dir_exists[ablation/direct/p1_composite]
PASSED test_score_structured_dir_exists[exp1_batch2]

8 failed, 4 passed in 0.06s
```

## Green-test run (after fix)

```
collected 1 item

PASSED test_score_structured_dirs.py::test_score_structured_dir_exists[exp1_batch2]

1 passed in 0.03s
```

`make check-fast`: 1845 passed, 5 skipped, 1 xfailed — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2Bb6ZbtsZCnRuxptsbiLS)_