### PR TITLE
tickets: stale sweep — close 11 (lots A/B/C ratified)

### DIFF
--- a/tickets/closed/0199-exp2-sota-frontier-spec-and-run.erg
+++ b/tickets/closed/0199-exp2-sota-frontier-spec-and-run.erg
@@ -2,6 +2,7 @@
 Title: Experiment 2 — §4 SOTA frontier: spec and run
 Created: 2026-05-21
 Author: claude
+Closed: umbrella complete — both arms run; writing tracked by 0253-0262; Phase C cross-eval deferred as 0171 (journal delta)
 
 --- log ---
 2026-05-21T12:20Z claude created — replacement for closed 0153 (Exp 2 leg)
@@ -11,6 +12,7 @@ Author: claude
 2026-05-21T14:46Z HDMX-coding-agent note blocker 0185 closed — Blocked-by removed.
 2026-05-23T13:30Z HDMX-coding-agent note Phase-C cross-eval (rubric + scoring harness, Figure 3) is tracked in 0171 — refreshed and rehomed there as this experiment's Phase-C leg; scores both arms (naive + optimized), 40 subject outputs. See 0171 for the anchored-rubric design. Action 3 here is operationalised by 0171.
 2026-05-23T13:45Z HDMX-coding-agent note annotated body with an as-built block (4 agents pinned, two arms, N=5, A/B-0/B/C phase structure, DONE/REMAINING status); 2026-05-21 spec left intact below as historical record. §4 manuscript sync (Action 9) still outstanding.
+2026-06-05T11:11Z HDMX-coding-agent closed — umbrella complete — both arms run; writing tracked by 0253-0262; Phase C cross-eval deferred as 0171 (journal delta)
 --- body ---
 
 ## Update — as-built reality (2026-05-23)

--- a/tickets/closed/0227-exp2-smoke-extend-to-qwen.erg
+++ b/tickets/closed/0227-exp2-smoke-extend-to-qwen.erg
@@ -2,10 +2,12 @@
 Title: Exp 2 smoke — extend the harness to Qwen (second agent, closes 0207)
 Created: 2026-05-21
 Author: claude
+Closed: overtaken — Exp 2 full run includes qwen3.7-max among the 4 agents
 
 --- log ---
 2026-05-21T19:00Z claude created — author's 2-hour autonomous window did not stretch to Qwen; ticket carries the spec
 
+2026-06-05T11:11Z HDMX-coding-agent closed — overtaken — Exp 2 full run includes qwen3.7-max among the 4 agents
 --- body ---
 
 ## Context

--- a/tickets/closed/0251-complete-exp2-analysis-report.erg
+++ b/tickets/closed/0251-complete-exp2-analysis-report.erg
@@ -2,6 +2,7 @@
 Title: Complete Exp2 analysis report
 Created: 2026-05-23
 Author: Copilot
+Closed: superseded by the Exp2 section split 0253-0262
 
 --- log ---
 2026-05-23T17:30Z Copilot created
@@ -9,6 +10,7 @@ Author: Copilot
 2026-05-23T21:00Z claude note Conference/post-conference split decided: (1) 0263 is the conference-critical deliverable — metadata-first Figure 3 from arm summary JSONs (inventory_rows, narrative_chars, cost), wired into exp2-analysis.mk, feeds main.md §4 Figure 3 placeholder before 2026-05-27. Full F1 evaluation against the 163-plant reference and H1-H6 hypothesis tests stay in child tickets 0253-0261, 0262 — post-conference. Canonical data: sota_exp2_naive_arm/ (Arm 1) and sota_exp2_brerun1/ (Arm 2, corrected classifier). sota_exp2_phase_b_full/ excluded (weak classifier). Child 0252 renamed 0262 to avoid ID collision with main.
 
 2026-06-05T07:25Z claude note — author containment decision 2026-06-05: sections land in a STANDALONE report.tex chapter (registration, plan, deviations, salvageable results, H1-H6), not in §sec:exp2. Naming canon ratified: epithets + registry (0432), 2025 probes demoted, « 2.0 » rejected. Annex C candid as-run rewrite = 0433. H6 still gated on 0171.
+2026-06-05T11:11Z HDMX-coding-agent closed — superseded by the Exp2 section split 0253-0262
 --- body ---
 ## Context
 This umbrella ticket coordinates full delivery of the Exp2 report from the protocol-first outline in `docs/exp2-analysis-v0.md`.

--- a/tickets/closed/0273-experimental-materials-preservation.erg
+++ b/tickets/closed/0273-experimental-materials-preservation.erg
@@ -2,10 +2,12 @@
 Title: Audit and complete experimental materials preservation — conversation, headers, provenance
 Created: 2026-05-24
 Author: HDMX-coding-agent
+Closed: superseded by 0405 phase-stratified artifact policy + PR #685 raw-output tracking + archive move
 
 --- log ---
 2026-05-24T09:30Z HDMX-coding-agent created
 
+2026-06-05T11:11Z HDMX-coding-agent closed — superseded by 0405 phase-stratified artifact policy + PR #685 raw-output tracking + archive move
 --- body ---
 ## Context
 

--- a/tickets/closed/0294-imagine-extract-web-search-metrics.erg
+++ b/tickets/closed/0294-imagine-extract-web-search-metrics.erg
@@ -2,10 +2,12 @@
 Title: Imagine post-processing extraction of web-search and pages-consulted counts
 Created: 2026-05-25
 Author: HDMX-coding-agent
+Closed: already delivered — n_web_search_calls/n_citations projected into metrics via 0172
 
 --- log ---
 2026-05-25T00:00Z HDMX-coding-agent created
 
+2026-06-05T11:11Z HDMX-coding-agent closed — already delivered — n_web_search_calls/n_citations projected into metrics via 0172
 --- body ---
 ## Context
 

--- a/tickets/closed/0311-spider-exp2-four-way.erg
+++ b/tickets/closed/0311-spider-exp2-four-way.erg
@@ -2,11 +2,13 @@
 Title: Spider — Exp 2 4-way quality profile (2×2 arms)
 Created: 2026-05-25
 Author: HDMX-coding-agent
+Closed: delivered — fig_quality_spider.pdf from sota_cross_eval_view, regenerated post-rebaseline 2026-06-05
 
 --- log ---
 2026-05-25T15:00Z HDMX-coding-agent created
 
 2026-05-25T13:44Z HDMX-coding-agent note blocker 0304 closed — Blocked-by removed.
+2026-06-05T11:11Z HDMX-coding-agent closed — delivered — fig_quality_spider.pdf from sota_cross_eval_view, regenerated post-rebaseline 2026-06-05
 --- body ---
 ## Context
 

--- a/tickets/closed/0346-titled-companions-for-remaining-plain-frames.erg
+++ b/tickets/closed/0346-titled-companions-for-remaining-plain-frames.erg
@@ -2,10 +2,12 @@
 Title: Add analytical titled frames for remaining plain-frame figures in slides
 Created: 2026-05-26
 Author: HDMX-coding-agent
+Closed: obsolete — talk delivered 2026-05-27, slides frozen (precedent 0152)
 
 --- log ---
 2026-05-26T12:00Z HDMX-coding-agent created
 
+2026-06-05T11:11Z HDMX-coding-agent closed — obsolete — talk delivered 2026-05-27, slides frozen (precedent 0152)
 --- body ---
 ## Context
 

--- a/tickets/closed/0347-slides-corrections-texte-mise-en-page.erg
+++ b/tickets/closed/0347-slides-corrections-texte-mise-en-page.erg
@@ -2,10 +2,12 @@
 Title: slides: corrections texte et mise en page (revue 2026-05-26)
 Created: 2026-05-26
 Author: haduong
+Closed: obsolete — talk delivered 2026-05-27, slides frozen (precedent 0152)
 
 --- log ---
 2026-05-26T20:30Z haduong created
 
+2026-06-05T11:11Z HDMX-coding-agent closed — obsolete — talk delivered 2026-05-27, slides frozen (precedent 0152)
 --- body ---
 ## Context
 Revue complète des slides avant conférence Econom'IA 2026-05-27.

--- a/tickets/closed/0356-english-label-figures-for-slides-en.erg
+++ b/tickets/closed/0356-english-label-figures-for-slides-en.erg
@@ -2,11 +2,13 @@
 Title: English-label variants of slide figures for slides-en.tex
 Created: 2026-05-27
 Author: HDMX-coding-agent
+Closed: obsolete — talk delivered 2026-05-27, slides frozen (precedent 0152)
 
 --- log ---
 2026-05-27T10:45Z HDMX-coding-agent created
 2026-05-27T14:30Z HDMX-coding-agent note slides-en.tex crops the fig_spider_exp1_families baked-in title ("Source is the universal failure mode") with trim+clip (PR #621) — a band-aid. When regenerating that figure, drop its title so the crop hack can be removed.
 
+2026-06-05T11:11Z HDMX-coding-agent closed — obsolete — talk delivered 2026-05-27, slides frozen (precedent 0152)
 --- body ---
 ## Context
 `slides/slides-en.tex` (English Econom'IA deck, added in PR #620) reuses the

--- a/tickets/closed/0359-align-manuscript-onto-slides.erg
+++ b/tickets/closed/0359-align-manuscript-onto-slides.erg
@@ -2,10 +2,12 @@
 Title: Align manuscript title, key messages, and argument flow onto the conference slides
 Created: 2026-05-27
 Author: haduong
+Closed: folded into 0435 — the manuscript finalization milestone owns message alignment
 
 --- log ---
 2026-05-27T13:55Z HDMX-coding-agent created
 
+2026-06-05T11:11Z HDMX-coding-agent closed — folded into 0435 — the manuscript finalization milestone owns message alignment
 --- body ---
 ## Context
 The slides were refined through the Econom'IA 2026 talk (delivered 2026-05-27)

--- a/tickets/closed/0372-status-distribution-gold-vs-best-llm.erg
+++ b/tickets/closed/0372-status-distribution-gold-vs-best-llm.erg
@@ -2,10 +2,12 @@
 Title: Présenter la distribution par status sur la gold list vs. best LLM
 Created: 2026-05-28
 Author: minh
+Closed: superseded by the annex delivered 2026-06-05: recognition matrix (0373, PR #744) + status difficulty table (0434, PR #749)
 
 --- log ---
 2026-05-28T19:45Z minh created — illustrate task difficulty by comparing the status mix of the reference list against the best LLM's recall
 
+2026-06-05T11:11Z HDMX-coding-agent closed — superseded by the annex delivered 2026-06-05: recognition matrix (0373, PR #744) + status difficulty table (0434, PR #749)
 --- body ---
 ## Context
 


### PR DESCRIPTION
Author-ratified staleness sweep (2026-06-05) over the 53 ready tickets.

**Lot A — mechanical evidence:** 0294 (web-search counts already in metrics via 0172), 0227 (Exp 2 ran with qwen3.7-max), 0311 (fig_quality_spider delivered, regenerated post-rebaseline).
**Lot B — superseded:** 0372 (→ annex 0373+0434), 0251 (→ sections 0253–0262), 0199 (umbrella: runs done, writing split, Phase C = 0171 deferred), 0273 (→ 0405 + #685 + archive move), 0359 (→ 0435).
**Lot C — slides frozen:** 0346, 0347, 0356 (talk delivered 2026-05-27; precedent 0152).

Kept alive on evidence: 0377 — the chore-filter bug is CONFIRMED still live (lint/build/tests ran on tickets-only PR #752).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)