### PR TITLE
ticket(0383): close umbrella — mart audit redress complete

### DIFF
--- a/tickets/0254-write-exp2-dataset-descriptive-statistics-section.erg
+++ b/tickets/0254-write-exp2-dataset-descriptive-statistics-section.erg
@@ -2,7 +2,6 @@
 Title: Write Exp2 dataset and descriptive statistics section
 Created: 2026-05-23
 Author: Copilot
-Blocked-by: 0383
 
 --- log ---
 2026-05-23T17:30Z Copilot created
@@ -10,6 +9,7 @@ Blocked-by: 0383
 2026-06-05T07:25Z claude note — raid Imagine 2026-06-05: target = same report.tex chapter as 0253 (containment decision); committed artifacts only (tab_exp2_bib_quality.tex, tab_exp2_2x2.csv); no turns/wall-time (not in committed artifacts); gated on 0432.
 2026-06-05T07:36Z claude note Blocked-by 0383 added — descriptive statistics must quote post-re-baseline numbers (mart staleness evidence in 0383 log)
 2026-06-05T07:50Z claude note — raid: 0254 PULLED from night-queue execute wave (newly Blocked-by 0383, supersedes the committed-artifacts-only plan below); 0253 proceeds alone, chapter stub for §donnees stays TODO(0254)
+2026-06-05T10:55Z HDMX-coding-agent note blocker 0383 closed — Blocked-by removed.
 --- body ---
 ## Context
 Write the Dataset and Descriptive Statistics section from `docs/exp2-analysis-v0.md`.

--- a/tickets/0384-mart-layer2-adherence-guard.erg
+++ b/tickets/0384-mart-layer2-adherence-guard.erg
@@ -2,12 +2,12 @@
 Title: Add Layer-2 mart adherence guard — schema field semantics + completeness
 Created: 2026-05-29
 Author: Claude
-Blocked-by: 0383
 
 --- log ---
 2026-05-29T00:00Z Claude created — keystone guard for the mart audit redress (0383)
 
 2026-06-05T08:15Z HDMX-coding-agent note Layer-2 guard delivered as tests/test_exp2_mart_contract.py: 5 adherence tests. Finding #3 (class_trace/n_bib_entries) asserted via strict-xfail on _build_run_records source (code-contract, not stale committed mart) — bites today (real AssertionError under --runxfail), strict so 0385's wiring forces marker removal. Finding #1 mapping pinned (already fixed f7f5c4ea). Finding #2 dropped columns documented out-of-scope pending 0386. Zero changes to contention file exp2_mart.py.
+2026-06-05T10:55Z HDMX-coding-agent note blocker 0383 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
+++ b/tickets/0413-adopter-la-r-f-rence-fix1-figures-avant.erg
@@ -3,7 +3,6 @@ Title: Adopter la référence v2 (régénérée par le pipe): figures avant/apr�
 Created: 2026-06-04
 Author: HDMX-coding-agent
 Blocked-by: 0416
-Blocked-by: 0383
 
 --- log ---
 2026-06-04T11:37Z HDMX-coding-agent created
@@ -16,6 +15,7 @@ Blocked-by: 0383
 2026-06-05T06:55Z claude note Blocked-by 0431 added (author-ratified) — scoring rows must cite their reference before the v2 switch, so the adoption is visible in the scientific record
 2026-06-05T07:36Z claude note Blocked-by 0383 added (author: 'de-hazard the data flow') — adoption re-scores everything; the mart re-baseline must land first so the v2 delta is the only delta
 2026-06-05T10:51Z HDMX-coding-agent note blocker 0431 closed — Blocked-by removed.
+2026-06-05T10:55Z HDMX-coding-agent note blocker 0383 closed — Blocked-by removed.
 --- body ---
 ## Contexte
 

--- a/tickets/closed/0383-mart-audit-redress-layer2-drift-from-0322.erg
+++ b/tickets/closed/0383-mart-audit-redress-layer2-drift-from-0322.erg
@@ -2,6 +2,7 @@
 Title: [tracking] Mart audit redress — close Layer-2 drift left open by 0322
 Created: 2026-05-29
 Author: Claude
+Closed: umbrella complete — all findings redressed, re-baseline merged, guards in place
 
 --- log ---
 2026-05-29T00:00Z Claude created — mart building audit ("columns really feed on what they say they encode"); tracking ticket for redress course
@@ -10,6 +11,8 @@ Author: Claude
 2026-06-05T08:35Z Claude note Re-baseline executed (PR pending): re-scored exp2_mart.jsonl + sota_cross_eval.csv through score.mk with current matcher/coherence scorers; regenerated mart-downstream committed artifacts via render.mk. Row set unchanged (80/80); 63/80 rows changed >=1 accuracy_* metric (matcher fix), e.g. arm3/claude run01 coverage 0.2883->0.3006 precision 0.9216->0.9608 f1 0.4393->0.4579; mean precision +0.0389, coverage +0.0185, f1 +0.0242. No coherence/provenance flips on the current base. class_trace/n_bib_entries stay null (0385 unchanged); Layer-2 strict-xfail still XFAILs. The 'rebuild + re-baseline' body decision is now done; umbrella stays open for 0384/0385/0386 + finding #1.
 2026-06-05T08:39Z Claude note Re-baseline PR is #743 (ticket/0383-rebaseline). Non-closing Ticket-ref; umbrella stays open for 0384/0385/0386 + finding #1.
 2026-06-05T09:15Z claude correction (gate REROLL PR #743): delta narrative was wrong on coherence — capacity_nonnegative newly populated None->1.0 on 80/80 (field not computed in old mart); status_vocab_adherence changed on 27/80 (1.0 -> lower, 6 rows to 0.0) — the INTENTIONAL surfacing of the Finding-1 naming bug (old mart read capacity_nonneg column for this field, masking real values). Provenance/temporality/field_completeness: zero changes. Accuracy delta figures confirmed independently by gate.
+2026-06-05T10:55Z claude note DoD complete: finding #1 fixed by PR #651 + data surfaced by re-baseline #743 + guarded by 0384 contract test; 0384 closed PR #740, 0385 PR #746, 0386 PR #750; re-baseline #743 merged; closing umbrella
+2026-06-05T10:55Z HDMX-coding-agent closed — umbrella complete — all findings redressed, re-baseline merged, guards in place
 --- body ---
 ## Context
 
@@ -71,6 +74,6 @@ the mart. Three further drifts accumulated undetected.
 
 ## Definition of done
 
-- [ ] 0384, 0385, 0386 closed
-- [ ] Finding #1 resolved (its own PR)
-- [ ] `make check` green
+- [x] 0384, 0385, 0386 closed
+- [x] Finding #1 resolved (its own PR)
+- [x] `make check` green


### PR DESCRIPTION
Closes the 0383 tracking umbrella. All Definition-of-done items satisfied:

- **0384** (Layer-2 contract guard) — PR #740
- **0385** (class_trace/n_bib_entries wiring) — PR #746
- **0386** (scorer columns, Option B intentional exclusion) — PR #750
- **Finding #1** (status_vocab_adherence naming bug) — fixed by PR #651, corrected values surfaced in data by the deliberate re-baseline PR #743, regression-guarded by the 0384 contract test
- Re-baseline #743 merged; 0431 (reference stamping, schema v2) — PR #753

The mart-staleness hazard documented in this ticket is retired: the committed mart is current with the scorers, guarded by adherence tests, and every score row cites its reference.

**Ticket:** tickets/0383-mart-audit-redress-layer2-drift-from-0322.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)