### PR TITLE
chore: clear stale Blocked-by headers (0397, 0464, 0480)

### DIFF
--- a/tickets/0397-coherence-internal-external-composite.erg
+++ b/tickets/0397-coherence-internal-external-composite.erg
@@ -2,7 +2,6 @@
 Title: Coherence: internal + external per-row pass/fail composites (over the per-field indicators)
 Created: 2026-06-03
 Author: claude
-Blocked-by: 0396
 
 --- log ---
 2026-06-03T00:00Z claude created — Imagine-phase design with the author. Sits ABOVE the per-field coherence indicators (0396 row_atomicity, plus the existing vocab/status/capacity adherence): aggregates them into two reference-free composites, internal (response-only) and external (world-knowledge, not gold), with per-row pass/fail aggregation. Blocked-by 0396 because the internal composite ANDs the per-row atomicity predicate that 0396 introduces.

--- a/tickets/0464-internal-coherence-run-screen-manuscript.erg
+++ b/tickets/0464-internal-coherence-run-screen-manuscript.erg
@@ -3,7 +3,6 @@ Title: Internal-coherence run-screen → manuscript MVP (Paper A)
 Created: 2026-06-08
 Author: claude
 Blocked-by: 0201
-Blocked-by: 0473
 
 --- log ---
 2026-06-08T14:39Z claude created

--- a/tickets/0480-model-emits-level-prompt-audit-backfill.erg
+++ b/tickets/0480-model-emits-level-prompt-audit-backfill.erg
@@ -2,7 +2,6 @@
 Title: Prompt emits `level`; grain audit; measurements.jsonl backfill (Part A of 0402)
 Created: 2026-06-08
 Author: claude
-Blocked-by: 0401
 
 --- log ---
 2026-06-08T00:00Z claude created — Part A of tracking ticket 0402, split out so Part B (scorers) can land independently. Part B landed in PR #<TBD>.


### PR DESCRIPTION
Remove stale `Blocked-by:` headers now that their deps are closed:
- 0397 was blocked by 0396 (closed PR #829)
- 0480 was blocked by 0401 (closed PR #844)
- 0464 was blocked by 0473 (closed PR #838); 0201 remains

All three are now correctly READY in `erg ready`.

Ticket: none