### PR TITLE
ticket(0360): add render.mk clean + root cleaner as P3 reproducibility oracle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@
 # replies only by explicitly invoking experiments/acquire.mk.
 
 .PHONY: test test-fast test-slow coverage lint check-fast check show-prompts \
-	report slides staleness world
+	report slides staleness world cleaner
 
 # --- Tests --------------------------------------------------------------------
 
@@ -141,3 +141,26 @@ world:
 	$(MAKE) -f $(RENDER_MK) all
 	$(MAKE) -C report
 	$(MAKE) -C slides
+
+# cleaner: content-diff reproducibility oracle for the P3 render phase.
+#
+# Removes every P3 render output (report/inputs/generated/**) whose source is
+# declared in render.mk's grouping-target variables, then regenerates them
+# from committed P2 outcomes. A non-empty `git diff` after regeneration means
+# a committed handoff artifact diverged from the data — the DAG is stale.
+# Never touches P2 sources (measurements.jsonl, mart, cross-eval CSVs) or
+# anything that requires an API call (P1 acquire).
+#
+# Usage (locally, or in a fresh checkout):
+#   make cleaner && git diff --exit-code -- report/inputs/generated/
+#
+# The `git diff --exit-code` is intentionally left to the caller:
+#   * in CI, `make cleaner` and the git-diff oracle are separate steps so
+#     the diff is visible in the log before the build fails;
+#   * locally, the caller may want to inspect the diff before deciding;
+#   * a combined "clean + regen + diff" single Make target would require
+#     the clean step, a sub-make, AND git invocation — three different tools
+#     in one recipe, with no way to surface the diff nicely.
+cleaner:
+	$(MAKE) -f $(RENDER_MK) clean
+	$(MAKE) -f $(RENDER_MK) all

--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -379,13 +379,22 @@ $(ANALYSIS_EXP2_WIKI_CSV) $(ANALYSIS_EXP2_WIKI_MACROS) &: \
 
 .PHONY: exp2-analysis-report exp1-analysis-figures report-tables report-figures chart-figures
 
-exp2-analysis-report: $(ANALYSIS_EXP2_REPORT_TARGETS) \
+RENDER_EXP2_ANALYSIS_REPORT := \
+	$(ANALYSIS_EXP2_REPORT_TARGETS) \
 	$(ANALYSIS_EXP2_2X2_TEX) $(ANALYSIS_EXP2_2X2_FR_TEX) \
 	$(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) \
-	$(ANALYSIS_SLIDE_MACROS)
+	$(ANALYSIS_SLIDE_MACROS) \
+	$(ANALYSIS_GEN)/stat_tests_arm1_vs_arm2.txt
 
-exp1-analysis-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES) $(ANALYSIS_EXP1_SPIDER_CLAUDE) \
-	$(ANALYSIS_EXP1_SPIDER_FAMILIES_FR) $(ANALYSIS_EXP1_SPIDER_CLAUDE_FR)
+exp2-analysis-report: $(RENDER_EXP2_ANALYSIS_REPORT)
+
+RENDER_EXP1_ANALYSIS_FIGURES := \
+	$(ANALYSIS_EXP1_SPIDER_FAMILIES) \
+	$(ANALYSIS_EXP1_SPIDER_CLAUDE) \
+	$(ANALYSIS_EXP1_SPIDER_FAMILIES_FR) \
+	$(ANALYSIS_EXP1_SPIDER_CLAUDE_FR)
+
+exp1-analysis-figures: $(RENDER_EXP1_ANALYSIS_FIGURES)
 
 # --- Report-side tables and figures (migrated from root Makefile by 0352) ---
 # These produce committed handoff artifacts under $(ANALYSIS_GEN). The root
@@ -543,7 +552,13 @@ exp3-fn-triage: $(ANALYSIS_EXP3_FN_TRIAGE_TEX)
 # Grouping targets — drive end-to-end regeneration of report-side handoff
 # artifacts. tab_self_consistency.tex and tab_per_run.tex are produced by the
 # `self-consistency` verb above (single producer, 0354 → migrated here 0410).
-report-tables: \
+#
+# DESIGN: the prerequisite lists are held in variables (RENDER_REPORT_TABLES,
+# RENDER_REPORT_FIGURES, RENDER_CHART_FIGURES) so the `clean` target below
+# can source its deletion set from the same vars — no hand-listed rm paths
+# that drift from the actual targets (ticket 0360).
+
+RENDER_REPORT_TABLES := \
 	$(ANALYSIS_GEN)/tab_decomposition.tex \
 	$(ANALYSIS_GEN)/tab_census.tex \
 	$(ANALYSIS_GEN)/macros.tex \
@@ -560,8 +575,14 @@ report-tables: \
 	$(ANALYSIS_GEN)/tab_status_difficulty.tex \
 	$(ANALYSIS_EXP2_WIKI_CSV)
 
-report-figures: $(ANALYSIS_EXP1_SPIDER_FAMILIES) $(ANALYSIS_EXP1_QUALITY_HEATMAP) \
+report-tables: $(RENDER_REPORT_TABLES)
+
+RENDER_REPORT_FIGURES := \
+	$(ANALYSIS_EXP1_SPIDER_FAMILIES) \
+	$(ANALYSIS_EXP1_QUALITY_HEATMAP) \
 	$(ANALYSIS_EXP1_SCREEN_VALID_CSV)
+
+report-figures: $(RENDER_REPORT_FIGURES)
 
 # --- Chart-data figures (migrated from root Makefile by 0370) -----------------
 # These produce committed handoff artifacts consumed by both report and slides.
@@ -689,11 +710,13 @@ $(ANALYSIS_GEN)/fig_spider_cross_exp.pdf: $(ANALYSIS_EXP1_CROSS_EVAL_CSV) $(ANAL
 	    --exp2 $(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
 	    --output $@
 
-chart-figures: \
+RENDER_CHART_FIGURES := \
 	$(ANALYSIS_GEN)/fig_direct_cost_quality.pdf \
 	$(ANALYSIS_GEN)/cost_quality.csv \
 	$(ANALYSIS_GEN)/fig_direct_p1_base.pdf \
+	$(ANALYSIS_GEN)/macros_p1_base.tex \
 	$(ANALYSIS_GEN)/fig_exp1_recognition_matrix.pdf \
+	$(ANALYSIS_GEN)/macros_exp1_matrix.tex \
 	$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_fr.pdf \
 	$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_strong.pdf \
 	$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_top.pdf \
@@ -708,6 +731,8 @@ chart-figures: \
 	$(ANALYSIS_GEN)/fig_scaling_curve.pdf \
 	$(ANALYSIS_GROUNDING_LADDER_FIG)
 
+chart-figures: $(RENDER_CHART_FIGURES)
+
 # --- Full-phase aggregate (P3 render surface) -------------------------------
 # `all` rebuilds every committed handoff artifact this phase produces, so the
 # root `world`/`staleness` entries (tracker 0406 S5, ticket 0415) drive the
@@ -720,3 +745,54 @@ chart-figures: \
 all: report-tables report-figures chart-figures self-consistency \
 	exp1-cost-summary exp1-reasoning-topup \
 	exp2-analysis-report exp1-analysis-figures
+
+# --- Clean: remove all P3 render outputs (ticket 0360) ----------------------
+# The deletion set is sourced from the SAME variables used by the grouping
+# targets above — never a hand-listed glob that could drift from actual targets
+# and delete the FROZEN tab_decomposition_fix.tex (which has no rule, so it
+# appears in no variable here). Also removes P3-internal intermediates
+# (variance_decomposition.json, tradeoff.csv) whose only consumers are render
+# targets; they are NOT P2 outcomes (those never get cleaned — see ticket body).
+#
+# Post-clean oracle: make -f experiments/render.mk all && git diff --exit-code
+# A non-empty diff means a committed handoff artifact is out of sync with
+# the data (timestamp-gated world misses this because it sees existing files as
+# up-to-date; forcing regeneration reveals the divergence).
+#
+# Usage:
+#   make -f experiments/render.mk clean   # P3 clean alone
+#   make cleaner                          # root entry: P3 clean + oracle check
+
+# (Reuse the grouping-target vars — clean set stays in sync with all targets.)
+RENDER_EXP2_ANALYSIS := $(RENDER_EXP2_ANALYSIS_REPORT)
+RENDER_EXP1_ANALYSIS := $(RENDER_EXP1_ANALYSIS_FIGURES)
+
+RENDER_SELF_CONSISTENCY := $(ANALYSIS_SC_TEX) $(ANALYSIS_SC_PERRUN)
+
+RENDER_EXP1_EXTRAS := $(ANALYSIS_EXP1_COST_TEX) $(ANALYSIS_EXP1_TOPUP_TEX)
+
+# P3-internal intermediates: produced by render.mk rules, consumed only by
+# later render.mk rules — not P2 outcomes (no rule in score.mk produces them).
+# Also includes ANALYSIS_EXP2_2X2_CSV, which lives under ANALYSIS_DERIVED_DIR
+# (not ANALYSIS_GEN) but is a P3 render output produced by the 2x2 table rule.
+RENDER_INTERMEDIATES := \
+	$(ANALYSIS_VARIANCE_JSON) \
+	$(ANALYSIS_VERIFICATION_TRADEOFF) \
+	$(ANALYSIS_EXP2_2X2_CSV) \
+	$(ANALYSIS_REF_COUNT_CSV) \
+	$(ANALYSIS_EXP2_WIKI_MACROS)
+
+RENDER_CLEAN_FILES := \
+	$(RENDER_REPORT_TABLES) \
+	$(RENDER_REPORT_FIGURES) \
+	$(RENDER_CHART_FIGURES) \
+	$(RENDER_EXP2_ANALYSIS) \
+	$(RENDER_EXP1_ANALYSIS) \
+	$(RENDER_SELF_CONSISTENCY) \
+	$(RENDER_EXP1_EXTRAS) \
+	$(RENDER_INTERMEDIATES)
+
+.PHONY: clean
+clean:
+	@echo 'render.mk clean: removing P3 render outputs (keeping P2 sources: measurements.jsonl, mart, cross-eval CSVs)'
+	rm -f $(RENDER_CLEAN_FILES)

--- a/tests/test_makefile_dag.py
+++ b/tests/test_makefile_dag.py
@@ -441,6 +441,65 @@ def test_no_p3_to_p3_side_output_edges() -> None:
 
 
 @pytest.mark.adherence
+def test_clean_never_lists_runs_floor() -> None:
+    """render.mk RENDER_CLEAN_FILES must not include any P2 outcome.
+
+    The clean target (ticket 0360) is the P3 reproducibility oracle: it deletes
+    P3 render outputs so that `make -f render.mk all` is forced to regenerate
+    them from committed P2 sources. If RENDER_CLEAN_FILES ever lists a P2
+    outcome (measurements.jsonl, *.record.json, the Exp2 mart, or a cross-eval
+    CSV), a `make cleaner` run would delete experiment data that requires API
+    calls to recreate.
+
+    This guard prevents silent regression as new paths are added to the
+    RENDER_CLEAN_FILES variable.
+    """
+    render_mk = REPO_ROOT / "experiments" / "render.mk"
+    assert render_mk.is_file(), f"render.mk not found at {render_mk}"
+
+    # Parse variables, then expand RENDER_CLEAN_FILES.
+    variables, _ = _parse_to_vars_rules(render_mk)
+    clean_files_raw = variables.get("RENDER_CLEAN_FILES", "")
+    clean_files = _expand(clean_files_raw, variables).split()
+
+    # P2 outcome floors: never in a clean set.
+    # Patterns (repo-root-relative, case-sensitive):
+    # - measurements.jsonl (mart v0, transitional — do NOT move or rename)
+    # - experiments/derived/exp2_mart.jsonl
+    # - experiments/derived/sota_cross_eval.csv
+    # - experiments/derived/exp1_cross_eval.csv
+    # - *.record.json anywhere under experiments/ or archive/
+    p2_outcome_names = {
+        "measurements.jsonl",
+        "exp2_mart.jsonl",
+        "sota_cross_eval.csv",
+        "exp1_cross_eval.csv",
+    }
+
+    def _is_p2_outcome(path: str) -> bool:
+        basename = os.path.basename(path)
+        if basename.endswith(".record.json"):
+            return True
+        # Exact basenames that are P2 outcomes (regardless of directory).
+        # Cross-eval CSVs live under experiments/derived/ — guard by basename
+        # since the path variables expand to that directory.
+        if basename in p2_outcome_names:
+            return True
+        return False
+
+    violations = [f for f in clean_files if _is_p2_outcome(f)]
+    detail = "\n".join(f"  - {v}" for v in sorted(violations))
+    assert not violations, (
+        "RENDER_CLEAN_FILES in experiments/render.mk lists P2 outcome(s) "
+        "(ticket 0360: clean must stop at the P3 render floor, never touch "
+        "data that requires API calls to regenerate):\n"
+        f"{detail}\n\n"
+        "Remove these paths from RENDER_CLEAN_FILES — they are P2 sources, "
+        "not P3 render outputs."
+    )
+
+
+@pytest.mark.adherence
 def test_no_empty_outputs_wildcard_with_nonempty_archive_sibling() -> None:
     """$(wildcard experiments/outputs/...) empty + non-empty archive sibling → fail.
 

--- a/tickets/0360-cleaner-target-reproducibility-oracle.erg
+++ b/tickets/0360-cleaner-target-reproducibility-oracle.erg
@@ -2,6 +2,7 @@
 Title: Add per-workpackage clean + project cleaner as a content-diff reproducibility oracle
 Created: 2026-05-27
 Author: claude
+Closed: implemented: render.mk clean target, root Makefile cleaner, adherence test in test_makefile_dag.py; make check passes
 
 --- log ---
 2026-05-27T00:00Z claude created
@@ -9,6 +10,7 @@ Author: claude
 
 2026-05-28T12:54Z HDMX-coding-agent note blocker 0352 closed — Blocked-by removed.
 2026-06-04T12:11Z claude note 0406 S5 landed make world — the oracle is now: make world && git diff --exit-code (CI-side content diff). Re-point implementation here.
+2026-06-08T20:05Z HDMX-coding-agent closed — implemented: render.mk clean target, root Makefile cleaner, adherence test in test_makefile_dag.py; make check passes
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- `experiments/render.mk` gains a `clean` PHONY target that removes all P3 render outputs (figures, tables, macros under `report/inputs/generated/`) plus P3-internal intermediates (`derived/variance_decomposition.json`, `derived/verification/tradeoff.csv`, `experiments/derived/tab_exp2_2x2.csv`), but never touches P2 outcomes (measurements.jsonl, mart, cross-eval CSVs)
- The deletion set is sourced from the same variables used by the grouping targets (`RENDER_REPORT_TABLES`, `RENDER_REPORT_FIGURES`, `RENDER_CHART_FIGURES`, `RENDER_EXP2_ANALYSIS_REPORT`, `RENDER_EXP1_ANALYSIS_FIGURES`) — no hand-listed globs, so the clean set auto-tracks future target additions. The FROZEN `tab_decomposition_fix.tex` is excluded by construction (no rule → no variable → not deleted).
- Root `Makefile` gains `make cleaner` = render.mk clean + render.mk all, enabling the content-diff oracle: `make cleaner && git diff --exit-code -- report/inputs/generated/`
- Adherence test `test_clean_never_lists_runs_floor` in `tests/test_makefile_dag.py` guards that `RENDER_CLEAN_FILES` never lists P2 outcomes
- `stat_tests_arm1_vs_arm2.txt` added to `exp2-analysis-report` (it had a producer rule but was absent from `all`, causing a persistent `git diff` after clean+regen)

## Test plan

- [x] `make check` passes (2102 passed)
- [x] `make -f experiments/render.mk clean -n` dry-run shows only P3 outputs
- [x] `make cleaner -n` dry-run shows clean + regen sequence
- [x] P2 outcomes (measurements.jsonl, *.record.json, mart/cross-eval CSVs) absent from clean list
- [x] FROZEN `tab_decomposition_fix.tex` absent from clean list
- [x] New adherence test `test_clean_never_lists_runs_floor` passes

**Ticket:** tickets/0360-cleaner-target-reproducibility-oracle.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)