### PR TITLE
plan: internal-coherence run-screen roadmap (trackers A/B) + STATE/MASTERPLAN

### DIFF
--- a/MASTERPLAN.md
+++ b/MASTERPLAN.md
@@ -66,6 +66,34 @@ Can the method scale to other countries? Update when plants change status?
 Fill gaps from totals? Resolve incoherences or escalate them?
 Prioritize sources when they conflict?
 
+## The methods contribution: a zero-reference coherence screen
+
+The quality bar of §2 is a *conjunction*: an acceptable dataset must clear
+accuracy, coherence, provenance, *and* temporality. The operational
+consequence is sharp — a **zero on any criterion means the bar is not
+cleared**, so that run, and aggregated upward that model, is trash. This is
+why the benchmark's headline contribution is a **screen**, not a leaderboard:
+the question is not "who scores highest" but "who fails to clear the floor at
+all."
+
+The non-obvious move is that the screen is **usable without ground truth**.
+Accuracy is the only criterion that needs the reference list; the other four
+are reference-free *by construction* — computable from a single run's own
+output. A model that emits 496 identical rows betrays itself on internal
+coherence with no gold standard in sight. That makes the screen deployable on
+the very campaigns (other countries, other component classes) where no
+reference yet exists — the whole point of Auto-PyPSA ASEAN.
+
+Two papers follow, at two units of analysis. **Paper A** (the manuscript MVP,
+tracker 0464) takes the **model** as the unit: a *capability floor*, written
+for a readership naive to LLMs, asking which models are even fit to be
+trusted as a source. **Paper B** (the information-fusion follow-up, tracker
+0465) takes the **run** as the unit, with the model demoted to a covariate:
+having screened out the uninformative runs, fuse the survivors into a single
+latent-truth estimate and bound the residual unseen share against a control
+total. The screen is the bridge — it is what lets fusion proceed on noisy,
+reference-free lists without being poisoned by degenerate runs.
+
 ## Method traits
 
 Beyond the four evaluation levels, certain architectural properties shape whether a method can scale from one country × one component class to 60 extraction campaigns (Auto-PyPSA ASEAN). These are *traits of the fusion primitive*, not quality scores.

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-06-08T10:18Z
+Last updated: 2026-06-08T11:10Z
 
 ## North star
 
@@ -28,6 +28,10 @@ Reference v2 (170 plants) adopted end-to-end: snapshot policy → aggregator (#7
 1. **0435 finalization** — acknowledgements (blessed wording), author read (incl. new coherence-screen paragraph), arXiv build. 0445 blocker cleared (173 settled + propagated).
 2. 0446-review follow-ons: 0453 (two-level coherence scoring), 0455 (preprint figures EN sweep), 0448 (caption dup), 0449 (Exp2 matrices), 0457 (cohort-filter test); imagines awaiting discussion: 0450/0451/0454. 0255–0262 deferred (Blocked-by 0435), owed to journal.
 3. Backlog: 0459 (re-derive+wire report.tex Exp3 decomposition table), 0461 (.DELETE_ON_ERROR build-wide + adherence guard), 0462 (armN stamp wildcard parse-time fragility), 0447 (hardcoded-size ratchet), 0441–0443, 0377.
+
+## Next: methods contribution
+
+Ratified internal-coherence run-screen roadmap captured under **tracker 0464** (Paper A, manuscript MVP: 0201 scorer → 0466 model-grain floor heatmap → 0467 run-grain validation → 0468 table move → 0469 slides sync). Fil rouge = §2 conjunctive quality bar = zero-is-trash. Information fusion (run-as-unit) deferred to **tracker 0465** (Paper B: 0470/0471/0398/0399-consensus/0293).
 
 ## Open issues
 

--- a/tickets/0201-quality-composite-axis-coherence-provenance-temporality.erg
+++ b/tickets/0201-quality-composite-axis-coherence-provenance-temporality.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-21T12:30Z claude created — follow-up from ticket 0196 (Pareto figure)
+2026-06-08T11:00Z claude note linked to tracker 0464
 
 --- body ---
 
@@ -37,3 +38,5 @@ variants (RAG, decomposed, agentic) that Exp 1 deliberately excludes.
   composite via a `--quality-axis` flag.
 - [ ] Manuscript Figure 2 caption updated to reflect whichever axis
   ends up canonical.
+
+Part of: 0464 — role A1 (deterministic reference-free scorer; 4 free criteria + source quality resolve→tier→value-in-source; accuracy is the only reference-full axis)

--- a/tickets/0225-theoretical-contribution-confidence-vocabulary-fil-rouge.erg
+++ b/tickets/0225-theoretical-contribution-confidence-vocabulary-fil-rouge.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-22T08:30Z claude created — author imagine direction; binds §1–§6 together via a single theoretical thesis
+2026-06-08T11:00Z claude note linked to tracker 0464
 
 --- body ---
 
@@ -125,3 +126,5 @@ both improve.
 Imagine-mode. Ratification = author edits §1–§6 to thread the thesis
 through, after which this ticket closes "thesis adopted, see git
 log on slides/manuscript/main.md."
+
+Reconciled into 0464: fil rouge = the §2 conjunctive quality bar = the zero-is-trash screen (subsumes the confidence-band-vocabulary framing)

--- a/tickets/0293-anchor-score-reference-count.erg
+++ b/tickets/0293-anchor-score-reference-count.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-05-25T00:00Z HDMX-coding-agent created
+2026-06-08T11:00Z claude note linked to tracker 0465
 
 --- body ---
 ## Context
@@ -30,3 +31,5 @@ indicator (not a standalone quality score).
 
 - [ ] One-page note with recommendation and caveats.
 - [ ] If retained, add explicit formula and anti-gaming guardrails.
+
+Part of: 0465 — alternate anchoring score

--- a/tickets/0396-scoring-row-atomicity-coherence-indicator.erg
+++ b/tickets/0396-scoring-row-atomicity-coherence-indicator.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-03T00:00Z claude created — promote row atomicity (1NF) from a matcher artefact (0393) to a first-class reference-free coherence indicator, measured at the verbal level
+2026-06-08T11:00Z claude note linked to tracker 0464
 
 --- body ---
 ## Context
@@ -112,3 +113,5 @@ rate is in `[0.01, 0.06]` (catches a naive regex).
   `src/aedist/exp2_mart.py` (schema bump), `src/aedist/measurements.py`
   (records_to_metrics, ADR-7)
 - 0393 (the matcher-side counterpart this may make optional)
+
+Part of: 0464 — atomicity (1NF) sub-score within A1 (0201)

--- a/tickets/0398-latent-truth-multiattribute-pu-fusion.erg
+++ b/tickets/0398-latent-truth-multiattribute-pu-fusion.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-03T00:00Z claude created from imagine-mode design + deep-research litreview
+2026-06-08T11:00Z claude note linked to tracker 0465
 
 --- body ---
 ## Context
@@ -100,3 +101,5 @@ def test_pu_anchor_absence_is_not_negative():
 - Keep the model **generic** (Country X / subsector Y), with ASEAN thermal as the first
   parameterized application (project rule: design for genericity).
 - Do not hard-discard models/runs in this ticket — emit continuous weights; gating is 0399.
+
+Part of: 0465 — PU/latent-truth fusion (run as unit)

--- a/tickets/0399-two-channel-run-quality-gate.erg
+++ b/tickets/0399-two-channel-run-quality-gate.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-03T00:00Z claude created from imagine-mode design + deep-research litreview
+2026-06-08T11:00Z claude note linked to tracker 0464
 
 --- body ---
 ## Context
@@ -88,3 +89,5 @@ def test_t0_reps_identical_is_not_degenerate():
   they can also gate runs BEFORE fusion (cheap early kill, cf. "test one before blasting").
 - Keep detectors generic/configurable (thresholds per attribute type), not hardcoded to
   power-plant specifics where avoidable (project rule: design for genericity).
+
+Split: model-free VETO half → 0464 (folds into 0453); CONSENSUS half → 0465

--- a/tickets/0453-two-level-internal-coherence-scoring-run.erg
+++ b/tickets/0453-two-level-internal-coherence-scoring-run.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-06-06T09:55Z HDMX-coding-agent note — author conjecture verified during the 0446 session; analysis committed at docs/internal-coherence-screen.md
 
 2026-06-06T11:15Z author idea (2026-06-06): once screen columns land, overlay the verdict on the recognition matrix — draw a line across rejected runs (--mark-incoherent on plot_exp1_matrix); deferred from 0446 review: rule is in-sample and scoring belongs in P2, not the renderer
+2026-06-08T11:00Z claude note linked to tracker 0464
 --- body ---
 ## Context
 
@@ -80,3 +81,5 @@ def test_capacity_variability_flags_template_runs():
 - 0436 (render DAG discipline), 0445 (extension FPs — orthogonal FP track)
 - main.md Discussion "Internal coherence as a zero-reference screen"
   (future-work paragraph added 2026-06-06)
+
+Part of: 0464 — two-level screen: run-grain veto (zero-is-trash on the 4 free criteria) + model-grain majority-red floor

--- a/tickets/0454-status-vocabulary-alignment-reference-fi.erg
+++ b/tickets/0454-status-vocabulary-alignment-reference-fi.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-06T09:26Z HDMX-coding-agent created — author at 0446 review: "a 4-way diff too much for a Saturday morning"; fold the GEM discussion here
+2026-06-08T11:00Z claude note linked to tracker 0464
 
 --- body ---
 ## Context
@@ -65,3 +66,5 @@ language — known limitation, cf. 0356 for slides).
 - 0449/0450/0451 (other 0446-review follow-ons)
 - evaluate.py `_STATUS_ORDINAL_PROJECTION`, exp1_recognition.py
   STATUS_LABELS, prompt_complete.txt status line
+
+Part of: 0464 — status-vocabulary alignment feeds A1's status-correct sub-score (dependency)

--- a/tickets/0464-internal-coherence-run-screen-manuscript.erg
+++ b/tickets/0464-internal-coherence-run-screen-manuscript.erg
@@ -1,0 +1,70 @@
+%erg 0.1
+Title: Internal-coherence run-screen → manuscript MVP (Paper A)
+Created: 2026-06-08
+Author: claude
+Blocked-by: 0201
+Blocked-by: 0453
+Blocked-by: 0466
+Blocked-by: 0467
+Blocked-by: 0468
+Blocked-by: 0469
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+The paper's methods contribution is an **internal-coherence run-screen**.
+Fil rouge: §2 of the manuscript (`slides/manuscript/main.md`) defines the
+quality bar as a **conjunction** of criteria — any acceptable dataset must
+clear *all* of them. A **zero on any criterion therefore means the bar is
+not cleared**: the run (or, aggregated, the model) is trash. This promotes
+the existing #771 Discussion paragraph "Internal coherence as a zero-reference
+screen" (`main.md` line ~123) from future-work to the present contribution.
+
+Scoring = **5 criteria × K sub-scores**. ACCURACY is the *only* reference-full
+criterion; the other four (coherence, provenance, temporality, source quality)
+are **reference-free by construction** — computable from the run alone. That is
+what makes the screen usable without ground truth.
+
+**Unit for Paper A = the MODEL** (a capability floor). A model whose runs
+systematically zero a free criterion is "too weak to clear the bar".
+Paper A is the MVP: talk-aligned, written for a readership naive to LLMs.
+The run-as-unit information-fusion programme is the sibling tracker 0465
+(Paper B), where the model becomes a covariate.
+
+This tracker captures the roadmap ratified with the author this session.
+It holds no production code of its own; each child lands its own merge request.
+
+## Children (ordered)
+
+- **A1 = 0201** (re-scoped): deterministic reference-free scorer — 4 free
+  criteria + source-quality (resolve → tier → value-in-source); accuracy is
+  the only reference-full axis. Folds in **0396** (atomicity / 1NF sub-score)
+  and depends on **0454** (status-vocabulary alignment → status-correct sub-score).
+- **A2 = 0466** (NEW): model-grain quality floor **heatmap** — replaces the
+  decorative quality spider's manuscript role; any red cell ⇒ model disqualified.
+- **A3 = 0467** (NEW): run-grain screen **validation annex** — proves the four
+  free criteria flag genuinely worse runs, within model, non-tautologically.
+- **A4 = 0468** (NEW): move the "why it is hard" difficulty table from Annex E
+  into task setup / head of Exp1 results (it characterises the task, so it
+  motivates difficulty up front).
+- **A5 = 0469** (NEW): `main.md ↔ slides` sync — talk-aligned manuscript revision.
+- **screen-design = 0453** (re-scoped): two-level screen — run-grain veto
+  (zero-is-trash on the four free criteria) + model-grain majority-red floor.
+
+## Relevant files
+
+- `slides/manuscript/main.md` — §2 quality bar; #771 Discussion paragraph (~L123); Annex E difficulty table (~L379–395)
+- `src/aedist/plot_quality_spider_exp1.py` — current decorative spider (A2 supersedes its manuscript role)
+- `docs/internal-coherence-screen.md` — the verified zero-reference analysis (0453)
+
+## Exit criteria (IDH tracking-ticket convention)
+
+- [ ] All children merged: 0201, 0453, 0466, 0467, 0468, 0469.
+- [ ] Manuscript presents the internal-coherence run-screen as a present
+      contribution (not future work) with the model-grain floor heatmap as
+      the canonical quality figure.
+- [ ] Closes only after the integration review (re-read child diffs, full
+      suite green, exit criteria verified), never on the bare last-child merge.

--- a/tickets/0465-information-fusion-follow-up-run-as-unit.erg
+++ b/tickets/0465-information-fusion-follow-up-run-as-unit.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: Information-fusion follow-up — run as unit (Paper B)
+Created: 2026-06-08
+Author: claude
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Paper B is the information-fusion follow-up to the manuscript MVP (Paper A,
+tracker 0464). **The unit of analysis is the RUN; the model is a covariate**
+(not the capability floor it is in Paper A). Paper B builds *on top of* Paper
+A's internal-coherence screen: the screen discards uninformative runs (those
+that zero a reference-free criterion) **before** fusion, so the latent-truth /
+capture–recapture machinery is not poisoned by template-like degenerate runs.
+
+Each reference plant becomes a column observed by many noisy runs — precisely
+the input object of latent-truth discovery and capture–recapture estimation
+(see `main.md` Discussion "From noisy runs to fused estimates", ~L125). Fusing
+incomplete, differently-reliable lists into a single estimate — bounding the
+residual share of unseen plants by linear programming against a control total
+(installed capacity per fuel) — is the research axis this opens.
+
+**Post-preprint.** This is a long-horizon tracker; its children are not on the
+arXiv-preprint critical path. It stays open until all children are merged
+(IDH tracking-ticket convention).
+
+## Children
+
+- **Cached LLM-judge faithfulness = 0470** (NEW): does document X say plant P
+  has fuel F / capacity C / status S? The deterministic value-in-source check
+  (Paper A / 0201) is the baseline; this is the LLM-judge upgrade with a
+  verdict cache for reproducibility and cost.
+- **E1→1N→1D grounding ladder = 0471** (NEW): paired within-agent deltas
+  isolating harness+tier (E1→1N), documents (1N→1D), and multi-turn (1D→5D);
+  emphasises source/provenance axes.
+- **0398**: PU / latent-truth multi-attribute fusion (run as unit).
+- **Consensus half of 0399**: the consensus / spammer-score channel of the
+  two-channel run-quality gate (the model-free VETO half folds into Paper A
+  via 0453).
+- **0293**: alternate anchoring score (reference-count based).
+
+## Relevant files
+
+- `slides/manuscript/main.md` — Discussion "From noisy runs to fused estimates" (~L125)
+- `src/aedist/plot_exp2_arms_split.py` — `_AGENT_EXP1_SLUG` map (the 4 agents in both Exp1 & Exp2; consumed by 0471)
+- `docs/2026-06-03-list-fusion-litreview.md` — fusion litreview (0398/0399)
+
+## Exit criteria
+
+- [ ] All children merged: 0470, 0471, 0398, the consensus half of 0399, 0293.
+- [ ] A run-as-unit fusion estimate exists that consumes Paper A's screen to
+      discard uninformative runs before fusion.
+- [ ] Closes only after integration review across the children, never on the
+      bare last-child merge.

--- a/tickets/0466-model-grain-quality-floor-heatmap-replac.erg
+++ b/tickets/0466-model-grain-quality-floor-heatmap-replac.erg
@@ -1,0 +1,104 @@
+%erg 0.1
+Title: Model-grain quality floor heatmap (replaces decorative quality spider)
+Created: 2026-06-08
+Author: claude
+Blocked-by: 0201
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Part of tracker 0464 (Paper A, role A2). The manuscript's quality figure is
+currently a decorative spider (`fig_spider_exp1_families`, four polar panels
+by family). It is hard for a naive reader to read off the **fil rouge** claim:
+the §2 quality bar is a *conjunction* — a zero on any criterion means the bar
+is not cleared. A heatmap makes that legible at a glance: a model with any
+disqualifying cell stands out as a red row.
+
+Replace the spider's **manuscript role** with a **model-grain quality floor
+heatmap**. The spider may stay for the talk (slides), but `main.md` shows the
+heatmap.
+
+**Cell rule.** Rows = the exact model set the current Exp1 spider renders
+(resolved from `_PANELS` in `plot_quality_spider_exp1.py`: families claude /
+gpt / mistral / qwen; deepseek is excluded — it has no panel). That is **12
+models**:
+
+```
+claude-haiku-4.5, claude-opus-4.6, claude-sonnet-4.6,
+gpt-5.5, gpt-oss-120b, gpt-oss-20b,
+mistral-large-2512, mistral-medium-3-5, mistral-small-2603,
+qwen3.6-35b-a3b, qwen3.6-flash, qwen3.7-max
+```
+
+(Resolve this set programmatically at build time from the same input the
+spider uses — `experiments/derived/exp1_cross_eval.csv` filtered by the
+spider's family panels — do **not** hardcode the list; project rule: never
+hardcode the model/reference set.)
+
+Columns = criteria × sub-scores (the 5-criteria × K-sub-score scoring from
+0201; accuracy is the only reference-full criterion).
+
+A **MODEL CELL is RED** iff a **majority (≥3 of 5)** of that model's runs score
+**zero** there. **Any red cell in a row ⇒ that model is disqualified** ("too
+weak to clear the bar"). Naive-reader legible (clear colour legend + a
+disqualified-row marker).
+
+## Relevant files
+
+- `src/aedist/plot_quality_spider_exp1.py` — current spider; `_PANELS` defines the model set to replicate
+- `experiments/derived/exp1_cross_eval.csv` — per-run sub-scores (input)
+- `experiments/render.mk` — wire the new `.pdf` artifact here (the spider targets are at ~L141–152)
+- `slides/manuscript/main.md` — Figure 2b include (~L37) swaps spider → heatmap
+- new: `src/aedist/plot_quality_floor_heatmap_exp1.py`
+
+## Actions
+
+1. New plot script `plot_quality_floor_heatmap_exp1.py`: read `exp1_cross_eval.csv`,
+   resolve the spider model set, compute per (model, sub-score) the fraction of
+   the 5 runs scoring zero, mark red iff ≥3/5.
+2. Add a Makefile `.pdf` target in `experiments/render.mk` (one output per rule).
+3. Swap the `main.md` Figure 2b include from `fig_spider_exp1_families.pdf` to
+   the heatmap; update the caption to state the conjunctive-bar reading.
+4. Leave the spider script + its slide include intact (talk role).
+
+## Test
+
+`tests/test_plot_quality_floor_heatmap_exp1.py`:
+
+```python
+def test_majority_zero_marks_red():
+    # 3 of 5 runs score zero on a sub-score → cell is red (disqualifying).
+    runs = [0.0, 0.0, 0.0, 0.4, 0.6]
+    assert cell_is_red(runs)           # 3/5 zero ≥ majority
+
+def test_minority_zero_not_red():
+    runs = [0.0, 0.0, 0.4, 0.5, 0.6]   # 2/5 zero < majority
+    assert not cell_is_red(runs)
+
+def test_model_set_matches_spider_panels():
+    # the heatmap rows == the models the spider renders (families claude/gpt/
+    # mistral/qwen), resolved from the same CSV — deepseek excluded.
+    assert set(heatmap_models(csv)) == set(spider_panel_models(csv))
+```
+
+## Verification
+
+- [ ] Heatmap PDF rebuilds via `make` and is committed (artifact discipline).
+- [ ] `main.md` includes the heatmap, not the spider; caption states the rule.
+- [ ] Model set equals the spider's 12 (test-guarded, not hardcoded).
+- [ ] No inline pgfplots (adherence test green).
+
+## Invariants
+
+- Spider script and slide include unchanged (talk still uses it).
+- Reference/model set never hardcoded.
+
+## Exit criteria
+
+- [ ] Heatmap supersedes the spider's **manuscript** role; any red cell ⇒
+      model disqualified; naive-reader legible; `make check` green.
+
+Part of: 0464 — role A2 (model-grain quality floor heatmap; supersedes the spider's manuscript role).

--- a/tickets/0467-run-grain-screen-validation-annex-within.erg
+++ b/tickets/0467-run-grain-screen-validation-annex-within.erg
@@ -1,0 +1,76 @@
+%erg 0.1
+Title: Run-grain screen validation annex (within-model, non-tautological)
+Created: 2026-06-08
+Author: claude
+Blocked-by: 0201
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Part of tracker 0464 (Paper A, role A3). The internal-coherence screen
+(0453/0201) vetoes runs on the four reference-free criteria. A reviewer's
+first objection: "of course coherence tracks accuracy — weak models are weak
+on everything." **At the model grain the screen is near-tautological**: weak
+models produce both incoherent and inaccurate runs.
+
+This annex must show the screen earns its keep at the **RUN grain, ideally
+WITHIN a model**: holding the model fixed, runs the four free criteria veto
+also have lower reference-based accuracy. Within-model removes the confound,
+so the result is non-tautological — the screen discriminates good from bad
+runs of the *same* model, not just good from bad models.
+
+This sets up Paper B's (0465) "uninformative run" claim: vetoed runs carry
+little information, so discarding them before fusion is sound.
+
+## Relevant files
+
+- `docs/internal-coherence-screen.md` — the verified ρ≈0.90 analysis (model-grain; this annex is the within-model strengthening)
+- `experiments/derived/exp1_cross_eval.csv` — per-run accuracy + screen sub-scores
+- `slides/manuscript/main.md` — annex destination (one validation panel/stat)
+- new: `src/aedist/plot_screen_validation_within_model.py` (or a stat table)
+
+## Actions
+
+1. For each model with both vetoed and non-vetoed runs, compute the
+   within-model accuracy gap (vetoed vs surviving runs). Aggregate as a paired
+   within-model statistic (e.g. mean within-model F1 delta, or a stratified
+   rank test) so the across-model confound is removed.
+2. Produce **one** manuscript-annex panel or stat: vetoed runs also have low
+   accuracy, *within model*.
+3. Wire the artifact into the Makefile (one output per rule) and include it in
+   the annex with a caption stating the non-tautology guard.
+
+## Test
+
+`tests/test_screen_validation_within_model.py`:
+
+```python
+def test_within_model_stratification_removes_across_model_signal():
+    # Two models, each with vetoed (low-F1) and surviving (high-F1) runs.
+    # A naive across-model correlation would be inflated by the model gap;
+    # the within-model statistic must isolate the run-grain effect.
+    stat = within_model_accuracy_gap(rows)
+    assert stat.is_within_model            # strata are (model,) not pooled
+    assert stat.vetoed_mean_f1 < stat.surviving_mean_f1
+```
+
+## Verification
+
+- [ ] Statistic / panel is RUN grain, stratified WITHIN model (not pooled).
+- [ ] Vetoed runs shown to also have lower accuracy within model.
+- [ ] One annex artifact committed + wired in the Makefile DAG.
+
+## Invariants
+
+- The screen sub-scores consumed here are the reference-free ones from 0201;
+  accuracy (reference-full) is the *outcome*, never an input to the veto.
+
+## Exit criteria
+
+- [ ] Non-tautological within-model validation panel/stat in the manuscript
+      annex; `make check` green.
+
+Part of: 0464 — role A3 (run-grain, within-model screen validation; sets up Paper B's "uninformative run" claim).

--- a/tickets/0468-move-the-why-it-is-hard-difficulty-table.erg
+++ b/tickets/0468-move-the-why-it-is-hard-difficulty-table.erg
@@ -1,0 +1,69 @@
+%erg 0.1
+Title: Move the why-it-is-hard difficulty table from Annex E into task setup
+Created: 2026-06-08
+Author: claude
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Part of tracker 0464 (Paper A, role A4). Prose-only. The "why it is hard"
+difficulty table currently lives in **Annex E** of `slides/manuscript/main.md`
+(the status-composition table at ~L379–395: the reference list is dominated by
+proposed plants, whose mean recognition rate is far below operational plants —
+so the low overall recognition is *structural*, a property of the list's
+composition).
+
+That table characterises the **task** — it is a property of the *reference*,
+not of any model — so it belongs **up front**, where it motivates the
+difficulty before any results are shown. Promote it from the annex into the
+**task setup (§2)** or the **head of the Exp1 results** section, and leave a
+short pointer in Annex E ("the difficulty table appears in §… ").
+
+## Relevant files
+
+- `slides/manuscript/main.md` — Annex E table (~L379–395); destination §2 / Exp1 results head
+- the table's data derivation (library `aedist.exp1_recognition`) — keep the
+  generated artifact wiring intact; only the prose placement moves
+
+## Actions
+
+1. Move the difficulty table block (table + its motivating sentences) from
+   Annex E to §2 task setup or the head of Exp1 results.
+2. Leave a one-line forward/backward pointer in Annex E (project writing rule:
+   forward-reference within the document, do not duplicate the table).
+3. Confirm any `\input`/include or generated-CSV reference still resolves from
+   the new location (artifact discipline — the table is generated, not hand-typed).
+
+## Test
+
+Adherence / placement check (source-inspection, no subprocess):
+
+```python
+def test_difficulty_table_in_task_setup_not_annex_only():
+    md = open("slides/manuscript/main.md").read()
+    setup = md.split("Annex E")[0]
+    assert "proposed" in setup and "recognition rate" in setup  # table moved up
+    # Annex E retains only a pointer, not the full table:
+    annex = md.split("Annex E")[1]
+    assert annex.count("| ") < FULL_TABLE_ROW_THRESHOLD
+```
+
+## Verification
+
+- [ ] Difficulty table renders in §2 / Exp1-results head, not the annex.
+- [ ] Annex E keeps a pointer, not a duplicate.
+- [ ] Generated-table wiring still resolves; manuscript builds clean.
+
+## Invariants
+
+- No new numeric literals introduced; the table stays generated, not hand-typed.
+
+## Exit criteria
+
+- [ ] Table moved up front with annex pointer; manuscript builds; placement
+      test green.
+
+Part of: 0464 — role A4 (promote the task-difficulty table from Annex E into task setup).

--- a/tickets/0469-main-md-slides-sync-talk-aligned-manuscr.erg
+++ b/tickets/0469-main-md-slides-sync-talk-aligned-manuscr.erg
@@ -1,0 +1,79 @@
+%erg 0.1
+Title: main.md ↔ slides sync — talk-aligned manuscript revision (naive readership)
+Created: 2026-06-08
+Author: claude
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Part of tracker 0464 (Paper A, role A5). Prose-only. The slides have been
+narratively refined past the preprint; the manuscript (`slides/manuscript/main.md`)
+should be brought into line with the talk's framing. **The readership is naive
+to LLMs** — the manuscript should explain, not assume, the concepts a general
+energy-statistics / methods audience needs. This is the talk-aligned MVP
+revision that makes Paper A read as a coherent whole around the
+internal-coherence run-screen contribution.
+
+**Sequencing — IMPORTANT.** This ticket touches figures and captions that are
+currently being modified by in-flight merge requests:
+
+- **#793** (ticket 0448) — global caption style (kill "Figure N: Figure N")
+- **#794** (ticket 0433) — rewrite Annex C to the as-run Exp2 story
+- **#795** (ticket 0455) — preprint figure-language sweep (all `main.md`
+  figures in English)
+
+**Do this work AFTER #793/#794/#795 have merged** — otherwise the sync conflicts
+with their figure/caption edits. (Deliberately NOT encoded as `Blocked-by:`:
+those tickets archive to `tickets/closed/` on merge, and a `Blocked-by:` ref to
+an archived ticket breaks `erg check`. The sequencing constraint lives here in
+the body, by design.)
+
+This ticket may legitimately **spawn sub-tickets** if the sync surfaces
+section-sized rewrites; split per the IDH multi-PR convention rather than
+ballooning one merge request.
+
+## Relevant files
+
+- `slides/manuscript/main.md` — the preprint to revise
+- `slides/` talk source — the more narratively-refined reference
+
+## Actions
+
+1. After #793/#794/#795 merge, diff the talk narrative against `main.md`
+   section by section; list the divergences.
+2. Align framing, terminology, and figure captions to the talk; expand
+   explanations for a readership naive to LLMs.
+3. Where a divergence is section-sized, spawn a sub-ticket (child of 0464)
+   rather than bundling it here.
+
+## Test
+
+Placement / consistency checks (source-inspection):
+
+```python
+def test_no_stale_figure_caption_pattern():
+    md = open("slides/manuscript/main.md").read()
+    assert "Figure N: Figure N" not in md      # post-#793 convention holds
+```
+
+## Verification
+
+- [ ] Sequenced after #793/#794/#795 (confirm those are merged before starting).
+- [ ] Manuscript framing matches the talk; naive-reader explanations added.
+- [ ] Any oversized divergence captured as a child sub-ticket, not silently dropped.
+
+## Invariants
+
+- Figures stay generated artifacts (no inline plots); numeric literals stay
+  derived from generated artifacts, never re-typed.
+
+## Exit criteria
+
+- [ ] `main.md` aligned with the refined talk narrative for a naive-to-LLM
+      readership; manuscript builds clean; sub-tickets filed for any deferred
+      section rewrites.
+
+Part of: 0464 — role A5 (talk-aligned manuscript sync; sequence after #793/#794/#795).

--- a/tickets/0470-cached-llm-judge-source-faithfulness-sco.erg
+++ b/tickets/0470-cached-llm-judge-source-faithfulness-sco.erg
@@ -1,0 +1,72 @@
+%erg 0.1
+Title: Cached LLM-judge source-faithfulness scorer (fuel/capacity/status in source)
+Created: 2026-06-08
+Author: claude
+Label: deferred
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Part of tracker 0465 (Paper B). **Post-preprint / future work.** The Paper A
+provenance baseline (0201) is a **deterministic** value-in-source check: the
+RAG sources are tabular, so "does the cited source contain value V for plant P"
+is a string/number lookup. This ticket is the **LLM-judge upgrade**: an
+adjudicator asks, in natural language, *does document X say plant P has fuel F,
+capacity C, status S?* — catching paraphrase, unit-restated, and table-layout
+cases the deterministic check misses.
+
+To keep the judge **reproducible and cheap**, every verdict is written to a
+**cache** keyed by (document-id, plant, attribute, claimed-value, judge-model,
+prompt-version). Re-runs read the cache; only novel (plant, claim) tuples hit
+the API. This is the standard cost/repro discipline for LLM-judge scorers.
+
+## Relevant files
+
+- `src/aedist/` — provenance/scoring modules (0201 baseline is the deterministic sibling)
+- the RAG corpus / source registry (judge reads documents from here)
+- new: `src/aedist/llm_judge_faithfulness.py` + a verdict cache (JSONL or sqlite)
+
+## Actions
+
+1. Define the judge prompt (fuel/capacity/status faithfulness, one verdict per
+   (plant, attribute)); pin model + seed/temperature + prompt-version.
+2. Implement a verdict cache; cache hit ⇒ no API call. Key includes judge-model
+   and prompt-version so a prompt change invalidates cleanly.
+3. Expose a per-run faithfulness scalar via `records_to_metrics()` (ADR-7) so
+   it sits alongside the deterministic provenance score.
+4. Follow project rule "test one before blasting": dry-run prompt assembly +
+   one real verdict per attribute before any batch.
+
+## Test
+
+`tests/test_llm_judge_faithfulness.py` (judge mocked — unit grain):
+
+```python
+def test_cache_hit_skips_api(monkeypatch):
+    judge = FaithfulnessJudge(cache=tmp_cache)
+    judge.verdict(doc, plant="P", attr="capacity", claim="600")   # API call #1
+    monkeypatch.setattr(judge, "_call_api", _boom)                # would raise
+    v = judge.verdict(doc, plant="P", attr="capacity", claim="600")  # cache hit
+    assert v.supported in (True, False)                            # no API call
+```
+
+## Verification
+
+- [ ] Verdicts cached and keyed by judge-model + prompt-version; re-run is API-free.
+- [ ] Per-run faithfulness scalar in the metrics dict (ADR-7).
+- [ ] Deterministic baseline (0201) left intact as the cheap first pass.
+
+## Invariants
+
+- The deterministic value-in-source check remains the baseline; this is an
+  upgrade layered on top, not a replacement.
+
+## Exit criteria
+
+- [ ] Cached LLM-judge faithfulness scorer landed with tests; deferred,
+      post-preprint — does not block the arXiv preprint.
+
+Part of: 0465 — cached LLM-judge faithfulness scorer (upgrade of the deterministic value-in-source baseline).

--- a/tickets/0471-e1-1n-1d-grounding-ladder-figure-paired.erg
+++ b/tickets/0471-e1-1n-1d-grounding-ladder-figure-paired.erg
@@ -1,0 +1,82 @@
+%erg 0.1
+Title: E1→1N→1D grounding ladder figure (paired, within-agent)
+Created: 2026-06-08
+Author: claude
+Label: deferred
+
+--- log ---
+2026-06-08T14:39Z claude created
+
+--- body ---
+## Context
+
+Part of tracker 0465 (Paper B). **Post-preprint / future work.** A grounding
+ladder figure that decomposes *what changes quality* along the experimental
+arms, as paired **within-agent** deltas.
+
+**Arm coding** (Exp2): the digit is the number of turns (1 or 5), the letter is
+whether documents are provided — N = no docs, D = documents. **E1** is the Exp1
+parametric-memory condition (no harness, no docs). The ladder isolates one
+factor per step:
+
+- **E1 → 1N**: isolates the **harness + tier** (single-shot agentic scaffold and
+  source tier, no documents yet).
+- **1N → 1D**: isolates the **documents** — web/harness held fixed in code
+  (confirmed by the author), so the only change is the provided documents.
+- **1D → 5D**: isolates **multi-turn** (turns 1 → 5 with documents).
+
+**Restrict to the 4 agents present in BOTH Exp1 & Exp2** — the keys of
+`_AGENT_EXP1_SLUG` in `src/aedist/plot_exp2_arms_split.py`:
+anthropic (claude-opus-4.6), mistral (mistral-large-2512), openai (gpt-5.5),
+qwen (qwen3.7-max). Plot **paired within-agent deltas** (each agent is its own
+control across the ladder) and **emphasise the source / provenance axes** — the
+ladder's point is grounding, so provenance/source-diversity deltas are the
+headline, not raw coverage.
+
+## Relevant files
+
+- `src/aedist/plot_exp2_arms_split.py` — `_AGENT_EXP1_SLUG` (the 4 agents) + the arm→label map (`_CONDITION_LABEL`: arm1=1N, arm2=5N, arm3=1D, arm4=5D)
+- `experiments/derived/` — Exp1 + Exp2 cross-eval CSVs (the E1 and arm sub-scores)
+- `experiments/render.mk` — wire the new `.pdf` artifact
+- new: `src/aedist/plot_grounding_ladder.py`
+
+## Actions
+
+1. Assemble, per agent, the ladder E1 → 1N → 1D → 5D from the cross-eval CSVs.
+2. Compute paired within-agent deltas at each rung; emphasise source/provenance
+   axes.
+3. New plot script + Makefile `.pdf` target (one output per rule, no inline plots).
+
+## Test
+
+`tests/test_plot_grounding_ladder.py`:
+
+```python
+def test_restricted_to_shared_four_agents():
+    from aedist.plot_exp2_arms_split import _AGENT_EXP1_SLUG
+    assert set(ladder_agents()) == set(_AGENT_EXP1_SLUG)   # exactly the 4
+
+def test_deltas_are_within_agent_paired():
+    d = ladder_deltas(rows)
+    # each rung delta is computed within one agent, never pooled across agents
+    assert all(step.agent is not None for step in d)
+```
+
+## Verification
+
+- [ ] Exactly the 4 shared agents (test-guarded against `_AGENT_EXP1_SLUG`).
+- [ ] Rungs E1→1N (harness+tier), 1N→1D (documents), 1D→5D (multi-turn),
+      each a within-agent paired delta.
+- [ ] Source/provenance axes emphasised; figure is a committed Makefile artifact.
+
+## Invariants
+
+- Within-agent pairing (no cross-agent pooling); arm→rung mapping reads the
+  existing `_CONDITION_LABEL`, not a re-typed map.
+
+## Exit criteria
+
+- [ ] Grounding-ladder figure landed with tests; deferred, post-preprint —
+      does not block the arXiv preprint.
+
+Part of: 0465 — E1→1N→1D grounding ladder (paired within-agent; documents-isolating rung).


### PR DESCRIPTION
## Plan deliverable — roadmap captured as tickets + STATE/MASTERPLAN

Captures the author-ratified design: the paper's methods contribution is an **internal-coherence run-screen**. §2's quality bar is a *conjunction* — a zero on any criterion means the bar is not cleared, so that run/model is trash. Accuracy is the only reference-full criterion; the other four are reference-free by construction, which is what makes the screen usable without ground truth. Two papers at two units of analysis.

### New tracker tickets
- **0464 — Paper A** (manuscript MVP, unit = MODEL, capability floor). Blocked-by its children.
- **0465 — Paper B** (information-fusion follow-up, unit = RUN, model = covariate). Long-horizon, post-preprint.

### New leaf tickets
- **0466** Model-grain quality floor heatmap (replaces the decorative quality spider's manuscript role; rows = the 12 models the Exp1 spider renders; any red cell ⇒ model disqualified). Blocked-by 0201.
- **0467** Run-grain screen validation annex (within-model, non-tautological). Blocked-by 0201.
- **0468** Move the "why it is hard" difficulty table from Annex E into task setup.
- **0469** main.md ↔ slides sync (sequence after #793/#794/#795; not a Blocked-by, by design).
- **0470** Cached LLM-judge source-faithfulness scorer (Paper B, `deferred`).
- **0471** E1→1N→1D grounding ladder figure (Paper B, `deferred`; restricted to the 4 shared agents).

### Cross-refs (log line + `Part of:`, no body rewrites)
0201, 0396, 0453 → 0464 · 0399 split (veto→0464 / consensus→0465) · 0454 → 0464 · 0398, 0293 → 0465 · 0225 reconciled into 0464.

### Planning docs
- `STATE.md` — terse "Next: methods contribution" subsection (38 lines, within cap).
- `MASTERPLAN.md` — strategic "why" section on the zero-reference screen → Paper A / Paper B.

### Validation
`erg check tickets/` PASS (454 tickets); `make check-fast` green (1997 passed, ruff clean, ticket structure OK).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
