### PR TITLE
fix(0433): annex test C→B→C rename + salvage spider --prompt-prefix filter

### DIFF
--- a/src/aedist/plot_quality_spider.py
+++ b/src/aedist/plot_quality_spider.py
@@ -98,6 +98,24 @@ def _load_rows(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(fh))
 
 
+def _filter_exp2_rows(rows: list[dict[str, str]], prompt_prefix: str) -> list[dict[str, str]]:
+    filtered = [
+        row for row in rows if str(row.get("prompt_version", "")).strip().startswith(prompt_prefix)
+    ]
+    dropped = len(rows) - len(filtered)
+    if dropped > 0:
+        log.warning(
+            "quality spider: dropped %d non-%s rows from input", dropped, prompt_prefix
+        )
+    if not filtered:
+        msg = (
+            f"quality spider: input has no rows with prompt_version prefix '{prompt_prefix}' "
+            "(this figure is currently Exp2-only)"
+        )
+        raise ValueError(msg)
+    return filtered
+
+
 def _load_config(path: Path) -> dict:
     with path.open(encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
@@ -304,8 +322,14 @@ def main(argv: list[str] | None = None) -> None:
         default=Path("report/inputs/generated/fig_quality_spider.pdf"),
         help="Path to write PDF figure",
     )
+    parser.add_argument(
+        "--prompt-prefix",
+        default="exp2",
+        help="Only rows whose prompt_version starts with this prefix are plotted",
+    )
     args = parser.parse_args(argv)
-    make_figure(_load_rows(args.input), _load_config(args.config), args.output)
+    rows = _filter_exp2_rows(_load_rows(args.input), args.prompt_prefix)
+    make_figure(rows, _load_config(args.config), args.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_md_annex_c_as_run.py
+++ b/tests/test_main_md_annex_c_as_run.py
@@ -1,15 +1,21 @@
-"""Ticket 0433 — main.md Annex B (formerly Annex C) rewritten to the as-run Exp2 story.
+"""Ticket 0433 — main.md Annex C (Exp2 tech spec) rewritten to the as-run story.
 
-Annex B of the preprint (slides/manuscript/main.md, renamed from Annex C in
-ticket 0469 restructure) was a PRE-RUN spec snapshot: it claimed Phase B at
-N=3, a $10/call dollar cap, and carried a "not yet executed" bracketed status
-note. That contradicted the as-run body (§5 "Experiment 2 — SOTA frontier",
-which states two arms, N=5, a 2×2 factorial) and the committed artifacts
+Annex C of the preprint (slides/manuscript/main.md) holds the Experiment 2
+technical specification. Naming history:
+- Originally Annex C (Exp2 tech spec).
+- Renamed to Annex B in ticket 0469 restructure (Annex A moved to Related Work).
+- Renamed back to Annex C in ticket 0482 section reorder (Temporality became
+  Annex A, Exp1-tech became Annex B, Exp2-tech became Annex C).
+
+The annex was a PRE-RUN spec snapshot: it claimed Phase B at N=3, a $10/call
+dollar cap, and carried a "not yet executed" bracketed status note. That
+contradicted the as-run body (§5 "Experiment 2 — SOTA frontier", which states
+two arms, N=5, a 2×2 factorial) and the committed artifacts
 (tab_exp2_2x2.csv, tab_exp2_bib_quality).
 
 This adherence test pins the rewrite's load-bearing invariants:
 
-1. No stale pre-run marker survives in Annex B: "N=3", the "not yet executed"
+1. No stale pre-run marker survives in Annex C: "N=3", the "not yet executed"
    note, the "$10.00" status cap, "≤$10" / "≤$31" budget figures.
 2. The as-run facts are present: two named arms (naive/optimised), N=5, the
    dual-axis cap (50K tokens + $3 guard), and the 2×2 / four-arm framing the
@@ -33,15 +39,15 @@ MAIN_MD = REPO_ROOT / "slides" / "manuscript" / "main.md"
 
 
 def _annex_c() -> str:
-    """The text of Annex B (Experiment 2) — from its heading up to the next top-level heading.
+    """The text of Annex C (Experiment 2) — from its heading up to the next top-level heading.
 
-    Formerly Annex C; renamed to Annex B in ticket 0469 restructure (Annex A
-    was moved to §9 Related Work in the body).
+    Named Annex C after ticket 0482 section reorder (Temporality→A, Exp1-tech→B,
+    Exp2-tech→C, Supplementary→D, Recognition→E, Screen→F).
     """
     text = MAIN_MD.read_text(encoding="utf-8")
-    start = text.index("## Annex B — Experiment 2: Technical specification")
+    start = text.index("## Annex C — Experiment 2: Technical specification")
     rest = text[start:]
-    nxt = rest.index("\n## Annex C", 1)
+    nxt = rest.index("\n## Annex D", 1)
     return rest[:nxt]
 
 


### PR DESCRIPTION
## Summary

- Fix `test_main_md_annex_c_as_run.py` broken by ticket 0482 annex reorder: `## Annex B — Experiment 2` → `## Annex C — Experiment 2`, end boundary `Annex C` → `Annex D`
- Salvage uncommitted `plot_quality_spider.py` feature from stale worktree: add `_filter_exp2_rows()` + `--prompt-prefix` flag so the Exp2 quality spider excludes Exp1 rows

## Test plan
- [ ] `pytest -m adherence` passes (9 previously failing tests now green)
- [ ] `make check` passes

Ticket: none
🤖 Generated with [Claude Code](https://claude.com/claude-code)