### PR TITLE
fix: hardcoded reference size sweep (regimes_scatter) + open ratchet ticket 0447

### DIFF
--- a/src/aedist/plot_cost_quality.py
+++ b/src/aedist/plot_cost_quality.py
@@ -16,7 +16,7 @@ Pareto-efficient envelope is drawn.
 Y axis: per-model **count of correctly identified plants** (true positives,
 ``n_matched`` in measurements) plotted as median with min/max whiskers
 across the 5 reps. A horizontal reference line marks the full reference
-inventory size (163 thermal plants).
+inventory size (reference_plant_count() thermal plants).
 
 Writes a CSV with columns:
     model, family, median_tp, min_tp, max_tp,

--- a/src/aedist/plot_exp1_matrix.py
+++ b/src/aedist/plot_exp1_matrix.py
@@ -75,7 +75,7 @@ def _order_plants(cells: list) -> tuple[list[int], dict[int, tuple[str, str, flo
 
     Returns (ordered_plant_ids, info) where info[plant_id] = (name, status,
     capacity_mw). Columns are keyed by plant_id so same-name reference plants
-    (Formosa phases) keep distinct columns and the reference count stays at 163.
+    (Formosa phases) keep distinct columns and the reference count stays exact.
     """
     info: dict[int, tuple[str, str, float]] = {}
     for c in cells:

--- a/src/aedist/plot_method_convergence.py
+++ b/src/aedist/plot_method_convergence.py
@@ -7,9 +7,9 @@ Each bar is a row of dots: 1 dot = 1 plant.
 Family-coloured dots (right of 0) = correctly identified (TP).
 Red dots (left of 0) = unrecognized (FP), using the repo-wide
 COLOR_ALERT false-positive convention.
-Dashed green line at 163 = complete inventory.
+Dashed green line at the reference size = complete inventory.
 
-A good method drives all bars to 163 with nothing in red.
+A good method drives all bars to the reference line with nothing in red.
 
 Usage:
     uv run python -m aedist.plot_method_convergence \

--- a/src/aedist/plot_regimes_scatter.py
+++ b/src/aedist/plot_regimes_scatter.py
@@ -16,9 +16,12 @@ from collections import defaultdict
 from pathlib import Path
 from statistics import median
 
+from .evaluate import reference_plant_count
 from .figures_config import load_modelset
 from .measurements import SYNTHETIC_SUFFIXES, load
 from .util import COLOR_REFERENCE, normalize_model
+
+_N_REFERENCE_PLANTS = reference_plant_count()
 
 log = logging.getLogger(__name__)
 
@@ -96,12 +99,12 @@ def write_pdf(
                         linewidths=0,
                     )
 
-    ax.axvline(x=163, color=COLOR_REFERENCE, linewidth=1, linestyle="--", alpha=0.7)
+    ax.axvline(x=_N_REFERENCE_PLANTS, color=COLOR_REFERENCE, linewidth=1, linestyle="--", alpha=0.7)
 
     ax.set_yticks(yticks)
     ax.set_yticklabels(ytick_labels, fontsize=7)
     ax.set_xlabel("Centrales identifiées (un point = une centrale)", fontsize=9)
-    ax.set_xlim(0, 175)
+    ax.set_xlim(0, _N_REFERENCE_PLANTS + 12)
     ymax = (len(models) - 1) * 4 + 2
     ax.set_ylim(-0.5, ymax + 0.5)
     ax.invert_yaxis()

--- a/tickets/0447-ratchet-test-pas-de-163-en-dur-dans-les-scripts-de-rendu.erg
+++ b/tickets/0447-ratchet-test-pas-de-163-en-dur-dans-les-scripts-de-rendu.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: Ratchet adhérence: pas de taille de référence en dur dans les scripts de rendu
+Created: 2026-06-05
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-05T17:00Z claude created — roar sweep post-#767: la classe a mordu 4 scripts le même jour
+
+--- body ---
+## Contexte
+
+L'adoption v2 (163→170 centrales) a révélé une classe de bug : la taille
+de la liste de référence codée en dur dans les scripts de rendu —
+étiquette `"163 plants"`, `axvline(x=163)`, `set_ylim(-50, 150)` qui
+clippe la ligne à 170 hors cadre. Quatre scripts touchés le 2026-06-05 :
+plot_exp2_arms_split, plot_exp2_arms_comparison, plot_method_convergence
+(PR #767), plot_regimes_scatter (PR de suite). Le point d'entrée
+canonique existe : `evaluate.reference_plant_count()`.
+
+Les tests structurels ne voient pas les pixels : la ligne clippée et le
+label menteur ont été attrapés par la comparaison visuelle de l'auteur,
+pas par la CI. Un ratchet textuel attrape la classe à la source.
+
+## Spécification du test
+
+`@pytest.mark.adherence` dans tests/test_no_hardcoded_reference_size.py :
+- Scanne `src/aedist/plot_*.py` et `src/aedist/tabulate_*.py`
+- Échoue sur le littéral `163` (et `170` !) hors commentaires/docstrings
+  — la valeur courante en dur est le même bug avec un an de retard
+- Allowlist explicite et commentée pour les exceptions légitimes :
+  `tabulate_self_consistency.py` (fallback n_reference des records
+  legacy v1, sémantiquement correct)
+- AST de préférence au regex (cf. test_no_hardcoded_reference_path.py
+  comme modèle existant)
+
+## Exit criteria
+
+- [ ] Test ratchet en place, passe sur l'arbre courant
+- [ ] Mutation check: réintroduire `axvline(x=163)` dans un plot_*.py
+      fait échouer le test (vérifié à la main, pas commité)
+- [ ] `make check-fast` vert
+
+## Related
+
+- PR #767 (la vague de fixes), 0446 (retravail figure matrice)
+- tests/test_no_hardcoded_reference_path.py (modèle AST existant)


### PR DESCRIPTION
Roar sweep after #767 found one live instance of the adoption's bug class outside the merged set: `plot_regimes_scatter.py` hardcoded `axvline(x=163)` and its xlim cap. Fixed to track `reference_plant_count()`, same pattern as the three scripts fixed in #767. Four stale '163' docstrings refreshed; legitimate fallbacks (legacy v1 records in tabulate_self_consistency) and the accurate historical note in evaluate.py kept.

Opens ticket 0447: an adherence ratchet (AST, modeled on test_no_hardcoded_reference_path.py) so the class cannot return — it bit four scripts in one day and structural tests don't see pixels.

Gates: make check-fast EXIT=0, adherence 96 passed.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)