### PR TITLE
docs(celebrate-0439): raw README staleness + 0416 ratchet-scope note

### DIFF
--- a/data/reference/raw/README.md
+++ b/data/reference/raw/README.md
@@ -19,14 +19,17 @@ before the first commit may overwrite; a committed snapshot never. See
 ## `pipeline-YYYY-MM-DD.ods`
 
 The master spreadsheet for the Vietnam thermal-units reference list, maintained
-in the author's "Market report on Gas to Power" project. One row per unit.
-Imported here by `import.sh` (which copies from the author's working copy and
-stamps with today's date; the master is absent from CI and from the workstation,
-so `import.sh` is documentation-grade and is never run in CI).
+in the author's "Market report on Gas to Power" project. One row per asset at
+its finest known grain — unit, plant, or complex — addressed by the
+three-column `Complex | Plant | Unit` scheme (ticket 0439; conventions live in
+the master's own `Conventions` sheet). Imported here by `import.sh` (which
+copies from the author's working copy and stamps with today's date; the master
+is absent from CI and from the workstation, so `import.sh` is
+documentation-grade and is never run in CI).
 
-To correct a data error (a duplicate name, a wrong capacity, a missing `Level`),
-fix it **in the master**, then re-run `import.sh` to produce a new datestamped
-snapshot. Config pins (e.g., `config.VN_THERMAL_MASTER_SNAPSHOT_ODS`) point at a
+To correct a data error (a duplicate designation, a wrong capacity, an
+out-of-vocabulary status), fix it **in the master**, then re-run `import.sh`
+to produce a new datestamped snapshot. Config pins (e.g., `config.VN_THERMAL_MASTER_SNAPSHOT_ODS`) point at a
 specific snapshot; downstream extraction reads from that pinned snapshot via
 `data/reference/extract_ods.py`. See `data/reference/PROVENANCE.md` for the full
 pipeline and the snapshot→release distinction.

--- a/tickets/0416-agr-gateur-unit-s-plantes-groupes-multi.erg
+++ b/tickets/0416-agr-gateur-unit-s-plantes-groupes-multi.erg
@@ -12,6 +12,7 @@ Author: HDMX-coding-agent
 2026-06-05T07:27Z claude note — raid 2026-06-05 Imagine: ESCALATE — grouping contract unspecified under no-synthesis rule (Q1/Q2 in body, § Imagine review). On hold for author; 0401 held with it.
 2026-06-05T09:12Z claude note — author ratified three-column master design (Complex|Plant|Unit): ESCALATE resolved, contrat v2 in body, Blocked-by 0439 (master migration, needs-human)
 2026-06-05T11:01Z HDMX-coding-agent note blocker 0439 closed — Blocked-by removed.
+2026-06-05T11:08Z claude note celebrate-0439 sweep: ratchet adherence (line ~150) says 'src/' only — HDM_aggregate.py and GEM_aggregate.py (the two live unit-name parsers) are in data/reference/; widen the ratchet glob to cover data/reference/ too
 --- body ---
 ## Contexte
 


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/0416-agr-gateur-unit-s-plantes-groupes-multi.erg

Celebrate sweep of 0439:
- `data/reference/raw/README.md`: 'one row per unit' → mixed-grain three-column address; 'missing `Level`' example → out-of-vocabulary status (Level is derived since 0439).
- 0416 log note: the name-parsing ratchet test scope should cover `data/reference/` (where HDM_aggregate.py and GEM_aggregate.py live), not only `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)