### PR TITLE
fix(0440): record-path matching — normalize prefixes, fail loudly on zero match

### DIFF
--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -438,8 +438,14 @@ $(ANALYSIS_GEN)/fig_direct_p1_base.pdf $(ANALYSIS_GEN)/macros_p1_base.tex &: $(A
 	    --title "How do models recall Vietnam's thermal power assets? Not well." \
 	    --ui-scale 1.35 \
 	    --fig-width 12 --fig-height-min 8 --fig-height-per-run 0.06 --fig-height-per-method 0.35 \
-	    --result-dir $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/ \
+	    --result-dir experiments/outputs/exp1_batch2/ \
 	    --output-macros $(dir $@)macros_p1_base.tex
+# --result-dir is a repo-root-relative constant, NOT $(ANALYSIS_EXPERIMENTS_DIR):
+# record result_file paths are always stored repo-root-relative (loaded via the
+# package-anchored measurements._REPO_ROOT, cwd-invariant), so the prefix filter
+# must be too. Wiring it to ANALYSIS_EXPERIMENTS_DIR made the filter track cwd
+# (./experiments/... under the default ANALYSIS_REPO_ROOT=.), failing the match →
+# 0 rows → degenerate figure (ticket 0440; cf. exp1_cost_quality.EXP1_BATCH2_DIR).
 
 # Exp1 recognition matrix (ticket 0373): plants aligned vertically on the
 # reference list, plus a top-40 false-positive panel. Derives per-(run x plant)

--- a/src/aedist/plot_method_convergence.py
+++ b/src/aedist/plot_method_convergence.py
@@ -19,6 +19,7 @@ Usage:
 import argparse
 import csv
 import logging
+import os
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -86,6 +87,42 @@ _METHOD_LABELS = {
 }
 
 
+def _normalize_record_path(path: str) -> str:
+    """Normalize a record path for prefix comparison.
+
+    ``ANALYSIS_REPO_ROOT`` defaults to ``.`` in the Makefiles, so a
+    ``--result-dir`` expands to ``./experiments/...`` while records store the
+    bare ``experiments/...`` form. ``os.path.normpath`` collapses the ``./``
+    prefix (and redundant ``//`` / trailing slashes) on both sides so the
+    comparison is cwd-invariant. Because normpath strips trailing slashes, the
+    call sites compare with ``norm == prefix or norm.startswith(prefix + os.sep)``
+    rather than a bare ``startswith`` — otherwise ``experiments/outputs/exp1``
+    would falsely match ``experiments/outputs/exp1_batch2``.
+    """
+    return os.path.normpath(path)
+
+
+def _zero_match_error(
+    *,
+    prompt_version: str | None,
+    result_dir: str | None,
+    sample_paths: list[str],
+) -> ValueError:
+    """Build an actionable error for a filter that selected zero records."""
+    filters = []
+    if prompt_version is not None:
+        filters.append(f"prompt_version={prompt_version!r}")
+    if result_dir is not None:
+        filters.append(f"result_dir={result_dir!r} (normalized {_normalize_record_path(result_dir)!r})")
+    sample = "\n  ".join(sample_paths[:8]) or "(no records with a result_file)"
+    return ValueError(
+        "No measurement records matched the active filter "
+        f"({', '.join(filters)}). This would emit an empty figure or crash on "
+        "min() of an empty sequence. Check the filter against the available "
+        f"record result_file paths, e.g.:\n  {sample}"
+    )
+
+
 def load_convergence_data(
     prompt_version: str | None = None,
     result_dir: str | None = None,
@@ -96,9 +133,18 @@ def load_convergence_data(
     Returns list of dicts with keys: method, model, tp, fp, fn.
     prompt_version: if set, only records with that prompt_version are included.
     result_dir: if set, only records whose result_file starts with this prefix.
+
+    Raises ValueError if ``prompt_version`` or ``result_dir`` is set but selects
+    zero records — a silent empty result is a silent-wrong-artifact hazard
+    (ticket 0440). The error names the active filters and a sample of available
+    result_file paths.
     """
+    norm_result_dir = _normalize_record_path(result_dir) if result_dir is not None else None
     rows = []
+    all_result_files: list[str] = []
     for record in load():
+        if record.result_file:
+            all_result_files.append(record.result_file)
         method = record.method.value
         if method not in _METHOD_ORDER:
             continue
@@ -106,9 +152,11 @@ def load_convergence_data(
             pv = getattr(record.method_params, "prompt_version", None)
             if pv != prompt_version:
                 continue
-        if result_dir is not None:
-            rf = record.result_file or ""
-            if not rf.startswith(result_dir):
+        if norm_result_dir is not None:
+            rf = _normalize_record_path(record.result_file or "")
+            # Match the directory itself or anything beneath it; guard against
+            # sibling-prefix false positives (exp1 vs exp1_batch2).
+            if rf != norm_result_dir and not rf.startswith(norm_result_dir + os.sep):
                 continue
         model = normalize_model(record.method_params.model)
         if excluded_models and model in excluded_models:
@@ -129,6 +177,12 @@ def load_convergence_data(
                 "local": ex.get("provider") == "Ollama/Padme",
                 "size_class": ex.get("size_class", ""),
             }
+        )
+    if not rows and (prompt_version is not None or result_dir is not None):
+        raise _zero_match_error(
+            prompt_version=prompt_version,
+            result_dir=result_dir,
+            sample_paths=all_result_files,
         )
     return rows
 
@@ -401,6 +455,7 @@ def _build_macros(
         f"\\newcommand{{\\CensusFPMax}}{{{max(fps)}}}",
     ]
     if prompt_version is not None or result_dir is not None:
+        norm_result_dir = _normalize_record_path(result_dir) if result_dir is not None else None
         raw = load()
         subset = []
         for r in raw:
@@ -408,8 +463,10 @@ def _build_macros(
                 pv = getattr(r.method_params, "prompt_version", None)
                 if pv != prompt_version:
                     continue
-            if result_dir is not None and not (r.result_file or "").startswith(result_dir):
-                continue
+            if norm_result_dir is not None:
+                rf = _normalize_record_path(r.result_file or "")
+                if rf != norm_result_dir and not rf.startswith(norm_result_dir + os.sep):
+                    continue
             model = normalize_model(r.method_params.model)
             if excluded_models and model in excluded_models:
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def write_measurements(path: Path, metrics: list[dict]) -> None:
                     cost_usd=entry.get("cost_usd"),
                     wall_s=entry.get("wall_seconds"),
                 ),
-                result_file=f"{label}.csv",
+                result_file=entry.get("result_file", f"{label}.csv"),
                 result_summary=ResultSummary(
                     n_plants=entry.get("n_system", tp + fp),
                     tp=tp,

--- a/tests/test_plot_method_convergence.py
+++ b/tests/test_plot_method_convergence.py
@@ -154,6 +154,130 @@ def test_main_writes_csv(tmp_path, monkeypatch):
     assert set(reader.fieldnames) == {"method", "model", "tp", "fp", "fn", "local", "size_class"}
 
 
+def test_result_dir_dot_prefix_matches(tmp_path, monkeypatch):
+    """0440: a ./-prefixed --result-dir still matches bare experiments/ paths.
+
+    Records store result_file as bare-relative (experiments/...), but the
+    Makefile default ANALYSIS_REPO_ROOT=. expands --result-dir to
+    ./experiments/... — the prefix comparison must be cwd-invariant.
+    """
+    metrics = [
+        {
+            "label": "rag/modelA-run1",
+            "n_matched": 100,
+            "n_hallucinated": 5,
+            "n_missed": 58,
+            "result_file": "experiments/outputs/exp1_batch2/modelA-run1.csv",
+        },
+        {
+            "label": "rag/modelB-run1",
+            "n_matched": 90,
+            "n_hallucinated": 2,
+            "n_missed": 71,
+            "result_file": "experiments/outputs/other/modelB-run1.csv",
+        },
+    ]
+    input_path = tmp_path / "measurements.jsonl"
+    write_measurements(input_path, metrics)
+    patch_measurements_loader(monkeypatch, input_path)
+
+    bare = load_convergence_data(result_dir="experiments/outputs/exp1_batch2/")
+    dotted = load_convergence_data(result_dir="./experiments/outputs/exp1_batch2/")
+    # Only the exp1_batch2 record is selected; the other/ record is excluded.
+    assert {r["model"] for r in bare} == {"modelA-run1"}
+    # Identical selection from the ./-prefixed (repo-root cwd) form.
+    assert [r["model"] for r in dotted] == [r["model"] for r in bare]
+    assert {r["model"] for r in dotted} == {"modelA-run1"}
+
+
+def test_result_dir_no_sibling_prefix_match(tmp_path, monkeypatch):
+    """0440: a directory prefix must not match a sibling sharing a name stem.
+
+    experiments/outputs/exp1 must not select experiments/outputs/exp1_batch2.
+    """
+    metrics = [
+        {
+            "label": "rag/modelA-run1",
+            "n_matched": 100,
+            "n_hallucinated": 5,
+            "n_missed": 58,
+            "result_file": "experiments/outputs/exp1_batch2/modelA-run1.csv",
+        },
+    ]
+    input_path = tmp_path / "measurements.jsonl"
+    write_measurements(input_path, metrics)
+    patch_measurements_loader(monkeypatch, input_path)
+
+    import pytest
+
+    with pytest.raises(ValueError, match="No measurement records matched"):
+        load_convergence_data(result_dir="experiments/outputs/exp1/")
+
+
+def test_zero_match_result_dir_raises(tmp_path, monkeypatch):
+    """0440: a result_dir that selects nothing is a hard error, not an empty figure."""
+    metrics = [
+        {
+            "label": "rag/modelA-run1",
+            "n_matched": 100,
+            "n_hallucinated": 5,
+            "n_missed": 58,
+            "result_file": "experiments/outputs/exp1_batch2/modelA-run1.csv",
+        },
+    ]
+    input_path = tmp_path / "measurements.jsonl"
+    write_measurements(input_path, metrics)
+    patch_measurements_loader(monkeypatch, input_path)
+
+    import pytest
+
+    with pytest.raises(ValueError) as exc:
+        load_convergence_data(result_dir="experiments/outputs/nonexistent/")
+    msg = str(exc.value)
+    # Diagnostic names the offending filter and an example available path.
+    assert "result_dir" in msg
+    assert "experiments/outputs/exp1_batch2/modelA-run1.csv" in msg
+
+
+def test_zero_match_prompt_version_raises(tmp_path, monkeypatch):
+    """0440: an empty prompt_version selection raises before min()-of-empty crash.
+
+    Covers the census-macro path (PR #754): measurements with no census records
+    must fail loudly, not crash on min() of an empty list.
+    """
+    metrics = [
+        {"label": "rag/modelA-run1", "n_matched": 100, "n_hallucinated": 5, "n_missed": 58},
+    ]
+    input_path = tmp_path / "measurements.jsonl"
+    write_measurements(input_path, metrics)
+    patch_measurements_loader(monkeypatch, input_path)
+
+    import pytest
+
+    with pytest.raises(ValueError, match="prompt_version"):
+        load_convergence_data(prompt_version="census")
+
+
+def test_no_filter_empty_does_not_raise(tmp_path, monkeypatch):
+    """0440: the unfiltered call returns [] for unrelated data without raising.
+
+    The hard error is scoped to an active filter — an empty unfiltered result
+    (e.g. a fixture with only excluded artifacts) must not raise.
+    """
+    # "verification/..." → Method.RAG_VERIFICATION, which is NOT in
+    # _METHOD_ORDER, so every row is dropped and the result is empty.
+    metrics = [
+        {"label": "verification/modelA-run1", "n_matched": 50, "n_hallucinated": 1, "n_missed": 0},
+    ]
+    input_path = tmp_path / "measurements.jsonl"
+    write_measurements(input_path, metrics)
+    patch_measurements_loader(monkeypatch, input_path)
+
+    # No filter active → no raise even though the result is empty.
+    rows = load_convergence_data()
+    assert rows == []
+
+
 def test_fp_segments_are_red(tmp_path):
     """0438: false-positive (negative-x) dots use red (COLOR_ALERT).
 

--- a/tickets/0440-render-mk-path-mismatch-analysis-repo-ro.erg
+++ b/tickets/0440-render-mk-path-mismatch-analysis-repo-ro.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-06-05T09:41Z claude created
 
+2026-06-05T11:25Z claude execute normalized prefix matching (normpath), repo-root-relative --result-dir constant in render.mk, loud zero-match ValueError, 5 regression tests
 --- body ---
 ## Context
 
@@ -35,10 +36,17 @@ cwd quietly commits an empty figure (the stale-PDF trap's cousin).
 
 ## Exit criteria
 
-- [ ] `make -f experiments/render.mk <fig targets>` produces identical
+- [x] `make -f experiments/render.mk <fig targets>` produces identical
       figures from repo root and from experiments/ cwd
-- [ ] Zero-match is a hard error with diagnostic, not a degenerate PDF
-- [ ] Regression tests green; `make check` passes
+      (--result-dir is now a repo-root-relative constant, byte-identical
+      across ANALYSIS_REPO_ROOT=. / .. / /abs; record paths load via the
+      package-anchored measurements._REPO_ROOT, cwd-invariant)
+- [x] Zero-match is a hard error with diagnostic, not a degenerate PDF
+      (load_convergence_data raises ValueError naming the active filters and
+      a sample of available result_file paths; covers the census min()-empty
+      path from PR #754)
+- [x] Regression tests green; `make check` passes (only known environmental
+      failure test_smoke_real_cli — live CLI, no credit/API spend)
 
 ## Related
 

--- a/tickets/closed/0440-render-mk-path-mismatch-analysis-repo-ro.erg
+++ b/tickets/closed/0440-render-mk-path-mismatch-analysis-repo-ro.erg
@@ -2,11 +2,13 @@
 Title: render.mk path mismatch: ANALYSIS_REPO_ROOT=. breaks record-prefix matching, degenerate figure
 Created: 2026-06-05
 Author: claude
+Closed: delivered by PR #759 — cwd-invariant result-dir, loud zero-match, gate APPROVED
 
 --- log ---
 2026-06-05T09:41Z claude created
 
 2026-06-05T11:25Z claude execute normalized prefix matching (normpath), repo-root-relative --result-dir constant in render.mk, loud zero-match ValueError, 5 regression tests
+2026-06-05T11:31Z HDMX-coding-agent closed — delivered by PR #759 — cwd-invariant result-dir, loud zero-match, gate APPROVED
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Problem

Invoking the `fig_direct_p1_base.pdf` target from repo root with the default
`ANALYSIS_REPO_ROOT=.` expanded `--result-dir ./experiments/outputs/exp1_batch2/`,
which failed to prefix-match record `result_file` paths stored bare-relative as
`experiments/...` → **0 rows selected → degenerate PDF, or `min() of empty
sequence` crash**. Nothing guarded the silent-wrong-artifact (discovered in PR #747).

## Root cause

The Makefile wired the `--result-dir` filter to `$(ANALYSIS_EXPERIMENTS_DIR)`,
which tracks cwd, to match strings that are **always repo-root-relative**:
records load via the package-anchored `measurements._REPO_ROOT` (cwd-invariant),
and `--result-dir` is a pure string-prefix filter, never opened as a path. The
filter must therefore be a repo-root-relative constant — mirroring the existing
`exp1_cost_quality.EXP1_BATCH2_DIR` pattern.

## Changes

- **render.mk**: `--result-dir` is now the constant `experiments/outputs/exp1_batch2/`
  (decoupled from `ANALYSIS_REPO_ROOT`), with a comment warning against restoring
  the cwd-tracking form. The filter is byte-identical across `ANALYSIS_REPO_ROOT=.`
  / `..` / `/abs` → identical figure from any cwd (**exit criterion satisfied by
  construction**, verified via `make -n`).
- **plot_method_convergence**: normalize `./`-prefixes via `os.path.normpath` on
  both sides of the comparison (defense-in-depth for the literal `./` case), with a
  sibling-prefix guard (`== or startswith(prefix + os.sep)`) so `exp1` does not
  match `exp1_batch2`. Applied at both selection sites (`load_convergence_data` and
  `_build_macros`).
- **Loud zero-match**: zero matched records with an active filter (`result_dir` or
  `prompt_version`) now raise a `ValueError` naming the active filters and a sample
  of available `result_file` paths — never an empty figure. Covers the census
  `min()`-empty crash (PR #754: `measurements.jsonl` has no census-prompt records).
- **Regression tests**: `./`-prefix finds the same rows as bare; sibling-prefix does
  not over-match; zero-match (both `result_dir` and `prompt_version`) raises;
  unfiltered empty does not raise. `conftest.write_measurements` gains an additive
  `result_file` override.

Committed PDFs unchanged: the p1_base selection still yields the identical 70 rows,
so figure content is byte-stable (verified at data level — not regenerated).

## Sibling audit

Only `plot_method_convergence` (and its reuse in `tabulate_census_macros`) takes a
user-supplied `--result-dir`. The other prefix-matchers (`exp1_cost_quality`,
`tabulate_exp1_cost_summary`, `tabulate_exp1_reasoning_topup`) use hardcoded
repo-root-relative constants and are not cwd-sensitive.

## Checks

`make check-fast`, `pytest -m adherence`, and full `make check` pass — only the
known environmental failure `test_smoke_real_cli` (live CLI, no credit/API spend).

**Ticket:** tickets/0440-render-mk-path-mismatch-analysis-repo-ro.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)