### PR TITLE
chore: label 0481 deferred

### DIFF
--- a/tickets/0481-per-attribute-fusion-gtm-ds-vintage.erg
+++ b/tickets/0481-per-attribute-fusion-gtm-ds-vintage.erg
@@ -2,10 +2,12 @@
 Title: Per-attribute fusion layer — GTM capacity, DS fuel, time-indexed status vintage
 Created: 2026-06-08
 Author: HDMX-coding-agent
+Label: deferred
 
 --- log ---
 2026-06-08T22:00Z HDMX-coding-agent created — split from 0398 during descope; three unimplemented DoD bullets promoted to child ticket
 
+2026-06-09T06:18Z HDMX-coding-agent label deferred
 --- body ---
 ## Context
 


### PR DESCRIPTION
Per-attribute fusion (GTM capacity, DS fuel, vintage status) requires
RunSet attribute fields that don't exist yet — structurally blocked until
upstream data model lands. Label deferred so it stays out of raid targets.

Ticket: none