### PR TITLE
ticket(0479): drop ~/.config/keys fallback from all four adapters

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -564,7 +564,7 @@ def run_anthropic_call(
     )
     enforce_cost_cap(estimated, cap_usd=cap_usd)
 
-    api_key = query_anthropic._load_key(query_anthropic.DEFAULT_KEY_PATH)
+    api_key = query_anthropic._load_key()
     client = anthropic.Anthropic(api_key=api_key)
     t0 = time.monotonic()
     resp = query_anthropic._call_with_retry(client, payload)

--- a/src/aedist/adapter_mistral.py
+++ b/src/aedist/adapter_mistral.py
@@ -51,7 +51,6 @@ AGENT_FAMILY = "mistral-direct"
 DEFAULT_MODEL = "mistral-large-2512"
 API_BASE = "https://api.mistral.ai"
 API_DOCS_VERIFIED = "2026-05-20"
-KEY_PATH = Path.home() / ".config" / "keys" / "mistral.env"
 TOKENS_PER_MTOK = 1_000_000
 
 
@@ -60,28 +59,18 @@ TOKENS_PER_MTOK = 1_000_000
 # ---------------------------------------------------------------------------
 
 
-def _load_api_key(path: Path = KEY_PATH) -> str:
-    """Read ``MISTRAL_API_KEY`` from ``~/.config/keys/mistral.env``.
+def _load_api_key() -> str:
+    """Read ``MISTRAL_API_KEY`` from the environment.
 
-    Falls back to the environment variable of the same name so callers
-    can override in tests. Raises ``SystemExit`` if neither is set.
+    Injected at Make level via ``uv run --env-file ../.env``.
+    Raises ``SystemExit`` if the variable is absent.
     """
-    if path.exists():
-        for raw in path.read_text().splitlines():
-            line = raw.strip()
-            if not line or line.startswith("#"):
-                continue
-            if line.startswith("MISTRAL_API_KEY="):
-                value = line.split("=", 1)[1].strip()
-                # Strip surrounding quotes if present.
-                if value and value[0] in {'"', "'"} and value[-1] == value[0]:
-                    value = value[1:-1]
-                if value:
-                    return value
-    env = os.environ.get("MISTRAL_API_KEY")
-    if env:
-        return env
-    raise SystemExit(f"MISTRAL_API_KEY not found in {path} or environment")
+    key = os.environ.get("MISTRAL_API_KEY")
+    if key:
+        return key
+    raise SystemExit(
+        "MISTRAL_API_KEY not set — inject via uv run --env-file ../.env"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/aedist/adapter_openai_responses.py
+++ b/src/aedist/adapter_openai_responses.py
@@ -332,26 +332,16 @@ def parse_response(resp: Any, price_card: dict) -> RunRecord:
 
 
 def _load_openai_key() -> str:
-    """Load OpenAI key from env or ``~/.config/keys/openai.env``.
+    """Load ``OPENAI_API_KEY_AEDIST`` from the environment.
 
-    Accepts only the project key ``OPENAI_API_KEY_AEDIST``.
+    Injected at Make level via ``uv run --env-file ../.env``.
+    Raises ``SystemExit`` if the variable is absent.
     """
     key = os.environ.get("OPENAI_API_KEY_AEDIST")
     if key:
         return key
-    env_file = Path.home() / ".config" / "keys" / "openai.env"
-    if env_file.exists():
-        for line in env_file.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                k, _, v = line.partition("=")
-                if k.strip() == "OPENAI_API_KEY_AEDIST":
-                    return v.strip().strip('"').strip("'")
     raise SystemExit(
-        "OpenAI key not set (expected OPENAI_API_KEY_AEDIST) "
-        "and not found in ~/.config/keys/openai.env"
+        "OPENAI_API_KEY_AEDIST not set — inject via uv run --env-file ../.env"
     )
 
 

--- a/src/aedist/adapter_qwen_dashscope.py
+++ b/src/aedist/adapter_qwen_dashscope.py
@@ -34,7 +34,6 @@ import logging
 import os
 import random
 import time
-from pathlib import Path
 from typing import Any
 
 import dashscope
@@ -326,27 +325,16 @@ def parse_response(
 
 
 def _resolve_api_key() -> str:
-    """Resolve the DashScope API key, preferring the project key file.
+    """Resolve ``QWEN_API_KEY_AEDIST`` from the environment.
 
-    Order: environment ``QWEN_API_KEY_AEDIST``, then
-    ``~/.config/keys/alibaba.env`` (KEY=VALUE format).
+    Injected at Make level via ``uv run --env-file ../.env``.
+    Raises ``SystemExit`` if the variable is absent.
     """
-    env_key = os.environ.get("QWEN_API_KEY_AEDIST")
-    if env_key:
-        return env_key
-    key_file = Path.home() / ".config" / "keys" / "alibaba.env"
-    if key_file.exists():
-        for line in key_file.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            if k.strip() == "QWEN_API_KEY_AEDIST":
-                return v.strip().strip('"').strip("'")
-    raise RuntimeError(
-        "QWEN_API_KEY_AEDIST not found in environment or ~/.config/keys/alibaba.env"
+    key = os.environ.get("QWEN_API_KEY_AEDIST")
+    if key:
+        return key
+    raise SystemExit(
+        "QWEN_API_KEY_AEDIST not set — inject via uv run --env-file ../.env"
     )
 
 

--- a/src/aedist/query_anthropic.py
+++ b/src/aedist/query_anthropic.py
@@ -63,8 +63,6 @@ DEFAULT_PRICE_PER_WEB_SEARCH_USD = 0.010
 TOKENS_PER_MTOK = 1_000_000
 API_DOCS_VERIFIED = "2026-05-20"
 
-# Path resolved at call time, never at import — `~` expansion + override-friendly.
-DEFAULT_KEY_PATH = "~/.config/keys/anthropic.env"
 
 
 # ---------------------------------------------------------------------------
@@ -72,26 +70,20 @@ DEFAULT_KEY_PATH = "~/.config/keys/anthropic.env"
 # ---------------------------------------------------------------------------
 
 
-def _load_key(path: str | os.PathLike = DEFAULT_KEY_PATH) -> str:
-    """Read ANTHROPIC_API_KEY from a KEY=value env file.
+def _load_key(*_: object) -> str:
+    """Read ``ANTHROPIC_API_KEY`` from the environment.
 
-    Lines starting with ``#`` and blank lines are ignored. Raises
-    ``SystemExit`` (matching ``harness.make_client``) when the key cannot
-    be found, so a missing key fails loudly at CLI exit.
+    Injected at Make level via ``uv run --env-file ../.env``.
+    The optional positional argument is accepted but ignored (backward
+    compatibility with experiment scripts that pass a key-file path).
+    Raises ``SystemExit`` if the variable is absent.
     """
-    p = Path(os.path.expanduser(str(path)))
-    if not p.exists():
-        raise SystemExit(f"Anthropic key file not found: {p}")
-    for raw in p.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            continue
-        k, _, v = line.partition("=")
-        if k.strip() == "ANTHROPIC_API_KEY":
-            return v.strip().strip('"').strip("'")
-    raise SystemExit(f"ANTHROPIC_API_KEY not found in {p}")
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if key:
+        return key
+    raise SystemExit(
+        "ANTHROPIC_API_KEY not set — inject via uv run --env-file ../.env"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -460,7 +452,6 @@ def dispatch(
     agent_mode: str = "smoke",
     budget: BudgetTracker | None = None,
     cap_usd: float = 0.50,
-    key_path: str | os.PathLike = DEFAULT_KEY_PATH,
     continuation: dict | None = None,
     extra_metadata: dict | None = None,
 ) -> dict:
@@ -532,7 +523,7 @@ def dispatch(
     # Live call — import the SDK lazily so dry-run + tests stay import-light.
     import anthropic
 
-    api_key = _load_key(key_path)
+    api_key = _load_key()
     client = anthropic.Anthropic(api_key=api_key)
 
     t0 = time.monotonic()
@@ -673,11 +664,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=1,
         help="Run number (used in the output filename).",
     )
-    p.add_argument(
-        "--key-path",
-        default=DEFAULT_KEY_PATH,
-        help=f"Path to anthropic.env (default: {DEFAULT_KEY_PATH}).",
-    )
     return p
 
 
@@ -715,7 +701,6 @@ def main(argv: list[str] | None = None) -> int:
             run=args.run,
             agent_mode=args.agent_mode,
             cap_usd=args.cap_usd,
-            key_path=args.key_path,
         )
     except CostCapExceeded as e:
         print(f"ERROR: {e}", flush=True)

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -1041,7 +1041,7 @@ def test_run_anthropic_call_turn1_sends_system_and_messages(monkeypatch, tmp_pat
     fake_client = type("C", (), {})()
     fake_client.messages = type("M", (), {"create": staticmethod(fake_create)})()
     monkeypatch.setattr("anthropic.Anthropic", lambda **kw: fake_client)  # noqa: ARG005
-    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda _: "sk-ant-test")
+    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda *_: "sk-ant-test")
 
     record = mod.run_anthropic_call(
         "the prompt",
@@ -1098,7 +1098,7 @@ def test_run_anthropic_call_turn2_replays_full_history(monkeypatch, tmp_path):
     fake_client = type("C", (), {})()
     fake_client.messages = type("M", (), {"create": staticmethod(fake_create)})()
     monkeypatch.setattr("anthropic.Anthropic", lambda **kw: fake_client)  # noqa: ARG005
-    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda _: "sk-ant-test")
+    monkeypatch.setattr("aedist.query_anthropic._load_key", lambda *_: "sk-ant-test")
 
     prior_history = [
         {"role": "user", "content": "first user message"},

--- a/tests/test_secret_loading_policy.py
+++ b/tests/test_secret_loading_policy.py
@@ -11,18 +11,11 @@ Policy (documented in experiments/common.mk):
 
 Approved exceptions
 -------------------
-The following modules pre-date the policy consolidation (ticket 0240) and
-contain file-fallback key loading. They are allowlisted here so the guard
-passes on current code; the intent is to shrink this list in follow-up work.
-
-- ``adapter_mistral.py`` — reads ``~/.config/keys/mistral.env``
-- ``adapter_openai_responses.py`` — reads ``~/.config/keys/openai.env``
-- ``adapter_qwen_dashscope.py`` — reads ``~/.config/keys/alibaba.env``
-- ``query_anthropic.py`` — accepts ``--key-file`` defaulting to
-  ``~/.config/keys/anthropic.env``
-Any new module exhibiting these patterns must be explicitly added here or
-the pattern eliminated; adding an exception is a conscious decision, not
-drift.
+All four pre-policy adapters (adapter_mistral, adapter_openai_responses,
+adapter_qwen_dashscope, query_anthropic) were cleaned up in ticket 0479.
+The allowlist is now empty.  Any new module exhibiting these patterns must
+be explicitly added here or the pattern eliminated; adding an exception is
+a conscious decision, not drift.
 """
 
 import re
@@ -57,14 +50,7 @@ _KEY_FILE_RE = re.compile(
 
 # ── allowlist: filenames exempt from the guard ───────────────────────────────
 
-APPROVED_EXCEPTIONS: frozenset[str] = frozenset(
-    {
-        "adapter_mistral.py",
-        "adapter_openai_responses.py",
-        "adapter_qwen_dashscope.py",
-        "query_anthropic.py",
-    }
-)
+APPROVED_EXCEPTIONS: frozenset[str] = frozenset()
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/tickets/0479-converge-adapter-secret-loading-to-env-only.erg
+++ b/tickets/0479-converge-adapter-secret-loading-to-env-only.erg
@@ -2,10 +2,12 @@
 Title: Converge adapter secret loading to env-only (drop ~/.config/keys fallback)
 Created: 2026-06-08
 Author: HDMX-coding-agent
+Closed: all four adapters read from env only; APPROVED_EXCEPTIONS empty; make check-fast passes
 
 --- log ---
 2026-06-08T00:00Z HDMX-coding-agent created — follow-up from ticket 0238 (secrets audit); allowlisted adapters tracked here
 
+2026-06-08T21:30Z HDMX-coding-agent closed — all four adapters read from env only; APPROVED_EXCEPTIONS empty; make check-fast passes
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- All four pre-policy adapters (`adapter_mistral`, `adapter_openai_responses`, `adapter_qwen_dashscope`, `query_anthropic`) now read their API keys from the environment only — no `~/.config/keys/` file fallback.
- `tests/test_secret_loading_policy.py` `APPROVED_EXCEPTIONS` is now empty.
- `experiments/sota/exp2_interactive_smoke.py` updated to call `_load_key()` with no args; test lambdas updated to `lambda *_`.

## Test plan

- [x] `uv run pytest tests/test_secret_loading_policy.py -v` — 6/6 passed
- [x] `make check-fast` — 2223 passed, 0 failed
- [x] `grep -rn "config/keys" src/` — no hits

**Ticket:** tickets/0479-converge-adapter-secret-loading-to-env-only.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)