### PR TITLE
tickets: 0425 — corriger le catalogue de skills d'AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,22 +70,20 @@ Cleanup worktrees and branches, summarize what was accomplished, reflect on less
 | `/start-ticket N` | Starting work on a GitHub issue | Create worktree, write first test, transition to Execute |
 | `/celebrate` | After completing a ticket | Reflect, update STATE, clean up |
 | `/end-session` | User ends a work session | Push branches, run tests, refresh STATE |
-| `/new-ticket` | Creating a GitHub issue | Write handoff document with test spec |
+| `/ticket-new` | Creating a ticket | Write handoff document with test spec |
 | `/review-pr N` | Reviewing a merge request (code) | Multi-perspective agent review |
 | `/review-pr-prose N` | Reviewing a merge request (prose) | Simulated peer review panel |
 | `/memory` | Writing or sweeping persistent memory | Enforce caps, TTLs, staleness |
-| `/autonomous` | Unsupervised autonomous session | Imperial Dragon cycles with 60/40 balance |
-| `/submission-branch` | Creating a submission branch | Sprout, freeze, revision lifecycle |
-| `/submission-readiness` | Pre-submission gate | Checklist before sprouting |
-| `/update-publist` | Adding/updating a publication | Edit Ha-Duong.bib, deposit on HAL via SWORD |
+| `/raid` | Unsupervised autonomous raid across multiple tickets | Picks targets, manages waves, enforces isolation |
+| `/update-publist` | Adding/updating a publication (à créer, IDH 0214) | Edit Ha-Duong.bib, deposit on HAL via SWORD |
 
 ### Chore tooling
 
 For one-shot chore PRs (tickets/, docs/, .claude/, top-level docs, .github/workflows/, *.md) use `scripts/quickpr.sh "<message>" <files...>` — one command branches off main, commits, pushes, opens a PR with auto-merge, and restores the starting branch. Refuses src/, tests/, experiments/ so implementation work still goes through `/start-ticket` → `/celebrate`.
 
-## Autonomous workflow (details in /orchestrator skill)
+## Autonomous workflow (details in /raid skill)
 
-Orchestrator runs tickets in waves with isolated worktrees and one ordered loop:
+The `/raid` skill runs tickets in waves with isolated worktrees and one ordered loop:
 1. Imagine: challenge ticket scope, motivation, and alternatives.
 2. Plan + Verify: produce plans, then independently check assumptions and feasibility.
 3. Execute + Verify: deliver a merge request, then fix all review findings.

--- a/tickets/0426-test-d-adh-rence-toute-r-f-rence-skill-d.erg
+++ b/tickets/0426-test-d-adh-rence-toute-r-f-rence-skill-d.erg
@@ -2,11 +2,11 @@
 Title: Test d'adhérence: toute référence /skill d'AGENTS.md doit résoudre vers un skill réel
 Created: 2026-06-04
 Author: HDMX-coding-agent
-Blocked-by: 0425
 
 --- log ---
 2026-06-04T16:18Z HDMX-coding-agent created
 
+2026-06-05T07:52Z HDMX-coding-agent note blocker 0425 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0425-corriger-le-catalogue-de-skills-d-agents.erg
+++ b/tickets/closed/0425-corriger-le-catalogue-de-skills-d-agents.erg
@@ -2,10 +2,12 @@
 Title: Corriger le catalogue de skills d'AGENTS.md — références fantômes et renommage
 Created: 2026-06-04
 Author: HDMX-coding-agent
+Closed: skill catalog phantom refs fixed + ticket-new rename
 
 --- log ---
 2026-06-04T16:18Z HDMX-coding-agent created
 
+2026-06-05T07:52Z HDMX-coding-agent closed — skill catalog phantom refs fixed + ticket-new rename
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0425-corriger-le-catalogue-de-skills-d-agents.erg

## Résumé

Résout 6 références fantômes dans le catalogue de skills d'AGENTS.md identifiées lors du sweep `/celebrate` du ticket 0412 :

| Ancienne référence | Action | Raison |
|---|---|---|
| `/new-ticket` | → `/ticket-new` | Le skill s'appelle réellement `ticket-new` |
| `/autonomous` | → `/raid` | Le skill raid a repris le rôle des sessions autonomes |
| `/submission-branch` | Supprimé | N'existe pas |
| `/submission-readiness` | Supprimé | N'existe pas |
| `/orchestrator` | → `/raid` | Dans le § Autonomous workflow |
| `/update-publist` | Marqué "(à créer, IDH 0214)" | Skill planifié mais pas encore créé |

Sweep terminé : aucune autre référence orpheline trouvée dans les fichiers .md du dépôt.

## Vérification

- [x] Chaque `/skill` cité dans AGENTS.md résout vers un skill installé, builtin, ou est marqué "à créer"
- [x] Aucune référence orpheline dans les autres .md (`/usr/bin/find . -name "*.md" -exec grep ...` → aucun résultat)
- [x] `tickets/erg check tickets/` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)