### PR TITLE
tickets: open 0440 — render.mk ANALYSIS_REPO_ROOT path mismatch, zero-match must fail loudly (PR #747 discovery)

### DIFF
--- a/tickets/0440-render-mk-path-mismatch-analysis-repo-ro.erg
+++ b/tickets/0440-render-mk-path-mismatch-analysis-repo-ro.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: render.mk path mismatch: ANALYSIS_REPO_ROOT=. breaks record-prefix matching, degenerate figure
+Created: 2026-06-05
+Author: claude
+
+--- log ---
+2026-06-05T09:41Z claude created
+
+--- body ---
+## Context
+
+Found by the 0438 worker (PR #747), confirmed pre-existing: invoking the
+`fig_direct_p1_base.pdf` target from repo root with the default
+`ANALYSIS_REPO_ROOT=.` expands `--result-dir ./experiments/...`, which
+fails to prefix-match record paths stored as `experiments/...` →
+0 rows selected → degenerate PDF, or `min() arg is an empty sequence`
+crash. The committed PDF was generated with the matching bare-relative
+path; nothing guards the mismatch.
+
+This is a silent-wrong-artifact hazard: a future rebuild from the wrong
+cwd quietly commits an empty figure (the stale-PDF trap's cousin).
+
+## Quoi faire
+
+1. Normalize the path comparison (resolve both sides, or normalize
+   `./`-prefixes) in the record-selection code used by
+   plot_method_convergence (and audit siblings reading record paths
+   with prefix matching).
+2. Fail loudly: zero matched records must raise with a diagnostic
+   naming the result-dir and an example record path — never emit an
+   empty figure.
+3. Regression test: invoke the selection with a `./`-prefixed
+   result-dir over a fixture and assert rows found; plus a
+   zero-match → raises test.
+
+## Exit criteria
+
+- [ ] `make -f experiments/render.mk <fig targets>` produces identical
+      figures from repo root and from experiments/ cwd
+- [ ] Zero-match is a hard error with diagnostic, not a degenerate PDF
+- [ ] Regression tests green; `make check` passes
+
+## Related
+
+- PR #747 (discovery), 0436 (render DAG hygiene — sibling class),
+  feedback memory "stale pre-fix PDFs".


### PR DESCRIPTION
Opened via scripts/quickpr.sh.