### PR TITLE
ticket(0247): Mistral follow-up self-guard — prepend metadata into content, not body

### DIFF
--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -488,9 +488,15 @@ def run(
        **follow-up turn**: skip agent creation, send follow-up message
        to existing conversation. No create, no delete.
 
-    ``extra_metadata`` is attached to the conversation request body's
-    ``metadata`` field when present. Wrapped defensively since the
-    Mistral beta API may not support it.
+    ``extra_metadata`` behaviour differs by turn:
+
+    - **Turn 1 (create + invoke):** attached as a body-level ``metadata``
+      key on the ``POST /v1/conversations`` request.
+    - **Follow-up turns:** the append endpoint (``POST /v1/conversations/{id}``)
+      returns HTTP 422 when a ``metadata`` key is present in the body
+      (confirmed empirically, ticket 0247). Instead the budget signal is
+      prepended as a ``[metadata] key=value; ...`` line inside the user
+      message content, matching the Qwen DashScope fallback pattern.
 
     ``system_prompt`` (ticket 0213) installs a designed system-level
     instruction on the Mistral agent at create time by overriding the
@@ -599,10 +605,21 @@ def run(
                 "Mistral follow-up turn requires continuation['conversation_id']; "
                 f"got {continuation!r}"
             )
+        # Mistral's append endpoint returns HTTP 422 with a body-level
+        # ``metadata`` key (confirmed ticket 0247). Preserve the budget
+        # signal by prepending a machine-parseable line into the message
+        # text — matching the Qwen DashScope fallback pattern.
+        user_content = prompt
+        if extra_metadata is not None:
+            meta_text = "; ".join(f"{k}={v}" for k, v in extra_metadata.items())
+            user_content = f"[metadata] {meta_text}\n{prompt}"
+            log.info(
+                "Mistral follow-up: extra_metadata prepended to user content "
+                "(body-level metadata key causes HTTP 422 on append endpoint)"
+            )
         conv_body: dict[str, Any] = {
-            "inputs": [{"role": "user", "content": prompt}],
+            "inputs": [{"role": "user", "content": user_content}],
         }
-        _attach_metadata(conv_body)
         with httpx.Client(base_url=API_BASE, headers=headers) as client:
             raw = _append_conversation(client, conversation_id, conv_body)
         agent_id = continuation["agent_id"]

--- a/tests/test_adapter_mistral.py
+++ b/tests/test_adapter_mistral.py
@@ -780,6 +780,91 @@ def test_run_extra_metadata_logged_without_crash(monkeypatch, caplog):
     assert record.method_params.extra == {"dry_run": True}
 
 
+def test_followup_extra_metadata_prepended_not_in_body(monkeypatch):
+    """Follow-up turn with extra_metadata: budget signal must be prepended
+    into the user message content, NOT placed in the request body's
+    ``metadata`` key (which causes HTTP 422 on the append endpoint —
+    confirmed empirically, ticket 0247).
+    """
+    import aedist.adapter_mistral as am
+
+    bodies: list[dict] = []
+
+    class FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "outputs": [
+                    {"type": "message.output", "content": "follow-up answer"},
+                ],
+                "usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 100,
+                    "connector_tokens": 0,
+                    "connectors": {"web_search": 0},
+                },
+                "conversation_id": "conv_1",
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, url, **kwargs):
+            bodies.append(kwargs.get("json") or {})
+            return FakeResponse()
+
+        def delete(self, url, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(am, "_load_api_key", lambda *a, **k: "fake-key")
+    monkeypatch.setattr(am.httpx, "Client", FakeClient)
+
+    run(
+        "what is the PDP8 capacity?",
+        dry_run=False,
+        model_meta=PRICE_CARD,
+        max_tokens=600,
+        cap_usd=10.0,
+        agent_mode="smoke",
+        continuation={"conversation_id": "conv_1", "agent_id": "ag_1"},
+        extra_metadata={"remaining_budget_usd": "3.50"},
+    )
+
+    assert len(bodies) == 1
+    body = bodies[0]
+
+    # The 422-triggering body-level metadata key must be absent.
+    assert "metadata" not in body, (
+        f"body-level 'metadata' key causes HTTP 422 on follow-up; body={body}"
+    )
+
+    # Budget signal must be preserved in the message content.
+    assert "inputs" in body
+    content = body["inputs"][0]["content"]
+    assert "[metadata]" in content, (
+        f"extra_metadata must be prepended as [metadata] line; content={content!r}"
+    )
+    assert "remaining_budget_usd=3.50" in content, (
+        f"metadata key=value missing from content; content={content!r}"
+    )
+    # Original prompt must still be present.
+    assert "what is the PDP8 capacity?" in content, (
+        f"original prompt missing from content; content={content!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Retry policy (ticket 0215)
 #

--- a/tickets/0247-adapter-mistral-self-guard-metadata-followup.erg
+++ b/tickets/0247-adapter-mistral-self-guard-metadata-followup.erg
@@ -3,10 +3,12 @@ Title: adapter_mistral: self-guard against metadata on follow-up turns
 Created: 2026-05-23
 Author: claude
 Label: deferred
+Closed: Self-guard against metadata on follow-up turns added via content prepend; docstring updated; unit test added
 
 --- log ---
 2026-05-23T00:00Z claude created — residual from 0218; caller-guard exists, adapter still attaches metadata on follow-up (footgun)
 
+2026-06-08T18:59Z HDMX-coding-agent closed — Self-guard against metadata on follow-up turns added via content prepend; docstring updated; unit test added
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- On the Mistral follow-up branch (`is_followup`), replace the unconditional `_attach_metadata(conv_body)` call (which puts a body-level `metadata` key) with a content prepend — `[metadata] key=value; ...` prepended to the user message text.
- The path-bound append endpoint (`POST /v1/conversations/{id}`) returns HTTP 422 with a body-level `metadata` key (confirmed empirically, ticket 0247). Turn-1 path is unchanged.
- Adapter docstring (~:491) updated to state the confirmed 422 and describe the per-turn split behaviour.
- New unit test `test_followup_extra_metadata_prepended_not_in_body` covers the follow-up metadata path with `dry_run=False` and a FakeClient, asserting: no `"metadata"` key in the request body, `[metadata]` present in content, original prompt preserved.

## Test plan

- [x] `uv run pytest tests/test_adapter_mistral.py -v` — 28/28 pass
- [x] `uv run pytest tests/` — 2063 passed, 7 skipped, 1 xfailed

**Ticket:** tickets/0247-adapter-mistral-self-guard-metadata-followup.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)