### PR TITLE
test: smoke_real_cli skips gracefully when API credits exhausted

### DIFF
--- a/tests/test_query_claude_cli.py
+++ b/tests/test_query_claude_cli.py
@@ -173,8 +173,14 @@ def test_smoke_real_cli():
             timeout=60.0,
         )
     except RuntimeError as exc:
-        if "Not logged in" in str(exc):
+        # Environment problems are skips, not failures: the test validates the
+        # adapter, not the account state. Observed strings: "Not logged in"
+        # (CLI auth) and "Credit balance is too low" (API 400, 2026-06-05).
+        msg = str(exc)
+        if "Not logged in" in msg:
             pytest.skip("claude CLI not logged in")
+        if "Credit balance is too low" in msg:
+            pytest.skip("Anthropic API credits exhausted")
         raise
     assert result["content"].strip().lower().startswith("pong")
     assert result["usage"]["completion_tokens"] > 0


### PR DESCRIPTION
One-line behavioral fix: `test_smoke_real_cli` now `pytest.skip`s on the CLI's "Credit balance is too low" error (API 400, observed live 2026-06-05), exactly as it already does for a missing binary or a logged-out CLI. The test re-arms itself when credits return — nothing to revert.

Without this, `make check` fails on every branch while credits are at zero, including the in-flight 0413 worker's pre-PR gate.

Verified: `tests/test_query_claude_cli.py` → 7 passed, 1 skipped.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)