### PR TITLE
ticket(0384): close orphaned ticket — guard already shipped in PR #740

### DIFF
--- a/tickets/0384-mart-layer2-adherence-guard.erg
+++ b/tickets/0384-mart-layer2-adherence-guard.erg
@@ -2,12 +2,14 @@
 Title: Add Layer-2 mart adherence guard — schema field semantics + completeness
 Created: 2026-05-29
 Author: Claude
+Closed: guard shipped in PR #740 (2026-06-05); chain completed via 0385/0386/0431; all exit criteria met — orphaned-open ticket
 
 --- log ---
 2026-05-29T00:00Z Claude created — keystone guard for the mart audit redress (0383)
 
 2026-06-05T08:15Z HDMX-coding-agent note Layer-2 guard delivered as tests/test_exp2_mart_contract.py: 5 adherence tests. Finding #3 (class_trace/n_bib_entries) asserted via strict-xfail on _build_run_records source (code-contract, not stale committed mart) — bites today (real AssertionError under --runxfail), strict so 0385's wiring forces marker removal. Finding #1 mapping pinned (already fixed f7f5c4ea). Finding #2 dropped columns documented out-of-scope pending 0386. Zero changes to contention file exp2_mart.py.
 2026-06-05T10:55Z HDMX-coding-agent note blocker 0383 closed — Blocked-by removed.
+2026-06-08T19:43Z HDMX-coding-agent closed — guard shipped in PR #740 (2026-06-05); chain completed via 0385/0386/0431; all exit criteria met — orphaned-open ticket
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Closes the orphaned open ticket 0384. No implementation diff.

- The Layer-2 mart adherence guard (`tests/test_exp2_mart_contract.py`, 5 `@pytest.mark.adherence` tests) was delivered in PR #740 and merged 2026-06-05.
- The full 0383→0384→0385→0386→0431 chain is complete on `origin/main`.
- All exit criteria are ticked in the ticket body.
- `erg-pr-merge` did not fire on #740, leaving the ticket orphaned-open.

This PR is bookkeeping only — one file change (the `Closed:` header on the ticket).

**Ticket:** tickets/0384-mart-layer2-adherence-guard.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)