### PR TITLE
ticket(0334): add deferral note — protocol_07 is frozen naive-arm stimulus

### DIFF
--- a/tickets/0334-prompt-ameliorations-format-reponse.erg
+++ b/tickets/0334-prompt-ameliorations-format-reponse.erg
@@ -6,6 +6,7 @@ Label: deferred
 
 --- log ---
 2026-05-26T10:00Z claude created
+2026-06-08T00:00Z HDMX-coding-agent note Deferral confirmed: (1) exit criterion "Test sur 1 modèle" requires API call ($$); (2) protocol_07_naive_prompt.md is the frozen naive-arm stimulus referenced by path in 49+ completed exp1_batch2 jobs and exp2_naive_arm.py — editing it in place would desync the archived data from the stimulus that produced it; (3) the requested structured scaffolding (mandated header, caption, Notes, Sources) is exactly what the naive arm is designed to lack (per protocol_05_experiment.md) — applying these changes would contaminate the Exp2 naive-vs-optimized contrast. If these improvements are wanted for future runs, they should target a new protocol document, not protocol_07.
 
 --- body ---
 ## Verbatim


### PR DESCRIPTION
## Summary

- Adds a deferral note to ticket 0334 documenting why this ticket cannot be implemented as-spec'd
- Exit criteria require an API call ($$); protocol_07_naive_prompt.md is a frozen experimental stimulus; the requested changes would contaminate the Exp2 naive-vs-optimized contrast

## Rationale

Three reasons to defer rather than implement:
1. Exit criterion "Test sur 1 modèle" requires running a real API call ($$) — per task instructions, stop when this is the case
2. `protocol_07_naive_prompt.md` is the frozen naive-arm stimulus referenced by path in 49+ completed `exp1_batch2` jobs and `exp2_naive_arm.py` — editing it in place would desync the archived data from the stimulus that produced it
3. The requested structured scaffolding (mandated header, caption, Notes, Sources sections) is precisely what the naive arm is designed to **lack** by design (`protocol_05_experiment.md`): "The naive arm thus shares the v2 task statement and v2 quality criteria with the optimized arm but has none of the v2 methodology" — adding this scaffolding would contaminate the Exp2 naive-vs-optimized contrast

If these prompt improvements are wanted for future runs, they should target a new protocol document, not `protocol_07`.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)