### PR TITLE
ticket(0470): cached LLM-judge source-faithfulness scorer

### DIFF
--- a/src/aedist/llm_judge_faithfulness.py
+++ b/src/aedist/llm_judge_faithfulness.py
@@ -1,0 +1,312 @@
+"""Cached LLM-judge source-faithfulness scorer (ticket 0470).
+
+For each (document, plant, attribute, claimed-value) tuple, asks an LLM:
+"Does document X say plant P has attribute A = claimed value?"
+
+Verdicts are cached in a JSONL file keyed by
+(document_id, plant, attribute, claimed_value, judge_model, prompt_version).
+Re-runs read the cache; only novel (plant, claim) tuples hit the API.
+
+Relationship to deterministic baseline (ticket 0201 / score_provenance.py):
+  - The deterministic scorer (score_provenance.py) is the fast first pass:
+    string/number lookup — does the cited source contain value V for plant P.
+  - This LLM judge is the upgrade layer: catches paraphrase, unit-restated,
+    and table-layout cases the deterministic check misses.
+  - The deterministic baseline is NOT replaced; it remains the cheap first pass.
+
+ADR-7: ``faithfulness_score`` is wired into ``records_to_metrics()`` via the
+``justification`` dict so it sits alongside the deterministic provenance score
+in the complete scientific record.
+
+Note: Action 4 from the ticket spec ("test one before blasting" — one real
+verdict per attribute before any batch) is a validation step for the first live
+deployment; it is deferred under the no-API constraint of this ticket.
+
+Usage::
+
+    judge = FaithfulnessJudge()
+    verdict = judge.verdict(
+        doc="Decision 1195/QD-TTg says Pha Lai has 440 MW coal capacity.",
+        plant="Pha Lai",
+        attr="capacity",
+        claim="440",
+    )
+    print(verdict.supported, verdict.explanation)
+"""
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ── Prompt ────────────────────────────────────────────────────────────────────
+
+PROMPT_VERSION = "v1"
+DEFAULT_JUDGE_MODEL = "openai/gpt-4o-mini"
+
+_SYSTEM_PROMPT = (
+    "You are an evidence auditor for a power-plant database. "
+    "You answer only 'supported', 'contradicted', or 'not_mentioned'."
+)
+
+_USER_TEMPLATE = (
+    "Document:\n{doc}\n\n"
+    "Claim: Plant '{plant}' has {attr} = {claim}.\n\n"
+    "Does the document support, contradict, or not mention this claim? "
+    "Reply with exactly one word: supported / contradicted / not_mentioned. "
+    "Then add a short explanation (one sentence)."
+)
+
+_VALID_VERDICTS = frozenset({"supported", "contradicted", "not_mentioned"})
+
+
+# ── Data structures ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class Verdict:
+    """One faithfulness verdict from the LLM judge."""
+
+    supported: bool | None  # True=supported, False=contradicted/not_mentioned, None=error
+    raw: str  # raw text from the model
+    verdict_label: str  # 'supported' | 'contradicted' | 'not_mentioned' | 'error'
+    explanation: str = ""
+    cache_hit: bool = False
+    model: str = DEFAULT_JUDGE_MODEL
+    prompt_version: str = PROMPT_VERSION
+
+
+@dataclass
+class FaithfulnessJudge:
+    """LLM judge that scores whether a document supports a factual claim.
+
+    All verdicts are written to a JSONL cache keyed by
+    (document_id, plant, attribute, claimed_value, judge_model, prompt_version).
+
+    Parameters
+    ----------
+    cache:
+        Path to the JSONL verdict cache file.  Created on first write if it
+        does not exist.  Pass ``None`` to disable caching (every call hits the
+        API, useful in tests that mock _call_api).
+    model:
+        Judge model identifier (OpenRouter / OpenAI format).
+    prompt_version:
+        Prompt template version string.  Changing this invalidates existing
+        cache entries because they are keyed by model + prompt_version.
+    """
+
+    cache: Path | None = None
+    model: str = DEFAULT_JUDGE_MODEL
+    prompt_version: str = PROMPT_VERSION
+    _cache_data: dict = field(default_factory=dict, repr=False, init=False)
+
+    def __post_init__(self) -> None:
+        if self.cache is not None:
+            self._load_cache()
+
+    # ── Cache I/O ─────────────────────────────────────────────────────────────
+
+    def _load_cache(self) -> None:
+        """Load verdict cache from disk (JSONL, one JSON object per line)."""
+        if self.cache is None or not self.cache.exists():
+            return
+        with open(self.cache, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    key = entry.get("key")
+                    if key:
+                        self._cache_data[key] = entry
+                except json.JSONDecodeError:
+                    log.warning("Skipping malformed cache line: %s", line[:80])
+
+    def _save_to_cache(self, key: str, entry: dict) -> None:
+        """Append one verdict entry to the JSONL cache file."""
+        if self.cache is None:
+            return
+        self.cache.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.cache, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def _make_key(doc_id: str, plant: str, attr: str, claim: str, model: str, pv: str) -> str:
+        """Deterministic cache key from the 6-tuple."""
+        raw = json.dumps(
+            {"doc_id": doc_id, "plant": plant, "attr": attr, "claim": claim, "model": model, "pv": pv},
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    # ── API seam ──────────────────────────────────────────────────────────────
+
+    def _call_api(self, *, doc: str, plant: str, attr: str, claim: str) -> str:
+        """Send one verdict request to the configured judge model.
+
+        Returns the model's raw text response.  This method is the sole
+        network boundary — mock it in tests to avoid live API calls.
+
+        Raises
+        ------
+        RuntimeError
+            When the API call fails (network, auth, rate limit).  Callers
+            catch this and record verdict_label='error'.
+        """
+        try:
+            import openai  # type: ignore[import]
+        except ImportError as exc:
+            raise RuntimeError("openai package not installed; run `uv add openai`") from exc
+
+        client = openai.OpenAI()  # reads OPENAI_API_KEY from env
+        user_msg = _USER_TEMPLATE.format(doc=doc, plant=plant, attr=attr, claim=claim)
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": user_msg},
+            ],
+            max_tokens=128,
+            temperature=0.0,
+        )
+        return response.choices[0].message.content or ""
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _doc_id(doc: str) -> str:
+        """Stable document identifier (SHA-256 prefix of the document text)."""
+        return hashlib.sha256(doc.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _parse_raw(raw: str) -> tuple[str, str]:
+        """Parse model output into (verdict_label, explanation).
+
+        The model is instructed to start with one of
+        'supported' / 'contradicted' / 'not_mentioned'.
+        """
+        text = raw.strip()
+        lower = text.lower()
+        for label in ("supported", "contradicted", "not_mentioned"):
+            if lower.startswith(label):
+                explanation = text[len(label):].lstrip(". \t\n")
+                return label, explanation
+        # Fallback: scan for keyword anywhere in first line
+        first_line = lower.split("\n")[0]
+        for label in ("supported", "contradicted", "not_mentioned"):
+            if label in first_line:
+                return label, text
+        return "error", text
+
+    def verdict(
+        self,
+        doc: str,
+        *,
+        plant: str,
+        attr: str,
+        claim: str,
+    ) -> Verdict:
+        """Return the faithfulness verdict for one (document, plant, attr, claim) tuple.
+
+        If the key is already in the cache, returns the cached verdict without
+        calling the API.  On a cache miss, calls ``_call_api``, parses the
+        response, writes to cache, and returns the verdict.
+
+        Parameters
+        ----------
+        doc:
+            The document text (or excerpt) to judge.
+        plant:
+            Plant name as it appears in the extraction.
+        attr:
+            Attribute being checked: 'fuel', 'capacity', or 'status'.
+        claim:
+            The claimed value (e.g. "440" for capacity, "coal" for fuel).
+
+        Returns
+        -------
+        Verdict
+            supported=True when label is 'supported', False otherwise.
+            supported=None on API / parse errors.
+        """
+        doc_id = self._doc_id(doc)
+        key = self._make_key(doc_id, plant, attr, claim, self.model, self.prompt_version)
+
+        # ── Cache hit ─────────────────────────────────────────────────────────
+        if key in self._cache_data:
+            entry = self._cache_data[key]
+            label = entry.get("verdict_label", "error")
+            return Verdict(
+                supported=(True if label == "supported" else (None if label == "error" else False)),
+                raw=entry.get("raw", ""),
+                verdict_label=label,
+                explanation=entry.get("explanation", ""),
+                cache_hit=True,
+                model=entry.get("model", self.model),
+                prompt_version=entry.get("prompt_version", self.prompt_version),
+            )
+
+        # ── Cache miss → API call ─────────────────────────────────────────────
+        try:
+            raw = self._call_api(doc=doc, plant=plant, attr=attr, claim=claim)
+            label, explanation = self._parse_raw(raw)
+        except Exception as exc:
+            log.warning("LLM judge API call failed for %s/%s/%s: %s", plant, attr, claim, exc)
+            raw = str(exc)
+            label = "error"
+            explanation = raw
+
+        supported: bool | None
+        if label == "supported":
+            supported = True
+        elif label == "error":
+            supported = None
+        else:
+            supported = False
+
+        entry: dict[str, Any] = {
+            "key": key,
+            "doc_id": doc_id,
+            "plant": plant,
+            "attr": attr,
+            "claim": claim,
+            "model": self.model,
+            "prompt_version": self.prompt_version,
+            "verdict_label": label,
+            "raw": raw,
+            "explanation": explanation,
+        }
+        self._cache_data[key] = entry
+        self._save_to_cache(key, entry)
+
+        return Verdict(
+            supported=supported,
+            raw=raw,
+            verdict_label=label,
+            explanation=explanation,
+            cache_hit=False,
+            model=self.model,
+            prompt_version=self.prompt_version,
+        )
+
+    def faithfulness_score(
+        self,
+        verdicts: list[Verdict],
+    ) -> float | None:
+        """Compute per-run faithfulness scalar from a list of verdicts.
+
+        Returns the fraction of verdicts that are 'supported', or None when
+        the verdict list is empty or contains only errors (ADR-7: None means
+        no verdicts cached yet, not a score of 0.0).
+        """
+        valid = [v for v in verdicts if v.verdict_label != "error"]
+        if not valid:
+            return None
+        return round(sum(1 for v in valid if v.supported is True) / len(valid), 4)

--- a/src/aedist/measurements.py
+++ b/src/aedist/measurements.py
@@ -237,6 +237,9 @@ def records_to_metrics(records: list[RunRecord]) -> list[dict]:
                 ("verification_mode", "verification_mode"),
                 ("mean_evidence_score", "mean_evidence_score"),
                 ("verification_cost_usd", "verification_cost_usd"),
+                # 0470: LLM-judge faithfulness scalar (upgrade of deterministic baseline)
+                # None = no verdicts cached yet (see f1=None semantics); 0.0 would mislead.
+                ("faithfulness_score", "faithfulness_score"),
             ):
                 if r.justification.get(src_key) is not None:
                     d[out_key] = r.justification[src_key]

--- a/tests/test_llm_judge_faithfulness.py
+++ b/tests/test_llm_judge_faithfulness.py
@@ -1,0 +1,312 @@
+"""Tests for the cached LLM-judge faithfulness scorer (ticket 0470).
+
+All tests mock _call_api — no live API calls are made.
+"""
+
+import json
+
+import pytest
+
+from aedist.llm_judge_faithfulness import (
+    DEFAULT_JUDGE_MODEL,
+    PROMPT_VERSION,
+    FaithfulnessJudge,
+    Verdict,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _canned_api(raw: str):
+    """Return a fake _call_api that always returns ``raw`` text."""
+
+    def _fake(*, doc, plant, attr, claim):
+        return raw
+
+    return _fake
+
+
+def _boom(*, doc, plant, attr, claim):
+    """Fake _call_api that must never be called."""
+    raise AssertionError("_call_api must not be called on a cache hit")
+
+
+# ── Cache-hit test (the canonical test from the ticket spec) ──────────────────
+
+
+class TestCacheHitSkipsApi:
+    """Cache hit must not call the API."""
+
+    def test_cache_hit_skips_api(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "verdicts.jsonl"
+        judge = FaithfulnessJudge(cache=cache_path)
+
+        # Inject fake _call_api so the first call doesn't hit the network
+        monkeypatch.setattr(judge, "_call_api", _canned_api("supported — the document states 440 MW."))
+
+        # First call: cache miss → fake API call #1
+        v1 = judge.verdict(
+            "Decision 1195/QD-TTg states Pha Lai has 440 MW coal capacity.",
+            plant="Pha Lai",
+            attr="capacity",
+            claim="440",
+        )
+        assert v1.supported in (True, False)
+        assert not v1.cache_hit
+
+        # Swap to bomb — any API call now would raise
+        monkeypatch.setattr(judge, "_call_api", _boom)
+
+        # Second call: same key → cache hit, no API call
+        v2 = judge.verdict(
+            "Decision 1195/QD-TTg states Pha Lai has 440 MW coal capacity.",
+            plant="Pha Lai",
+            attr="capacity",
+            claim="440",
+        )
+        assert v2.supported in (True, False)
+        assert v2.cache_hit
+
+
+# ── Verdict parsing ───────────────────────────────────────────────────────────
+
+
+class TestParseRaw:
+    """_parse_raw extracts the label and explanation from model output."""
+
+    def test_supported_verdict(self):
+        label, expl = FaithfulnessJudge._parse_raw("supported — the document states 440 MW.")
+        assert label == "supported"
+        assert "440" in expl
+
+    def test_contradicted_verdict(self):
+        label, _ = FaithfulnessJudge._parse_raw("contradicted. The document says 500 MW.")
+        assert label == "contradicted"
+
+    def test_not_mentioned(self):
+        label, _ = FaithfulnessJudge._parse_raw("not_mentioned The document is silent on this.")
+        assert label == "not_mentioned"
+
+    def test_unknown_becomes_error(self):
+        label, raw = FaithfulnessJudge._parse_raw("I don't know.")
+        assert label == "error"
+
+    def test_case_insensitive(self):
+        label, _ = FaithfulnessJudge._parse_raw("SUPPORTED — value confirmed.")
+        assert label == "supported"
+
+
+# ── Verdict dataclass ─────────────────────────────────────────────────────────
+
+
+class TestVerdictSemantics:
+    """Verdict.supported follows the three-way semantics."""
+
+    def test_supported_true(self, tmp_path, monkeypatch):
+        judge = FaithfulnessJudge(cache=tmp_path / "v.jsonl")
+        monkeypatch.setattr(judge, "_call_api", _canned_api("supported — confirmed."))
+        v = judge.verdict("doc text", plant="P", attr="fuel", claim="coal")
+        assert v.supported is True
+        assert v.verdict_label == "supported"
+
+    def test_contradicted_false(self, tmp_path, monkeypatch):
+        judge = FaithfulnessJudge(cache=tmp_path / "v.jsonl")
+        monkeypatch.setattr(judge, "_call_api", _canned_api("contradicted — doc says gas."))
+        v = judge.verdict("doc text", plant="P", attr="fuel", claim="coal")
+        assert v.supported is False
+        assert v.verdict_label == "contradicted"
+
+    def test_not_mentioned_false(self, tmp_path, monkeypatch):
+        judge = FaithfulnessJudge(cache=tmp_path / "v.jsonl")
+        monkeypatch.setattr(judge, "_call_api", _canned_api("not_mentioned No fuel info."))
+        v = judge.verdict("doc text", plant="P", attr="fuel", claim="coal")
+        assert v.supported is False
+        assert v.verdict_label == "not_mentioned"
+
+    def test_api_error_returns_none(self, tmp_path, monkeypatch):
+        judge = FaithfulnessJudge(cache=tmp_path / "v.jsonl")
+
+        def _raise(**kwargs):
+            raise RuntimeError("network failure")
+
+        monkeypatch.setattr(judge, "_call_api", _raise)
+        v = judge.verdict("doc text", plant="P", attr="fuel", claim="coal")
+        assert v.supported is None
+        assert v.verdict_label == "error"
+
+
+# ── Cache persistence ─────────────────────────────────────────────────────────
+
+
+class TestCachePersistence:
+    """Cache survives process restart (new FaithfulnessJudge reads existing file)."""
+
+    def test_written_verdicts_survive_reload(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "v.jsonl"
+        judge1 = FaithfulnessJudge(cache=cache_path)
+        monkeypatch.setattr(judge1, "_call_api", _canned_api("supported — confirmed."))
+
+        judge1.verdict("doc A", plant="P", attr="capacity", claim="600")
+
+        # New judge instance loads the cache
+        judge2 = FaithfulnessJudge(cache=cache_path)
+        monkeypatch.setattr(judge2, "_call_api", _boom)  # must not be called
+
+        v = judge2.verdict("doc A", plant="P", attr="capacity", claim="600")
+        assert v.cache_hit
+        assert v.supported is True
+
+    def test_cache_file_is_valid_jsonl(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "v.jsonl"
+        judge = FaithfulnessJudge(cache=cache_path)
+        monkeypatch.setattr(judge, "_call_api", _canned_api("supported — yes."))
+
+        judge.verdict("doc B", plant="Q", attr="status", claim="operating")
+
+        lines = [ln for ln in cache_path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["plant"] == "Q"
+        assert entry["attr"] == "status"
+        assert entry["verdict_label"] == "supported"
+        assert entry["model"] == DEFAULT_JUDGE_MODEL
+        assert entry["prompt_version"] == PROMPT_VERSION
+
+
+# ── Cache key includes model + prompt_version ─────────────────────────────────
+
+
+class TestCacheKeyInvalidation:
+    """Changing model or prompt_version bypasses cached verdicts."""
+
+    def test_different_model_is_cache_miss(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "v.jsonl"
+
+        judge_a = FaithfulnessJudge(cache=cache_path, model="openai/gpt-4o-mini")
+        call_count = {"n": 0}
+
+        def _count(**kwargs):
+            call_count["n"] += 1
+            return "supported — by model A."
+
+        monkeypatch.setattr(judge_a, "_call_api", _count)
+        judge_a.verdict("doc C", plant="R", attr="fuel", claim="gas")
+        assert call_count["n"] == 1
+
+        judge_b = FaithfulnessJudge(cache=cache_path, model="anthropic/claude-3-haiku")
+        call_count2 = {"n": 0}
+
+        def _count2(**kwargs):
+            call_count2["n"] += 1
+            return "supported — by model B."
+
+        monkeypatch.setattr(judge_b, "_call_api", _count2)
+        judge_b.verdict("doc C", plant="R", attr="fuel", claim="gas")
+        assert call_count2["n"] == 1, "different model should be a cache miss"
+
+
+# ── faithfulness_score scalar ─────────────────────────────────────────────────
+
+
+class TestFaithfulnessScore:
+    """faithfulness_score reduces a list of verdicts to a float | None."""
+
+    def test_all_supported(self):
+        verdicts = [
+            Verdict(supported=True, raw="supported", verdict_label="supported"),
+            Verdict(supported=True, raw="supported", verdict_label="supported"),
+        ]
+        judge = FaithfulnessJudge()
+        assert judge.faithfulness_score(verdicts) == 1.0
+
+    def test_mixed_verdicts(self):
+        verdicts = [
+            Verdict(supported=True, raw="supported", verdict_label="supported"),
+            Verdict(supported=False, raw="contradicted", verdict_label="contradicted"),
+            Verdict(supported=False, raw="not_mentioned", verdict_label="not_mentioned"),
+        ]
+        judge = FaithfulnessJudge()
+        score = judge.faithfulness_score(verdicts)
+        assert score == pytest.approx(1 / 3, abs=1e-4)
+
+    def test_empty_list_returns_none(self):
+        """ADR-7 / f1=None semantics: no verdicts = None, not 0.0."""
+        judge = FaithfulnessJudge()
+        assert judge.faithfulness_score([]) is None
+
+    def test_all_errors_returns_none(self):
+        """All-error verdicts carry no information → None."""
+        verdicts = [
+            Verdict(supported=None, raw="err", verdict_label="error"),
+            Verdict(supported=None, raw="err", verdict_label="error"),
+        ]
+        judge = FaithfulnessJudge()
+        assert judge.faithfulness_score(verdicts) is None
+
+    def test_errors_excluded_from_denominator(self):
+        """Error verdicts are excluded from the denominator."""
+        verdicts = [
+            Verdict(supported=True, raw="supported", verdict_label="supported"),
+            Verdict(supported=None, raw="err", verdict_label="error"),
+        ]
+        judge = FaithfulnessJudge()
+        assert judge.faithfulness_score(verdicts) == 1.0
+
+
+# ── measurements.py wiring (ADR-7) ───────────────────────────────────────────
+
+
+class TestMeasurementsWiring:
+    """faithfulness_score is projected from justification into the metrics dict."""
+
+    def _make_record(self, justification: dict | None):
+
+        from aedist.schema import Method, MethodParams, ResultSummary, RunRecord
+
+        return RunRecord(
+            method=Method.RAG,
+            method_params=MethodParams(model="test/model"),
+            result_summary=ResultSummary(tp=1, fp=0, fn=0, f1=1.0),
+            justification=justification,
+        )
+
+    def test_faithfulness_score_present_when_in_justification(self):
+        from aedist.measurements import records_to_metrics
+
+        record = self._make_record({"faithfulness_score": 0.75})
+        metrics = records_to_metrics([record])
+        assert len(metrics) == 1
+        assert metrics[0]["faithfulness_score"] == pytest.approx(0.75)
+
+    def test_faithfulness_score_absent_when_null(self):
+        """None value is omitted (same as other omit-when-absent fields)."""
+        from aedist.measurements import records_to_metrics
+
+        record = self._make_record({"faithfulness_score": None})
+        metrics = records_to_metrics([record])
+        assert "faithfulness_score" not in metrics[0]
+
+    def test_faithfulness_score_absent_when_no_justification(self):
+        """No justification → key not present in metrics dict."""
+        from aedist.measurements import records_to_metrics
+
+        record = self._make_record(None)
+        metrics = records_to_metrics([record])
+        assert "faithfulness_score" not in metrics[0]
+
+    def test_existing_verification_scalars_unaffected(self):
+        """Adding faithfulness_score does not disturb existing justification keys."""
+        from aedist.measurements import records_to_metrics
+
+        record = self._make_record(
+            {
+                "verification_mode": "strict",
+                "mean_evidence_score": 3.5,
+                "faithfulness_score": 0.9,
+            }
+        )
+        metrics = records_to_metrics([record])
+        m = metrics[0]
+        assert m["verification_mode"] == "strict"
+        assert m["mean_evidence_score"] == pytest.approx(3.5)
+        assert m["faithfulness_score"] == pytest.approx(0.9)

--- a/tickets/0470-cached-llm-judge-source-faithfulness-sco.erg
+++ b/tickets/0470-cached-llm-judge-source-faithfulness-sco.erg
@@ -3,10 +3,12 @@ Title: Cached LLM-judge source-faithfulness scorer (fuel/capacity/status in sour
 Created: 2026-06-08
 Author: claude
 Label: deferred
+Closed: implemented with mocked tests; deferred per post-preprint scope
 
 --- log ---
 2026-06-08T14:39Z claude created
 
+2026-06-08T21:41Z HDMX-coding-agent closed — implemented with mocked tests; deferred per post-preprint scope
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Adds `FaithfulnessJudge` in `src/aedist/llm_judge_faithfulness.py` with a JSONL verdict cache keyed by `(doc_id, plant, attr, claim, judge_model, prompt_version)`. Cache hits skip the API; changing model or prompt_version invalidates stale entries.
- Wires `faithfulness_score` scalar into `records_to_metrics()` via the `justification` dict (ADR-7 omit-when-absent; `None` = no verdicts yet, not `0.0`).
- Deterministic baseline (`score_provenance.py`, ticket 0201) is untouched — this is a layered upgrade, not a replacement.

## Test plan

- [x] 22 unit tests in `tests/test_llm_judge_faithfulness.py`; `_call_api` fully mocked — no live API calls
- [x] Cache-hit test (canonical ticket spec): second call with same key uses cache, never calls API
- [x] Verdict parsing, three-way semantics (supported/contradicted/not_mentioned/error)
- [x] Cache persistence across `FaithfulnessJudge` instances
- [x] `faithfulness_score` ADR-7 wiring (present, absent-when-null, absent-when-no-justification)
- [x] `make check-fast` passes (2292 passed, 0 failed on new code; pre-existing ruff test also fixed by renaming `l` → `ln`)

**Ticket:** tickets/0470-cached-llm-judge-source-faithfulness-sco.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)