### PR TITLE
fix(plan/0297): remove dependency cycle on ticket 0475, fix hardcoded count

### DIFF
--- a/tickets/0475-mart-v2-architecture-schema-design.erg
+++ b/tickets/0475-mart-v2-architecture-schema-design.erg
@@ -2,7 +2,6 @@
 Title: Mart v2 architecture decision + schema extension (tracker: 0297)
 Created: 2026-06-08
 Author: HDMX-coding-agent
-Blocked-by: 0297
 
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created

--- a/tickets/0476-mart-v2-exp1-adapter-equivalence.erg
+++ b/tickets/0476-mart-v2-exp1-adapter-equivalence.erg
@@ -61,7 +61,7 @@ def test_exp1_mart_matches_measurements_jsonl():
 
 ## Verification
 
-- [ ] `experiments/derived/exp1_mart.jsonl` exists and has 70 records.
+- [ ] `experiments/derived/exp1_mart.jsonl` exists and record count matches exp1_batch2 artifact count.
 - [ ] Equivalence test passes (all metrics within 0.0001 tolerance).
 - [ ] `make check` passes.
 - [ ] `measurements.jsonl` is NOT modified or deleted by this PR.
@@ -74,6 +74,6 @@ def test_exp1_mart_matches_measurements_jsonl():
 
 ## Exit criteria
 
-- `exp1_mart.jsonl` exists with 70 exp1 records.
+- `exp1_mart.jsonl` exists with one record per exp1_batch2 output file.
 - Equivalence test demonstrates mart == measurements.jsonl for exp1 metrics.
 - 0477 can safely replace measurements.jsonl readers with mart readers.


### PR DESCRIPTION
## Summary

- Removes `Blocked-by: 0297` from ticket 0475 — a cycle since 0297 is the tracker, not a prerequisite of its own child
- Replaces hardcoded "70 records" verification checkbox in 0476 with a derived count check per project rules

## What happened

PR #841 (plan/0297 decomposition) merged but a follow-up `erg check` caught that 0475 had a circular `Blocked-by: 0297` header. The tracker closes *after* its children, so a child can never unblock from the tracker. The real gate on 0475 is the author's architectural decision (documented in the ticket body).

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)