### PR TITLE
ticket(0460): convert exp1_cross_eval stamp to plain-file rule + .DELETE_ON_ERROR

### DIFF
--- a/experiments/derived/score.mk
+++ b/experiments/derived/score.mk
@@ -49,6 +49,14 @@ SCORE_MK_SELF := $(abspath $(lastword $(MAKEFILE_LIST)))
 
 include $(dir $(lastword $(MAKEFILE_LIST)))../paths.mk
 
+# Atomicity: delete a target whose recipe fails mid-write. Without this, a
+# crash partway through an append/stream write (e.g. score_exp1 appending to
+# exp1_cross_eval.csv, or any --output writer here) leaves a PARTIAL file with
+# a fresh mtime that Make treats as up-to-date — a silent stale-artifact
+# hazard. This is the correctness guarantee that lets single-known-output
+# recipes drop their .done sentinels and be plain-file rules (ticket 0460).
+.DELETE_ON_ERROR:
+
 # --- P2-local tooling -------------------------------------------------------
 # Bare `uv run` (no --env-file): P2 scoring makes no API calls, so it needs no
 # secrets. This mirrors the former P2 score makefile's convention and keeps
@@ -140,10 +148,8 @@ rebuild-measurements:
 #                                          pulls $(ANALYSIS_EXP2_CROSS_EVAL_CSV)
 #                                          = sota_cross_eval.csv + the arm .done
 #                                          stamps)
-#   * exp1_cross_eval/.done               (produces exp1_cross_eval.csv — a
-#                                          side-effect of this stamp, named here
-#                                          because the CSV itself is not a make
-#                                          target)
+#   * exp1_cross_eval.csv                 (Exp1 cross-eval; a plain-file rule —
+#                                          single known output, no stamp)
 #   * self_consistency_summary.json       (P2 SC outcome; no current P3 consumer
 #                                          but part of a full P2 re-run)
 # This rule runs P2 for REAL (extract → evaluate → assemble): it (re)writes
@@ -154,7 +160,7 @@ rebuild-measurements:
 all-outcomes:
 	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(ANALYSIS_MEASUREMENTS)
 	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(ANALYSIS_EXP2_MART_JSONL)
-	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval/.done
+	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(ANALYSIS_EXP1_CROSS_EVAL_CSV)
 	@$(MAKE) --no-print-directory -f $(SCORE_MK_SELF) $(SCORE_SC_JSON)
 
 # === Self-consistency scorer (archive rag_extract → derived/rag_consistency)
@@ -210,13 +216,15 @@ $(ANALYSIS_DERIVED_DIR)/arm2_flat/.done: $(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/
 	    --output-dir $(ANALYSIS_DERIVED_DIR)/arm2_flat
 	touch $@
 
-$(ANALYSIS_DERIVED_DIR)/exp1_cross_eval/.done: $(ANALYSIS_EXP1_INPUT_CSVS) $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_exp1.py
-	rm -f $(ANALYSIS_EXP1_CROSS_EVAL_CSV)
+# exp1_cross_eval.csv is a single known output (score_exp1 writes exactly one
+# file and mkdirs its own parent), so it is a plain-file rule — no .done stamp,
+# no dedicated holding directory. score_exp1 appends, hence the rm -f; the
+# .DELETE_ON_ERROR above makes a crashed write self-clean (ticket 0460).
+$(ANALYSIS_EXP1_CROSS_EVAL_CSV): $(ANALYSIS_EXP1_INPUT_CSVS) $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_exp1.py
+	rm -f $@
 	uv run python -m aedist.score_exp1 \
 	    --input-dir $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2 \
-	    --output $(ANALYSIS_EXP1_CROSS_EVAL_CSV)
-	mkdir -p $(ANALYSIS_DERIVED_DIR)/exp1_cross_eval
-	touch $@
+	    --output $@
 
 $(ANALYSIS_DERIVED_DIR)/arm3_flat/.done: $(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/outputs/sota_exp3_arm3_batch1/run*/*.json)
 	uv run python -m aedist.extract_arm_single_turn \

--- a/tests/test_score_mk_exp1_cross_eval.py
+++ b/tests/test_score_mk_exp1_cross_eval.py
@@ -1,0 +1,63 @@
+"""`experiments/derived/score.mk` — Exp1 cross-eval is a plain-file rule.
+
+Ticket 0460 converted the `exp1_cross_eval` build from a sentinel-stamp rule
+(`experiments/derived/exp1_cross_eval/.done`) to a plain-file rule on the single
+known output `exp1_cross_eval.csv`. The stamp was ceremony — `score_exp1` writes
+exactly one file and mkdirs its own parent — and its dedicated directory was an
+orphan untracked dir (flagged at ticket 0444 close).
+
+The conversion is only correct paired with `.DELETE_ON_ERROR`: `score_exp1`
+appends, so the recipe `rm -f`s then writes; without atomicity a mid-write crash
+would leave a partial CSV with a fresh mtime that Make treats as current. These
+guards lock both halves so the stamp cannot creep back and atomicity cannot be
+dropped.
+
+The four `armN_flat/.done` stamps are the CORRECT idiom (dynamic multi-output,
+un-enumerable filenames) and are intentionally NOT guarded against here.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCORE_MK = REPO_ROOT / "experiments" / "derived" / "score.mk"
+
+
+def _score_mk_text() -> str:
+    return SCORE_MK.read_text(encoding="utf-8")
+
+
+def test_delete_on_error_is_set():
+    """Atomicity: a crashed recipe must not leave a stale-but-fresh artifact."""
+    assert ".DELETE_ON_ERROR:" in _score_mk_text(), (
+        "score.mk must set .DELETE_ON_ERROR so a recipe that crashes mid-write "
+        "(e.g. score_exp1 appending to exp1_cross_eval.csv) does not leave a "
+        "partial output with a current mtime"
+    )
+
+
+def test_exp1_cross_eval_is_plain_file_rule():
+    """The CSV itself is a rule target, not a stamp side-effect."""
+    text = _score_mk_text()
+    # A rule line whose target resolves to exp1_cross_eval.csv. The makefile
+    # uses the $(ANALYSIS_EXP1_CROSS_EVAL_CSV) variable; accept either the
+    # variable-form target or the literal basename as a rule target.
+    has_csv_target = any(
+        line.lstrip().startswith(("$(ANALYSIS_EXP1_CROSS_EVAL_CSV):",))
+        or "exp1_cross_eval.csv:" in line
+        for line in text.splitlines()
+    )
+    assert has_csv_target, (
+        "score.mk must declare exp1_cross_eval.csv as a plain-file rule target"
+    )
+
+
+def test_no_exp1_cross_eval_stamp():
+    """The stamp + its orphan directory must be gone for good."""
+    assert "exp1_cross_eval/.done" not in _score_mk_text(), (
+        "exp1_cross_eval must not be keyed on a .done stamp — it has a single "
+        "known output; the stamp's directory was an orphan untracked dir"
+    )

--- a/tickets/0460-convert-exp1-cross-eval-stamp-to-plain-f.erg
+++ b/tickets/0460-convert-exp1-cross-eval-stamp-to-plain-f.erg
@@ -1,0 +1,100 @@
+%erg 0.1
+Title: Convert exp1_cross_eval stamp to plain-file rule + add .DELETE_ON_ERROR
+Created: 2026-06-08
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-08T09:28Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`score.mk` keys the Exp1 cross-eval build on a sentinel stamp
+`experiments/derived/exp1_cross_eval/.done` (rule ~line 213). But
+`score_exp1` writes exactly ONE known output — `exp1_cross_eval.csv` — and
+already `mkdir`s the CSV's own parent. The stamp + its dedicated
+`exp1_cross_eval/` directory (created solely by the Makefile's `mkdir -p` to
+hold `.done`) are pure ceremony. That empty directory is the orphan untracked
+dir flagged at the close of ticket 0444.
+
+This is unlike the four `armN_flat/.done` stamps, which are the *correct*
+idiom — each extraction emits ~60 files with data-dependent names the Makefile
+cannot enumerate. Those stay. Only the single-known-output `exp1_cross_eval`
+rule is convertible to a plain-file target.
+
+**Atomicity catch (load-bearing).** The stamp gives failure-atomicity for
+free: it `touch`es only on success, so a mid-recipe crash leaves no stamp →
+correct rebuild. `score_exp1` appends (`open(..., "a")`), so the rule does
+`rm -f` then writes. A naive `CSV: inputs` rule would lose atomicity: a crash
+mid-write leaves a PARTIAL CSV with a fresh mtime → Make treats it as current
+→ stale artifact ships silently. `.DELETE_ON_ERROR` is currently set NOWHERE
+in the build. So the conversion MUST be paired with adding `.DELETE_ON_ERROR:`
+to score.mk — a one-line, build-wide correctness win (the real "let Make
+manage deps properly" fix: today any recipe crashing mid-write leaves a
+stale-but-fresh artifact).
+
+The CSV is LIVE — consumed by `plot_quality_spider_exp1.py` and
+`plot_spider_cross_exp.py` (`--input` / `--exp1`). Convert, do not delete.
+
+## Relevant files
+
+- `experiments/derived/score.mk` — the `exp1_cross_eval/.done` rule (~213), its
+  reference in `all-outcomes` (~157), the SOURCES/OUTCOMES doc comments
+  (~22, ~143). Add `.DELETE_ON_ERROR:` near the top.
+- `src/aedist/score_exp1.py` — append-mode writer (`--output`); no side
+  outputs (verified). No change expected.
+
+## Actions
+
+1. Add `.DELETE_ON_ERROR:` to `score.mk` (top, near `SHELL`/self-path block).
+2. Replace the stamp rule with a plain-file rule:
+   `$(ANALYSIS_EXP1_CROSS_EVAL_CSV): $(ANALYSIS_EXP1_INPUT_CSVS) <score_exp1.py>`
+   recipe: `rm -f $@; uv run python -m aedist.score_exp1 --input-dir … --output $@`
+   (drop the `mkdir exp1_cross_eval/` and `touch`). score_exp1 already mkdirs
+   the CSV parent.
+3. Repoint the `all-outcomes` reference (~157) from `.../exp1_cross_eval/.done`
+   to `$(ANALYSIS_EXP1_CROSS_EVAL_CSV)`.
+4. Update the doc-comment mentions of the stamp (~143) to describe the plain
+   target.
+5. Remove the orphan dir: `git rm -r --cached` is N/A (untracked); just ensure
+   no rule recreates `experiments/derived/exp1_cross_eval/`.
+
+## Test (write first — red)
+
+`tests/test_score_mk_exp1_cross_eval.py` (source-inspection, no subprocess):
+- assert `score.mk` contains `.DELETE_ON_ERROR`.
+- assert `score.mk` declares `$(ANALYSIS_EXP1_CROSS_EVAL_CSV)` /
+  `exp1_cross_eval.csv` as a rule target (line matching `exp1_cross_eval.csv:`).
+- assert `score.mk` no longer references `exp1_cross_eval/.done`.
+
+## Verification
+
+- [ ] `grep -n 'exp1_cross_eval/.done' experiments/derived/score.mk` → no match.
+- [ ] `grep -n 'DELETE_ON_ERROR' experiments/derived/score.mk` → matches.
+- [ ] `make -f experiments/derived/score.mk experiments/derived/exp1_cross_eval.csv`
+      regenerates the CSV; no `exp1_cross_eval/` directory is created.
+- [ ] `make -f experiments/derived/score.mk all-outcomes` still builds.
+- [ ] `pytest tests/test_score_mk_exp1_cross_eval.py` green; `make check` green.
+
+## Invariants
+
+- The four `armN_flat/.done` stamps are UNTOUCHED (correct dynamic-output idiom).
+- `exp1_cross_eval.csv` content unchanged (same script, same inputs); its two
+  spider-plot consumers keep working.
+- `make check` green.
+
+## Exit criteria
+
+- [ ] `exp1_cross_eval` builds via a plain-file rule on `exp1_cross_eval.csv`;
+      no stamp, no orphan `exp1_cross_eval/` directory.
+- [ ] `.DELETE_ON_ERROR:` set in score.mk; adherence test guards both.
+- [ ] `make check` green.
+
+## Related / flagged follow-up
+
+- 0444 (flagged the orphan `exp1_cross_eval/.done` dir; PR #781).
+- FOLLOW-UP (separate ticket): the `$(wildcard run*/*.json)` prereqs in the
+  armN stamp rules are parse-time fragile — on a fresh checkout where the JSONs
+  do not yet exist, the wildcard expands empty and the stamp never rebuilds
+  when data later lands. Afflicts stamp and non-stamp rules equally; orthogonal
+  to this conversion. Not fixed here.

--- a/tickets/closed/0460-convert-exp1-cross-eval-stamp-to-plain-f.erg
+++ b/tickets/closed/0460-convert-exp1-cross-eval-stamp-to-plain-f.erg
@@ -2,10 +2,12 @@
 Title: Convert exp1_cross_eval stamp to plain-file rule + add .DELETE_ON_ERROR
 Created: 2026-06-08
 Author: HDMX-coding-agent
+Closed: Converted exp1_cross_eval stamp to plain-file rule on exp1_cross_eval.csv; added .DELETE_ON_ERROR to score.mk for build-wide write atomicity; orphan exp1_cross_eval/ dir eliminated. armN stamps left as correct idiom. Adherence test guards all three.
 
 --- log ---
 2026-06-08T09:28Z HDMX-coding-agent created
 
+2026-06-08T09:36Z HDMX-coding-agent closed — Converted exp1_cross_eval stamp to plain-file rule on exp1_cross_eval.csv; added .DELETE_ON_ERROR to score.mk for build-wide write atomicity; orphan exp1_cross_eval/ dir eliminated. armN stamps left as correct idiom. Adherence test guards all three.
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Removes the one genuine stamp hack in `score.mk` and adds the atomicity guarantee that makes plain-file rules safe — the real "let Make manage deps as it should" fix.

- **Convert** `exp1_cross_eval/.done` stamp → plain-file rule on `exp1_cross_eval.csv`. `score_exp1` writes exactly one known output and mkdirs its own parent, so the stamp + its dedicated directory were pure ceremony — and that empty directory was the orphan untracked dir flagged at ticket 0444's close. Make now tracks the real artifact's mtime instead of a decoupled stamp that could drift from it.
- **Add `.DELETE_ON_ERROR:`** to `score.mk` (set nowhere before). The stamp gave failure-atomicity for free; since `score_exp1` appends (recipe `rm -f`s then writes), a naive plain rule would leave a partial CSV with a fresh mtime on a mid-write crash → silent stale artifact. `.DELETE_ON_ERROR` covers every `--output` writer in the phase, not just this one.
- **Adherence test** (`test_score_mk_exp1_cross_eval.py`) guards all three: `.DELETE_ON_ERROR` set, CSV is a rule target, stamp gone.

**Left untouched on purpose:** the four `armN_flat/.done` stamps emit ~60 files with data-dependent names the Makefile cannot enumerate — the *correct* stamp idiom, not a hack.

**Flagged follow-up (separate ticket, not fixed here):** the `$(wildcard run*/*.json)` prereqs in the armN rules are parse-time fragile (empty list on a fresh checkout before data lands). Orthogonal to this conversion.

**Ticket:** tickets/0460-convert-exp1-cross-eval-stamp-to-plain-f.erg

## Test plan

- [x] New adherence test red before the change, green after
- [x] CSV rebuilds byte-identical via the plain rule; no orphan `exp1_cross_eval/` dir created
- [x] Idempotent (second `make` is a no-op); `all-outcomes` resolves to the CSV target
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)