### PR TITLE
plan: manuscript restructure + §5 fusion MVP + Kien Luong ticket

### DIFF
--- a/tickets/0464-internal-coherence-run-screen-manuscript.erg
+++ b/tickets/0464-internal-coherence-run-screen-manuscript.erg
@@ -8,9 +8,11 @@ Blocked-by: 0466
 Blocked-by: 0467
 Blocked-by: 0468
 Blocked-by: 0469
+Blocked-by: 0473
 
 --- log ---
 2026-06-08T14:39Z claude created
+2026-06-08T15:43Z claude note added child A6=0473 (§5 fusion MVP); A5=0469 re-scoped synopsis→paper restructure
 
 --- body ---
 ## Context
@@ -50,7 +52,12 @@ It holds no production code of its own; each child lands its own merge request.
 - **A4 = 0468** (NEW): move the "why it is hard" difficulty table from Annex E
   into task setup / head of Exp1 results (it characterises the task, so it
   motivates difficulty up front).
-- **A5 = 0469** (NEW): `main.md ↔ slides` sync — talk-aligned manuscript revision.
+- **A5 = 0469** (re-scoped): synopsis→paper restructure of `main.md` (was
+  "slides sync") — real title, structured abstract, numbered IMRaD, Related
+  Work into the body, author/affiliations.
+- **A6 = 0473** (NEW): §5 naive presence-fusion MVP — union vs ≥2-models,
+  discovery gain vs best single model in E1 & E2-1D (no copulas; full
+  treatment in 0465).
 - **screen-design = 0453** (re-scoped): two-level screen — run-grain veto
   (zero-is-trash on the four free criteria) + model-grain majority-red floor.
 
@@ -62,7 +69,7 @@ It holds no production code of its own; each child lands its own merge request.
 
 ## Exit criteria (IDH tracking-ticket convention)
 
-- [ ] All children merged: 0201, 0453, 0466, 0467, 0468, 0469.
+- [ ] All children merged: 0201, 0453, 0466, 0467, 0468, 0469, 0473.
 - [ ] Manuscript presents the internal-coherence run-screen as a present
       contribution (not future work) with the model-grain floor heatmap as
       the canonical quality figure.

--- a/tickets/0465-information-fusion-follow-up-run-as-unit.erg
+++ b/tickets/0465-information-fusion-follow-up-run-as-unit.erg
@@ -27,6 +27,10 @@ residual share of unseen plants by linear programming against a control total
 arXiv-preprint critical path. It stays open until all children are merged
 (IDH tracking-ticket convention).
 
+A naive presence-fusion **TEASER** lives in Paper A §5 (leaf 0473 under tracker
+0464); Paper B retains the full latent-truth / capture–recapture / copula-or-
+advanced fusion and the E1→1N→1D ladder (0471).
+
 ## Children
 
 - **Cached LLM-judge faithfulness = 0470** (NEW): does document X say plant P

--- a/tickets/0469-main-md-slides-sync-talk-aligned-manuscr.erg
+++ b/tickets/0469-main-md-slides-sync-talk-aligned-manuscr.erg
@@ -5,65 +5,89 @@ Author: claude
 
 --- log ---
 2026-06-08T14:39Z claude created
+2026-06-08T12:30Z claude note re-scoped from 'slides sync' to synopsis→paper restructure
 
 --- body ---
 ## Context
 
-Part of tracker 0464 (Paper A, role A5). Prose-only. The slides have been
-narratively refined past the preprint; the manuscript (`slides/manuscript/main.md`)
-should be brought into line with the talk's framing. **The readership is naive
-to LLMs** — the manuscript should explain, not assume, the concepts a general
-energy-statistics / methods audience needs. This is the talk-aligned MVP
-revision that makes Paper A read as a coherent whole around the
-internal-coherence run-screen contribution.
+`slides/manuscript/main.md` is a conference **SYNOPSIS** — title
+"# Synopsis — Beyond RAG…", rhetorical "First / Second / Third / Fourth /
+Fifth" sections, Related Work buried in Annex A, no abstract / introduction /
+conclusion / affiliations / heading numbers. Convert it to a **proper paper**
+for arXiv / journal. **Author-ratified this session.** The readership is naive
+to LLMs (a general energy-statistics / methods audience). Align with the
+talk / slides narrative.
 
-**Sequencing — IMPORTANT.** This ticket touches figures and captions that are
-currently being modified by in-flight merge requests:
-
-- **#793** (ticket 0448) — global caption style (kill "Figure N: Figure N")
-- **#794** (ticket 0433) — rewrite Annex C to the as-run Exp2 story
-- **#795** (ticket 0455) — preprint figure-language sweep (all `main.md`
-  figures in English)
-
-**Do this work AFTER #793/#794/#795 have merged** — otherwise the sync conflicts
-with their figure/caption edits. (Deliberately NOT encoded as `Blocked-by:`:
-those tickets archive to `tickets/closed/` on merge, and a `Blocked-by:` ref to
-an archived ticket breaks `erg check`. The sequencing constraint lives here in
-the body, by design.)
-
-This ticket may legitimately **spawn sub-tickets** if the sync surfaces
-section-sized rewrites; split per the IDH multi-PR convention rather than
-ballooning one merge request.
+Part of tracker 0464 (Paper A, role A5). Prose-only. The sequencing predecessors
+#793/#794/#795 (tickets 0448/0433/0455 — caption style, Annex C as-run Exp2
+story, figure-language sweep) have all merged, so the restructure proceeds
+unblocked. This ticket may legitimately **spawn sub-tickets** (children of 0464)
+if a section-sized rewrite surfaces; split per the IDH multi-PR convention
+rather than ballooning one merge request.
 
 ## Relevant files
 
-- `slides/manuscript/main.md` — the preprint to revise
-- `slides/` talk source — the more narratively-refined reference
+- `slides/manuscript/main.md` — the synopsis to restructure into a paper
+- `slides/` talk source — the narrative reference to align with
+- `slides/manuscript/macros.tex`, `slides/manuscript/macros_exp1_matrix.tex` — the generated numeric macros (the abstract numbers MUST come from these, not re-typed)
+- `.claude/rules/writing.md` — Related Work citation budget, per-paragraph mix, gap-paragraph rules
 
-## Actions
+## Actions / Exit-criteria checklist
 
-1. After #793/#794/#795 merge, diff the talk narrative against `main.md`
-   section by section; list the divergences.
-2. Align framing, terminology, and figure captions to the talk; expand
-   explanations for a readership naive to LLMs.
-3. Where a divergence is section-sized, spawn a sub-ticket (child of 0464)
-   rather than bundling it here.
+- [ ] **Real title** — drop "Synopsis".
+- [ ] **Structured ABSTRACT** that LEADS with the frontier-falls-short result,
+      then the other key results: the parametric ceiling (best model ~71.5 F1 /
+      DeepSeek V3.2 68.6; best local ~24.4 — **PIN the canonical macro**:
+      `macros.tex` says best = 71.5 but `macros_exp1_matrix` says 65.5 / Qwen,
+      two contexts. **Verify which is the abstract's number, do not pick
+      blindly.**), the conjunctive quality bar, the reference-free coherence
+      screen, and the fusion potential. Numbers come from the generated
+      macros / artifacts **ONLY**; guard the abstract literals with an
+      adherence test.
+- [ ] **Numbered IMRaD** — Introduction · Methods · Results (Exp 1/2/3) ·
+      Discussion · Conclusion — replacing the rhetorical "First…Fifth" headings.
+- [ ] **Author(s) + affiliations.**
+- [ ] **Related Work OUT of Annex A INTO the body** (respect
+      `.claude/rules/writing.md`: citation budget, per-paragraph mix, gap
+      paragraph).
+- [ ] **Decorative figures OUT of the body to an annex** — Fig 2b (quality
+      spider, superseded by the heatmap, ticket 0466), Fig 5 (capability DAG),
+      Fig 6 (exp2 coverage-certainty). **Results artifacts INTO the body** —
+      the model-grain floor heatmap (0466, positioned as a follow-up to
+      Figure 1) and the difficulty table (0468).
+- [ ] **§5 reframed** from "a tailored solution can work" to "Need and potential
+      for fusion" — the analysis / figure is the new leaf **0473**; §5 prose
+      frames it as the answer to the talk Q&A "did you fuse the results?" → yes,
+      naive fusion already helps, full treatment is Paper B (0465).
+- [ ] **PURGE leaked dev / historical notes** from the prose ("since resolved",
+      "now scored", status parentheticals, process commentary).
+- [ ] `make -C slides manuscript` clean.
 
 ## Test
 
 Placement / consistency checks (source-inspection):
 
 ```python
-def test_no_stale_figure_caption_pattern():
+def test_no_synopsis_framing():
     md = open("slides/manuscript/main.md").read()
-    assert "Figure N: Figure N" not in md      # post-#793 convention holds
+    assert "Synopsis" not in md             # retitled to a real paper title
+    assert "## First" not in md             # rhetorical headings replaced by IMRaD
+
+def test_abstract_number_from_macros():
+    # the abstract's parametric-ceiling literal is re-derived from the
+    # canonical macro, never re-typed (guards the 71.5 / 65.5 ambiguity)
+    ...
 ```
 
 ## Verification
 
-- [ ] Sequenced after #793/#794/#795 (confirm those are merged before starting).
-- [ ] Manuscript framing matches the talk; naive-reader explanations added.
-- [ ] Any oversized divergence captured as a child sub-ticket, not silently dropped.
+- [ ] Real title; structured abstract leading with the frontier result.
+- [ ] Numbered IMRaD; Related Work in the body; author + affiliations.
+- [ ] Decorative figures moved to annex; heatmap (0466) + difficulty table
+      (0468) in the body.
+- [ ] §5 reframed to "Need and potential for fusion" around leaf 0473.
+- [ ] Dev/historical notes purged.
+- [ ] Abstract literals guarded by an adherence test re-deriving from macros.
 
 ## Invariants
 
@@ -72,8 +96,9 @@ def test_no_stale_figure_caption_pattern():
 
 ## Exit criteria
 
-- [ ] `main.md` aligned with the refined talk narrative for a naive-to-LLM
-      readership; manuscript builds clean; sub-tickets filed for any deferred
-      section rewrites.
+- [ ] `main.md` restructured from synopsis to a proper IMRaD paper for a
+      naive-to-LLM readership; abstract numbers derived from canonical macros
+      and guarded; `make -C slides manuscript` clean; sub-tickets filed for any
+      deferred section rewrites.
 
-Part of: 0464 — role A5 (talk-aligned manuscript sync; sequence after #793/#794/#795).
+Part of: 0464 — role A5 (synopsis→paper restructure; predecessors #793/#794/#795 merged).

--- a/tickets/0471-e1-1n-1d-grounding-ladder-figure-paired.erg
+++ b/tickets/0471-e1-1n-1d-grounding-ladder-figure-paired.erg
@@ -6,6 +6,7 @@ Label: deferred
 
 --- log ---
 2026-06-08T14:39Z claude created
+2026-06-08T15:43Z claude note Paper A §5 naive presence-fusion teaser (0473) precedes this full ladder
 
 --- body ---
 ## Context

--- a/tickets/0472-search-evidence-for-kien-luong-update-re.erg
+++ b/tickets/0472-search-evidence-for-kien-luong-update-re.erg
@@ -1,0 +1,75 @@
+%erg 0.1
+Title: Search evidence for Kien Luong, update reference master
+Created: 2026-06-08
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-08T15:43Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Kien Luong Phase 1/2/3 (Kiên Giang province, coal, ~1200 MW each, 2×600 MW
+units) appear in `data/reference/gem_thermal.csv` and `data/reference/gem_units.csv`
+as `cancelled`, but are **ABSENT** from the classified master
+`data/reference/vietnam_thermal_plants_v2_classified.csv` — which otherwise
+carries cancelled plants (status code 9) and whose task claims "all lifecycle
+statuses". A model that lists Kien Luong is therefore scored
+unrecognized/FP although it is a real (cancelled) project — not a
+hallucination. **Observation only**; cause (deliberate per-plant exclusion vs
+reference gap) is not yet established.
+
+This is a data-curation ticket, not a manuscript ticket — a sibling of the
+0442/0443 reference-curation family.
+
+## Relevant files
+
+- `data/reference/gem_thermal.csv` — GEM tracker plants; Kien Luong present (`cancelled`)
+- `data/reference/gem_units.csv` — GEM tracker units; Kien Luong 2×600 MW units present
+- `data/reference/vietnam_thermal_plants_v2_classified.csv` — the classified master; Kien Luong ABSENT
+- the ODS→extract pipeline in `data/reference/` — the canonical path that derives the classified master (status, capacity, units, sources)
+
+## Actions
+
+1. **Search primary evidence** for Kien Luong 1 & 2: GEM Global Energy Monitor
+   tracker entries, Vietnam PDP (Power Development Plan) documents, and news on
+   the Tan Hong / Kien Luong coal project and its cancellation.
+2. **Decide include-or-exclude** per the reference's documented inclusion policy.
+3. **If INCLUDE:** add to the classified master *through the existing ODS→extract
+   pipeline* in `data/reference/` (status, capacity, units, sources) and
+   re-derive downstream. `reference_plant_count()` may change — **never hardcode
+   the reference size**; use `reference_plant_count()` everywhere.
+4. **If EXCLUDE:** document the per-plant exclusion rationale (in the pipeline
+   ODS / reference docs) so Kien Luong is not re-flagged in future audits.
+
+## Test
+
+An assertion/check that Kien Luong's treatment matches the decision:
+- present-with-status in the classified master (INCLUDE branch), OR
+- documented-excluded with a recorded rationale (EXCLUDE branch).
+
+```python
+def test_kien_luong_treatment_matches_decision():
+    master = read_classified_master()
+    # INCLUDE: present with a lifecycle status (e.g. cancelled / status 9)
+    # EXCLUDE: absent AND a recorded exclusion rationale exists for Kien Luong
+    assert kien_luong_present(master) or kien_luong_exclusion_documented()
+```
+
+## Verification
+
+- [ ] Primary evidence for Kien Luong 1 & 2 gathered and cited.
+- [ ] Include-or-exclude decision made against the documented inclusion policy.
+- [ ] If INCLUDE: master updated via the ODS→extract pipeline; downstream re-derived; `reference_plant_count()` used (not hardcoded).
+- [ ] If EXCLUDE: per-plant exclusion rationale documented so it is not re-flagged.
+
+## Invariants
+
+- Reference size is never hardcoded — always `reference_plant_count()`.
+- The classified master is regenerated through the existing ODS→extract
+  pipeline, never hand-edited in the CSV.
+
+## Exit criteria
+
+- Evidence gathered + cited; master updated OR exclusion documented;
+  downstream re-derived; `make check` green.

--- a/tickets/0473-5-fusion-mvp-naive-presence-fusion-union.erg
+++ b/tickets/0473-5-fusion-mvp-naive-presence-fusion-union.erg
@@ -1,0 +1,84 @@
+%erg 0.1
+Title: §5 fusion MVP: naive presence fusion (union vs ≥2-models) — discovery gain vs best single model
+Created: 2026-06-08
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-08T15:43Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+§5 of the manuscript ("Need and potential for fusion") needs a quantified
+demo. **NO copulas** (deferred to Paper B / 0465). This is naive **PRESENCE
+fusion** over a **MAXIMAL pool** — all valid runs, all models, no
+coherence-screen restraint. A "valid run" = parseable list, F1 ≠ None, not a
+refusal / parse-failure. This is the *unconstrained discovery exercise*; the
+answer to the talk Q&A "did you fuse the results?".
+
+## Relevant files
+
+- `experiments/derived/` — Exp1 (E1) + Exp2 (arm 1D) cross-eval CSVs with per-run plant detections
+- `src/aedist/measurements.py` — `reference_plant_count()` (do NOT hardcode the reference size)
+- `experiments/render.mk` — wire the new `.pdf` artifact (one output per rule)
+- new: `src/aedist/plot_fusion_mvp.py`
+
+## Actions
+
+Pool plant detections across the maximal set of valid runs in a regime, then
+apply **two merge rules**:
+- **R1 UNION** — a plant is in the fused list if detected by ≥1 valid run
+  (any model).
+- **R2 ≥2-MODELS** — a plant is in the fused list if detected by ≥2 DISTINCT
+  models.
+
+Score each fused list's **precision / recall / F1** against the reference
+(use `reference_plant_count()`, do not hardcode). Compare to the **BEST SINGLE
+MODEL's** F1 in the regime. Do this in **two regimes**:
+- **E1** — Exp1 memory-only.
+- **E2-1D** — Exp2 single-turn WITH documents (arm 1D).
+
+Expected narrative: UNION maximizes TP (and FP); ≥2-models trims FP at some TP
+cost — the FP/TP tradeoff; fused F1 exceeds the best single model (discovery
+gain). Produce the figure (committed PDF, wired in `experiments/render.mk`) +
+the macro numbers for §5 prose.
+
+## Test (first)
+
+A unit test on the two merge rules over a tiny synthetic multi-run /
+multi-model fixture (R1 and R2 yield the expected fused sets); then the regime
+computation reads the mart.
+
+```python
+def test_union_and_2models_merge_rules():
+    runs = synthetic_runs()   # tiny multi-run / multi-model fixture
+    assert union_fuse(runs) == {expected_union_set}
+    assert at_least_2_models_fuse(runs) == {expected_2model_set}
+```
+
+## Verification
+
+- [ ] Fused F1 (R1, R2) vs best-single computed for E1 and E2-1D from the mart.
+- [ ] Figure built + committed; wired in `experiments/render.mk` (no inline plots).
+- [ ] Macros generated + guarded by an adherence test.
+- [ ] `make check-fast` + adherence green.
+- [ ] Author review of the gain figure.
+
+## Invariants
+
+- Reference size via `reference_plant_count()`, never hardcoded.
+- Naive presence only — NO copulas / latent-truth / capture–recapture (those
+  are Paper B, 0465 / 0471).
+- Figure is a committed Makefile artifact; numeric literals in §5 prose derive
+  from the generated macros.
+
+## Exit criteria
+
+- Fused F1 (R1, R2) vs best-single computed for E1 and E2-1D from the mart;
+  figure built + committed; macros generated + guarded; `make check-fast` +
+  adherence green; author review of the gain figure.
+
+## Part of: 0464 — role A6 (Paper A fusion teaser)
+
+Full latent-truth / capture–recapture / copula or advanced fusion is Paper B
+(0465 / 0471).


### PR DESCRIPTION
PLAN-phase deliverable: tickets only, no production code. Captures the ratified manuscript-restructure decisions.

## Created
- **0472** — Kien Luong reference gap: present `cancelled` in `gem_thermal.csv`/`gem_units.csv` but absent from the classified master `vietnam_thermal_plants_v2_classified.csv` (which carries cancelled status-9 plants). Search primary evidence, decide include/exclude, re-derive downstream via the ODS→extract pipeline; never hardcode `reference_plant_count()`. Data-curation, sibling of 0442/0443.
- **0473** — §5 fusion MVP (Paper A role A6): naive PRESENCE fusion over a maximal pool — R1 UNION (≥1 valid run) vs R2 ≥2-MODELS — scored against the reference, vs best single model, in two regimes E1 (memory-only) and E2-1D (single-turn with documents). No copulas (deferred to Paper B / 0465). Figure + macros for §5 prose.

## Re-scoped
- **0469** — from "slides sync" to **synopsis→paper restructure**: real title (drop "Synopsis"), structured abstract leading with the frontier-falls-short result (with a PIN-the-canonical-macro caveat for 71.5 vs 65.5/Qwen — verify, don't pick blindly), numbered IMRaD, author/affiliations, Related Work out of Annex A into the body, decorative figures to annex / results artifacts in, §5 reframed to "Need and potential for fusion". Predecessors #793/#794/#795 (0448/0433/0455) confirmed merged, so the old sequencing note is dropped cleanly. Log line added; "Part of: 0464 — role A5" retained.

## Updated trackers
- **0464** — child **A6 = 0473** added to `Blocked-by`, `## Children`, and the exit-criteria child list; A5 (0469) noted re-scoped.
- **0465** / **0471** — light notes: the naive presence-fusion teaser (0473) precedes the full Paper-B fusion / E1→1N→1D grounding-ladder work.

## Validation
- `erg check tickets/` PASS (456 tickets — no broken Blocked-by, no dup IDs).
- `make check-fast` green (2009 passed, ruff clean, ticket structure OK).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)