### PR TITLE
ticket(0217): guard non-worker query paths against null content

### DIFF
--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -710,8 +710,15 @@ def query_single_turn(
     # exposed by OpenRouter for reasoning-capable models). Falls back to {} if the
     # provider returned no usage block. Ticket 0195.
     usage = response.usage.model_dump() if response.usage is not None else {}
+    content = choice.message.content
+    if content is None:
+        raise RuntimeError(
+            f"Null content from {model_id}: provider returned HTTP 200 "
+            f"but message.content is None "
+            f"(finish_reason={choice.finish_reason})"
+        )
     return {
-        "content": choice.message.content,
+        "content": content,
         "finish_reason": choice.finish_reason,
         "usage": usage,
         "wall_seconds": wall_seconds,

--- a/src/aedist/query_multiturn.py
+++ b/src/aedist/query_multiturn.py
@@ -80,8 +80,16 @@ def run_conversation(
 
     def _call(msgs):
         if is_ollama:
-            return query_ollama_native(ollama_url, model_id, msgs, num_ctx, no_think=no_think)
-        return query_single_turn(client, model_id, msgs, **api_kwargs)
+            result = query_ollama_native(ollama_url, model_id, msgs, num_ctx, no_think=no_think)
+        else:
+            result = query_single_turn(client, model_id, msgs, **api_kwargs)
+        if result.get("content") is None:
+            raise RuntimeError(
+                f"Null content from {model_id}: provider returned HTTP 200 "
+                f"but message.content is None "
+                f"(finish_reason={result.get('finish_reason')})"
+            )
+        return result
 
     messages: list[dict] = []
     turns: list[dict] = []

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -527,6 +527,30 @@ def test_query_single_turn_handles_missing_usage():
     assert result["usage"] == {}
 
 
+def test_query_single_turn_raises_on_null_content():
+    """query_single_turn raises RuntimeError when content is None (ticket 0217).
+
+    Providers like deepseek-v4-pro can return HTTP 200 with message.content=None.
+    This must not silently propagate to callers — a RuntimeError with the model
+    ID is raised immediately so callers get a diagnostic, not an AttributeError
+    or corrupt data.
+    """
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    from aedist.harness import query_single_turn
+
+    client = MagicMock()
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content=None), finish_reason="stop")]
+    response.usage = MagicMock(model_dump=MagicMock(return_value={}))
+    client.chat.completions.create.return_value = response
+
+    with pytest.raises(RuntimeError, match="null-content-model"):
+        query_single_turn(client, "null-content-model", [{"role": "user", "content": "hi"}])
+
+
 def test_make_client_default_sets_max_retries():
     """make_client() (OpenRouter default) pins max_retries=1 on the OpenAI client."""
     import os

--- a/tests/test_query_multiturn.py
+++ b/tests/test_query_multiturn.py
@@ -331,6 +331,67 @@ def test_stateless_mode_resets_messages():
     assert "Response 2" not in last_call_msgs[0]["content"]
 
 
+def test_run_conversation_raises_on_null_content_cloud(monkeypatch):
+    """Null content from a cloud provider raises RuntimeError (ticket 0217).
+
+    query_single_turn now raises before returning, so this is exercised via the
+    cloud branch of _call. Covers exit criterion: query_multiturn does not
+    append None content to messages.
+    """
+    import pytest
+
+    from aedist.harness import BudgetTracker
+    from aedist.query_multiturn import run_conversation
+
+    client = MagicMock()
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content=None), finish_reason="stop")]
+    response.usage = MagicMock(model_dump=MagicMock(return_value={}))
+    client.chat.completions.create.return_value = response
+
+    model = {"context_window": 100000, "price_per_mtok_in": 0, "price_per_mtok_out": 0}
+    budget = BudgetTracker(budget_usd=None)
+
+    with pytest.raises(RuntimeError, match="null-mt-model"):
+        run_conversation(client, "null-mt-model", "hi", [], model, budget)
+
+
+def test_run_conversation_raises_on_null_content_ollama(monkeypatch):
+    """Null content from the Ollama branch raises RuntimeError (ticket 0217).
+
+    The Ollama route bypasses query_single_turn, so _call's own guard is what
+    catches it. This covers the path that corrupted conversation state in
+    query_multiturn:114 before the fix.
+    """
+    import pytest
+
+    from aedist.harness import BudgetTracker
+    from aedist.query_multiturn import run_conversation
+
+    monkeypatch.setattr(
+        "aedist.query_multiturn.query_ollama_native",
+        lambda *a, **kw: {
+            "content": None,
+            "finish_reason": "stop",
+            "usage": {},
+            "wall_seconds": 0.1,
+        },
+    )
+
+    model = {
+        "route": "ollama",
+        "context_window": 100000,
+        "price_per_mtok_in": 0,
+        "price_per_mtok_out": 0,
+    }
+    budget = BudgetTracker(budget_usd=None)
+
+    with pytest.raises(RuntimeError, match="null-ollama-model"):
+        run_conversation(
+            None, "null-ollama-model", "hi", [], model, budget, ollama_base_url="http://localhost:11434/v1"
+        )
+
+
 def test_no_context_window_skips_guard():
     """Models without context_window field skip the guard entirely."""
     from aedist.harness import BudgetTracker

--- a/tickets/0217-null-content-guard-non-worker-paths.erg
+++ b/tickets/0217-null-content-guard-non-worker-paths.erg
@@ -3,10 +3,12 @@ Title: Guard non-worker query paths against null content from provider
 Created: 2026-05-21
 Author: claude
 Label: deferred
+Closed: guard implemented in query_single_turn and multiturn._call; 3 tests added
 
 --- log ---
 2026-05-21T18:50Z claude created — celebrate sweep for PR #402
 
+2026-06-08T19:00Z HDMX-coding-agent closed — guard implemented in query_single_turn and multiturn._call; 3 tests added
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add `RuntimeError` guard in `query_single_turn()` when `message.content is None`, covering all cloud callers (query_direct, query_rag, query_livesearch, verify, smoke)
- Add second guard in `query_multiturn._call()` covering the Ollama branch which bypasses `query_single_turn`
- Add 3 unit tests: null-content cloud path, null-content Ollama path, and base `query_single_turn` guard

## Test plan
- [x] `test_query_single_turn_raises_on_null_content` — cloud provider returns None
- [x] `test_run_conversation_raises_on_null_content_cloud` — multiturn cloud branch
- [x] `test_run_conversation_raises_on_null_content_ollama` — multiturn Ollama branch
- [x] `make check-fast` passes (2029 passed + 3 new)

**Ticket:** tickets/0217-null-content-guard-non-worker-paths.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)