### PR TITLE
ticket(0461): .DELETE_ON_ERROR across all build makefiles + class guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@
 # full re-run must never trigger a money-costing re-acquisition. Re-acquire raw
 # replies only by explicitly invoking experiments/acquire.mk.
 
+# Atomicity: delete a target whose recipe crashes mid-write so Make never treats
+# a partial file as up-to-date. The recursive $(MAKE) delegations run as their
+# own invocations and get this from their own makefiles (paths.mk / common.mk /
+# the phase root); this line covers any direct-write recipe in THIS root
+# invocation (ticket 0461, generalising 0460).
+.DELETE_ON_ERROR:
+
 .PHONY: test test-fast test-slow coverage lint check-fast check show-prompts \
 	report slides staleness world cleaner
 

--- a/experiments/common.mk
+++ b/experiments/common.mk
@@ -11,6 +11,13 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
+# Atomicity: delete a target whose recipe crashes mid-write so Make never sees a
+# partial file with a fresh mtime as up-to-date. Set here as the single source
+# for the three invocation roots that include this file (acquire.mk +
+# experiment1.mk + experiment2.mk); a special target in an included file is
+# honoured for the whole invocation (ticket 0461).
+.DELETE_ON_ERROR:
+
 # Canonical uv invocation: project venv + project .env.
 UV_RUN := uv run --project .. --env-file ../.env
 

--- a/experiments/derived/score.mk
+++ b/experiments/derived/score.mk
@@ -49,13 +49,11 @@ SCORE_MK_SELF := $(abspath $(lastword $(MAKEFILE_LIST)))
 
 include $(dir $(lastword $(MAKEFILE_LIST)))../paths.mk
 
-# Atomicity: delete a target whose recipe fails mid-write. Without this, a
-# crash partway through an append/stream write (e.g. score_exp1 appending to
-# exp1_cross_eval.csv, or any --output writer here) leaves a PARTIAL file with
-# a fresh mtime that Make treats as up-to-date — a silent stale-artifact
-# hazard. This is the correctness guarantee that lets single-known-output
-# recipes drop their .done sentinels and be plain-file rules (ticket 0460).
-.DELETE_ON_ERROR:
+# Atomicity (.DELETE_ON_ERROR) is set in the included paths.mk as the single
+# source for both phases that read it (P2 here + P3 render.mk) — ticket 0461,
+# generalising 0460 which first added it locally here. A special target set in
+# an included file is honoured for the whole invocation, so this phase still
+# self-cleans crashed writes without a duplicate directive.
 
 # --- P2-local tooling -------------------------------------------------------
 # Bare `uv run` (no --env-file): P2 scoring makes no API calls, so it needs no
@@ -236,8 +234,9 @@ $(ANALYSIS_DERIVED_DIR)/arm2_flat/.done: $(ANALYSIS_EXPERIMENTS_DIR)/outputs/sot
 
 # exp1_cross_eval.csv is a single known output (score_exp1 writes exactly one
 # file and mkdirs its own parent), so it is a plain-file rule — no .done stamp,
-# no dedicated holding directory. score_exp1 appends, hence the rm -f; the
-# .DELETE_ON_ERROR above makes a crashed write self-clean (ticket 0460).
+# no dedicated holding directory. score_exp1 appends, hence the rm -f;
+# .DELETE_ON_ERROR (set via the included paths.mk) makes a crashed write
+# self-clean (tickets 0460, 0461).
 $(ANALYSIS_EXP1_CROSS_EVAL_CSV): $(ANALYSIS_EXP1_INPUT_CSVS) $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_exp1.py
 	rm -f $@
 	uv run python -m aedist.score_exp1 \

--- a/experiments/paths.mk
+++ b/experiments/paths.mk
@@ -1,6 +1,7 @@
 # Shared path/variable definitions for the AEDIST analysis + render phases.
 #
-# VARIABLES ONLY — this file declares zero rules. It is included by both
+# VARIABLES ONLY — this file declares zero rules (the lone `.DELETE_ON_ERROR:`
+# special target below is a directive, not a rule). It is included by both
 # experiments/derived/score.mk (P2 score & consolidate) and
 # experiments/render.mk (P3 analyze & render) so the two phases agree on where
 # the repository tree, the derived data, and the P2 outcomes they share live.
@@ -19,6 +20,17 @@
 # purpose — ticket 0409 / tracker 0406 S2).
 
 SHELL := /bin/bash
+
+# Atomicity: delete a target whose recipe fails mid-write. Without this, a crash
+# partway through an append/stream write (e.g. score_exp1 appending to
+# exp1_cross_eval.csv, or any --output / tectonic writer in a phase that reads
+# this file) leaves a PARTIAL file with a fresh mtime that Make treats as
+# up-to-date — a silent stale-artifact hazard. Set here as the single source for
+# both including phases (P2 score.mk + P3 render.mk); a special target set in an
+# included file is honoured for the whole invocation (ticket 0461, generalising
+# 0460 which first added this to score.mk). This is also the guarantee that lets
+# single-known-output recipes drop their .done sentinels and be plain-file rules.
+.DELETE_ON_ERROR:
 
 ANALYSIS_REPO_ROOT ?= .
 ANALYSIS_EXPERIMENTS_DIR ?= $(ANALYSIS_REPO_ROOT)/experiments

--- a/report/Makefile
+++ b/report/Makefile
@@ -6,6 +6,11 @@
 
 GENERATED := inputs/generated
 
+# Atomicity: delete a target whose recipe crashes mid-write — a tectonic run
+# killed partway leaves a truncated report.pdf with a fresh mtime that Make
+# would treat as up-to-date (ticket 0461, generalising 0460).
+.DELETE_ON_ERROR:
+
 .PHONY: all clean cleaner
 
 all: report.pdf

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -4,6 +4,11 @@
 # no data access. To regenerate figures/tables, run the render (P3) workpackage:
 #   make -f experiments/render.mk exp2-analysis-report
 
+# Atomicity: delete a target whose recipe crashes mid-write — a tectonic run
+# killed partway leaves a truncated slides/manuscript PDF with a fresh mtime
+# that Make would treat as up-to-date (ticket 0461, generalising 0460).
+.DELETE_ON_ERROR:
+
 ROOT_REPORT_GEN := report/inputs/generated
 LOCAL_ROOT_REPORT_GEN := ../report/inputs/generated
 

--- a/tests/test_makefile_delete_on_error.py
+++ b/tests/test_makefile_delete_on_error.py
@@ -1,0 +1,111 @@
+"""Every build makefile that runs recipes must have `.DELETE_ON_ERROR` in force.
+
+`.DELETE_ON_ERROR` makes Make delete a target whose recipe crashed mid-write,
+instead of leaving a partial file with a fresh mtime that Make then treats as
+up-to-date (a silent stale artifact). The directive is global to a single
+`make` invocation, not per-rule, and it is honoured even when set in an
+`include`d file. So a makefile is *covered* when the directive lives in the
+file itself OR in any file it (transitively) includes.
+
+This is the standing class guard (ticket 0461, generalising 0460 from score.mk):
+a new phase makefile added later without the directive — directly or via a
+shared include like `paths.mk`/`common.mk` — fails this test.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# `include <path>` — capture the raw argument. We resolve the project's two
+# idioms: a plain relative path, and the cwd-independent
+# `$(dir $(lastword $(MAKEFILE_LIST)))<rel>` prefix (which expands to the
+# including makefile's own directory).
+_INCLUDE_RE = re.compile(r"^\s*[-]?include\s+(\S.*?)\s*$", re.MULTILINE)
+_MAKEFILE_LIST_DIR = "$(dir $(lastword $(MAKEFILE_LIST)))"
+
+
+def _makefiles() -> list[Path]:
+    """All committed makefiles in the repo (root Makefile + *.mk, any depth)."""
+    found = [
+        p
+        for pat in ("Makefile", "*.mk")
+        for p in REPO_ROOT.rglob(pat)
+        if ".git" not in p.parts
+    ]
+    return sorted(set(found))
+
+
+def _resolve_include(makefile: Path, raw: str) -> Path | None:
+    """Resolve an `include` argument to a path relative to `makefile`'s dir.
+
+    Returns None for arguments we cannot statically resolve (variables we do
+    not expand, globs) — those are simply not followed.
+    """
+    expr = raw.replace(_MAKEFILE_LIST_DIR, "").strip()
+    if "$(" in expr or "*" in expr or "?" in expr:
+        return None
+    candidate = (makefile.parent / expr).resolve()
+    return candidate if candidate.is_file() else None
+
+
+def _includes(makefile: Path) -> list[Path]:
+    text = makefile.read_text(encoding="utf-8")
+    out = []
+    for raw in _INCLUDE_RE.findall(text):
+        resolved = _resolve_include(makefile, raw)
+        if resolved is not None:
+            out.append(resolved)
+    return out
+
+
+def _has_recipes(makefile: Path) -> bool:
+    """True if the makefile defines at least one recipe.
+
+    A recipe is a TAB-indented command line. We exclude TAB-indented
+    backslash-continuations of a variable assignment (e.g. a `VAR = \\` list),
+    which also start with a tab: a line is a recipe only when the *previous*
+    physical line does not end with a backslash.
+    """
+    prev_continues = False
+    for line in makefile.read_text(encoding="utf-8").splitlines():
+        if line.startswith("\t") and not prev_continues:
+            return True
+        prev_continues = line.rstrip().endswith("\\")
+    return False
+
+
+def _sets_directive(makefile: Path) -> bool:
+    return ".DELETE_ON_ERROR" in makefile.read_text(encoding="utf-8")
+
+
+def _reachable(makefile: Path, seen: set[Path] | None = None) -> bool:
+    """True if `.DELETE_ON_ERROR` is set in `makefile` or anything it includes."""
+    seen = seen if seen is not None else set()
+    if makefile in seen:
+        return False
+    seen.add(makefile)
+    if _sets_directive(makefile):
+        return True
+    return any(_reachable(inc, seen) for inc in _includes(makefile))
+
+
+def test_recipe_makefiles_have_delete_on_error():
+    recipe_makefiles = [m for m in _makefiles() if _has_recipes(m)]
+    # Sanity: discovery actually found the build makefiles.
+    assert recipe_makefiles, "no recipe-bearing makefiles discovered"
+
+    uncovered = [
+        m.relative_to(REPO_ROOT).as_posix()
+        for m in recipe_makefiles
+        if not _reachable(m)
+    ]
+    assert not uncovered, (
+        ".DELETE_ON_ERROR not reachable (self or via include) in build "
+        f"makefiles that run recipes: {uncovered}. Add `.DELETE_ON_ERROR:` to "
+        "the file or to a shared include it reads (paths.mk / common.mk)."
+    )

--- a/tests/test_makefile_delete_on_error.py
+++ b/tests/test_makefile_delete_on_error.py
@@ -79,8 +79,17 @@ def _has_recipes(makefile: Path) -> bool:
     return False
 
 
+# The directive as an actual special-target declaration: `.DELETE_ON_ERROR`
+# at the start of a line (optional leading whitespace) followed by its colon.
+# A line that merely MENTIONS the string in a comment (`# .DELETE_ON_ERROR …`)
+# does not match — otherwise a makefile documenting the directive would be
+# scored as setting it, and a real regression (the line deleted but a comment
+# left behind) would slip through.
+_DIRECTIVE_RE = re.compile(r"^[ \t]*\.DELETE_ON_ERROR[ \t]*:", re.MULTILINE)
+
+
 def _sets_directive(makefile: Path) -> bool:
-    return ".DELETE_ON_ERROR" in makefile.read_text(encoding="utf-8")
+    return _DIRECTIVE_RE.search(makefile.read_text(encoding="utf-8")) is not None
 
 
 def _reachable(makefile: Path, seen: set[Path] | None = None) -> bool:

--- a/tests/test_score_mk_exp1_cross_eval.py
+++ b/tests/test_score_mk_exp1_cross_eval.py
@@ -24,6 +24,10 @@ pytestmark = pytest.mark.adherence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCORE_MK = REPO_ROOT / "experiments" / "derived" / "score.mk"
+# score.mk includes ../paths.mk, where the directive now lives as the single
+# source for both phases that read it (ticket 0461). A special target set in an
+# included file is honoured for the whole invocation.
+PATHS_MK = REPO_ROOT / "experiments" / "paths.mk"
 
 
 def _score_mk_text() -> str:
@@ -31,11 +35,22 @@ def _score_mk_text() -> str:
 
 
 def test_delete_on_error_is_set():
-    """Atomicity: a crashed recipe must not leave a stale-but-fresh artifact."""
-    assert ".DELETE_ON_ERROR:" in _score_mk_text(), (
-        "score.mk must set .DELETE_ON_ERROR so a recipe that crashes mid-write "
-        "(e.g. score_exp1 appending to exp1_cross_eval.csv) does not leave a "
-        "partial output with a current mtime"
+    """Atomicity: a crashed recipe must not leave a stale-but-fresh artifact.
+
+    Since ticket 0461 the directive lives in the included ../paths.mk (single
+    source for score.mk + render.mk), not literally in score.mk. We assert the
+    guarantee is in force for the score phase regardless of which of the two
+    files carries it. The whole-class guard is test_makefile_delete_on_error.py.
+    """
+    in_force = (
+        ".DELETE_ON_ERROR:" in _score_mk_text()
+        or ".DELETE_ON_ERROR:" in PATHS_MK.read_text(encoding="utf-8")
+    )
+    assert in_force, (
+        "the score phase must have .DELETE_ON_ERROR in force (in score.mk or in "
+        "the ../paths.mk it includes) so a recipe that crashes mid-write (e.g. "
+        "score_exp1 appending to exp1_cross_eval.csv) does not leave a partial "
+        "output with a current mtime"
     )
 
 

--- a/tickets/0461-add-delete-on-error-across-all-build-mak.erg
+++ b/tickets/0461-add-delete-on-error-across-all-build-mak.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-08T09:41Z HDMX-coding-agent created
+2026-06-09T00:00Z claude note delivered. Placement uses two shared-include single sources + three standalone roots: .DELETE_ON_ERROR set in paths.mk (covers score.mk + render.mk, both include it) and in common.mk (covers acquire.mk + experiment1.mk + experiment2.mk, all include it); plus root Makefile, report/Makefile, slides/Makefile (independent invocation roots, no relevant include). score.mk's local 0460 directive dropped — now inherited from paths.mk (single source). SCOPE FINDING: the original "6 of 7" sweep missed experiment1.mk and experiment2.mk (both carry recipes, both include common.mk) — same class defect, folded in. 0460's test (test_score_mk_exp1_cross_eval.py::test_delete_on_error_is_set) updated to assert the guarantee in force via score.mk OR the included paths.mk, per Actions step 3. New class guard tests/test_makefile_delete_on_error.py: source-inspection, follows includes transitively, negative-control verified (removing the directive from common.mk turns acquire/experiment1/experiment2 red). make check-fast green; pre-existing unrelated failure test_agents_md_skills::test_agents_md_skill_refs_resolve (fails on parent commit too, IDH skills absent in checkout).
 
 --- body ---
 ## Context

--- a/tickets/closed/0461-add-delete-on-error-across-all-build-mak.erg
+++ b/tickets/closed/0461-add-delete-on-error-across-all-build-mak.erg
@@ -2,11 +2,13 @@
 Title: Add .DELETE_ON_ERROR across all build makefiles + adherence guard
 Created: 2026-06-08
 Author: HDMX-coding-agent
+Closed: opened PR 879 — .DELETE_ON_ERROR build-wide + class guard; experiment1/2.mk folded in beyond the original 6/7 sweep
 
 --- log ---
 2026-06-08T09:41Z HDMX-coding-agent created
 2026-06-09T00:00Z claude note delivered. Placement uses two shared-include single sources + three standalone roots: .DELETE_ON_ERROR set in paths.mk (covers score.mk + render.mk, both include it) and in common.mk (covers acquire.mk + experiment1.mk + experiment2.mk, all include it); plus root Makefile, report/Makefile, slides/Makefile (independent invocation roots, no relevant include). score.mk's local 0460 directive dropped — now inherited from paths.mk (single source). SCOPE FINDING: the original "6 of 7" sweep missed experiment1.mk and experiment2.mk (both carry recipes, both include common.mk) — same class defect, folded in. 0460's test (test_score_mk_exp1_cross_eval.py::test_delete_on_error_is_set) updated to assert the guarantee in force via score.mk OR the included paths.mk, per Actions step 3. New class guard tests/test_makefile_delete_on_error.py: source-inspection, follows includes transitively, negative-control verified (removing the directive from common.mk turns acquire/experiment1/experiment2 red). make check-fast green; pre-existing unrelated failure test_agents_md_skills::test_agents_md_skill_refs_resolve (fails on parent commit too, IDH skills absent in checkout).
 
+2026-06-09T08:14Z Claude closed — opened PR 879 — .DELETE_ON_ERROR build-wide + class guard; experiment1/2.mk folded in beyond the original 6/7 sweep
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Generalises ticket 0460's `score.mk` atomicity directive **build-wide**: any phase whose recipe crashes mid-write previously could leave a partial file with a fresh mtime that Make treats as up-to-date (a silent stale artifact). `.DELETE_ON_ERROR` is now in force across every recipe-bearing build makefile.

## Placement — single source per include-cluster + standalone roots

| Source file | Covers |
|---|---|
| `experiments/paths.mk` | `score.mk` + `render.mk` (both `include` it) |
| `experiments/common.mk` | `acquire.mk` + `experiment1.mk` + `experiment2.mk` (all `include` it) |
| `Makefile`, `report/Makefile`, `slides/Makefile` | themselves (independent invocation roots, no relevant include) |

`score.mk`'s local 0460 copy is dropped — now inherited from `paths.mk`, so there is one source of truth for the two phases that read it. A special target set in an `include`d file is honoured for the whole invocation, so each phase still self-cleans crashed writes.

## Scope finding

The originating "6 of 7" sweep had **missed `experiment1.mk` and `experiment2.mk`** — both carry recipes and lacked the directive (same class defect). Folded in via `common.mk`; the class guard fails without them.

## Tests

- **NEW** `tests/test_makefile_delete_on_error.py` (`@pytest.mark.adherence`): source inspection, no subprocess. For every recipe-bearing makefile, asserts `.DELETE_ON_ERROR` is reachable in the file or anything it transitively `include`s. Negative control verified: removing the directive from `common.mk` turns `acquire`/`experiment1`/`experiment2` red.
- **Updated** `tests/test_score_mk_exp1_cross_eval.py::test_delete_on_error_is_set`: asserts the guarantee in force via `score.mk` **or** the included `paths.mk` (location moved, guarantee kept — Actions step 3).

## Verification

- `make -n` parses clean on all invocation roots; `make lint` green.
- Full fast suite green except a **pre-existing unrelated** failure (`test_agents_md_skills::test_agents_md_skill_refs_resolve`, fails identically on the parent commit — IDH skills absent in this checkout).
- No artifact content changes — this only affects crash behaviour.

Closes ticket 0461.

https://claude.ai/code/session_01RUGx9wvmiPxzKV4PU4zPsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUGx9wvmiPxzKV4PU4zPsu)_