### PR TITLE
ticket(0281): check_provenance_urls — N=10 HTTP provenance spot-check per run

### DIFF
--- a/docs/scoring-contract.md
+++ b/docs/scoring-contract.md
@@ -206,6 +206,7 @@ Null conditions: `n_rows == 0` → `no_rows`; all values are sentinels → `colu
 `score_exp1.py` for `exp1_cross_eval.csv`. They are intentionally **not** wired
 into the Exp2 mart `ScoreSummary` (ticket 0386 Option B carve-out; see
 `docs/scoring-contract.md` §Mart schema section).
+
 ---
 
 ## Provenance URL spot-check — `check_provenance_urls.py`

--- a/docs/scoring-contract.md
+++ b/docs/scoring-contract.md
@@ -206,7 +206,6 @@ Null conditions: `n_rows == 0` → `no_rows`; all values are sentinels → `colu
 `score_exp1.py` for `exp1_cross_eval.csv`. They are intentionally **not** wired
 into the Exp2 mart `ScoreSummary` (ticket 0386 Option B carve-out; see
 `docs/scoring-contract.md` §Mart schema section).
-
 ---
 
 ## Provenance URL spot-check — `check_provenance_urls.py`
@@ -286,7 +285,6 @@ currently has no effect on row selection.
 
 ---
 
->>>>>>> a5ff2499 (wip: ticket 0396 — coherence_row_atomicity indicator (temp commit))
 ### Temporality
 
 As-of date is resolved from the first non-empty of: `status_as_of`, `as_of`,

--- a/src/aedist/check_provenance_urls.py
+++ b/src/aedist/check_provenance_urls.py
@@ -1,0 +1,643 @@
+"""Automated provenance spot-check — verify N=10 source URLs per run.
+
+Pipeline phase: P2 companion (on-demand only) — not wired into the default
+Makefile/report DAG to avoid network dependencies in clean-room builds.
+
+For each run, samples N=10 matched plant rows and verifies whether Source 1
+is (a) a real URL that resolves and (b) a page whose text mentions the plant
+by name and (plausibly) the claimed capacity.
+
+Algorithm:
+1. Parse the run's .md file to extract the plant table and bibliography.
+2. For a row with a citation-key Source 1 (e.g. [1], [23]), resolve the key
+   against the bibliography to obtain a full URL.
+3. HTTP GET the URL (10s timeout, single retry on network error).
+   Classify result: resolved / unresolved / no-url / no-source.
+4. If resolved, search page text for the plant's name (Vietnamese or English,
+   case-insensitive). If found, extract capacity figures and normalise to MWe
+   (GW × 1000, MW as-is); if any found capacity is within ±10% of the claimed
+   value: PASS.
+5. Emit per-row result and aggregate: provenance_score = n_pass / n_sampled.
+
+Design choice — row selection:
+  Rows are sampled from those whose Source 1 is not "not found" / empty
+  (i.e. rows that have a non-trivial citation to check). This directly tests
+  the verifiable fraction of the run's citations without requiring per-plant
+  match metadata from sota_cross_eval.csv.  The caller may optionally restrict
+  to a list of plant names (from matched rows in the cross-eval CSV) via the
+  --plant-names argument.
+
+Usage:
+    python -m aedist.check_provenance_urls \\
+        --md experiments/derived/arm1_flat/anthropic_run01.md \\
+        --output derived/provenance_sample_anthropic_run01.csv
+
+    # Limit to N=5 samples, dry-run (no HTTP):
+    python -m aedist.check_provenance_urls \\
+        --md experiments/derived/arm1_flat/anthropic_run01.md \\
+        --n 5 --dry-run
+
+    # Restrict to matched plants from cross-eval:
+    python -m aedist.check_provenance_urls \\
+        --md experiments/derived/arm1_flat/anthropic_run01.md \\
+        --cross-eval experiments/derived/sota_cross_eval.csv \\
+        --arm naive --model claude-opus-4-6 --run 1
+"""
+
+import argparse
+import csv
+import json
+import logging
+import random
+import re
+import time
+from pathlib import Path
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_N = 10
+_HTTP_TIMEOUT = 10.0  # seconds
+_CAPACITY_TOLERANCE = 0.10  # ±10%
+
+# Patterns that indicate no useful source was cited
+_EMPTY_MARKERS: frozenset[str] = frozenset({"", "—", "–", "-", "n/a", "na", "none"})
+_NOTFOUND_PATTERNS = [
+    "not found",
+    "not available",
+    "unable to verify",
+    "could not verify",
+    "no source",
+    "unverified",
+]
+
+# Output columns for the provenance sample CSV
+_OUT_FIELDNAMES = [
+    "plant_name_vi",
+    "plant_name_en",
+    "claimed_capacity_mwe",
+    "source_1_raw",
+    "source_1_url",
+    "url_status",
+    "name_found",
+    "capacity_match",
+    "verdict",
+    "detail",
+]
+
+# ---------------------------------------------------------------------------
+# Markdown parsing helpers
+# ---------------------------------------------------------------------------
+
+_SEPARATOR_RE = re.compile(r"^[\s|:\-]+$")
+# Bibliography entry: **[N]** … URL: `https://...`
+_BIB_ENTRY_RE = re.compile(r"^\*\*\[(\d+)\]\*\*")
+_BIB_URL_RE = re.compile(r"URL:\s+`(https?://[^`]+)`")
+# Source 1/2 cell containing only a citation key like [1] or [20]
+_CITATION_KEY_RE = re.compile(r"^\s*\[(\d+)\]\s*$")
+# URL embedded directly in a cell (some runs use markdown links)
+_INLINE_URL_RE = re.compile(r"https?://[^\s)>\]]+")
+# Capacity figures in MW / GW on a page
+_MW_RE = re.compile(r"([\d,\.]+)\s*(?:MW|mw)")
+_GW_RE = re.compile(r"([\d,\.]+)\s*(?:GW|gw)")
+
+
+def _is_empty(cell: str) -> bool:
+    return cell.strip().lower() in _EMPTY_MARKERS
+
+
+def _is_notfound(cell: str) -> bool:
+    lower = cell.strip().lower()
+    return any(pat in lower for pat in _NOTFOUND_PATTERNS)
+
+
+def _parse_table(text: str) -> tuple[list[str], list[list[str]]]:
+    """Return (header_cells, data_rows) from the pipe table in the markdown.
+
+    Looks for the first table whose header contains both 'Source 1'
+    and at least 8 columns (the full plant table).
+    """
+    lines = text.split("\n")
+    header_cells: list[str] = []
+    data_rows: list[list[str]] = []
+    found_header = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            if found_header and data_rows:
+                break  # table ended
+            continue
+        if _SEPARATOR_RE.match(stripped):
+            continue
+
+        cells = [c.strip() for c in stripped.split("|")]
+        if cells and cells[0] == "":
+            cells = cells[1:]
+        if cells and cells[-1] == "":
+            cells = cells[:-1]
+
+        if not found_header:
+            lower = [c.lower() for c in cells]
+            has_src1 = any(c in ("source 1", "src 1") for c in lower)
+            if has_src1 and len(cells) >= 8:
+                header_cells = cells
+                found_header = True
+            continue
+
+        # Skip repeated header rows
+        lower = [c.lower() for c in cells]
+        is_repeated = any(c in ("source 1", "source 2", "src 1", "src 2") for c in lower)
+        if not is_repeated:
+            data_rows.append(cells)
+
+    return header_cells, data_rows
+
+
+def _parse_bibliography(text: str) -> dict[str, str]:
+    """Return {citation_number_str: url} from the bibliography section.
+
+    Handles the format: **[N]** … URL: `https://...`
+    Returns an empty dict when no bibliography section is found.
+    Entries without a URL: `...` are excluded.
+    """
+    result: dict[str, str] = {}
+    in_bib = False
+
+    for line in text.split("\n"):
+        stripped = line.strip()
+
+        # Detect bib section start
+        if not in_bib:
+            if re.match(
+                r"^#{1,4}\s+.*(?:bibliography|references|annotated\s+bibliography)",
+                stripped,
+                re.IGNORECASE,
+            ):
+                in_bib = True
+            continue
+
+        m_entry = _BIB_ENTRY_RE.match(stripped)
+        if m_entry:
+            key = m_entry.group(1)
+            m_url = _BIB_URL_RE.search(stripped)
+            if m_url:
+                result[key] = m_url.group(1)
+
+    return result
+
+
+def _col_index(header: list[str], *names: str) -> int | None:
+    """Return the index of the first header cell matching any of the given names."""
+    lower = [c.lower() for c in header]
+    for name in names:
+        if name.lower() in lower:
+            return lower.index(name.lower())
+    return None
+
+
+def _resolve_source_url(cell: str, bib: dict[str, str]) -> str | None:
+    """Return the URL for a Source 1 cell, or None if not resolvable.
+
+    - Citation key [N] → look up in bib dict.
+    - Inline URL (https://...) → return directly.
+    - Anything else (inline text, "not found", empty) → None.
+    """
+    cell = cell.strip()
+
+    # Citation key form
+    m = _CITATION_KEY_RE.match(cell)
+    if m:
+        return bib.get(m.group(1))  # None if key absent from bib
+
+    # Inline URL in the cell
+    m2 = _INLINE_URL_RE.search(cell)
+    if m2:
+        return m2.group()
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# HTTP verification
+# ---------------------------------------------------------------------------
+
+
+def _fetch_page(url: str) -> tuple[str, int | None]:
+    """Fetch URL and return (page_text, status_code).
+
+    On network error: returns ("", None).
+    Retries once on connection error.
+    """
+    for attempt in range(2):
+        try:
+            resp = httpx.get(
+                url,
+                timeout=_HTTP_TIMEOUT,
+                follow_redirects=True,
+                headers={"User-Agent": "Mozilla/5.0 (research bot; academic use)"},
+            )
+            return resp.text, resp.status_code
+        except (httpx.HTTPError, httpx.InvalidURL) as exc:
+            if attempt == 0:
+                log.debug("Retry after error on %s: %s", url, exc)
+                time.sleep(1)
+            else:
+                log.debug("Failed to fetch %s: %s", url, exc)
+    return "", None
+
+
+def _name_found(page_text: str, name_vi: str, name_en: str) -> bool:
+    """Return True if either plant name appears in the page text."""
+    lower = page_text.lower()
+    return bool(
+        (name_vi and name_vi.lower() in lower)
+        or (name_en and name_en.lower() in lower)
+    )
+
+
+def _capacity_matches(page_text: str, claimed_mwe: float) -> bool:
+    """Return True if any capacity figure on the page is within ±10% of claimed_mwe."""
+    candidates: list[float] = []
+    for m in _MW_RE.findall(page_text):
+        try:
+            candidates.append(float(m.replace(",", "")))
+        except ValueError:
+            pass
+    for m in _GW_RE.findall(page_text):
+        try:
+            candidates.append(float(m.replace(",", "")) * 1000.0)
+        except ValueError:
+            pass
+    if not candidates:
+        return False
+    lo = claimed_mwe * (1 - _CAPACITY_TOLERANCE)
+    hi = claimed_mwe * (1 + _CAPACITY_TOLERANCE)
+    return any(lo <= c <= hi for c in candidates)
+
+
+# ---------------------------------------------------------------------------
+# Per-row verification
+# ---------------------------------------------------------------------------
+
+
+def check_row(
+    name_vi: str,
+    name_en: str,
+    claimed_mwe: float | None,
+    source_1_raw: str,
+    bib: dict[str, str],
+    dry_run: bool = False,
+) -> dict:
+    """Check one plant row and return a result dict.
+
+    Verdict values: PASS, FAIL, UNRESOLVED, NO_URL, NO_SOURCE.
+    """
+    url = _resolve_source_url(source_1_raw, bib)
+
+    base = {
+        "plant_name_vi": name_vi,
+        "plant_name_en": name_en,
+        "claimed_capacity_mwe": str(claimed_mwe) if claimed_mwe is not None else "",
+        "source_1_raw": source_1_raw,
+        "source_1_url": url or "",
+        "url_status": "",
+        "name_found": "",
+        "capacity_match": "",
+        "verdict": "",
+        "detail": "",
+    }
+
+    if _is_notfound(source_1_raw) or _is_empty(source_1_raw):
+        base["verdict"] = "NO_SOURCE"
+        base["detail"] = "Source 1 is empty or 'not found'"
+        return base
+
+    if url is None:
+        base["verdict"] = "NO_URL"
+        base["detail"] = "Source 1 has no resolvable URL (inline-text citation)"
+        return base
+
+    if dry_run:
+        base["verdict"] = "DRY_RUN"
+        base["detail"] = f"Would fetch: {url}"
+        return base
+
+    page_text, status = _fetch_page(url)
+
+    if status is None:
+        base["url_status"] = "network_error"
+        base["verdict"] = "UNRESOLVED"
+        base["detail"] = "Network error fetching URL"
+        return base
+
+    base["url_status"] = str(status)
+
+    if status >= 400:
+        base["verdict"] = "UNRESOLVED"
+        base["detail"] = f"HTTP {status}"
+        return base
+
+    # Page resolved — check name
+    found = _name_found(page_text, name_vi, name_en)
+    base["name_found"] = "yes" if found else "no"
+
+    if not found:
+        base["verdict"] = "FAIL"
+        base["detail"] = "Page loaded but plant name not found in text"
+        return base
+
+    # Name found — check capacity if we have a claimed value
+    if claimed_mwe is None or claimed_mwe <= 0:
+        base["verdict"] = "PASS"
+        base["capacity_match"] = "n/a"
+        base["detail"] = "Name found; no claimed capacity to check"
+        return base
+
+    cap_match = _capacity_matches(page_text, claimed_mwe)
+    base["capacity_match"] = "yes" if cap_match else "no"
+    if cap_match:
+        base["verdict"] = "PASS"
+        base["detail"] = "Name and capacity (±10%) both found on page"
+    else:
+        base["verdict"] = "FAIL"
+        base["detail"] = "Name found but no matching capacity figure on page"
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Run-level spot-check
+# ---------------------------------------------------------------------------
+
+
+def _parse_capacity(cell: str) -> float | None:
+    """Parse a capacity cell like '1,200' or '~600' to float MWe."""
+    cell = cell.strip().lstrip("~≈").replace(",", "")
+    try:
+        return float(cell)
+    except ValueError:
+        return None
+
+
+def _load_matched_plants(
+    cross_eval_csv: Path, arm: str, model: str, run: int
+) -> set[str] | None:
+    """Return the set of English plant names matched for a given run, or None.
+
+    The cross_eval CSV is run-level aggregate (no per-plant matches), so this
+    function currently returns None — meaning no filtering is applied and all
+    rows with citable sources are eligible for sampling.
+
+    If a per-plant match file becomes available in the future, this is the hook
+    to add that filter.
+    """
+    return None  # no per-plant match data available in sota_cross_eval.csv
+
+
+def spot_check_run(
+    md_path: Path,
+    n: int = _DEFAULT_N,
+    seed: int = 42,
+    dry_run: bool = False,
+    plant_names: set[str] | None = None,
+) -> dict:
+    """Run the provenance spot-check on one run's markdown file.
+
+    Returns a dict with:
+      - sampled_rows: list of per-row result dicts
+      - n_sampled: actual number of rows checked
+      - n_pass: count of PASS verdicts
+      - n_fail: count of FAIL verdicts
+      - n_unresolved: count of UNRESOLVED verdicts
+      - n_no_url: count of NO_URL verdicts
+      - n_no_source: count of NO_SOURCE verdicts
+      - provenance_score: n_pass / n_sampled (None if n_sampled == 0)
+    """
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+    header_cells, data_rows = _parse_table(text)
+    bib = _parse_bibliography(text)
+
+    if not header_cells or not data_rows:
+        log.warning("No plant table found in %s", md_path)
+        return _empty_result()
+
+    col_name_vi = _col_index(header_cells, "Name (Vietnamese)", "name_vi", "name (vietnamese)")
+    col_name_en = _col_index(header_cells, "Name (English)", "name_en", "name (english)")
+    col_capacity = _col_index(
+        header_cells, "Total MWe", "total_mwe", "capacity_mwe", "capacity"
+    )
+    col_src1 = _col_index(header_cells, "Source 1", "source 1", "src 1")
+
+    if col_src1 is None:
+        log.warning("No 'Source 1' column in %s", md_path)
+        return _empty_result()
+
+    def _cell(row: list[str], idx: int | None) -> str:
+        if idx is None or idx >= len(row):
+            return ""
+        return row[idx].strip()
+
+    # Build candidate rows: those with a non-trivial, URL-bearing Source 1
+    candidates: list[tuple[str, str, float | None, str]] = []
+    for row in data_rows:
+        src1 = _cell(row, col_src1)
+        if _is_empty(src1) or _is_notfound(src1):
+            continue
+        name_vi = _cell(row, col_name_vi)
+        name_en = _cell(row, col_name_en)
+
+        # Optional filter by matched plant names
+        if plant_names is not None and name_en not in plant_names:
+            continue
+
+        cap_raw = _cell(row, col_capacity)
+        cap = _parse_capacity(cap_raw)
+        candidates.append((name_vi, name_en, cap, src1))
+
+    if not candidates:
+        log.warning("No citable rows in %s", md_path)
+        return _empty_result()
+
+    # Sample
+    rng = random.Random(seed)
+    sample = rng.sample(candidates, min(n, len(candidates)))
+
+    results: list[dict] = []
+    for name_vi, name_en, cap, src1 in sample:
+        r = check_row(name_vi, name_en, cap, src1, bib, dry_run=dry_run)
+        results.append(r)
+        log.info(
+            "%s (%s) → %s",
+            name_en or name_vi,
+            r["source_1_url"] or r["source_1_raw"],
+            r["verdict"],
+        )
+
+    verdict_counts = {
+        "PASS": 0,
+        "FAIL": 0,
+        "UNRESOLVED": 0,
+        "NO_URL": 0,
+        "NO_SOURCE": 0,
+        "DRY_RUN": 0,
+    }
+    for r in results:
+        verdict_counts[r["verdict"]] = verdict_counts.get(r["verdict"], 0) + 1
+
+    n_sampled = len(results)
+    n_pass = verdict_counts["PASS"]
+    score = round(n_pass / n_sampled, 3) if n_sampled > 0 else None
+
+    return {
+        "n_candidates": len(candidates),
+        "n_sampled": n_sampled,
+        "n_pass": n_pass,
+        "n_fail": verdict_counts["FAIL"],
+        "n_unresolved": verdict_counts["UNRESOLVED"],
+        "n_no_url": verdict_counts["NO_URL"],
+        "n_no_source": verdict_counts["NO_SOURCE"],
+        "provenance_score": score,
+        "sampled_plants": [r["plant_name_en"] or r["plant_name_vi"] for r in results],
+        "rows": results,
+    }
+
+
+def _empty_result() -> dict:
+    return {
+        "n_candidates": 0,
+        "n_sampled": 0,
+        "n_pass": 0,
+        "n_fail": 0,
+        "n_unresolved": 0,
+        "n_no_url": 0,
+        "n_no_source": 0,
+        "provenance_score": None,
+        "sampled_plants": [],
+        "rows": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(
+        description="Provenance spot-check — verify N=10 source URLs for a single run"
+    )
+    parser.add_argument(
+        "--md",
+        required=True,
+        type=Path,
+        help="Path to the run's .md file (plant table + bibliography)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Path to write per-row CSV output (default: stdout summary only)",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=None,
+        help="Path to write full JSON result",
+    )
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=_DEFAULT_N,
+        help=f"Number of rows to sample (default: {_DEFAULT_N})",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for sampling (default: 42)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip HTTP requests; show which URLs would be fetched",
+    )
+    parser.add_argument(
+        "--cross-eval",
+        type=Path,
+        default=None,
+        help=(
+            "Path to sota_cross_eval.csv (or sota_cross_eval_view.csv). "
+            "Currently reserved for future per-plant match filtering."
+        ),
+    )
+    parser.add_argument("--arm", default=None, help="Arm label (for cross-eval filtering)")
+    parser.add_argument("--model", default=None, help="Model ID (for cross-eval filtering)")
+    parser.add_argument(
+        "--run", type=int, default=None, help="Run index (for cross-eval filtering)"
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.md.exists():
+        raise SystemExit(f"Markdown file not found: {args.md}")
+
+    plant_names: set[str] | None = None
+    if args.cross_eval and args.arm and args.model and args.run:
+        plant_names = _load_matched_plants(args.cross_eval, args.arm, args.model, args.run)
+
+    result = spot_check_run(
+        md_path=args.md,
+        n=args.n,
+        seed=args.seed,
+        dry_run=args.dry_run,
+        plant_names=plant_names,
+    )
+
+    # Print summary
+    score_str = (
+        f"{result['provenance_score']:.3f}" if result["provenance_score"] is not None else "N/A"
+    )
+    log.info(
+        "\nProvenance spot-check: %s",
+        args.md,
+    )
+    log.info(
+        "  Sampled %d/%d candidates | PASS %d | FAIL %d | UNRESOLVED %d | "
+        "NO_URL %d | NO_SOURCE %d",
+        result["n_sampled"],
+        result["n_candidates"],
+        result["n_pass"],
+        result["n_fail"],
+        result["n_unresolved"],
+        result["n_no_url"],
+        result["n_no_source"],
+    )
+    log.info("  provenance_score = %s", score_str)
+
+    # Write CSV output
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=_OUT_FIELDNAMES)
+            writer.writeheader()
+            writer.writerows(result["rows"])
+        log.info("Wrote per-row CSV to %s", args.output)
+
+    # Write JSON output
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        payload = {k: v for k, v in result.items() if k != "rows"}
+        payload["rows"] = result["rows"]
+        args.json_output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+        log.info("Wrote JSON result to %s", args.json_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_provenance_urls.py
+++ b/tests/test_check_provenance_urls.py
@@ -1,0 +1,360 @@
+"""Tests for check_provenance_urls.py — HTTP calls are always mocked."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aedist.check_provenance_urls import (
+    _capacity_matches,
+    _name_found,
+    _parse_bibliography,
+    _parse_capacity,
+    _parse_table,
+    _resolve_source_url,
+    check_row,
+    main,
+    spot_check_run,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PLANT_TABLE = """\
+| Name (Vietnamese) | Name (English) | Province | Fuel | Technology | Units × MW | Total MWe | Status | Status as-of-date | COD | Owner/Developer | Confidence | Source 1 | Source 2 | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Nhiệt điện Phả Lại 1 | Pha Lai 1 | Hải Dương | Coal | Subcritical | 4 × 110 | 440 | Operating | 2023-06 | 1983 | EVN | MEDIUM | [1] | [3] | Soviet-era plant. |
+| Nhiệt điện Uông Bí | Uong Bi TPP | Quảng Ninh | Coal | Subcritical | 1 × 300 | 300 | Operating | 2023-06 | 2014 | EVN | LOW | not found | — | Lead: Wikipedia. |
+| Nhiệt điện Mông Dương 2 | Mong Duong 2 | Quảng Ninh | Coal | Subcritical | 2 × 620 | 1,240 | Operating | 2023-09 | 2015 | AES Corp | MEDIUM | [2] | — | BOT. |
+| NĐ BOT Vân Phong 1 | Van Phong 1 | Khánh Hòa | Coal | Supercritical | 2 × 660 | 1,320 | Operating | 2025-05 | 2024 | Sumitomo Corp | HIGH | [99] | — | No bib entry. |
+"""
+
+_BIB_SECTION = """\
+## Bibliography
+
+**[1]** Green Finance DC. "PDP8." June 2023. URL: `https://greenfdc.org/pdp8/`. — *Drawn on for coal.*
+
+**[2]** GEM. "Mong Duong 2." URL: `https://gem.wiki/mong_duong_2`. — *BOT details.*
+
+**[3]** Baker McKenzie. "Analysis." December 2022. URL: `https://example.com/analysis`. — *Draft PDP8 analysis.*
+"""
+
+_FULL_MD = _PLANT_TABLE + "\n" + _BIB_SECTION
+
+
+# ---------------------------------------------------------------------------
+# _parse_bibliography
+# ---------------------------------------------------------------------------
+
+
+class TestParseBibliography:
+    def test_extracts_urls(self):
+        bib = _parse_bibliography(_FULL_MD)
+        assert bib["1"] == "https://greenfdc.org/pdp8/"
+        assert bib["2"] == "https://gem.wiki/mong_duong_2"
+        assert bib["3"] == "https://example.com/analysis"
+
+    def test_empty_if_no_bib_section(self):
+        bib = _parse_bibliography(_PLANT_TABLE)
+        assert bib == {}
+
+    def test_entry_without_url_excluded(self):
+        text = (
+            "## Bibliography\n\n"
+            "**[10]** Decision 500/QĐ-TTg. *PDP8*. — *No URL.*\n"
+        )
+        bib = _parse_bibliography(text)
+        assert "10" not in bib
+
+
+# ---------------------------------------------------------------------------
+# _parse_table
+# ---------------------------------------------------------------------------
+
+
+class TestParseTable:
+    def test_finds_header_and_rows(self):
+        header, rows = _parse_table(_FULL_MD)
+        assert "Source 1" in header
+        assert len(rows) == 4
+
+    def test_empty_on_no_table(self):
+        header, rows = _parse_table("## Just text\nNo table here.")
+        assert header == []
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_source_url
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSourceUrl:
+    def test_citation_key_resolves(self):
+        bib = {"1": "https://greenfdc.org/pdp8/", "2": "https://gem.wiki/x"}
+        assert _resolve_source_url("[1]", bib) == "https://greenfdc.org/pdp8/"
+
+    def test_citation_key_missing_from_bib(self):
+        bib = {"1": "https://greenfdc.org/pdp8/"}
+        assert _resolve_source_url("[99]", bib) is None
+
+    def test_inline_url(self):
+        bib: dict = {}
+        url = _resolve_source_url("See https://example.com/report", bib)
+        assert url == "https://example.com/report"
+
+    def test_notfound_returns_none(self):
+        assert _resolve_source_url("not found", {}) is None
+
+    def test_empty_returns_none(self):
+        assert _resolve_source_url("", {}) is None
+
+    def test_dash_returns_none(self):
+        assert _resolve_source_url("—", {}) is None
+
+
+# ---------------------------------------------------------------------------
+# _name_found
+# ---------------------------------------------------------------------------
+
+
+class TestNameFound:
+    def test_vi_name_match(self):
+        assert _name_found("Nhiệt điện Phả Lại 1 is a coal plant", "Nhiệt điện Phả Lại 1", "")
+
+    def test_en_name_match(self):
+        assert _name_found("The Pha Lai power station", "", "Pha Lai")
+
+    def test_case_insensitive(self):
+        # Use ASCII English for case-insensitivity test — Vietnamese diacritics
+        # do not round-trip through str.lower() in all locales.
+        assert _name_found("PHU MY POWER CENTER", "", "Phu My")
+
+    def test_not_found(self):
+        assert not _name_found("Completely unrelated content", "Phả Lại", "Pha Lai")
+
+
+# ---------------------------------------------------------------------------
+# _capacity_matches
+# ---------------------------------------------------------------------------
+
+
+class TestCapacityMatches:
+    def test_exact_mw(self):
+        assert _capacity_matches("Total capacity: 440 MW", 440.0)
+
+    def test_within_tolerance(self):
+        assert _capacity_matches("1,200 MW installed", 1200.0)
+        # 10% below
+        assert _capacity_matches("1,080 MW", 1200.0)
+        # 10% above
+        assert _capacity_matches("1,320 MW", 1200.0)
+
+    def test_outside_tolerance(self):
+        assert not _capacity_matches("500 MW", 1200.0)
+
+    def test_gw_conversion(self):
+        # 1.2 GW = 1200 MWe claimed
+        assert _capacity_matches("1.2 GW plant", 1200.0)
+
+    def test_no_capacity_on_page(self):
+        assert not _capacity_matches("No numbers here", 440.0)
+
+
+# ---------------------------------------------------------------------------
+# _parse_capacity
+# ---------------------------------------------------------------------------
+
+
+class TestParseCapacity:
+    def test_plain_number(self):
+        assert _parse_capacity("440") == 440.0
+
+    def test_comma_thousands(self):
+        assert _parse_capacity("1,240") == 1240.0
+
+    def test_tilde_prefix(self):
+        assert _parse_capacity("~600") == 600.0
+
+    def test_invalid(self):
+        assert _parse_capacity("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# check_row — with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRow:
+    def test_no_source(self):
+        r = check_row("Nhà máy A", "Plant A", 440.0, "not found", {})
+        assert r["verdict"] == "NO_SOURCE"
+
+    def test_no_url(self):
+        r = check_row("Nhà máy A", "Plant A", 440.0, "Decision 500/QD-TTg", {})
+        assert r["verdict"] == "NO_URL"
+
+    def test_citation_key_missing_from_bib(self):
+        r = check_row("Nhà máy A", "Plant A", 440.0, "[99]", {})
+        assert r["verdict"] == "NO_URL"
+
+    def test_dry_run(self):
+        bib = {"1": "https://example.com"}
+        r = check_row("Nhà máy A", "Plant A", 440.0, "[1]", bib, dry_run=True)
+        assert r["verdict"] == "DRY_RUN"
+        assert "https://example.com" in r["detail"]
+
+    def test_resolved_name_and_capacity_pass(self):
+        bib = {"1": "https://greenfdc.org/pdp8/"}
+        page_body = "Pha Lai 1 power station, capacity 440 MW, coal."
+        mock_resp = MagicMock()
+        mock_resp.text = page_body
+        mock_resp.status_code = 200
+        with patch("aedist.check_provenance_urls.httpx.get", return_value=mock_resp):
+            r = check_row("Phả Lại 1", "Pha Lai 1", 440.0, "[1]", bib)
+        assert r["verdict"] == "PASS"
+        assert r["name_found"] == "yes"
+        assert r["capacity_match"] == "yes"
+
+    def test_resolved_name_not_found_fail(self):
+        bib = {"1": "https://greenfdc.org/pdp8/"}
+        page_body = "This page is about solar energy in Germany."
+        mock_resp = MagicMock()
+        mock_resp.text = page_body
+        mock_resp.status_code = 200
+        with patch("aedist.check_provenance_urls.httpx.get", return_value=mock_resp):
+            r = check_row("Phả Lại 1", "Pha Lai 1", 440.0, "[1]", bib)
+        assert r["verdict"] == "FAIL"
+        assert r["name_found"] == "no"
+
+    def test_http_404_unresolved(self):
+        bib = {"1": "https://greenfdc.org/pdp8/"}
+        mock_resp = MagicMock()
+        mock_resp.text = ""
+        mock_resp.status_code = 404
+        with patch("aedist.check_provenance_urls.httpx.get", return_value=mock_resp):
+            r = check_row("Phả Lại 1", "Pha Lai 1", 440.0, "[1]", bib)
+        assert r["verdict"] == "UNRESOLVED"
+
+    def test_network_error_unresolved(self):
+        import httpx as _httpx
+
+        bib = {"1": "https://greenfdc.org/pdp8/"}
+        with patch(
+            "aedist.check_provenance_urls.httpx.get", side_effect=_httpx.ConnectError("")
+        ):
+            r = check_row("Phả Lại 1", "Pha Lai 1", 440.0, "[1]", bib)
+        assert r["verdict"] == "UNRESOLVED"
+
+    def test_resolved_name_found_no_capacity(self):
+        """Pass when name found and claimed_mwe is None (no capacity to check)."""
+        bib = {"1": "https://example.com/report"}
+        page_body = "Pha Lai 1 plant history."
+        mock_resp = MagicMock()
+        mock_resp.text = page_body
+        mock_resp.status_code = 200
+        with patch("aedist.check_provenance_urls.httpx.get", return_value=mock_resp):
+            r = check_row("Phả Lại 1", "Pha Lai 1", None, "[1]", bib)
+        assert r["verdict"] == "PASS"
+        assert r["capacity_match"] == "n/a"
+
+    def test_name_found_capacity_fails(self):
+        """FAIL when name is on page but no capacity figure matches ±10%."""
+        bib = {"1": "https://example.com/report"}
+        page_body = "Pha Lai 1 capacity 50 MW (old units)."
+        mock_resp = MagicMock()
+        mock_resp.text = page_body
+        mock_resp.status_code = 200
+        with patch("aedist.check_provenance_urls.httpx.get", return_value=mock_resp):
+            r = check_row("Phả Lại 1", "Pha Lai 1", 440.0, "[1]", bib)
+        assert r["verdict"] == "FAIL"
+        assert r["capacity_match"] == "no"
+
+
+# ---------------------------------------------------------------------------
+# spot_check_run — dry_run (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestSpotCheckRun:
+    def test_dry_run_on_fixture(self, tmp_path):
+        md_file = tmp_path / "run.md"
+        md_file.write_text(_FULL_MD, encoding="utf-8")
+        result = spot_check_run(md_file, n=3, seed=0, dry_run=True)
+        assert result["n_sampled"] >= 1
+        # Rows with resolvable URLs → DRY_RUN; rows with missing bib key ([99]) → NO_URL
+        assert all(r["verdict"] in {"DRY_RUN", "NO_URL"} for r in result["rows"])
+        # No PASS in dry-run
+        assert result["n_pass"] == 0
+
+    def test_empty_on_missing_table(self, tmp_path):
+        md_file = tmp_path / "empty.md"
+        md_file.write_text("## No table here\n", encoding="utf-8")
+        result = spot_check_run(md_file)
+        assert result["n_sampled"] == 0
+        assert result["provenance_score"] is None
+
+    def test_skips_notfound_rows(self, tmp_path):
+        """Rows with 'not found' as Source 1 should not appear in the sample."""
+        # Only 1 citeable row (Phả Lại 1, [1]); Uong Bi and Van Phong 1 have issues
+        md_file = tmp_path / "run.md"
+        md_file.write_text(_FULL_MD, encoding="utf-8")
+        result = spot_check_run(md_file, n=10, seed=0, dry_run=True)
+        # The "not found" row (Uong Bi) should not be in sampled plants
+        sampled = result["sampled_plants"]
+        assert "Uong Bi TPP" not in sampled
+
+    def test_n_capped_at_candidates(self, tmp_path):
+        """When n > number of citeable rows, sample all citeable rows."""
+        md_file = tmp_path / "run.md"
+        md_file.write_text(_FULL_MD, encoding="utf-8")
+        result = spot_check_run(md_file, n=100, seed=0, dry_run=True)
+        # _FULL_MD has 3 rows with non-empty, non-notfound Source 1
+        # ([1], [2], [99]) but [99] has no bib entry → still included as candidate
+        assert result["n_sampled"] == result["n_candidates"]
+
+    def test_output_csv(self, tmp_path):
+        md_file = tmp_path / "run.md"
+        md_file.write_text(_FULL_MD, encoding="utf-8")
+        out_csv = tmp_path / "out.csv"
+        main(
+            [
+                "--md",
+                str(md_file),
+                "--output",
+                str(out_csv),
+                "--n",
+                "2",
+                "--dry-run",
+            ]
+        )
+        assert out_csv.exists()
+        text = out_csv.read_text(encoding="utf-8")
+        assert "verdict" in text
+        assert "DRY_RUN" in text
+
+    def test_json_output(self, tmp_path):
+        import json as _json
+
+        md_file = tmp_path / "run.md"
+        md_file.write_text(_FULL_MD, encoding="utf-8")
+        out_json = tmp_path / "out.json"
+        main(
+            [
+                "--md",
+                str(md_file),
+                "--json-output",
+                str(out_json),
+                "--n",
+                "2",
+                "--dry-run",
+            ]
+        )
+        assert out_json.exists()
+        data = _json.loads(out_json.read_text())
+        assert "provenance_score" in data
+        assert "rows" in data
+
+    def test_main_missing_md_exits(self, tmp_path):
+        with pytest.raises(SystemExit):
+            main(["--md", str(tmp_path / "nonexistent.md")])

--- a/tests/test_no_hardcoded_reference_path.py
+++ b/tests/test_no_hardcoded_reference_path.py
@@ -110,12 +110,15 @@ def test_config_default_reference_exists():
 
 
 def test_raw_snapshots_are_datestamped():
-    """All files in raw/ (except README.md, import.sh) must have -YYYY-MM-DD.ext pattern."""
+    """All files in raw/ (except README.md, import.sh) must have -YYYY-MM-DD pattern.
+
+    Accepts optional +descriptor suffix after the date (e.g. pipeline-2026-06-05+ext.ods).
+    """
     import re
 
     raw = REPO_ROOT / "data" / "reference" / "raw"
     exempt = {"README.md", "import.sh"}
-    pat = re.compile(r"-\d{4}-\d{2}-\d{2}\.[a-z0-9]+$")
+    pat = re.compile(r"-\d{4}-\d{2}-\d{2}([+][^.]+)?\.[a-z0-9]+$")
     undated = [f.name for f in raw.iterdir()
                if f.name not in exempt and not pat.search(f.name)]
     assert undated == [], f"raw/ files without capture datestamp: {undated}"

--- a/tickets/0281-provenance-spot-check-scorer.erg
+++ b/tickets/0281-provenance-spot-check-scorer.erg
@@ -3,6 +3,7 @@ Title: Automated provenance spot-check — verify N=10 source URLs per run
 Created: 2026-05-24
 Author: haduong
 Blocked-by: 0118
+Closed: implemented in PR #823
 
 --- log ---
 2026-05-24T14:30Z haduong created
@@ -11,6 +12,7 @@ Blocked-by: 0118
 2026-05-24T17:37Z HDMX-coding-agent note blocker 0276 closed — Blocked-by removed.
 2026-05-24T18:05Z HDMX-coding-agent note deferred post-conference and linked to 0118 — 0281 is now scoped as a lightweight companion metric to Phase 2 source-grounding adjudication, not a pre-conference standalone track.
 2026-05-27T20:59Z Claude untag deferred
+2026-06-08T19:22Z HDMX-coding-agent closed — implemented in PR #823
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0281-provenance-spot-check-scorer.erg

## Summary

- Adds `src/aedist/check_provenance_urls.py`: on-demand CLI that samples N=10 plant rows per run, resolves citation-key `Source 1` cells against the bibliography, HTTP-GETs each URL (10 s timeout, 1 retry), checks plant name presence and capacity ±10%, and emits a per-row CSV + aggregate JSON with `provenance_score = n_pass/n_sampled`
- 41 tests in `tests/test_check_provenance_urls.py` — all HTTP calls mocked, no network access in `make check-fast`
- Docs: provenance URL spot-check section added to `docs/scoring-contract.md`
- Not wired into the Makefile DAG (network dep would break clean-room builds)

Also fixes two pre-existing issues:
- Remove unused `names` variable in `data/reference/add_kien_luong.py` (ruff F841)
- Allow optional `+descriptor` after datestamp in `test_raw_snapshots_are_datestamped` to accept `pipeline-YYYY-MM-DD+extensions-as-plants.ods` naming

## Smoke test

```
uv run python -m aedist.check_provenance_urls \
  --md experiments/derived/arm1_flat/anthropic_run01.md \
  --n 5 --dry-run
```
Output: 58 candidates found, 5 URLs identified from bibliography entries (DRY_RUN).

## Test plan

- [x] `make check-fast` passes (41 new tests + full suite, 2 pre-existing failures unrelated)
- [x] Dry-run smoke test on `arm1_flat/anthropic_run01.md` succeeds
- [x] All HTTP interactions mocked in tests (`unittest.mock.patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)