### PR TITLE
ticket(0238): close — secret audit done; fix prototype_v1_verify_agent policy violation

### DIFF
--- a/src/aedist/prototype_v1_verify_agent.py
+++ b/src/aedist/prototype_v1_verify_agent.py
@@ -15,7 +15,9 @@ Usage::
     python -m aedist.prototype_v1_verify_agent --plant "Song Hau 1" --country Vietnam
 
 Requirements:
-    ANTHROPIC_API_KEY and TAVILY_API_KEY must be set (or in ~/.claude/.env).
+    ANTHROPIC_API_KEY and TAVILY_API_KEY must be set in the environment.
+    Use ``uv run --env-file ../.env python -m aedist.prototype_v1_verify_agent``
+    to inject them from the project .env file.
 
 Architecture:
     deepagents.create_deep_agent wraps a LangGraph react loop with:
@@ -264,13 +266,10 @@ def main():
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-    # Load env from ~/.claude/.env if present
-    env_file = Path.home() / ".claude" / ".env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            if "=" in line and not line.startswith("#"):
-                key, _, val = line.partition("=")
-                os.environ.setdefault(key.strip(), val.strip())
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("ANTHROPIC_API_KEY is not set — run with uv run --env-file ../.env")
+    if not os.environ.get("TAVILY_API_KEY"):
+        raise SystemExit("TAVILY_API_KEY is not set — run with uv run --env-file ../.env")
 
     log.info("Verifying plant: %s (%s) with model %s", args.plant, args.country, args.model)
 

--- a/tests/test_secret_loading_policy.py
+++ b/tests/test_secret_loading_policy.py
@@ -20,9 +20,6 @@ passes on current code; the intent is to shrink this list in follow-up work.
 - ``adapter_qwen_dashscope.py`` — reads ``~/.config/keys/alibaba.env``
 - ``query_anthropic.py`` — accepts ``--key-file`` defaulting to
   ``~/.config/keys/anthropic.env``
-- ``prototype_v1_verify_agent.py`` — reads ``~/.claude/.env`` (pre-policy
-  prototype; never wired into the main pipeline)
-
 Any new module exhibiting these patterns must be explicitly added here or
 the pattern eliminated; adding an exception is a conscious decision, not
 drift.
@@ -66,7 +63,6 @@ APPROVED_EXCEPTIONS: frozenset[str] = frozenset(
         "adapter_openai_responses.py",
         "adapter_qwen_dashscope.py",
         "query_anthropic.py",
-        "prototype_v1_verify_agent.py",
     }
 )
 

--- a/tickets/0238-audit-secret-loading-and-yagni-launchers.erg
+++ b/tickets/0238-audit-secret-loading-and-yagni-launchers.erg
@@ -2,11 +2,13 @@
 Title: Audit secret loading paths and YAGNI launcher options
 Created: 2026-05-23
 Author: claude
+Closed: all exit criteria met; adapter convergence tracked in 0479
 
 --- log ---
 2026-05-23T00:16Z claude created — post-conference audit of secret injection patterns across repo and harness layers
 2026-05-23T08:58Z claude note closed in merge request #434
 2026-05-23T09:30Z claude note reopened — #434 was doc cleanup only; secrets audit exit criteria not met; add fail-fast hardening as explicit deliverable
+2026-06-08T00:00Z HDMX-coding-agent closed — inventory test in main (0240); prototype_v1_verify_agent fixed (drop ~/.claude/.env read, add explicit SystemExit); adapter file-fallback convergence deferred to 0479; launcher YAGNI (uv run --env-file covers the use case); IDH/.claude/settings.json has no key-injection hook; uv --env-file is the canonical pattern
 
 --- body ---
 

--- a/tickets/0479-converge-adapter-secret-loading-to-env-only.erg
+++ b/tickets/0479-converge-adapter-secret-loading-to-env-only.erg
@@ -1,0 +1,76 @@
+%erg 0.1
+Title: Converge adapter secret loading to env-only (drop ~/.config/keys fallback)
+Created: 2026-06-08
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-08T00:00Z HDMX-coding-agent created — follow-up from ticket 0238 (secrets audit); allowlisted adapters tracked here
+
+--- body ---
+## Context
+
+Ticket 0238 audited secret-loading patterns across the repo. Four adapter
+modules pre-date the policy (experiments/common.mk: project `.env` via
+`uv run --env-file`) and fall back to reading `~/.config/keys/*.env` directly:
+
+- `src/aedist/adapter_mistral.py` — reads `~/.config/keys/mistral.env`
+- `src/aedist/adapter_openai_responses.py` — reads `~/.config/keys/openai.env`
+- `src/aedist/adapter_qwen_dashscope.py` — reads `~/.config/keys/alibaba.env`
+- `src/aedist/query_anthropic.py` — accepts `--key-file` defaulting to
+  `~/.config/keys/anthropic.env`
+
+These are allowlisted in `tests/test_secret_loading_policy.py` (APPROVED_EXCEPTIONS).
+The allowlist exists to make drift observable — any *new* module with the pattern
+must be added explicitly.
+
+The ticket-0238 recommendation: this file-fallback creates a second, non-auditable
+secret-loading path that can silently override the Make-level `.env` injection.
+Policy intent is: env var only (injected by `uv run --env-file ../.env` at Make
+level); no direct file reads in production adapter code.
+
+Out of scope for ticket 0238 per the "no refactor during conference push" constraint.
+
+## Relevant files
+
+- `src/aedist/adapter_mistral.py` — `_load_api_key()` with `~/.config/keys/mistral.env`
+- `src/aedist/adapter_openai_responses.py` — `_load_openai_key()` with `~/.config/keys/openai.env`
+- `src/aedist/adapter_qwen_dashscope.py` — `_load_api_key()` with `~/.config/keys/alibaba.env`
+- `src/aedist/query_anthropic.py` — `_load_key()` with `~/.config/keys/anthropic.env`
+- `tests/test_secret_loading_policy.py` — APPROVED_EXCEPTIONS allowlist to shrink
+
+## Actions
+
+1. In each adapter, replace the file-fallback key loader with a pure
+   `os.environ.get("KEY_NAME")` read and a `raise SystemExit` if absent.
+2. Update `tests/test_secret_loading_policy.py` APPROVED_EXCEPTIONS to remove
+   each adapted module once its file-fallback is gone.
+3. Verify `make check-fast` passes after each change.
+4. Update developer docs / Makefile header if needed to document that
+   `uv run --env-file ../.env` is the only injection path.
+
+## Test
+
+Before touching any adapter, write a failing test that asserts APPROVED_EXCEPTIONS
+shrinks by 1 for each module cleaned up (parametrize over module names).
+The test is green when all four modules are removed from the allowlist.
+
+## Verification
+
+- [ ] `tests/test_secret_loading_policy.py` APPROVED_EXCEPTIONS is empty (or
+  contains only modules with a documented legitimate reason for file reads).
+- [ ] `grep -rn "config/keys" src/` returns no hits.
+- [ ] `make check-fast` passes.
+
+## Invariants
+
+- Do not break existing experiment runs; the Make-level injection already sets
+  these env vars, so removing the file fallback affects only direct (non-Make)
+  invocations which are not part of the documented workflow.
+- Do not introduce `load_dotenv()`.
+
+## Exit criteria
+
+- [ ] All four adapters read API keys from environment only (no file fallback).
+- [ ] APPROVED_EXCEPTIONS in the adherence test is empty or contains only
+  documented exceptions.
+- [ ] `make check-fast` passes.


### PR DESCRIPTION
## Summary

Closes the reopened ticket 0238 (secret-loading audit). The previous close via PR #434 was doc cleanup only; this PR delivers the missing code deliverables:

- **Fix**: `prototype_v1_verify_agent.py` read from `~/.claude/.env` (policy violation: "never ~/.claude/.env") and returned an error string instead of raising `SystemExit` when keys were absent. Fixed: remove the `~/.claude/.env` block, add explicit `SystemExit` guards for both `ANTHROPIC_API_KEY` and `TAVILY_API_KEY`, update docstring to reference `uv run --env-file ../.env`.
- **Tighten**: Remove `prototype_v1_verify_agent.py` from the `APPROVED_EXCEPTIONS` allowlist in `tests/test_secret_loading_policy.py` (the violation is gone, so the exception is gone).
- **Follow-up**: New ticket 0479 tracks convergence of the 4 pre-policy adapters still falling back to `~/.config/keys/*.env` reads.

## Audit findings (exit criteria documentation)

**Inventory** (criterion 1): `tests/test_secret_loading_policy.py` already on `main` (via ticket 0240) scans `src/aedist/` for `load_dotenv()` calls and direct `~/.config/keys` / `~/.claude` reads. Drift is mechanically observable.

**IDH/hooks review** (criterion 2): `.claude/settings.json` has no key-injection hook or facility. The only hooks fire on Edit/Write for ticket validation (erg validate). No key setup, env-file handling, or launcher support exists in the harness layer.

**uv review** (criterion 3): `uv run --env-file ../.env` (experiments/common.mk `UV_RUN`) is already the canonical injection pattern. Keys are passed at child-process spawn time without transiting a Make variable or argv. No additional glue is needed.

**Launcher recommendation** (criterion 4): **YAGNI**. The `UV_RUN := uv run --project .. --env-file ../.env` pattern in `experiments/common.mk` already covers every real use case. No `load_dotenv()` exists anywhere in source. A bespoke launcher would duplicate what `uv --env-file` already does cleanly.

**Adapter convergence** (criterion 6): Follow-up ticket 0479 tracks the 4 pre-policy adapters (`adapter_mistral`, `adapter_openai_responses`, `adapter_qwen_dashscope`, `query_anthropic`) still falling back to `~/.config/keys/*.env`. They are allowlisted in the adherence test as tracked conscious exceptions. Migration deferred per ticket 0238 "Out of scope: no refactor during conference push."

## Test plan

- [ ] `uv run pytest tests/test_secret_loading_policy.py -v` — 6 tests pass
- [ ] `make check-fast` — 2213 tests pass

**Ticket:** tickets/0238-audit-secret-loading-and-yagni-launchers.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)