### PR TITLE
ticket(0401): Level enum, derive_reference_level, taxonomy audit

### DIFF
--- a/src/aedist/config.py
+++ b/src/aedist/config.py
@@ -25,6 +25,13 @@ GEM_THERMAL_REFERENCE_CSV = (
     _REPO_ROOT / "data" / "reference" / "gem_thermal.csv"
 )
 
+# Vietnam thermal units release (v2) — unit-grain CSV produced by extract_ods.py.
+# Carries three-column address (complex/plant/unit) and pre-assigned `level`.
+# Primary source for derive_reference_level() (ticket 0401).
+VN_THERMAL_UNITS_RELEASE_CSV = (
+    _REPO_ROOT / "data" / "reference" / "vietnam_thermal_units_v2.csv"
+)
+
 # Vietnam thermal master snapshot (pipeline.ods) — the pinned ODS capture
 # from the author's "Market report on Gas to Power" master spreadsheet.
 # Datestamped immutable; extraction reads this to produce v2 releases.

--- a/src/aedist/reference_level.py
+++ b/src/aedist/reference_level.py
@@ -1,0 +1,212 @@
+"""Derive and audit granularity levels for the v2 reference dataset.
+
+The v2 unit-grain CSV (vietnam_thermal_units_v2.csv) carries three address
+columns: complex, plant, unit.  The Level for each row is the finest non-empty
+address column:
+
+    unit set     → Level.UNIT
+    plant set    → Level.PLANT    (unit empty)
+    complex set  → Level.COMPLEX  (plant and unit empty)
+    all empty    → Level.UNKNOWN
+
+This derivation exactly reconstructs the pre-assigned `level` column
+already present in the v2 CSV (verified: 100 % match across 258 rows).
+The function is a cross-check and a forward-compatible path for new rows.
+
+Taxonomy audit (tickets 0401 / 0402 gate):
+
+Checks three capacity caps against the derived levels on the v2 reference:
+  (a) every operating/constructing Plant row has capacity ≤ 1600 MW
+  (b) every Unit row has capacity ≤ 1350 MW
+  (c) Complex rows carry the highest capacities (> 3200 MW tail)
+
+Audit passes when caps (a) and (b) hold; (c) is informational only.
+If either cap is violated the audit returns a non-finding with diagnostics
+and does not raise — the caller decides whether to treat as hard error.
+
+Ticket 0401.
+"""
+
+import csv
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .config import VN_THERMAL_UNITS_RELEASE_CSV
+from .schema import Level
+
+logger = logging.getLogger(__name__)
+
+# Statuses in v2 unit CSV that map to "operational or constructing"
+# (numeric-prefix vocab from extract_ods.py: "5 construction", "6 operating")
+_OPERATIONAL_STATUSES = frozenset({"5 construction", "6 operating"})
+
+# Capacity caps (MW) — domain knowledge, ticket 0401
+_UNIT_CAP_MW = 1350.0       # world-record single shaft; VN alert above 700
+_PLANT_OP_CAP_MW = 1600.0   # operating/constructing plant ceiling
+_COMPLEX_FLOOR_MW = 3200.0  # complex threshold (informational)
+
+
+def derive_level_from_address(
+    complex_col: str,
+    plant_col: str,
+    unit_col: str,
+) -> Level:
+    """Return the Level for one row given its three address columns.
+
+    Rule: finest non-empty address column wins.
+    ``Block`` is not derivable from address columns alone (requires CCGT
+    multi-shaft knowledge not currently in the reference); it remains
+    available for model-emitted values (ticket 0402).
+    """
+    if unit_col.strip():
+        return Level.UNIT
+    if plant_col.strip():
+        return Level.PLANT
+    if complex_col.strip():
+        return Level.COMPLEX
+    return Level.UNKNOWN
+
+
+def derive_reference_level(
+    units_csv: Path | str | None = None,
+) -> list[dict]:
+    """Read the v2 unit CSV and return one dict per row with a derived level.
+
+    Each dict contains: ``name``, ``derived_level``, ``recorded_level``,
+    ``capacity_mwe`` (float or None), ``status``.
+
+    ``derived_level`` is the Level derived from address columns;
+    ``recorded_level`` is the string already in the CSV's ``level`` column
+    (cross-check only — the caller should treat ``derived_level`` as
+    authoritative for new work).
+
+    Args:
+        units_csv: Path to the unit-grain CSV.  Defaults to
+            ``VN_THERMAL_UNITS_RELEASE_CSV``.
+    """
+    path = Path(units_csv) if units_csv is not None else VN_THERMAL_UNITS_RELEASE_CSV
+    rows = []
+    with open(path, encoding="utf-8", newline="") as f:
+        for row in csv.DictReader(f):
+            cap_str = row.get("capacity_mwe", "").strip()
+            try:
+                cap = float(cap_str) if cap_str else None
+            except ValueError:
+                cap = None
+                logger.warning("Non-numeric capacity %r for %r", cap_str, row.get("name"))
+
+            derived = derive_level_from_address(
+                row.get("complex", ""),
+                row.get("plant", ""),
+                row.get("unit", ""),
+            )
+            rows.append(
+                {
+                    "name": row.get("name", ""),
+                    "derived_level": derived,
+                    "recorded_level": row.get("level", ""),
+                    "capacity_mwe": cap,
+                    "status": row.get("status", ""),
+                }
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy audit
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AuditResult:
+    """Result of the reference taxonomy audit.
+
+    ``passed`` is True when all hard caps hold.
+    ``unknown_count`` is the number of rows that could not be classified.
+    ``violations`` lists (name, level, capacity_mwe, rule) for each cap breach.
+    ``informational`` carries non-failing observations (e.g. complex-floor info).
+    """
+
+    passed: bool
+    total: int
+    level_counts: dict[str, int]
+    unknown_count: int
+    violations: list[tuple[str, str, float, str]] = field(default_factory=list)
+    informational: list[str] = field(default_factory=list)
+
+
+def audit_reference_taxonomy(
+    units_csv: Path | str | None = None,
+) -> AuditResult:
+    """Run the taxonomy audit on the v2 reference.
+
+    Checks:
+      (a) operating/constructing Plant rows: capacity ≤ 1600 MW
+      (b) Unit rows: capacity ≤ 1350 MW
+      (c) informational: Complex rows carry capacities ≥ expected floor
+
+    Returns an AuditResult.  Does not raise on cap violations; the caller
+    controls failure behaviour (hard error vs. logged warning).
+    """
+    rows = derive_reference_level(units_csv)
+    total = len(rows)
+
+    level_counts: dict[str, int] = {}
+    unknown_count = 0
+    violations: list[tuple[str, str, float, str]] = []
+
+    for r in rows:
+        lv = r["derived_level"]
+        lv_str = lv.value
+        level_counts[lv_str] = level_counts.get(lv_str, 0) + 1
+        if lv == Level.UNKNOWN:
+            unknown_count += 1
+            continue
+
+        cap = r["capacity_mwe"]
+        if cap is None:
+            continue
+        status = r["status"]
+
+        # (a) operating/constructing Plants must stay under the ceiling
+        if lv == Level.PLANT and status in _OPERATIONAL_STATUSES and cap > _PLANT_OP_CAP_MW:
+            violations.append(
+                (
+                    r["name"],
+                    lv_str,
+                    cap,
+                    f"Plant op/constr cap > {_PLANT_OP_CAP_MW} MW",
+                )
+            )
+
+        # (b) Units must stay under world-record single-shaft ceiling
+        if lv == Level.UNIT and cap > _UNIT_CAP_MW:
+            violations.append(
+                (r["name"], lv_str, cap, f"Unit cap > {_UNIT_CAP_MW} MW")
+            )
+
+    # (c) informational: max complex capacity
+    complex_caps = [
+        r["capacity_mwe"]
+        for r in rows
+        if r["derived_level"] == Level.COMPLEX and r["capacity_mwe"] is not None
+    ]
+    informational = []
+    if complex_caps:
+        max_complex = max(complex_caps)
+        informational.append(
+            f"Max Complex capacity: {max_complex:.0f} MW "
+            f"(floor {_COMPLEX_FLOOR_MW:.0f} MW; "
+            f"{'above' if max_complex >= _COMPLEX_FLOOR_MW else 'BELOW — check'} floor)"
+        )
+
+    passed = len(violations) == 0
+    return AuditResult(
+        passed=passed,
+        total=total,
+        level_counts=level_counts,
+        unknown_count=unknown_count,
+        violations=violations,
+        informational=informational,
+    )

--- a/src/aedist/schema.py
+++ b/src/aedist/schema.py
@@ -40,6 +40,34 @@ class PlantStatus(StrEnum):
     UNKNOWN = "unknown"
 
 
+class Level(StrEnum):
+    """Granularity level of a reference or system power-plant row.
+
+    Reference:
+    - Unit    — one turbo-set / tranche (single shaft). Coal ≤ 1350 MW world
+                record; VN typically 300/600/660 MW; alert above 700 MW.
+    - Block   — CCGT multi-shaft assembly (2+ GT + 1 ST). CCGT-only; above
+                1300 MW is normal for a block; not a single turbo-set.
+    - Plant   — a centrale = "Site + number" (e.g. Vũng Áng 2). Operating
+                plants ≤ ~1500 MW; planned LNG plants ≤ ~3200 MW.
+    - Complex — a site / power center that aggregates several named plants
+                (bare "Site" label). Can exceed 3200 MW up to 6000+ MW.
+    - Unknown — grain not determinable from the available data.
+
+    The hierarchy is not a clean linear order: Block is CCGT-only between
+    Unit and Plant. A single-block CCGT may simultaneously be a Block and
+    a Plant; the rule of assignment is the finest grain the row represents.
+
+    Ticket 0401.
+    """
+
+    UNIT = "unit"
+    BLOCK = "block"
+    PLANT = "plant"
+    COMPLEX = "complex"
+    UNKNOWN = "unknown"
+
+
 class Plant(BaseModel):
     """A single power plant entry in canonical form.
 
@@ -52,6 +80,14 @@ class Plant(BaseModel):
     cod: str | None = Field(default=None, description="Connection date (year or YYYY-MM-DD).")
     province: str | None = Field(default=None)
     capacity_mwe: float | None = Field(default=None, ge=0)
+    level: Level = Field(
+        default=Level.UNKNOWN,
+        description=(
+            "Row granularity: Unit / Block / Plant / Complex / Unknown. "
+            "Derived from the three-column address (complex/plant/unit) in "
+            "the v2 reference; emitted by the model in 0402."
+        ),
+    )
     source_ref: str | None = Field(
         default=None,
         description="Primary source document reference, e.g. 'Decision 1509/QĐ-BCT, Annexe II.1'.",

--- a/tests/test_level.py
+++ b/tests/test_level.py
@@ -1,0 +1,276 @@
+"""Tests for Level enum, Plant.level field, and derive_reference_level.
+
+Ticket 0401: schema-level enum + reference derivation.
+
+Coverage:
+- Level enum importable with five members.
+- Plant / SourcedPlant round-trip with level field.
+- derive_level_from_address: address column → Level mapping.
+- derive_reference_level: reads v2 units CSV, returns correct levels.
+- Taxonomy audit: operating/constructing plants ≤ 1600 MW; units ≤ 1350 MW.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from aedist.reference_level import (
+    AuditResult,
+    audit_reference_taxonomy,
+    derive_level_from_address,
+    derive_reference_level,
+)
+from aedist.schema import Level, Plant, SourcedPlant
+
+# ---------------------------------------------------------------------------
+# Level enum
+# ---------------------------------------------------------------------------
+
+
+def test_level_enum_has_five_members():
+    """Level has exactly the five canonical members."""
+    assert set(Level) == {
+        Level.UNIT,
+        Level.BLOCK,
+        Level.PLANT,
+        Level.COMPLEX,
+        Level.UNKNOWN,
+    }
+
+
+def test_level_enum_values():
+    """Level members have the expected string values (StrEnum)."""
+    assert Level.UNIT == "unit"
+    assert Level.BLOCK == "block"
+    assert Level.PLANT == "plant"
+    assert Level.COMPLEX == "complex"
+    assert Level.UNKNOWN == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Plant / SourcedPlant round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_plant_level_default():
+    """Plant.level defaults to Level.UNKNOWN."""
+    p = Plant(name="Test Plant")
+    assert p.level == Level.UNKNOWN
+
+
+def test_plant_level_round_trip():
+    """Plant serialises and deserialises level correctly."""
+    p = Plant(name="Vinh Tan 2 Unit 1", level=Level.UNIT)
+    data = p.model_dump()
+    assert data["level"] == "unit"
+    p2 = Plant.model_validate(data)
+    assert p2.level == Level.UNIT
+
+
+def test_sourced_plant_level_round_trip():
+    """SourcedPlant inherits the level field and round-trips."""
+    sp = SourcedPlant(name="LNG Mỹ Giang", level=Level.COMPLEX)
+    data = sp.model_dump()
+    assert data["level"] == "complex"
+    sp2 = SourcedPlant.model_validate(data)
+    assert sp2.level == Level.COMPLEX
+
+
+def test_plant_all_levels_valid():
+    """All five Level values are accepted by Plant."""
+    for lv in Level:
+        p = Plant(name=f"Plant {lv}", level=lv)
+        assert p.level == lv
+
+
+# ---------------------------------------------------------------------------
+# derive_level_from_address
+# ---------------------------------------------------------------------------
+
+
+def test_derive_unit_when_unit_nonempty():
+    assert derive_level_from_address("", "Vinh Tan 2", "Unit 1") == Level.UNIT
+
+
+def test_derive_plant_when_unit_empty():
+    assert derive_level_from_address("", "An Khánh - Bac Giang", "") == Level.PLANT
+
+
+def test_derive_complex_when_only_complex():
+    assert derive_level_from_address("LNG Mỹ Giang", "", "") == Level.COMPLEX
+
+
+def test_derive_unknown_when_all_empty():
+    assert derive_level_from_address("", "", "") == Level.UNKNOWN
+
+
+def test_derive_unit_takes_priority_over_plant():
+    """unit column wins even when plant is also set."""
+    assert derive_level_from_address("", "Parent Plant", "Unit 1") == Level.UNIT
+
+
+def test_derive_strips_whitespace():
+    """Leading/trailing whitespace does not prevent derivation."""
+    assert derive_level_from_address("  ", "  My Plant  ", "  ") == Level.PLANT
+
+
+# ---------------------------------------------------------------------------
+# derive_reference_level against live v2 CSV
+# ---------------------------------------------------------------------------
+
+_V2_UNITS_CSV = (
+    Path(__file__).parent.parent / "data" / "reference" / "vietnam_thermal_units_v2.csv"
+)
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_derive_reference_level_returns_rows():
+    """derive_reference_level returns one dict per CSV row."""
+    rows = derive_reference_level()
+    assert len(rows) > 0
+    assert all("name" in r and "derived_level" in r for r in rows)
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_derive_reference_level_no_unknown():
+    """All v2 rows resolve to a non-Unknown level (address columns complete)."""
+    rows = derive_reference_level()
+    unknown = [r for r in rows if r["derived_level"] == Level.UNKNOWN]
+    assert unknown == [], f"Unexpected Unknown rows: {[r['name'] for r in unknown]}"
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_derive_reference_level_matches_recorded():
+    """Derived level matches the pre-assigned level column for all v2 rows."""
+    rows = derive_reference_level()
+    mismatches = [
+        r for r in rows if r["derived_level"].value != r["recorded_level"]
+    ]
+    assert mismatches == [], (
+        f"Derived / recorded mismatch: {[(r['name'], r['derived_level'], r['recorded_level']) for r in mismatches]}"
+    )
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_derive_complex_row_example():
+    """LNG Mỹ Giang is Complex (bare complex column, no plant/unit)."""
+    rows = {r["name"]: r for r in derive_reference_level()}
+    assert "LNG Mỹ Giang" in rows
+    assert rows["LNG Mỹ Giang"]["derived_level"] == Level.COMPLEX
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_derive_plant_row_example():
+    """An Khánh - Bac Giang is Plant (plant column set, unit empty)."""
+    rows = {r["name"]: r for r in derive_reference_level()}
+    assert "An Khánh - Bac Giang" in rows
+    assert rows["An Khánh - Bac Giang"]["derived_level"] == Level.PLANT
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_derive_unit_row_example():
+    """An Khánh 1 Unit 1 is Unit (unit column set)."""
+    rows = {r["name"]: r for r in derive_reference_level()}
+    assert "An Khánh 1 Unit 1" in rows
+    assert rows["An Khánh 1 Unit 1"]["derived_level"] == Level.UNIT
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_audit_passes_on_v2():
+    """Taxonomy audit passes on the v2 reference (no cap violations)."""
+    result = audit_reference_taxonomy()
+    assert isinstance(result, AuditResult)
+    assert result.passed, (
+        f"Audit failed. Violations: {result.violations}"
+    )
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_audit_no_unknown_rows():
+    """Audit reports zero Unknown rows for the v2 reference."""
+    result = audit_reference_taxonomy()
+    assert result.unknown_count == 0
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_audit_operating_plants_under_cap():
+    """No operating/constructing Plant row exceeds 1600 MW (the audit assertion
+    that would catch a broken derivation labelling a 6000 MW Complex as Plant).
+    """
+    rows = derive_reference_level()
+    op_plant_caps = [
+        r["capacity_mwe"]
+        for r in rows
+        if r["derived_level"] == Level.PLANT
+        and r["status"] in ("5 construction", "6 operating")
+        and r["capacity_mwe"] is not None
+    ]
+    assert op_plant_caps, "No operating/constructing plant rows found — check the CSV"
+    assert max(op_plant_caps) <= 1600.0, (
+        f"Operating/constructing plant cap violation: max={max(op_plant_caps)} MW"
+    )
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_audit_units_under_cap():
+    """No Unit row exceeds 1350 MW (world-record single shaft ceiling)."""
+    rows = derive_reference_level()
+    unit_caps = [
+        r["capacity_mwe"]
+        for r in rows
+        if r["derived_level"] == Level.UNIT and r["capacity_mwe"] is not None
+    ]
+    assert unit_caps, "No unit rows found — check the CSV"
+    assert max(unit_caps) <= 1350.0, (
+        f"Unit cap violation: max={max(unit_caps)} MW"
+    )
+
+
+@pytest.mark.skipif(not _V2_UNITS_CSV.exists(), reason="v2 units CSV not present")
+def test_audit_level_counts_plausible():
+    """Audit reports non-zero counts for unit, plant, and complex levels."""
+    result = audit_reference_taxonomy()
+    assert result.level_counts.get("unit", 0) > 0
+    assert result.level_counts.get("plant", 0) > 0
+    assert result.level_counts.get("complex", 0) > 0
+
+
+def test_audit_accepts_custom_csv(tmp_path):
+    """audit_reference_taxonomy accepts a custom CSV path."""
+    csv_text = (
+        "name,complex,plant,unit,province,asset_type,capacity_mwe,status,level\n"
+        "My Complex,My Complex,,,Province A,Coal power plant,4000,2 proposed,complex\n"
+        "My Plant,,My Plant,,Province A,Coal power plant,600,6 operating,plant\n"
+        "My Unit,,My Plant,Unit 1,Province A,Coal power plant,300,6 operating,unit\n"
+    )
+    csv_file = tmp_path / "test_units.csv"
+    csv_file.write_text(csv_text, encoding="utf-8")
+
+    result = audit_reference_taxonomy(units_csv=csv_file)
+    assert result.passed
+    assert result.total == 3
+    assert result.unknown_count == 0
+    assert result.level_counts["complex"] == 1
+    assert result.level_counts["plant"] == 1
+    assert result.level_counts["unit"] == 1
+
+
+def test_audit_detects_cap_violation(tmp_path):
+    """audit_reference_taxonomy flags a Plant row that exceeds the op cap."""
+    csv_text = (
+        "name,complex,plant,unit,province,asset_type,capacity_mwe,status,level\n"
+        # 2000 MW operating plant — exceeds 1600 MW cap
+        "Huge Plant,,Huge Plant,,Province A,Coal power plant,2000,6 operating,plant\n"
+    )
+    csv_file = tmp_path / "test_units.csv"
+    csv_file.write_text(csv_text, encoding="utf-8")
+
+    result = audit_reference_taxonomy(units_csv=csv_file)
+    assert not result.passed
+    assert len(result.violations) == 1
+    assert result.violations[0][0] == "Huge Plant"

--- a/tickets/0401-schema-level-enum-and-reference-derivation.erg
+++ b/tickets/0401-schema-level-enum-and-reference-derivation.erg
@@ -2,6 +2,7 @@
 Title: Schema: add `level` enum (Unit/Block/Plant/Complex/Unknown) + derive reference Level + taxonomy audit
 Created: 2026-06-03
 Author: claude
+Closed: Level enum, derive_reference_level, taxonomy audit implemented; 25 tests green
 
 --- log ---
 2026-06-04T20:30Z claude note — Blocked-by 0416 added (raid curation): the aggregator rework propagates Level through the pipe; derive/audit reference Level on its output, not on the soon-replaced v1
@@ -10,6 +11,7 @@ Author: claude
 2026-06-05T07:27Z claude note — raid 2026-06-05: held with 0416 (ESCALATE on grouping contract); Level derivation targets the post-0416 pipe output, re-validate paths/columns once 0416 unblocks.
 2026-06-05T09:12Z claude note — three-column master ratified (0439/0416 contrat v2): Level derivation reduces to finest-non-empty address column on the v2 unit CSV; re-validate columns when 0416 lands; still OUT of preprint perimeter (0435)
 2026-06-05T11:59Z HDMX-coding-agent note blocker 0416 closed — Blocked-by removed.
+2026-06-08T20:57Z HDMX-coding-agent closed — Level enum, derive_reference_level, taxonomy audit implemented; 25 tests green
 --- body ---
 ## Context
 

--- a/tickets/0402-model-emits-level-and-capacity-coherence.erg
+++ b/tickets/0402-model-emits-level-and-capacity-coherence.erg
@@ -2,11 +2,11 @@
 Title: Model emits `level`; level-conditioned capacity-plausibility coherence check
 Created: 2026-06-03
 Author: claude
-Blocked-by: 0401
 
 --- log ---
 2026-06-03T00:00Z claude created — Imagine session. Once `level` exists in the schema and is validated on the reference (0401), the capacity-plausibility check becomes a per-row INTERNAL self-consistency signal: is the capacity plausible *given the level the model declared*, and is the declared level consistent with the name. This replaces the flat [30,1600] band that the verification proved wrong (operating max 1500, but power-centers reach 6000). Author decision: the model assigns level.
 
+2026-06-08T20:57Z HDMX-coding-agent note blocker 0401 closed — Blocked-by removed.
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0401-schema-level-enum-and-reference-derivation.erg

## Summary

- Add `Level(StrEnum)` with five members (Unit/Block/Plant/Complex/Unknown) to `schema.py`; add `level: Level = Level.UNKNOWN` field to `Plant` and `SourcedPlant`.
- Add `reference_level.py` with `derive_level_from_address()` (finest-non-empty address column rule) and `derive_reference_level()` reading `vietnam_thermal_units_v2.csv`. Derivation matches pre-assigned `level` column 100% across all 258 rows.
- Add `audit_reference_taxonomy()`: confirms caps hold — no operating/constructing Plant > 1600 MW, no Unit > 1350 MW. Audit passes on the real v2 reference.
- Add `VN_THERMAL_UNITS_RELEASE_CSV` path constant to `config.py`.
- `tests/test_level.py`: 25 tests, all green.

## Taxonomy audit finding (gates ticket 0402)

Audit PASSED. Clean partition on v2 reference:
- 147 units, 92 plants, 19 complexes, 0 unknown
- Max operating/constructing plant capacity: 1500 MW (≤ 1600 cap holds)
- Max unit capacity: 1000 MW (≤ 1350 cap holds)
- Max complex capacity: 6000 MW (> 3200 floor as expected)

Ticket 0402 (model-emits-level + capacity coherence scoring) is now unblocked.

## Test plan
- [ ] `make check-fast` passes (exit 0, verified locally: 2205 tests pass)
- [ ] `pytest tests/test_level.py -v` → 25 passed
- [ ] Adherence tests pass (150 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)