### PR TITLE
plan(0297): decompose measurements.jsonl retirement into 4 child tickets

### DIFF
--- a/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
+++ b/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
@@ -9,6 +9,7 @@ Label: deferred
 2026-05-25T11:00Z haduong note Architectural direction set in conversation: mart (exp2_mart.jsonl) is the v2 successor to measurements.jsonl; retirement is post-talk
 
 2026-05-25T12:22Z HDMX-coding-agent tag deferred
+2026-06-08T12:00Z HDMX-coding-agent note Converted to tracking ticket. Child tickets created: 0475 (architect question + schema), 0476 (exp1 adapter + equivalence), 0477 (port consumers), 0478 (delete old stack). This tracker stays open until all children merge and make check passes.
 --- body ---
 ## Context
 
@@ -35,3 +36,83 @@ single source of truth for all experiments (exp1 through exp3+), and the old sta
 - [ ] All figures/tables that currently read `measurements.jsonl` ported to read the mart
 - [ ] `measurements.jsonl`, `evaluate.py assemble`, `schema.RunRecord` deleted
 - [ ] `make check` passes with no reference to the old stack
+
+## Tracking: child tickets
+
+This is a tracking ticket. Children must land in dependency order:
+
+| ID | Title | Status |
+|----|-------|--------|
+| 0475 | Architect question: generalize vs shoehorn + schema design | open |
+| 0476 | Exp1 adapter + mart equivalence test | blocked on 0475 |
+| 0477 | Port reporting consumers from measurements.jsonl to mart | blocked on 0476 |
+| 0478 | Delete old stack (measurements.jsonl, evaluate.py assemble, RunRecord) | blocked on 0477 |
+
+Tracker closes only after 0478 merges and a final `make check` confirms no old-stack references remain.
+
+## Architectural question (must resolve before 0475)
+
+The current mart is named `exp2_mart` (schema v3). Retirement means making it the
+single source of truth for exp1 through exp3+. The author must answer:
+
+> **Generalize or shoehorn?**
+> - *Generalize*: rename `exp2_mart.py` → `mart.py`, rename schema `"exp2_mart"` → `"mart"`,
+>   add an `Exp1RunMartRecord` record kind (no arm, single turn, method=direct).
+> - *Shoehorn*: reuse `exp2_mart` schema as-is, mapping exp1 arms to a synthetic arm value.
+>
+> Generalize is architecturally cleaner (the ticket's stated goal is "all experiments").
+> Shoehorn risks silent data corruption if exp1 fields don't fit exp2 field semantics.
+
+The exp2_mart schema currently stores **ratios** in score_summary (f1, coverage, precision
+as MetricValue), not raw counts (tp/fp/fn). The ticket lists raw counts as required.
+The raw counts must be added to ScoreSummary before an exp1 adapter is possible.
+
+## Key files
+
+- `src/aedist/exp2_mart.py` — current mart schema (v3, exp2-named)
+- `src/aedist/schema.py` — RunRecord and related classes (531 lines, to be deleted)
+- `src/aedist/measurements.py` — sole read interface (253 lines, to be deleted)
+- `src/aedist/evaluate.py` — `assemble` subcommand writes measurements.jsonl (to be deleted)
+- `experiments/derived/score.mk` — builds measurements.jsonl and exp2_mart.jsonl
+- `experiments/derived/exp2_mart.jsonl` — 80 run + 80 score records (exp2 only)
+- `measurements.jsonl` — 669 records (exp1 + exp2 + exp3, live as of 2026-06-08)
+
+## Consumer inventory (things that read measurements.jsonl / RunRecord)
+
+These must all be ported before deletion:
+
+Scripts that call `load_metrics()` or `load()`:
+- `src/aedist/select_models.py`
+- `src/aedist/plot_scaling_curve.py`
+- `src/aedist/tabulate_comparaison.py`
+- `src/aedist/tabulate_relances.py`
+- `src/aedist/tabulate_self_consistency.py`
+- `src/aedist/variance_decomposition.py`
+- `src/aedist/exp1_census.py`
+- `src/aedist/plot_method_convergence.py`
+- `src/aedist/plot_regimes_scatter.py`
+- `src/aedist/tabulate_census_macros.py`
+- `src/aedist/tabulate_cost_quality.py`
+- `src/aedist/exp1_cost_quality.py`
+- `src/aedist/tabulate_macros.py`
+- `src/aedist/tabulate_census.py`
+- `src/aedist/tabulate_decomposition.py`
+- `src/aedist/tabulate_exp1_cost_summary.py`
+- `src/aedist/tabulate_reconciliation.py`
+
+Collection-side code that builds RunRecord (must be rewritten, not just ported):
+- `src/aedist/adapter_base.py`
+- `src/aedist/adapter_qwen_dashscope.py`
+- `src/aedist/query_anthropic.py`
+- `experiments/sota/exp2_interactive_smoke.py`
+- (other query_*.py and adapter_*.py files)
+
+Tests that reference RunRecord or records_to_metrics (289 occurrences total):
+- `tests/test_measurements.py`
+- `tests/test_measurements_agent_fields.py`
+- `tests/test_worker.py`
+- `tests/test_evaluate.py`
+- `tests/test_harness.py`
+- `tests/test_tabulate_macros.py`
+- `tests/test_tabulate_decomposition.py`
+- `tests/test_plot_cost_quality.py`

--- a/tickets/0475-mart-v2-architecture-schema-design.erg
+++ b/tickets/0475-mart-v2-architecture-schema-design.erg
@@ -1,0 +1,73 @@
+%erg 0.1
+Title: Mart v2 architecture decision + schema extension (tracker: 0297)
+Created: 2026-06-08
+Author: HDMX-coding-agent
+Blocked-by: 0297
+
+--- log ---
+2026-06-08T12:00Z HDMX-coding-agent created
+--- body ---
+## Context
+
+0297 (tracking ticket) wants to retire `measurements.jsonl` in favour of a unified mart.
+Before any code can land, two architectural questions must be resolved by the author:
+
+1. **Generalize or shoehorn?**
+   The current mart is named `exp2_mart` (schema v3, `_MART_SCHEMA_NAME = "exp2_mart"`).
+   - *Generalize*: rename to `mart.py`, schema name `"mart"`, add experiment-generic
+     record kinds. This is the clean approach for "all experiments" scope.
+   - *Shoehorn*: keep `exp2_mart` naming, map exp1 to a synthetic arm value.
+   Generalize is architecturally correct per the ticket's stated goal.
+
+2. **Raw counts in ScoreSummary?**
+   The ticket lists `result_summary.tp / fp / fn` (raw counts) as required fields.
+   The current `ScoreSummary` stores only ratios (f1, coverage, precision as
+   `MetricValue`). Before an exp1 adapter can work, raw counts must be added.
+   Where do they go: on `ScoreSummary` directly, or on a new `RawCountsSummary`?
+
+## Relevant files
+
+- `src/aedist/exp2_mart.py` — current mart schema (531 lines)
+- `src/aedist/schema.py` — RunRecord source of truth for what must be absorbed
+- `experiments/derived/score.mk` — builds both mart and measurements.jsonl
+- `experiments/derived/exp2_mart.jsonl` — 80 run + 80 score records
+
+## Actions
+
+1. Author answers: generalize vs shoehorn, raw counts placement.
+2. Once decided: rename `exp2_mart.py` if generalizing (update all imports, Makefile).
+3. Add raw count fields to `ScoreSummary` (tp, fp, fn as `int | None`).
+4. Bump `_MART_SCHEMA_VERSION` to 4 with changelog comment.
+5. Update `build_exp2_mart.py` to populate raw counts from scorer output.
+
+## Test
+
+```python
+def test_score_summary_has_raw_counts():
+    from aedist.exp2_mart import ScoreSummary
+    s = ScoreSummary(n_rows=10, tp=7, fp=1, fn=3)
+    assert s.tp == 7
+    assert s.fp == 1
+    assert s.fn == 3
+```
+
+## Verification
+
+- [ ] Author has confirmed generalize vs shoehorn decision (written in ticket log).
+- [ ] `ScoreSummary` carries `tp`, `fp`, `fn` as `int | None` fields.
+- [ ] Schema version bumped, changelog comment updated.
+- [ ] `build_exp2_mart.py` populates raw counts.
+- [ ] `make check` passes.
+
+## Invariants
+
+- `exp2_mart.jsonl` format must not break existing consumers (`check_exp2_mart_parity.py`).
+- Schema version bump is mandatory when adding fields (enforced by `model_config extra="forbid"`).
+- Do not touch `measurements.jsonl`, `RunRecord`, or `evaluate.py assemble` in this PR.
+
+## Exit criteria
+
+- Architecture decision is documented (in ticket log or commit message).
+- `ScoreSummary` carries `tp`, `fp`, `fn`.
+- `make check` passes.
+- 0476 can proceed without further schema changes.

--- a/tickets/0476-mart-v2-exp1-adapter-equivalence.erg
+++ b/tickets/0476-mart-v2-exp1-adapter-equivalence.erg
@@ -1,0 +1,79 @@
+%erg 0.1
+Title: Exp1 adapter + mart equivalence test (tracker: 0297)
+Created: 2026-06-08
+Author: HDMX-coding-agent
+Blocked-by: 0475
+
+--- log ---
+2026-06-08T12:00Z HDMX-coding-agent created
+--- body ---
+## Context
+
+After 0475 resolves the architecture and schema, this ticket builds the exp1 adapter
+that reads `exp1_batch2/*.json` (RunRecord-shaped raw outputs) and writes mart records.
+This is the safety rail: prove the mart can represent exp1 data before porting consumers.
+
+The equivalence test is the critical deliverable: mart-derived exp1 metrics must match
+measurements.jsonl values run-for-run before any consumer is migrated.
+
+## Relevant files
+
+- `src/aedist/exp2_mart.py` (or `mart.py` if renamed) — mart schema (post-0475)
+- `src/aedist/measurements.py` — reference metrics for equivalence test
+- `src/aedist/evaluate.py` — `assemble` command writes measurements.jsonl (source of RunRecord)
+- `experiments/derived/exp2_mart.jsonl` — existing mart (exp2 only, 80 run + 80 score)
+- `experiments/derived/score.mk` — build pipeline
+
+## Scope
+
+Exp1 runs: `experiments/derived/exp1_batch2/` (70 runs, single-turn, no arm, method=direct).
+The mart record kind for exp1 runs must map:
+- `method=direct` → `arm` field (the decision from 0475 determines the value)
+- single turn → `run_summary.turns = 1`
+- `result_summary.tp/fp/fn` → `ScoreSummary.tp/fp/fn` (added in 0475)
+- `resource_use.cost_usd` / `wall_s` → `RunSummary.cost_usd` / `wall_s`
+
+## Actions
+
+1. Write `src/aedist/build_exp1_mart.py` — reads exp1_batch2/*.record.json,
+   emits mart records to `experiments/derived/exp1_mart.jsonl`.
+2. Add `experiments/derived/exp1_mart.jsonl` target to `score.mk`.
+3. Write equivalence test in `tests/test_mart_exp1_equivalence.py`:
+   - load exp1 mart records + measurements.jsonl exp1 subset
+   - compare f1, coverage, precision, n_matched, n_missed, n_hallucinated per run
+   - assert max absolute difference < 0.0001 (float rounding tolerance)
+
+## Test (write first — TDD red step)
+
+```python
+# tests/test_mart_exp1_equivalence.py
+import pytest
+
+@pytest.mark.slow
+def test_exp1_mart_matches_measurements_jsonl():
+    """Mart exp1 metrics must match measurements.jsonl for every run."""
+    from aedist.measurements import load_metrics
+    # Load exp1 mart once build_exp1_mart.py exists
+    # Compare f1, coverage, precision, n_matched, n_missed, n_hallucinated
+    # per run_id match
+    pass  # Replace with real assertions after adapter exists
+```
+
+## Verification
+
+- [ ] `experiments/derived/exp1_mart.jsonl` exists and has 70 records.
+- [ ] Equivalence test passes (all metrics within 0.0001 tolerance).
+- [ ] `make check` passes.
+- [ ] `measurements.jsonl` is NOT modified or deleted by this PR.
+
+## Invariants
+
+- `measurements.jsonl` stays intact — this PR only adds the mart parallel.
+- No consumer code is ported yet (that's 0477).
+- Schema version stable (no changes after 0475).
+
+## Exit criteria
+
+- `exp1_mart.jsonl` exists with 70 exp1 records.
+- Equivalence test demonstrates mart == measurements.jsonl for exp1 metrics.
+- 0477 can safely replace measurements.jsonl readers with mart readers.

--- a/tickets/0477-mart-v2-port-reporting-consumers.erg
+++ b/tickets/0477-mart-v2-port-reporting-consumers.erg
@@ -1,0 +1,80 @@
+%erg 0.1
+Title: Port all reporting consumers from measurements.jsonl to mart (tracker: 0297)
+Created: 2026-06-08
+Author: HDMX-coding-agent
+Blocked-by: 0476
+
+--- log ---
+2026-06-08T12:00Z HDMX-coding-agent created
+--- body ---
+## Context
+
+After 0476 proves the exp1 mart is equivalent to measurements.jsonl, this ticket
+ports the 17 reporting scripts to read from the mart. The old stack is NOT deleted
+yet — both run in parallel until all consumers are green, then 0478 deletes.
+
+This ticket may need to be split further if the consumer surface is too large.
+The inventory is:
+
+## Relevant files
+
+Consumers to port (all read `measurements.jsonl` via `load_metrics()` or `load()`):
+- `src/aedist/select_models.py`
+- `src/aedist/plot_scaling_curve.py`
+- `src/aedist/tabulate_comparaison.py`
+- `src/aedist/tabulate_relances.py`
+- `src/aedist/tabulate_self_consistency.py`
+- `src/aedist/variance_decomposition.py`
+- `src/aedist/exp1_census.py`
+- `src/aedist/plot_method_convergence.py`
+- `src/aedist/plot_regimes_scatter.py`
+- `src/aedist/tabulate_census_macros.py`
+- `src/aedist/tabulate_cost_quality.py`
+- `src/aedist/exp1_cost_quality.py`
+- `src/aedist/tabulate_macros.py`
+- `src/aedist/tabulate_census.py`
+- `src/aedist/tabulate_decomposition.py`
+- `src/aedist/tabulate_exp1_cost_summary.py`
+- `src/aedist/tabulate_reconciliation.py`
+
+Collection-side code that constructs RunRecord (must be rewritten, not just ported):
+- `src/aedist/adapter_base.py`
+- `src/aedist/adapter_qwen_dashscope.py`
+- `src/aedist/query_anthropic.py`
+- Other `query_*.py` and `adapter_*.py` files
+
+Test files that reference RunRecord or records_to_metrics:
+- `tests/test_measurements.py` (replace with mart-equivalent tests)
+- `tests/test_measurements_agent_fields.py`
+- `tests/test_worker.py`
+- `tests/test_evaluate.py`
+- `tests/test_harness.py`
+- `tests/test_tabulate_macros.py`
+- `tests/test_tabulate_decomposition.py`
+- `tests/test_plot_cost_quality.py`
+
+## Actions
+
+1. Assess: may need to split into sub-tickets (e.g. reporting-only vs collection-side).
+   Collection-side is higher risk — RunRecord is used at write time by adapters.
+2. For each reporting consumer: replace `load_metrics()` → mart reader function.
+3. Run golden-output tests for each ported figure/table (no visual regression).
+4. For collection-side: design the mart-write path (adapter emits mart record instead of RunRecord).
+
+## Verification
+
+- [ ] All 17 reporting scripts ported.
+- [ ] Golden-output tests pass (figures/tables produce identical results).
+- [ ] `make check` passes.
+- [ ] `measurements.jsonl` is NOT deleted yet.
+
+## Invariants
+
+- No figures or tables may change values during porting (equivalence test in 0476 is the guard).
+- Collection-side changes must preserve backward compat until 0478 deletes.
+
+## Exit criteria
+
+- All consumers in inventory above read from mart, not measurements.jsonl.
+- `make check` passes.
+- 0478 can safely delete the old stack.

--- a/tickets/0478-mart-v2-delete-old-stack.erg
+++ b/tickets/0478-mart-v2-delete-old-stack.erg
@@ -1,0 +1,60 @@
+%erg 0.1
+Title: Delete old stack: measurements.jsonl, evaluate.py assemble, RunRecord (tracker: 0297)
+Created: 2026-06-08
+Author: HDMX-coding-agent
+Blocked-by: 0477
+
+--- log ---
+2026-06-08T12:00Z HDMX-coding-agent created
+--- body ---
+## Context
+
+Final step of the retirement (0297 tracker). After 0477 ports all consumers, this
+ticket deletes the old stack. This is the riskiest step — deletion is irreversible.
+Run `make check` and a full grep audit before committing.
+
+## Relevant files
+
+To delete:
+- `measurements.jsonl` (top-level, 669 records — data already in mart)
+- `src/aedist/evaluate.py` `assemble` subcommand (the only path that writes measurements.jsonl)
+- `src/aedist/schema.py` `RunRecord` class and associated infrastructure
+- `src/aedist/measurements.py` (entire module — replaced by mart reader)
+- `experiments/derived/score.mk` targets that build measurements.jsonl
+
+Tests to delete/replace:
+- `tests/test_measurements.py`
+- `tests/test_measurements_agent_fields.py`
+- Any test that imports from `aedist.measurements` or `aedist.schema.RunRecord`
+
+## Actions
+
+1. Grep audit: `grep -rn "measurements.jsonl\|RunRecord\|records_to_metrics" --include="*.py" --include="*.mk" --include="Makefile" .`
+   Confirm zero hits (excluding archive/ and worktrees/).
+2. Delete `measurements.jsonl` from git.
+3. Delete `src/aedist/measurements.py`.
+4. Remove `RunRecord`, `Method`, `MethodParams`, `ResourceUse`, `ResultSummary` from `schema.py`
+   (or delete `schema.py` if nothing else uses it).
+5. Remove `assemble` subcommand from `evaluate.py`.
+6. Remove `measurements.jsonl` target from `score.mk`.
+7. Delete or rewrite `tests/test_measurements.py` and `tests/test_measurements_agent_fields.py`.
+8. Run `make check` — must pass clean.
+
+## Verification
+
+- [ ] `grep -rn "measurements.jsonl\|RunRecord\|records_to_metrics" src/ tests/ experiments/` → zero hits.
+- [ ] `make check` passes.
+- [ ] No report figure or table value changed (verify against golden outputs from 0477).
+- [ ] Tracking ticket 0297 closes after this PR merges.
+
+## Invariants
+
+- Deletion is LAST — only after all consumers are ported and green (0477 done).
+- Do not delete `evaluate.py` subcommands other than `assemble` — other verbs remain.
+- `schema.py` may retain non-RunRecord classes (Plant, FuelType, PlantStatus, etc.).
+
+## Exit criteria
+
+- Zero grep hits for old-stack symbols in src/, tests/, experiments/ (excluding archive/).
+- `make check` passes.
+- 0297 tracker can be closed.


### PR DESCRIPTION
## Summary

- Converts ticket 0297 (retire measurements.jsonl → mart v2) from a single monolithic ticket into a tracking ticket with 4 sequenced children
- Files child tickets 0475–0478 covering the full migration path
- Surfaces an architectural decision that must be resolved by the author before code can land

## Why this PR

0297 is a whole-pipeline migration with 669 live RunRecords, 17 reporting consumers, 289 RunRecord usages across source + tests, and collection-side adapters. It cannot land in a single PR:
- `RunRecord` is both the ingestion type (adapters build it) and the reporting type (consumers read it)
- `exp2_mart` schema stores ratios only; raw `tp/fp/fn` counts needed for exp1 compatibility are missing
- Deleting the old stack before all consumers are ported would break `make check` with no recovery path inside the PR
- Active manuscript sessions are writing to main.md/figures concurrently — a 20-file migration PR is a collision hazard

## Child ticket sequence

| ID | Title | Blocker |
|----|-------|---------|
| 0475 | Architect decision + schema extension (raw counts in ScoreSummary) | Author must answer generalize vs shoehorn |
| 0476 | Exp1 adapter + mart equivalence test | blocked on 0475 |
| 0477 | Port all reporting consumers | blocked on 0476 |
| 0478 | Delete old stack | blocked on 0477 |

## Architectural question for the author

The current mart is named `exp2_mart` (schema v3). Retirement means making it the source of truth for exp1–exp3+. Please confirm:

> **Generalize or shoehorn?**
> - *Generalize*: rename `exp2_mart.py` → `mart.py`, schema name `"exp2_mart"` → `"mart"`, add an `Exp1RunMartRecord` kind
> - *Shoehorn*: reuse existing schema, map exp1 to a synthetic arm value
>
> Generalize is cleaner for "all experiments" scope. Shoehorn risks semantic mismatches.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)