### PR TITLE
ticket(0442): extract_ods — hard-stop capacity validator

### DIFF
--- a/data/reference/extract_ods.py
+++ b/data/reference/extract_ods.py
@@ -209,6 +209,40 @@ def validate_status_vocabulary(df: pd.DataFrame) -> None:
         )
 
 
+def validate_capacity_numeric(df: pd.DataFrame) -> None:
+    """Abort if any Capacity cell is non-empty and non-numeric.
+
+    A spreadsheet error value (e.g. ``Err:510``, ``#VALUE!``, ``#REF!``) is
+    corruption leaked from a formula cell, not data — writing it to the CSV
+    would silently break downstream numeric aggregation (the capacity sum in
+    aggregate_units.py). Empty is allowed (legitimately unknown capacity for
+    planned plants). The message names the offending spreadsheet row and the
+    bad value so the author can fix the master.
+
+    Ticket 0442: Err:510 leaked through extraction into the CSV; the failure
+    surfaced only downstream in aggregate_units.py's capacity guard (0416).
+    Per the layered-guards doctrine, extraction is the primary catch.
+    """
+    offenders = []
+    for idx, value in df["Capacity (MW)"].items():
+        cell = _cell(value)
+        if not cell:
+            continue
+        try:
+            float(cell)
+        except ValueError:
+            offenders.append(
+                f"row {idx + HEADER_ROW + 2}: {cell!r}"
+            )
+    if offenders:
+        raise ValueError(
+            "Non-numeric capacity cells in the master ODS — a spreadsheet "
+            "formula error (e.g. Err:510, #VALUE!, #REF!) leaked through. "
+            "Fix the formula in the master, then re-import:\n  "
+            + "\n  ".join(offenders)
+        )
+
+
 def validate_input(df: pd.DataFrame) -> None:
     """Run every input validator. Hard stop on the first failure.
 
@@ -218,6 +252,7 @@ def validate_input(df: pd.DataFrame) -> None:
     validate_address_shape(df)
     validate_no_duplicate_names(df)
     validate_status_vocabulary(df)
+    validate_capacity_numeric(df)
 
 
 def read_ods(path: Path) -> pd.DataFrame:

--- a/tests/test_extract_ods.py
+++ b/tests/test_extract_ods.py
@@ -13,6 +13,7 @@ All extraction is dtype=str (no coercion ever): the zero-prefix preservation
 principle that bit ires_code (0121 -> 121) applies to every column here.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -28,6 +29,7 @@ from data.reference.extract_ods import (
     read_ods,
     select_columns,
     validate_address_shape,
+    validate_capacity_numeric,
     validate_input,
     validate_no_duplicate_names,
     validate_status_vocabulary,
@@ -211,6 +213,89 @@ def test_validate_input_includes_vocabulary():
     """validate_input composes the vocabulary check."""
     df = _df([("", "Plant A", "")], **{"Project stage": ["bogus"]})
     with pytest.raises(ValueError, match="bogus"):
+        validate_input(df)
+
+
+# --- validate_capacity_numeric (ticket 0442) ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "Err:510",
+        "#VALUE!",
+        "#REF!",
+        "#DIV/0!",
+        "#NAME?",
+        "#N/A",
+        "#NULL!",
+        "abc",
+    ],
+    ids=lambda v: v.replace("#", "hash-").replace("!", "").replace("/", "-").replace(":", "-"),
+)
+def test_capacity_error_string_hard_stops(bad_value):
+    """Spreadsheet error strings in capacity must hard-stop extraction.
+
+    Ticket 0442: Err:510 leaked through extract_ods into the CSV; the failure
+    surfaced only downstream in aggregate_units. Extraction is the primary
+    catch — it must refuse with an actionable message naming both the offending
+    row and the bad value.
+    """
+    df = _df(
+        [("", "Plant A", "Unit 1")],
+        **{"Capacity (MW)": [bad_value]},
+    )
+    with pytest.raises(ValueError, match=re.escape(bad_value)):
+        validate_capacity_numeric(df)
+
+
+def test_capacity_empty_is_allowed():
+    """Empty capacity is legitimate (planned plants with unknown MW)."""
+    df = _df(
+        [("", "Plant A", "")],
+        **{"Capacity (MW)": [""]},
+    )
+    validate_capacity_numeric(df)  # must not raise
+
+
+def test_capacity_nan_is_allowed():
+    """NaN capacity (raw ODS blank cell) is treated like empty — allowed."""
+    df = _df(
+        [("", "Plant A", "")],
+        **{"Capacity (MW)": [float("nan")]},
+    )
+    validate_capacity_numeric(df)  # must not raise
+
+
+def test_capacity_valid_number_passes():
+    """A valid numeric capacity string passes validation."""
+    df = _df(
+        [("", "Plant A", "Unit 1"), ("", "Plant B", "")],
+        **{"Capacity (MW)": ["650", "1200.5"]},
+    )
+    validate_capacity_numeric(df)  # must not raise
+
+
+def test_capacity_error_message_names_row():
+    """The diagnostic must name the offending spreadsheet row number.
+
+    Row numbering: df index 0 + HEADER_ROW(4) + 2 = row 6 in the spreadsheet.
+    """
+    df = _df(
+        [("", "Plant A", "Unit 1")],
+        **{"Capacity (MW)": ["Err:510"]},
+    )
+    with pytest.raises(ValueError, match="row 6"):
+        validate_capacity_numeric(df)
+
+
+def test_validate_input_includes_capacity_check():
+    """validate_input composes the capacity numericness check (ticket 0442)."""
+    df = _df(
+        [("", "Plant A", "")],
+        **{"Capacity (MW)": ["Err:510"], "Project stage": ["6 operating"]},
+    )
+    with pytest.raises(ValueError, match="Err:510"):
         validate_input(df)
 
 

--- a/tickets/closed/0442-extract-ods-hard-stop-capacity-validator.erg
+++ b/tickets/closed/0442-extract-ods-hard-stop-capacity-validator.erg
@@ -2,10 +2,12 @@
 Title: extract_ods: hard-stop capacity validator (Err:510 leaked through extraction)
 Created: 2026-06-05
 Author: claude
+Closed: autoclosed — PR #789
 
 --- log ---
 2026-06-05T11:39Z claude created
 
+2026-06-08T13:18Z HDMX-coding-agent closed — autoclosed — PR #789
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Add `validate_capacity_numeric` to `extract_ods.py`'s `validate_input` chain: every non-empty `Capacity (MW)` cell must parse as a float. Spreadsheet error strings (`Err:NNN`, `#VALUE!`, `#REF!`, `#DIV/0!`, `#NAME?`, `#N/A`, `#NULL!`) trigger a hard stop with an actionable message naming the offending spreadsheet row and the bad value. Empty capacity is allowed (legitimately unknown for planned plants).

**Ticket:** tickets/0442-extract-ods-hard-stop-capacity-validator.erg

## Scope notes

- The redundant downstream guard in `aggregate_units.py` (`validate_capacity_numeric`) is preserved intact (defence in depth, ticket 0416).
- The current pinned snapshot (`pipeline+extensions-as-plants-2026-06-05.ods`) is clean — no non-numeric capacity values. The validator prevents future regressions.
- Empty capacity is allowed: 4 rows in the snapshot have legitimately blank capacity (planned plants with unknown MW).

## Test

- `test_capacity_error_string_hard_stops` — parametrized over 8 error strings (`Err:510`, `#VALUE!`, `#REF!`, `#DIV/0!`, `#NAME?`, `#N/A`, `#NULL!`, `abc`)
- `test_capacity_empty_is_allowed` — empty string passes
- `test_capacity_nan_is_allowed` — NaN (raw ODS blank) passes
- `test_capacity_valid_number_passes` — valid numbers pass
- `test_capacity_error_message_names_row` — diagnostic includes spreadsheet row number
- `test_validate_input_includes_capacity_check` — composition through `validate_input`
- Integration test `test_tracked_ods_extraction_green` still passes (pinned snapshot is clean)
- Full suite: 2017 passed, 7 skipped, 1 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)