### PR TITLE
ticket(0269): prompt modularization — accepted divergence + extract evidence preamble

### DIFF
--- a/experiments/prompts/README.md
+++ b/experiments/prompts/README.md
@@ -9,3 +9,43 @@ Prompt templates used by the sweep configurations in `experiments.toml`.
 | `prompt_complete.txt` | frontier | Comprehensive report prompt for reasoning models |
 | `prompt_scenarios.txt` | frontier_scenarios | Scenario-based assessment variant |
 | `prompt_followups.txt` | multiturn | Follow-up questions for multi-turn conversations |
+
+---
+
+## ADR: Prompt modularization scope for Exp 2 and Exp 3 (ticket 0269)
+
+**Decision: accepted divergence (option c).** Exp 1 modules and Exp 2/3 prompts
+remain independent sources of truth. The naive arm prompt (`protocol_07_naive_prompt.md`)
+is a frozen experimental stimulus and must not be modified or regenerated.
+
+### Divergence map
+
+| Source | Columns | Sections not in Exp 1 modules |
+|--------|---------|-------------------------------|
+| `modules/2_goal.txt` + `modules/5_table.txt` (Exp 1 baseline) | 13 | — |
+| `sota/protocol_07_naive_prompt.md` (Exp 2 naive arm — frozen) | 15 | QUALITY DIMENSIONS, CONTEXT (source rules, confidence vocab, asset-row rules) |
+| `sota/protocol_02_metaprompt.md` (Exp 2/3 optimised arm — frozen) | 15 | ROLE, QUALITY DIMENSIONS, FORMAT, CONTEXT (budget, planning, tools, source rules, confidence vocab, asset-row rules) |
+
+The two extra columns in Exp 2/3 (`Status as-of-date`, `Confidence`) and the
+whole-section additions (source admissibility, confidence calibration, asset-row
+rules) have no module counterpart. Option (a) — assembling the naive prompt from
+modules — would produce a semantically different prompt (it would include
+`3_overview.txt` and `A_Statistics.txt` that the naive prompt explicitly bans).
+Option (b) — regenerating the frozen file — is excluded by the stimulus-freeze
+constraint. Both options require authoring new modules that do not correspond to
+`prompt_complete.txt`, breaking the `test_modules_cover_prompt_complete` invariant.
+
+The sections shared verbatim between the naive prompt and the metaprompt (source
+quality management, calibrated confidence vocabulary, asset-row rules) suggest a
+future extraction opportunity if a third experiment warrants a new prompt with the
+same rules, but that refactoring would require unfreezing or replacing the existing
+stimuli — out of scope here.
+
+### Evidence-pack preamble (Exp 3)
+
+The one concrete modularization performed: `harness.assemble_evidence_pack()` now
+reads its introductory sentence from `modules/7_evidence.txt` instead of a
+hardcoded string. This gives the text a version-controlled home alongside the other
+modules, making future updates auditable. The `7_evidence` module is **not** part
+of `assemble_prompt()` / Exp 1 assembly; `test_modules_cover_prompt_complete`
+explicitly excludes it.

--- a/experiments/prompts/modules/7_evidence.txt
+++ b/experiments/prompts/modules/7_evidence.txt
@@ -1,0 +1,3 @@
+## Evidence pack preamble
+
+These are manually curated primary sources meant to boost but not replace your own deep research.

--- a/experiments/prompts/modules/README.md
+++ b/experiments/prompts/modules/README.md
@@ -17,6 +17,7 @@ filename matches the natural reading order of the assembled prompt:
 | `4_narratives.txt` | Per-plant discussion |
 | `5_table.txt` | Structured table specification (always included) |
 | `6_bibliography.txt` | Annotated bibliography |
+| `7_evidence.txt` | Evidence-pack preamble sentence (Exp 3 only — not part of Exp 1 assembly) |
 | `A_Statistics.txt` | Cross-tabulations |
 | `B_Temporality.txt` | Observed vs projected discipline |
 | `C_Uncertainty.txt` | Confidence levels and source guardrails |

--- a/src/aedist/harness.py
+++ b/src/aedist/harness.py
@@ -155,6 +155,11 @@ EVIDENCE_PACK_HEADER_FIELDS = (
 
 EVIDENCE_PACK_SECTION_TITLE = "# Evidence pack"
 
+# Path to the evidence-pack preamble module, relative to the repo root.
+# Extracting this sentence to a versioned file (ticket 0269) keeps it aligned
+# with the other prompt modules and avoids a hardcoded string buried in Python.
+_EVIDENCE_PREAMBLE_MODULE = Path(__file__).resolve().parents[2] / "experiments" / "prompts" / "modules" / "7_evidence.txt"
+
 
 def assemble_prompt(modules_dir: Path, module_names: list[str]) -> str:
     """Assemble a prompt from the always-pair plus named optional modules.
@@ -225,10 +230,15 @@ def assemble_evidence_pack(manifest_path: Path) -> str:
     corpus_root = _resolve_manifest_source_root(manifest_path, source_root)
 
     items = manifest["items"]
-    manifest_lines = [
-        "These are manually curated primary sources meant to boost but not replace your own deep research.",
-        "",
+    # Read the static preamble sentence from the versioned module file.
+    # The section header line ("## Evidence pack preamble") is stripped;
+    # only the content sentence is used.
+    preamble_lines = [
+        line
+        for line in _EVIDENCE_PREAMBLE_MODULE.read_text().splitlines()
+        if line and not line.startswith("#")
     ]
+    manifest_lines = preamble_lines + [""]
     for index, item in enumerate(items, start=1):
         manifest_lines.append(f"{index}. {item['source_id']} — {item.get('document_title', '')}")
     preamble = "\n".join(manifest_lines)

--- a/tests/test_modules_match_prompt_complete.py
+++ b/tests/test_modules_match_prompt_complete.py
@@ -33,13 +33,22 @@ def _content_lines(text: str) -> set[str]:
 
 @pytest.mark.adherence
 def test_modules_cover_prompt_complete():
-    """Assembled composite covers every content line of prompt_complete.txt."""
+    """Assembled composite covers every content line of prompt_complete.txt.
+
+    ``7_evidence`` is excluded from this comparison: it is the evidence-pack
+    preamble module (ticket 0269), not part of the Exp 1 prompt assembly
+    anchored to ``prompt_complete.txt``.
+    """
     from aedist.harness import assemble_prompt
 
     modules_dir = EXPERIMENTS_DIR / "prompts" / "modules"
     prompt_complete = (EXPERIMENTS_DIR / "prompts" / "prompt_complete.txt").read_text()
 
-    all_stems = sorted(p.stem for p in modules_dir.glob("*.txt"))
+    # Exclude evidence-pack preamble module — it feeds assemble_evidence_pack,
+    # not the Exp 1 prompt assembly.
+    all_stems = sorted(
+        p.stem for p in modules_dir.glob("*.txt") if p.stem != "7_evidence"
+    )
     assembled = assemble_prompt(modules_dir, all_stems)
 
     expected = _content_lines(prompt_complete)

--- a/tickets/0269-prompt-modularization-exp2-exp3.erg
+++ b/tickets/0269-prompt-modularization-exp2-exp3.erg
@@ -2,10 +2,13 @@
 Title: Explore prompt modularization for Exp 2 and Exp 3 — consolidate sources of truth
 Created: 2026-05-24
 Author: HDMX-coding-agent
+Closed: Accepted divergence documented; evidence-pack preamble extracted to modules/7_evidence.txt
 
 --- log ---
 2026-05-24T08:30Z HDMX-coding-agent created
+2026-06-08T00:00Z HDMX-coding-agent implemented: option (c) accepted divergence. Diff table in experiments/prompts/README.md ADR. Evidence-pack preamble extracted to modules/7_evidence.txt (harness reads it; byte-identical output). Frozen stimuli not touched.
 
+2026-06-08T21:21Z HDMX-coding-agent closed — Accepted divergence documented; evidence-pack preamble extracted to modules/7_evidence.txt
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Audited divergence between Exp 1 modules (`2_goal.txt`, `5_table.txt`) and Exp 2/3 frozen protocols (`protocol_07_naive_prompt.md`, `protocol_02_metaprompt.md`). Naive prompt has 15 columns vs 13 in Exp 1, plus whole sections (source rules, confidence vocab, asset-row rules) with no module counterpart — options (a) and (b) from the ticket are ruled out by the stimulus-freeze constraint.
- Documents the decision in `experiments/prompts/README.md` as an ADR with a divergence table.
- Extracts the evidence-pack preamble sentence from a hardcoded string in `harness.py` to `modules/7_evidence.txt`. Runtime output is byte-identical; text is now version-controlled alongside other modules.
- Updates `test_modules_match_prompt_complete` to exclude `7_evidence` (it feeds `assemble_evidence_pack`, not the Exp 1 prompt assembly).

## Test plan

- [x] `uv run pytest -x -q -m "not slow and not integration"` — 2213 passed
- [x] `uv run pytest -x -q -m adherence` — 150 passed
- [x] Evidence-pack assembly tests pass with byte-identical output verified

**Ticket:** tickets/0269-prompt-modularization-exp2-exp3.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)