### PR TITLE
ticket(0428): GEM reference dedup + generalize hardcoded-ref ratchet to all CSVs

### DIFF
--- a/scripts/audit_source_urls.py
+++ b/scripts/audit_source_urls.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import httpx
 from rapidfuzz import fuzz
 
+from aedist.config import GEM_THERMAL_REFERENCE_CSV
 from aedist.verify import (
     _PRIMARY_PATTERNS,
     classify_source_by_text,
@@ -36,7 +37,7 @@ _DEFAULT_INPUTS = [
     Path("experiments/outputs/rag_cited/claude-opus-4.6-run2.csv"),
     Path("experiments/outputs/rag_cited/claude-opus-4.6-run3.csv"),
 ]
-_DEFAULT_GEM = Path("data/reference/gem_thermal.csv")
+_DEFAULT_GEM = GEM_THERMAL_REFERENCE_CSV
 _DEFAULT_OUTPUT_DIR = Path("derived/audit/")
 
 

--- a/src/aedist/config.py
+++ b/src/aedist/config.py
@@ -18,6 +18,13 @@ VN_THERMAL_PLANTS_RELEASE_CSV = (
     _REPO_ROOT / "data" / "reference" / "vietnam_thermal_plants_v2_classified.csv"
 )
 
+# GEM (Global Energy Monitor) thermal reference CSV — used by reconciliation
+# and source-URL audit scripts.  Single source of truth; do not hardcode the
+# filename outside this module (ticket 0428 ratchet).
+GEM_THERMAL_REFERENCE_CSV = (
+    _REPO_ROOT / "data" / "reference" / "gem_thermal.csv"
+)
+
 # Vietnam thermal master snapshot (pipeline.ods) — the pinned ODS capture
 # from the author's "Market report on Gas to Power" master spreadsheet.
 # Datestamped immutable; extraction reads this to produce v2 releases.

--- a/src/aedist/tabulate_reconciliation.py
+++ b/src/aedist/tabulate_reconciliation.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import numpy as np
 from scipy import stats as scipy_stats
 
-from .config import VN_THERMAL_PLANTS_RELEASE_CSV
+from .config import GEM_THERMAL_REFERENCE_CSV, VN_THERMAL_PLANTS_RELEASE_CSV
 from .evaluate import load_plants_csv
 from .measurements import SYNTHETIC_SUFFIXES, load, load_metrics
 from .metrics import compute_metrics
@@ -33,7 +33,7 @@ from .tabulate_utils import strip_label
 log = logging.getLogger(__name__)
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
-_GEM_REF = _REPO_ROOT / "data" / "reference" / "gem_thermal.csv"
+_GEM_REF = GEM_THERMAL_REFERENCE_CSV
 
 _MATCHED_TYPES = {
     MatchType.EXACT,

--- a/tests/test_no_hardcoded_reference_path.py
+++ b/tests/test_no_hardcoded_reference_path.py
@@ -1,16 +1,19 @@
-"""No hardcoded default-reference filename outside config.py, docstrings, comments.
+"""No hardcoded data/reference CSV filename outside config.py, docstrings, comments.
 
-Exit criterion 1 of ticket 0419 (extended by 0413's v2 adoption): a single
-source of truth for the default reference path. The literal filename may only
-live in ``src/aedist/config.py``; everywhere else modules import
-``config.VN_THERMAL_PLANTS_RELEASE_CSV``. ``TARGET`` tracks the *current*
-adopted default (v2) so the guard stays live.
+Exit criterion 1 of ticket 0419, extended by 0413 (v2 adoption) and 0428
+(GEM reference dedup): any ``data/reference/*.csv`` filename may only appear
+as a string literal in ``src/aedist/config.py``.  Everywhere else, modules
+import the constant from config.  This guards the full *class* — not just one
+filename — so renaming or adding a new reference CSV doesn't silently
+re-introduce hardcoded strings.
 
 The filename can only appear inside a Python string literal, so exempting all
 string literals would make this check vacuous. Instead we exempt only
 *docstrings* (the first ``Expr``-wrapped string statement of a module, class, or
 function) and ``#`` comments. Ordinary string literals — including path-building
 expressions and ``help=`` strings — are checked.
+
+Coverage: ``src/aedist/*.py`` (0419) + ``scripts/*.py`` (0428).
 """
 
 import ast
@@ -22,12 +25,9 @@ pytestmark = pytest.mark.adherence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC_DIR = REPO_ROOT / "src" / "aedist"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
 CONFIG_MODULE = SRC_DIR / "config.py"
-# The adopted default reference filename (ticket 0413: v2 replaced v1). Tracking
-# the *current* default keeps the guard live — if it lagged on the retired v1
-# name, nothing would reference it and the check would pass while protecting
-# nothing.
-TARGET = "vietnam_thermal_plants_v2_classified.csv"
+REF_DIR = REPO_ROOT / "data" / "reference"
 
 
 def _docstring_lines(tree: ast.Module) -> set[int]:
@@ -72,14 +72,28 @@ def _code_lines(path: Path) -> list[tuple[int, str]]:
 
 
 def test_no_hardcoded_reference_path():
-    """TARGET must not appear in code lines of any src/aedist/*.py except config.py."""
+    """No data/reference CSV filename may appear as a code literal outside config.py.
+
+    Guards src/aedist/*.py (ticket 0419) and scripts/*.py (ticket 0428).
+    The set of guarded filenames is derived from data/reference/*.csv on disk,
+    so adding a new reference CSV file automatically extends the ratchet.
+    """
+    # Derive the guarded set from disk — no manual maintenance.
+    targets = {f.name for f in REF_DIR.glob("*.csv")}
+    assert targets, f"No CSV files found in {REF_DIR}; check REPO_ROOT resolution"
+
+    py_files = sorted(SRC_DIR.glob("*.py")) + sorted(SCRIPTS_DIR.glob("*.py"))
     violations = []
-    for py_file in sorted(SRC_DIR.glob("*.py")):
+    for py_file in py_files:
         if py_file == CONFIG_MODULE:
             continue  # config.py is the single allowed home
         for lineno, line in _code_lines(py_file):
-            if TARGET in line:
-                violations.append(f"{py_file.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+            for target in targets:
+                if target in line:
+                    violations.append(
+                        f"{py_file.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}"
+                    )
+                    break  # one violation per line is enough
     assert not violations, (
         f"{len(violations)} hardcoded reference path(s) outside config.py:\n"
         + "\n".join(f"  {v}" for v in violations)

--- a/tickets/0428-config-dedup-gem-reference-path-constant.erg
+++ b/tickets/0428-config-dedup-gem-reference-path-constant.erg
@@ -2,10 +2,12 @@
 Title: Config: dedup GEM reference path constants + generalize the hardcoded-path ratchet
 Created: 2026-06-04
 Author: HDMX-coding-agent
+Closed: GEM_THERMAL_REFERENCE_CSV added to config.py; tabulate_reconciliation.py and audit_source_urls.py re-pointed; ratchet extended to all data/reference CSVs and scripts/
 
 --- log ---
 2026-06-04T20:19Z HDMX-coding-agent created
 
+2026-06-08T17:52Z HDMX-coding-agent closed — GEM_THERMAL_REFERENCE_CSV added to config.py; tabulate_reconciliation.py and audit_source_urls.py re-pointed; ratchet extended to all data/reference CSVs and scripts/
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add `GEM_THERMAL_REFERENCE_CSV` to `src/aedist/config.py` as single source of truth for `gem_thermal.csv`
- Re-point the two hardcoded literals: `tabulate_reconciliation.py:_GEM_REF` and `scripts/audit_source_urls.py:_DEFAULT_GEM` now use the config constant
- Generalize `tests/test_no_hardcoded_reference_path.py` ratchet from guarding one filename (`TARGET`) to the full set of `data/reference/*.csv` discovered at test time — new reference CSVs are automatically protected
- Extend ratchet coverage to `scripts/*.py` (previously only `src/aedist/*.py` was guarded)

**Ticket:** tickets/0428-config-dedup-gem-reference-path-constant.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)