### PR TITLE
chore(0296): standardize JSON EOF newline policy across runtime writers

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -56,3 +56,13 @@ Rules:
 - If the hook fires and strips your import anyway, do not re-add the import alone — re-add import + usage together (or import alone if usages now exist).
 
 **Why:** The ruff hook runs after every Edit. This trap hit twice in ticket 0302, and twice again in the 0439 session (2026-06-05) where both Edits were in the same message — proving the parallel-Edits loophole is imaginary. The failure mode is subtle because the NameError appears at test time, not at edit time.
+
+## JSON EOF newline policy
+
+All single-object JSON files written by this project end with exactly one trailing newline (`\n`).
+
+**Applies to:** `*.json` output files — `json.dump()` + `f.write("\n")`, and `.write_text(json.dumps(...) + "\n")`, and `.write_text(model.model_dump_json(...) + "\n")`.
+
+**Does not apply to:** JSONL writers (`to_jsonl_line() + "\n"` per record, no extra newline after the last line), or in-memory `json.dumps()` that is not written to a file.
+
+**Why:** Newline-only diffs (`No newline at end of file`) are non-semantic but noisy in reviews and audits. Verified by `tests/test_json_eof_newline.py` (`@pytest.mark.adherence`).

--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -459,7 +459,7 @@ def run_openai_call(
     resp = client.responses.create(**payload)
     wall = round(time.monotonic() - t0, 3)
 
-    raw_output_path.write_text(resp.model_dump_json(indent=2), encoding="utf-8")
+    raw_output_path.write_text(resp.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
     record = adapter_openai_responses.parse_response(resp, meta)
     record.agent_mode = agent_mode
@@ -571,7 +571,7 @@ def run_anthropic_call(
     wall = round(time.monotonic() - t0, 3)
 
     raw_output_path.write_text(
-        json.dumps(query_anthropic._response_to_dict(resp), indent=2, default=str),
+        json.dumps(query_anthropic._response_to_dict(resp), indent=2, default=str) + "\n",
         encoding="utf-8",
     )
 
@@ -705,7 +705,7 @@ def run_qwen_call(
     wall = round(time.monotonic() - t0, 3)
 
     raw_dump = adapter_qwen_dashscope._response_to_dict(resp)
-    raw_output_path.write_text(json.dumps(raw_dump, indent=2, default=str), encoding="utf-8")
+    raw_output_path.write_text(json.dumps(raw_dump, indent=2, default=str) + "\n", encoding="utf-8")
 
     record = adapter_qwen_dashscope.parse_response(
         resp,
@@ -1086,7 +1086,7 @@ def run_phase_b_multiturn(
         remaining_tokens -= tokens_this_turn
         elapsed_s += record.resource_use.wall_s or 0.0
 
-        paths["record"].write_text(record.model_dump_json(indent=2), encoding="utf-8")
+        paths["record"].write_text(record.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
         # Classify the assistant's response. Classifier cost is harness
         # overhead, tracked separately from the SOTA agent's spend.
@@ -1094,13 +1094,13 @@ def run_phase_b_multiturn(
         conversation_history.append({"role": "user", "content": user_text})
         conversation_history.append({"role": "assistant", "content": narrative})
         conversation_path.write_text(
-            json.dumps({"messages": conversation_history}, indent=2, ensure_ascii=False),
+            json.dumps({"messages": conversation_history}, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8",
         )
         cls_result = dialogue_classifier.classify_report(narrative)
         total_classifier_cost_usd += cls_result.classifier_cost_usd
         paths["classification"].write_text(
-            json.dumps(dialogue_classifier.result_to_artefact_dict(cls_result), indent=2),
+            json.dumps(dialogue_classifier.result_to_artefact_dict(cls_result), indent=2) + "\n",
             encoding="utf-8",
         )
 
@@ -1121,7 +1121,8 @@ def run_phase_b_multiturn(
                     "classifier_cost_usd": cls_result.classifier_cost_usd,
                 },
                 indent=2,
-            ),
+            )
+            + "\n",
             encoding="utf-8",
         )
 
@@ -1328,12 +1329,12 @@ def _run_one_agent(args: argparse.Namespace, agent: str) -> dict:
             max_tokens=args.phase_a_max_tokens,
         )
         phase_a_path = agent_output_dir / f"{agent}_phase_a.json"
-        phase_a_path.write_text(phase_a.model_dump_json(indent=2), encoding="utf-8")
+        phase_a_path.write_text(phase_a.model_dump_json(indent=2) + "\n", encoding="utf-8")
 
         narrative_a = _narrative_from_record_or_raw(phase_a, phase_a_raw_path)
         design = extract_phase_a_design(narrative_a)
         design_path = agent_output_dir / f"{agent}_phase_a_design.json"
-        design_path.write_text(json.dumps(design, indent=2, ensure_ascii=False), encoding="utf-8")
+        design_path.write_text(json.dumps(design, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     if args.stop_after_phase_a:
         return {
@@ -1486,7 +1487,7 @@ def main(argv: list[str] | None = None) -> int:
 
     summary_path = _write_summary(args.output_dir, per_agent)
     (args.output_dir / "summary.json").write_text(
-        json.dumps(per_agent, indent=2), encoding="utf-8"
+        json.dumps(per_agent, indent=2) + "\n", encoding="utf-8"
     )
 
     total_cost_usd = sum(float(item.get("total_cost_usd", 0.0)) for item in per_agent)

--- a/experiments/sota/exp2_naive_arm.py
+++ b/experiments/sota/exp2_naive_arm.py
@@ -218,7 +218,7 @@ def probe_openai(prompt: str, output_dir: Path) -> dict:
                         if isinstance(url, str):
                             sources.append((str(title), url))
     raw_path = output_dir / "openai_probe.raw.json"
-    raw_path.write_text(resp.model_dump_json(indent=2), encoding="utf-8")
+    raw_path.write_text(resp.model_dump_json(indent=2) + "\n", encoding="utf-8")
     usage = resp.usage
     tokens_in = getattr(usage, "input_tokens", 0) or 0
     tokens_out = getattr(usage, "output_tokens", 0) or 0
@@ -269,7 +269,7 @@ def probe_qwen(prompt: str, output_dir: Path) -> dict:
         except (KeyError, IndexError, TypeError):
             narrative = ""
     raw_path = output_dir / "qwen_probe.raw.json"
-    raw_path.write_text(json.dumps(dict(resp), default=str, indent=2), encoding="utf-8")
+    raw_path.write_text(json.dumps(dict(resp), default=str, indent=2) + "\n", encoding="utf-8")
     usage = getattr(resp, "usage", None) or {}
     tokens_in = (usage.get("input_tokens") if isinstance(usage, dict) else 0) or 0
     tokens_out = (usage.get("output_tokens") if isinstance(usage, dict) else 0) or 0
@@ -412,7 +412,7 @@ def main(argv: list[str] | None = None) -> int:
                 ),
             }
             (args.output_dir / f"{tag}.json").write_text(
-                json.dumps(meta_record, indent=2),
+                json.dumps(meta_record, indent=2) + "\n",
                 encoding="utf-8",
             )
             summary.append(meta_record)
@@ -428,7 +428,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     (args.output_dir / "summary.json").write_text(
-        json.dumps(summary, indent=2),
+        json.dumps(summary, indent=2) + "\n",
         encoding="utf-8",
     )
     summary_md_path = _write_summary_md(args.output_dir, summary)

--- a/experiments/sota/exp2_phase_b0_consolidate.py
+++ b/experiments/sota/exp2_phase_b0_consolidate.py
@@ -272,7 +272,7 @@ def consolidate(phase_b0_dir: Path, run_number: int = 1) -> None:
 
         run_json = {k: v for k, v in rec.items()}
         (phase_b0_dir / f"{agent}_{run_slug}.json").write_text(
-            json.dumps(run_json, indent=2), encoding="utf-8"
+            json.dumps(run_json, indent=2) + "\n", encoding="utf-8"
         )
 
         if final_turn_base:
@@ -307,7 +307,7 @@ def consolidate(phase_b0_dir: Path, run_number: int = 1) -> None:
         kept = []
     all_records = kept + records
     all_records.sort(key=lambda r: (r.get("run", 0), r.get("agent", "")))
-    summary_path.write_text(json.dumps(all_records, indent=2), encoding="utf-8")
+    summary_path.write_text(json.dumps(all_records, indent=2) + "\n", encoding="utf-8")
     _write_readme(phase_b0_dir, all_records, run_date, probes_dir)
 
     log.info("Consolidation complete. Output: %s", phase_b0_dir)

--- a/experiments/sota/exp2_protocol_review.py
+++ b/experiments/sota/exp2_protocol_review.py
@@ -160,7 +160,7 @@ def review_openai(spec: str, output_dir: Path) -> dict:
                 if getattr(content, "type", "") == "output_text":
                     narrative += content.text or ""
     raw_path = output_dir / "openai_review.raw.json"
-    raw_path.write_text(resp.model_dump_json(indent=2), encoding="utf-8")
+    raw_path.write_text(resp.model_dump_json(indent=2) + "\n", encoding="utf-8")
     usage = resp.usage
     tokens_in = getattr(usage, "input_tokens", 0) or 0
     tokens_out = getattr(usage, "output_tokens", 0) or 0
@@ -215,7 +215,7 @@ def review_qwen(spec: str, output_dir: Path) -> dict:
         except (KeyError, IndexError, TypeError):
             narrative = ""
     raw_path = output_dir / "qwen_review.raw.json"
-    raw_path.write_text(json.dumps(dict(resp), default=str, indent=2), encoding="utf-8")
+    raw_path.write_text(json.dumps(dict(resp), default=str, indent=2) + "\n", encoding="utf-8")
     usage = getattr(resp, "usage", None) or {}
     tokens_in = (usage.get("input_tokens") if isinstance(usage, dict) else 0) or 0
     tokens_out = (usage.get("output_tokens") if isinstance(usage, dict) else 0) or 0
@@ -346,7 +346,8 @@ def main(argv: list[str] | None = None) -> int:
                     "review_chars": len(result["narrative"]),
                 },
                 indent=2,
-            ),
+            )
+            + "\n",
             encoding="utf-8",
         )
         summary.append(
@@ -361,7 +362,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     summary_path = args.output_dir / "summary.json"
-    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
     total_cost = sum(s.get("cost_usd", 0) or 0 for s in summary)
     log.info(
         "Done. %d agents reviewed. Total cost $%.4f. Summary -> %s",

--- a/scripts/audit_argument.py
+++ b/scripts/audit_argument.py
@@ -129,6 +129,7 @@ def save_response(result: dict) -> Path:
     path = OUTPUT_DIR / f"{slug}.json"
     with open(path, "w") as f:
         json.dump(result, f, indent=2)
+        f.write("\n")
     return path
 
 

--- a/scripts/sweep_matching_threshold.py
+++ b/scripts/sweep_matching_threshold.py
@@ -186,6 +186,7 @@ def sweep_thresholds(
     stability_path = output_path.parent / "matching_stability.json"
     with open(stability_path, "w", encoding="utf-8") as f:
         json.dump(stability, f, indent=2)
+        f.write("\n")
 
     # Print summary
     _print_stability_summary(stability)

--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -629,7 +629,7 @@ def run(
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # Persist the raw response — never lose the source of truth.
-        output_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False))
+        output_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False) + "\n")
         log.info("Saved Mistral raw response to %s", output_path)
 
     record = parse_response(raw, meta, wall_s=wall_s, agent_mode=agent_mode, prompt=prompt)

--- a/src/aedist/adapter_openai_responses.py
+++ b/src/aedist/adapter_openai_responses.py
@@ -501,6 +501,7 @@ def _smoke(args: argparse.Namespace) -> None:
     }
     with open(artifact_path, "w") as f:
         json.dump(payload_dict, f, indent=2, ensure_ascii=False, default=str)
+        f.write("\n")
 
     n_searches = len(record.web_search_calls or [])
     n_citations = len(record.citations or [])

--- a/src/aedist/build_corpus.py
+++ b/src/aedist/build_corpus.py
@@ -555,7 +555,7 @@ def main(argv=None):
         "min_score": args.min_score,
     }
     manifest_path = args.output / "manifest.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
     log.info("Manifest: %s", manifest_path)
 
 

--- a/src/aedist/evaluate.py
+++ b/src/aedist/evaluate.py
@@ -328,7 +328,7 @@ def _write_record(record: RunRecord, out: Path, stem: str) -> Path:
     """Write a RunRecord to {out}/{stem}.record.json, return the path."""
     record_path = out / f"{stem}.record.json"
     record_path.parent.mkdir(parents=True, exist_ok=True)
-    record_path.write_text(record.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
+    record_path.write_text(record.model_dump_json(indent=2, exclude_none=True) + "\n", encoding="utf-8")
     return record_path
 
 

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -409,6 +409,7 @@ def save_json(filepath: Path, record: dict) -> None:
     filepath.parent.mkdir(parents=True, exist_ok=True)
     with open(filepath, "w") as f:
         json.dump(record, f, indent=2, ensure_ascii=False)
+        f.write("\n")
     log.info("Saved %s", filepath)
 
 

--- a/src/aedist/prototype_v1_fusion.py
+++ b/src/aedist/prototype_v1_fusion.py
@@ -594,6 +594,7 @@ def save_provenance(master: list[MasterRecord], path: Path) -> None:
         out.append(entry)
     with path.open("w", encoding="utf-8") as fh:
         json.dump(out, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
     log.info("Saved provenance: %s", path)
 
 

--- a/src/aedist/prototype_v1_verify_agent.py
+++ b/src/aedist/prototype_v1_verify_agent.py
@@ -302,7 +302,7 @@ def main():
     print("=" * 60)
 
     if args.output:
-        Path(args.output).write_text(json.dumps(result_dict, indent=2, ensure_ascii=False))
+        Path(args.output).write_text(json.dumps(result_dict, indent=2, ensure_ascii=False) + "\n")
         log.info("Saved to %s", args.output)
 
 

--- a/src/aedist/query_fusion.py
+++ b/src/aedist/query_fusion.py
@@ -197,6 +197,7 @@ def run_fusion(
     summary_path = output_dir / "fusion_summary.json"
     with summary_path.open("w", encoding="utf-8") as f:
         json.dump(summary, f, ensure_ascii=False, indent=2)
+        f.write("\n")
     log.info("Saved fusion summary: %s", summary_path)
 
     return summary

--- a/src/aedist/self_consistency.py
+++ b/src/aedist/self_consistency.py
@@ -497,6 +497,7 @@ def main() -> None:
     summary_path = output_dir / "self_consistency_summary.json"
     with open(summary_path, "w") as f:
         json.dump(results, f, indent=2)
+        f.write("\n")
     log.info("\nSaved: %s", summary_path)
 
     # Write RunRecords to measurements.jsonl

--- a/src/aedist/smoke.py
+++ b/src/aedist/smoke.py
@@ -147,7 +147,7 @@ def smoke_one(
     output_dir.mkdir(parents=True, exist_ok=True)
     suffix = "run" if promote_as_production else "smoke"
     filepath = output_dir / f"{slug}-{suffix}{call_number}.json"
-    filepath.write_text(json.dumps(record, indent=2))
+    filepath.write_text(json.dumps(record, indent=2) + "\n")
     log.info("Saved %s", filepath)
 
     return {
@@ -290,7 +290,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.summary_output:
         args.summary_output.parent.mkdir(parents=True, exist_ok=True)
-        args.summary_output.write_text(json.dumps(summaries, indent=2))
+        args.summary_output.write_text(json.dumps(summaries, indent=2) + "\n")
         log.info("Summary written to %s", args.summary_output)
 
     # Exit non-zero if any call errored or any call hit finish=length —

--- a/src/aedist/verify.py
+++ b/src/aedist/verify.py
@@ -750,6 +750,7 @@ def main():
     summary_path = output_dir / f"{stem}_summary.json"
     with open(summary_path, "w") as f:
         json.dump(summary, f, indent=2)
+        f.write("\n")
     log.info("Wrote %s", summary_path)
     log.info(
         "Verification complete. Mean evidence score: %.2f", summary.get("mean_evidence_score", 0)

--- a/tests/test_json_eof_newline.py
+++ b/tests/test_json_eof_newline.py
@@ -1,0 +1,129 @@
+"""JSON EOF newline policy: all single-object JSON writers must append exactly one trailing newline.
+
+Project stance (see .claude/rules/workflow.md § "JSON EOF newline policy"):
+- json.dump(x, f, ...) must be followed by f.write("\\n") on the next non-blank line.
+- .write_text(json.dumps(...)) must end with + "\\n".
+- .write_text(model.model_dump_json(...)) must end with + "\\n".
+
+JSONL writers (to_jsonl_line() + "\\n" per record) are exempt.
+
+Verification command:
+    pytest -m adherence tests/test_json_eof_newline.py
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _tracked_python_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [
+        REPO_ROOT / f
+        for f in result.stdout.split("\0")
+        if f.endswith(".py") and not f.startswith("tests/")
+    ]
+
+
+# Matches write_text(json.dumps(...)) or write_text(model.model_dump_json(...))
+# that does NOT already end with + "\n" before the closing paren/comma.
+_WRITE_TEXT_DUMPS_RE = re.compile(
+    r'\.write_text\(\s*(?:json\.dumps|[\w.]+\.model_dump_json)\s*\(',
+)
+
+# Matches write_text calls that already have + "\n" somewhere before encoding=
+_ALREADY_NEWLINE_RE = re.compile(r'\+\s*"\\n"')
+
+
+def _check_write_text_violations(path: Path) -> list[str]:
+    """Return list of 'file:lineno' for write_text(json.dumps/model_dump_json)
+    calls that don't contain + "\\n"."""
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    violations = []
+
+    i = 0
+    while i < len(lines):
+        if _WRITE_TEXT_DUMPS_RE.search(lines[i]):
+            # Gather the full statement (may span multiple lines)
+            stmt_lines = []
+            depth = 0
+            j = i
+            while j < len(lines):
+                stmt_lines.append(lines[j])
+                depth += lines[j].count("(") - lines[j].count(")")
+                j += 1
+                if depth <= 0:
+                    break
+            stmt = "\n".join(stmt_lines)
+            if not _ALREADY_NEWLINE_RE.search(stmt):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{i + 1}")
+        i += 1
+
+    return violations
+
+
+def test_write_text_json_has_trailing_newline():
+    """write_text(json.dumps(...)) and write_text(model_dump_json(...)) must include + '\\n'."""
+    all_violations = []
+    for py_file in _tracked_python_files():
+        all_violations.extend(_check_write_text_violations(py_file))
+
+    assert not all_violations, (
+        f"{len(all_violations)} write_text JSON call(s) missing trailing newline "
+        f"(see .claude/rules/workflow.md § JSON EOF newline policy):\n"
+        + "\n".join(f"  {v}" for v in sorted(all_violations))
+    )
+
+
+def test_json_dump_to_file_has_trailing_newline():
+    """json.dump(x, f, ...) calls must be followed by f.write('\\n').
+
+    Checks that every json.dump( line in a 'with open(... "w") as f:' context
+    has f.write("\\n") (or fh.write / handle.write) on the next non-blank,
+    non-comment line within the same indentation block.
+    """
+    all_violations = []
+    for py_file in _tracked_python_files():
+        source = py_file.read_text(encoding="utf-8")
+        lines = source.splitlines()
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            # Match json.dump( calls (not json.dumps)
+            if not re.search(r"\bjson\.dump\s*\(", stripped):
+                continue
+            if "json.dumps" in stripped:
+                continue
+            # Look at the next non-blank, non-comment line
+            j = i + 1
+            while j < len(lines) and (
+                not lines[j].strip() or lines[j].strip().startswith("#")
+            ):
+                j += 1
+            if j >= len(lines):
+                rel = py_file.relative_to(REPO_ROOT)
+                all_violations.append(f"{rel}:{i + 1} (end of file after json.dump)")
+                continue
+            next_stripped = lines[j].strip()
+            if not re.search(r'\.write\s*\(\s*"\\n"\s*\)', next_stripped):
+                rel = py_file.relative_to(REPO_ROOT)
+                all_violations.append(f"{rel}:{i + 1}")
+
+    assert not all_violations, (
+        f"{len(all_violations)} json.dump() call(s) not followed by .write('\\n') "
+        f"(see .claude/rules/workflow.md § JSON EOF newline policy):\n"
+        + "\n".join(f"  {v}" for v in sorted(all_violations))
+    )

--- a/tickets/0296-standardize-json-eof-newline-policy.erg
+++ b/tickets/0296-standardize-json-eof-newline-policy.erg
@@ -2,12 +2,14 @@
 Title: Standardize JSON EOF newline policy across runtime writers
 Created: 2026-05-25
 Author: HDMX-coding-agent
+Closed: JSON EOF newline policy standardized across all runtime writers
 
 --- log ---
 2026-05-25T00:00Z HDMX-coding-agent created
 2026-05-25T00:00Z HDMX-coding-agent note deferred per user request: schedule after talk / slow day.
 
 2026-05-27T20:59Z Claude untag deferred
+2026-06-08T18:43Z HDMX-coding-agent closed — JSON EOF newline policy standardized across all runtime writers
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- All single-object JSON writers now append exactly one trailing newline (`\n`), eliminating `No newline at end of file` noise in diffs.
- Fixes 20 files across `src/aedist/`, `experiments/sota/`, and `scripts/` using two patterns: `f.write("\n")` after `json.dump()`, and `+ "\n"` appended to `write_text(json.dumps(...))` / `write_text(model_dump_json(...))`.
- Policy documented in `.claude/rules/workflow.md`; enforced by new `tests/test_json_eof_newline.py` (`@pytest.mark.adherence`).

JSONL writers (`to_jsonl_line() + "\n"` per record) are explicitly out of scope — they are already correct.

## Test plan

- [x] `pytest -m adherence tests/test_json_eof_newline.py` — 2 tests pass
- [x] `pytest -m "not integration and not slow" -q` — 2018 passed, 0 failed

**Ticket:** tickets/0296-standardize-json-eof-newline-policy.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)