### PR TITLE
ticket(0412): close — Econom'IA Cergy communication fully archived

### DIFF
--- a/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
+++ b/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
@@ -2,7 +2,6 @@
 Title: Adopter la référence v2 (régénérée par le pipe): figures avant/après puis recâblage
 Created: 2026-06-04
 Author: HDMX-coding-agent
-Blocked-by: 0412
 Blocked-by: 0416
 Blocked-by: 0419
 
@@ -12,6 +11,7 @@ Blocked-by: 0419
 2026-06-04T12:58Z claude note — pipeline revision (0418/0416/0419): adoption now targets the pipe-produced v2 regenerated from the corrected master; fix1 (PR #699) is the interim integrity patch; Blocked-by 0416 added
 2026-06-04T13:37Z HDMX-coding-agent note blocker 0394 closed — Blocked-by removed.
 2026-06-04T13:41Z claude note — refreshed post-leapfrog: adoption targets the v2 produced by the 0420->0416 pipe (fix1 never shipped); delta oracle = PROVENANCE known-defects checklist; Blocked-by 0419 added (single-switch rewiring)
+2026-06-04T20:09Z HDMX-coding-agent note blocker 0412 closed — Blocked-by removed.
 --- body ---
 ## Contexte
 

--- a/tickets/closed/0412-archiver-la-communication-econom-ia-cerg.erg
+++ b/tickets/closed/0412-archiver-la-communication-econom-ia-cerg.erg
@@ -2,6 +2,7 @@
 Title: Archiver la communication Econom'IA Cergy: release + tag + HAL + page perso
 Created: 2026-06-04
 Author: HDMX-coding-agent
+Closed: Communication archivée: tag + release + HAL validé (hal-05644906) + page perso
 
 --- log ---
 2026-06-04T11:37Z HDMX-coding-agent created
@@ -15,6 +16,8 @@ Author: HDMX-coding-agent
 2026-06-04T15:45Z HDMX-coding-agent note Ticket 0421 déplacé vers IDH (ticket 0214, PR ImperialDragonHarness#279) — le travail skill appartient au dépôt du harness
 2026-06-04T15:45Z HDMX-coding-agent note Ack HAL reçu par l'auteur: hal-05644906 v1 confirmé en modération (soumis 2026-06-04 16:11). Page perso publiée (make sync fait)
 2026-06-04T15:54Z HDMX-coding-agent note NB collision d'ID: 0421 a été réalloué en parallèle sur main (render-rules, PR #713, sans rapport). Le ticket skill /update-publist vit uniquement dans IDH 0214 (PR ImperialDragonHarness#279)
+2026-06-04T16:30Z HDMX-coding-agent note Validation HAL confirmée par l'auteur: hal-05644906 v1 en ligne. Dernier critère satisfait
+2026-06-04T20:09Z HDMX-coding-agent closed — Communication archivée: tag + release + HAL validé (hal-05644906) + page perso
 --- body ---
 ## Contexte
 
@@ -37,8 +40,8 @@ exactement présenté AVANT toute adoption (prérequis de 0413).
 
 - [x] Tag poussé sur le commit de la version présentée (economia-2026-cergy → bbc4a013)
 - [x] Release GitHub avec le PDF des slides attaché
-- [ ] Notice HAL en ligne (hal-05644906 v1 soumis 2026-06-04, en modération —
-      confirmé par l'ack HAL reçu par l'auteur ; reste l'attente de validation)
+- [x] Notice HAL en ligne (hal-05644906 v1 soumis 2026-06-04, validation
+      confirmée par l'auteur le 2026-06-04)
 - [x] Page perso à jour (entrée fusionnée EN/FR publiée — `make sync` fait)
 
 ## Related


### PR DESCRIPTION
**Ticket:** tickets/0412-archiver-la-communication-econom-ia-cerg.erg

HAL notice hal-05644906 v1 validated (author-confirmed 2026-06-04) — the last open exit criterion. Closes and archives 0412; erg auto-unblocks 0413 (fix1 adoption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)