### PR TITLE
ticket(0364): close — REJECT arms rename (WON'T-DO, documented non-finding)

### DIFF
--- a/tickets/0364-evaluate-exp2-arms-terminology-rename.erg
+++ b/tickets/0364-evaluate-exp2-arms-terminology-rename.erg
@@ -3,10 +3,12 @@ Title: Evaluate renaming the Exp2 mart "arms" terminology to the 2x2 cell labels
 Created: 2026-05-27
 Author: claude
 Label: deferred
+Closed: evaluated — REJECT: reader-facing figures and tables carry no armN labels; standard vocab + 254-occurrence blast radius + committed CSV data values make this a WON'T-DO
 
 --- log ---
 2026-05-27T00:00Z claude created — split out of 0362's scope revision; the mart "arms" rename is a separate, larger, lower-payoff refactor
 
+2026-06-08T19:39Z HDMX-coding-agent closed — evaluated — REJECT: reader-facing figures and tables carry no armN labels; standard vocab + 254-occurrence blast radius + committed CSV data values make this a WON'T-DO
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Evaluates the optional rename of Exp2 mart `arm1..arm4` vocabulary to 2×2 cell labels (1N/5N/1D/5D)
- Decision: **REJECT / WON'T-DO** — the ticket's own default reconsider-clause was not triggered
- Closes with a documented non-finding per the "Audit before instrumenting" workflow rule

## Findings

1. **No reader-facing armN exposure**: figure axes already use 2×2 cell labels (`_CONDITION_LABEL = {"arm1": "1N", ...}`); `tabulate_exp2_2x2.py` emits human labels ("Single query + docs" etc.) — not "arm1".
2. **Committed handoff data carries arm labels as data values**: `report/inputs/generated/sota_cross_eval_view.csv` column 1 contains `arm3`/`arm4` values — renaming invalidates the committed CSV and forces a mart rebuild.
3. **254 occurrences across 24 files** — high blast radius for zero reader-facing payoff.
4. **Standard vocabulary**: "arms" is correct experimental-design terminology; the 2×2 is the presentation layer.

## Test plan

- [x] No code changed — tickets-only PR, no `make check` needed
- [x] Ticket closed with `erg close` (Closed: header + log entry present)
- [x] ERG validation passed on commit

**Ticket:** tickets/0364-evaluate-exp2-arms-terminology-rename.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)