### PR TITLE
Derisk mart migration: add 0489 shim + 0490 forensic snapshot, re-thread 0297 DAG

### DIFF
--- a/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
+++ b/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
@@ -10,6 +10,7 @@ Label: deferred
 
 2026-05-25T12:22Z HDMX-coding-agent tag deferred
 2026-06-08T12:00Z HDMX-coding-agent note Converted to tracking ticket. Child tickets created: 0475 (architect question + schema), 0476 (exp1 adapter + equivalence), 0477 (port consumers), 0478 (delete old stack). This tracker stays open until all children merge and make check passes.
+2026-06-09T08:14Z note Derisk pass: created children 0489 (mart_to_metrics shim + golden test) and 0490 (exp3/legacy ingest source); re-pointed 0476 Blocked-by 0475->0489; added 0490 as second blocker on 0478; added field-audit step to 0475.
 --- body ---
 ## Context
 
@@ -41,14 +42,27 @@ single source of truth for all experiments (exp1 through exp3+), and the old sta
 
 This is a tracking ticket. Children must land in dependency order:
 
+DAG: `0475 → 0489 → {0476 → 0477 → 0478, 0490 → 0478}`
+
 | ID | Title | Status |
 |----|-------|--------|
-| 0475 | Architect question: generalize vs shoehorn + schema design | open |
-| 0476 | Exp1 adapter + mart equivalence test | blocked on 0475 |
+| 0475 | Architect question: generalize vs shoehorn + schema design + field audit | open |
+| 0489 | Read-path shim: `mart_to_metrics()` flattener + golden equivalence test | blocked on 0475 |
+| 0476 | Exp1 adapter + mart equivalence test | blocked on 0489 |
+| 0490 | Exp3/legacy ingest source: `.record.json` vs frozen snapshot | blocked on 0489 |
 | 0477 | Port reporting consumers from measurements.jsonl to mart | blocked on 0476 |
-| 0478 | Delete old stack (measurements.jsonl, evaluate.py assemble, RunRecord) | blocked on 0477 |
+| 0478 | Delete old stack (read interface; RunRecord write-path is a separate epic) | blocked on 0477, 0490 |
 
 Tracker closes only after 0478 merges and a final `make check` confirms no old-stack references remain.
+
+Derisk note (2026-06-09): the migration is a **shape change** (flat dict per run → 3 nested
+mart records joined by `parent_record_id`), not a rename. Two children were inserted: **0489**
+(the `mart_to_metrics()` shim that turns 0477's irreversible 27-script rewrite into a one-line
+loader swap, and is the real cutover gate the exp2-only parity check is not) and **0490** (the
+exp3/legacy ingest gap — `measurements.jsonl` holds exp1+exp2+exp3, but exp3 is record-only
+with no recoverable raw, so no raw-reading adapter can rebuild it). 0478 is also re-scoped to
+delete the **read** stack only; deleting `RunRecord` is blocked by the live collection path
+(5 adapters + `query_*` + `worker`) and belongs to its own epic.
 
 ## Architectural question (must resolve before 0475)
 

--- a/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
+++ b/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
@@ -42,15 +42,15 @@ single source of truth for all experiments (exp1 through exp3+), and the old sta
 
 This is a tracking ticket. Children must land in dependency order:
 
-DAG: `0475 → 0489 → {0476 → 0477 → 0478, 0490 → 0478}`
+DAG: `0475 → 0489 → 0476 → 0477 → 0490 → 0478`
 
 | ID | Title | Status |
 |----|-------|--------|
 | 0475 | Architect question: generalize vs shoehorn + schema design + field audit | open |
 | 0489 | Read-path shim: `mart_to_metrics()` flattener + golden equivalence test | blocked on 0475 |
 | 0476 | Exp1 adapter + mart equivalence test | blocked on 0489 |
-| 0490 | Exp3/legacy ingest source: `.record.json` vs frozen snapshot | blocked on 0489 |
 | 0477 | Port reporting consumers from measurements.jsonl to mart | blocked on 0476 |
+| 0490 | Exp3/legacy: forensic snapshot (Option B) + no-published-dep guard | blocked on 0477 |
 | 0478 | Delete old stack (read interface; RunRecord write-path is a separate epic) | blocked on 0477, 0490 |
 
 Tracker closes only after 0478 merges and a final `make check` confirms no old-stack references remain.
@@ -59,10 +59,13 @@ Derisk note (2026-06-09): the migration is a **shape change** (flat dict per run
 mart records joined by `parent_record_id`), not a rename. Two children were inserted: **0489**
 (the `mart_to_metrics()` shim that turns 0477's irreversible 27-script rewrite into a one-line
 loader swap, and is the real cutover gate the exp2-only parity check is not) and **0490** (the
-exp3/legacy ingest gap — `measurements.jsonl` holds exp1+exp2+exp3, but exp3 is record-only
-with no recoverable raw, so no raw-reading adapter can rebuild it). 0478 is also re-scoped to
-delete the **read** stack only; deleting `RunRecord` is blocked by the live collection path
-(5 adapters + `query_*` + `worker`) and belongs to its own epic.
+exp3/legacy gap — `measurements.jsonl` holds exp1+exp2+exp3, but exp3 legacy is record-only
+with no recoverable raw). The author chose **Option B** for 0490: retain a forensic snapshot
+rather than ingest record-only rows, under the hard constraint that **nothing published may
+depend on the snapshot** — enforced by a guard test, so it cannot decay into a second live
+source of truth. The audit only means anything after consumers point at the mart, so 0490
+gates on 0477. 0478 is also re-scoped to delete the **read** stack only; deleting `RunRecord`
+is blocked by the live collection path (5 adapters + `query_*` + `worker`) and is its own epic.
 
 ## Architectural question (must resolve before 0475)
 

--- a/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
+++ b/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
@@ -10,7 +10,7 @@ Label: deferred
 
 2026-05-25T12:22Z HDMX-coding-agent tag deferred
 2026-06-08T12:00Z HDMX-coding-agent note Converted to tracking ticket. Child tickets created: 0475 (architect question + schema), 0476 (exp1 adapter + equivalence), 0477 (port consumers), 0478 (delete old stack). This tracker stays open until all children merge and make check passes.
-2026-06-09T08:14Z note Derisk pass: created children 0489 (mart_to_metrics shim + golden test) and 0490 (exp3/legacy ingest source); re-pointed 0476 Blocked-by 0475->0489; added 0490 as second blocker on 0478; added field-audit step to 0475.
+2026-06-09T08:14Z HDMX-coding-agent note Derisk pass: created children 0489 (mart_to_metrics shim + golden test) and 0490 (exp3/legacy ingest source); re-pointed 0476 Blocked-by 0475->0489; added 0490 as second blocker on 0478; added field-audit step to 0475.
 --- body ---
 ## Context
 
@@ -35,14 +35,15 @@ single source of truth for all experiments (exp1 through exp3+), and the old sta
 - [ ] Mart schema absorbs all RunRecord fields listed above
 - [ ] Exp1 adapter: reads `exp1_batch2/*.json` → mart records (no arm, single turn, method=direct)
 - [ ] All figures/tables that currently read `measurements.jsonl` ported to read the mart
-- [ ] `measurements.jsonl`, `evaluate.py assemble`, `schema.RunRecord` deleted
+- [ ] `measurements.jsonl`, `measurements.py`, `evaluate.py assemble` deleted (read stack); `RunRecord` write-path retirement tracked as a separate epic
 - [ ] `make check` passes with no reference to the old stack
 
 ## Tracking: child tickets
 
 This is a tracking ticket. Children must land in dependency order:
 
-DAG: `0475 → 0489 → 0476 → 0477 → 0490 → 0478`
+DAG (fork-join at the tail): `0475 → 0489 → 0476 → 0477 → 0490 → 0478`, where 0478 also
+gates directly on 0477 — i.e. `0477 → {0490, 0478}` and `0490 → 0478`.
 
 | ID | Title | Status |
 |----|-------|--------|
@@ -50,22 +51,23 @@ DAG: `0475 → 0489 → 0476 → 0477 → 0490 → 0478`
 | 0489 | Read-path shim: `mart_to_metrics()` flattener + golden equivalence test | blocked on 0475 |
 | 0476 | Exp1 adapter + mart equivalence test | blocked on 0489 |
 | 0477 | Port reporting consumers from measurements.jsonl to mart | blocked on 0476 |
-| 0490 | Exp3/legacy: forensic snapshot (Option B) + no-published-dep guard | blocked on 0477 |
+| 0490 | Legacy rows: forensic snapshot (Option B) + no-published-dep guard | blocked on 0477 |
 | 0478 | Delete old stack (read interface; RunRecord write-path is a separate epic) | blocked on 0477, 0490 |
 
 Tracker closes only after 0478 merges and a final `make check` confirms no old-stack references remain.
 
 Derisk note (2026-06-09): the migration is a **shape change** (flat dict per run → 3 nested
 mart records joined by `parent_record_id`), not a rename. Two children were inserted: **0489**
-(the `mart_to_metrics()` shim that turns 0477's irreversible 27-script rewrite into a one-line
+(the `mart_to_metrics()` shim that turns 0477's irreversible consumer rewrite into a one-line
 loader swap, and is the real cutover gate the exp2-only parity check is not) and **0490** (the
-exp3/legacy gap — `measurements.jsonl` holds exp1+exp2+exp3, but exp3 legacy is record-only
-with no recoverable raw). The author chose **Option B** for 0490: retain a forensic snapshot
-rather than ingest record-only rows, under the hard constraint that **nothing published may
-depend on the snapshot** — enforced by a guard test, so it cannot decay into a second live
-source of truth. The audit only means anything after consumers point at the mart, so 0490
-gates on 0477. 0478 is also re-scoped to delete the **read** stack only; deleting `RunRecord`
-is blocked by the live collection path (5 adapters + `query_*` + `worker`) and is its own epic.
+record-only legacy gap — `measurements.jsonl` is the exp1 benchmark, 669 rows; some are
+record-only with raw archived per 0422, so a raw-reading adapter cannot rebuild them). The
+author chose **Option B** for 0490: retain a forensic snapshot rather than ingest record-only
+rows, under the hard constraint that **nothing published may depend on the snapshot** —
+enforced by a guard test, so it cannot decay into a second live source of truth. The audit
+only means anything after consumers point at the mart, so 0490 gates on 0477. 0478 is also
+re-scoped to delete the **read** stack only; deleting `RunRecord` is blocked by the live
+collection path (the adapters + `query_*` + `worker`) and is its own epic.
 
 ## Architectural question (must resolve before 0475)
 
@@ -92,7 +94,7 @@ The raw counts must be added to ScoreSummary before an exp1 adapter is possible.
 - `src/aedist/evaluate.py` — `assemble` subcommand writes measurements.jsonl (to be deleted)
 - `experiments/derived/score.mk` — builds measurements.jsonl and exp2_mart.jsonl
 - `experiments/derived/exp2_mart.jsonl` — 80 run + 80 score records (exp2 only)
-- `measurements.jsonl` — 669 records (exp1 + exp2 + exp3, live as of 2026-06-08)
+- `measurements.jsonl` — 669 exp1-benchmark records (methods direct/rag/frontier/multiturn/verification; exp2 is mart-only, SOTA exp3 is raw-only)
 
 ## Consumer inventory (things that read measurements.jsonl / RunRecord)
 

--- a/tickets/0475-mart-v2-architecture-schema-design.erg
+++ b/tickets/0475-mart-v2-architecture-schema-design.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created
 2026-06-08T23:00Z haduong decided Generalize: rename exp2_mart.py → mart.py, schema name "mart"; no shoehorn; raw counts (tp/fp/fn) as int|None on ScoreSummary directly
+2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: added a field-audit step (§Field audit) — 0297's "fields to absorb" list is incomplete vs what records_to_metrics() actually projects. The whole controlled-condition vector (temperature, seed, num_ctx, provider_order, max_tokens, no_think, system_instruction, reasoning_effort), plus validation and the justification scalars, has no mart home today. Read by no current consumer (so not a blast-radius risk) but required for ADR-7 completeness if the mart is to be the single scientific record.
 --- body ---
 ## Context
 
@@ -40,6 +41,33 @@ Two architectural questions are resolved:
 3. Add raw count fields to `ScoreSummary` (tp, fp, fn as `int | None`).
 4. Bump `_MART_SCHEMA_VERSION` to 4 with changelog comment.
 5. Update `build_exp2_mart.py` to populate raw counts from scorer output.
+6. **Field audit** (see §Field audit): diff the full key set of `records_to_metrics()`
+   output against the mart field tree; for each missing key, decide absorb-now /
+   defer-with-ticket / drop-as-bookkeeping, and record the disposition in this ticket.
+
+## Field audit
+
+0297's "fields to absorb" list (method, tp/fp/fn, web_search_calls, agent_mode, validation)
+is **incomplete** against what `records_to_metrics()` (`measurements.py:130-247`) actually
+projects. The mart must not silently drop the experimental axes.
+
+Has no mart home today and must be triaged here:
+
+- **Controlled-condition vector** (the experimental variables exp1 pivots on): `temperature`,
+  `seed`, `num_ctx`, `provider_order`, `max_tokens`, `no_think`, `system_instruction`,
+  `reasoning_effort`. None are read by current consumers (verified 2026-06-09), so deferring
+  them does not break a figure — but they are part of the "complete scientific record"
+  ADR-7 requires, so the mart should carry them (likely a typed `conditions` sub-model).
+- `validation` dict (run-quality flag from `validate_run()`) — listed by 0297, no mart field.
+- Justification scalars (source-grounding): `verification_mode`, `mean_evidence_score`,
+  `verification_cost_usd`, `faithfulness_score`.
+- Partial run-level: `thinking_tokens`, `tool_calls_cost_usd`, `cost_breakdown`,
+  `reasoning_summary`, `retry_count`, `error`, `finish_reason` (RunSummary has cost/tokens
+  but not these).
+
+Disposition for each: **absorb now** (wire into the schema this PR), **defer** (own ticket,
+named here), or **drop** (bookkeeping only — `run_id`, `timestamp`, `result_file`,
+`validation`-as-bookkeeping per ADR-7's exclusion list). Write the table into the log.
 
 ## Test
 
@@ -56,6 +84,8 @@ def test_score_summary_has_raw_counts():
 
 - [ ] Author has confirmed generalize vs shoehorn decision (written in ticket log).
 - [ ] `ScoreSummary` carries `tp`, `fp`, `fn` as `int | None` fields.
+- [ ] Field audit complete: every `records_to_metrics()` key has a disposition
+      (absorb / defer-with-ticket / drop) recorded in the log.
 - [ ] Schema version bumped, changelog comment updated.
 - [ ] `build_exp2_mart.py` populates raw counts.
 - [ ] `make check` passes.

--- a/tickets/0475-mart-v2-architecture-schema-design.erg
+++ b/tickets/0475-mart-v2-architecture-schema-design.erg
@@ -48,8 +48,10 @@ Two architectural questions are resolved:
 ## Field audit
 
 0297's "fields to absorb" list (method, tp/fp/fn, web_search_calls, agent_mode, validation)
-is **incomplete** against what `records_to_metrics()` (`measurements.py:130-247`) actually
-projects. The mart must not silently drop the experimental axes.
+is **incomplete** against what `records_to_metrics()` (`measurements.py:75-248`) actually
+projects. The mart must not silently drop the experimental axes. The audit is over the FULL
+projected key set — the lists below are illustrative, not exhaustive; the executor diffs the
+real key set against the mart field tree.
 
 Has no mart home today and must be triaged here:
 
@@ -61,9 +63,11 @@ Has no mart home today and must be triaged here:
 - `validation` dict (run-quality flag from `validate_run()`) — listed by 0297, no mart field.
 - Justification scalars (source-grounding): `verification_mode`, `mean_evidence_score`,
   `verification_cost_usd`, `faithfulness_score`.
-- Partial run-level: `thinking_tokens`, `tool_calls_cost_usd`, `cost_breakdown`,
-  `reasoning_summary`, `retry_count`, `error`, `finish_reason` (RunSummary has cost/tokens
-  but not these).
+- Partial run-level / diagnostic: `tokens_in`, `tokens_out`, `thinking_tokens`,
+  `tool_calls_cost_usd`, `cost_breakdown`, `reasoning_summary`, `retry_count`, `error`,
+  `finish_reason` (RunSummary has cost but not all of these).
+- Agent-mode + trace: `agent_family`, `agent_mode`, `synopsis_sha`, `designed_prompt_sha`,
+  `n_web_search_calls`, `n_citations`, `parsed_table_path` (mart `Exp2MartBase` has none).
 
 Disposition for each: **absorb now** (wire into the schema this PR), **defer** (own ticket,
 named here), or **drop** (bookkeeping only — `run_id`, `timestamp`, `result_file`,

--- a/tickets/0476-mart-v2-exp1-adapter-equivalence.erg
+++ b/tickets/0476-mart-v2-exp1-adapter-equivalence.erg
@@ -2,10 +2,11 @@
 Title: Exp1 adapter + mart equivalence test (tracker: 0297)
 Created: 2026-06-08
 Author: HDMX-coding-agent
-Blocked-by: 0475
+Blocked-by: 0489
 
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created
+2026-06-09T08:12Z HDMX-coding-agent note Re-pointed Blocked-by 0475 -> 0489. The exp1 equivalence test IS an instance of 0489's golden test (mart_to_metrics(exp1) == records_to_metrics(exp1)); reuse the shim rather than hand-rolling a second comparator. 0489 is itself blocked-by 0475, so the schema dependency is preserved transitively.
 --- body ---
 ## Context
 

--- a/tickets/0478-mart-v2-delete-old-stack.erg
+++ b/tickets/0478-mart-v2-delete-old-stack.erg
@@ -3,9 +3,11 @@ Title: Delete old stack: measurements.jsonl, evaluate.py assemble, RunRecord (tr
 Created: 2026-06-08
 Author: HDMX-coding-agent
 Blocked-by: 0477
+Blocked-by: 0490
 
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created
+2026-06-09T08:12Z HDMX-coding-agent note Added Blocked-by 0490. Deletion target (measurements.jsonl) holds exp1+exp2+exp3, but exp3 is record-only (raw deleted post-edda724b) and no adapter can rebuild it from raw. 0490 must resolve the exp3/legacy ingest source (record.json ingest or retained snapshot) before this deletion is safe.
 --- body ---
 ## Context
 

--- a/tickets/0478-mart-v2-delete-old-stack.erg
+++ b/tickets/0478-mart-v2-delete-old-stack.erg
@@ -1,5 +1,5 @@
 %erg 0.1
-Title: Delete old stack: measurements.jsonl, evaluate.py assemble, RunRecord (tracker: 0297)
+Title: Delete old read stack: measurements.jsonl + read interface (tracker: 0297)
 Created: 2026-06-08
 Author: HDMX-coding-agent
 Blocked-by: 0477
@@ -7,7 +7,7 @@ Blocked-by: 0490
 
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created
-2026-06-09T08:12Z HDMX-coding-agent note Added Blocked-by 0490. Deletion target (measurements.jsonl) holds exp1+exp2+exp3, but exp3 is record-only (raw deleted post-edda724b) and no adapter can rebuild it from raw. 0490 must resolve the exp3/legacy ingest source before this deletion is safe.
+2026-06-09T08:12Z HDMX-coding-agent note Added Blocked-by 0490. Deletion target (measurements.jsonl, the exp1 benchmark, 669 rows) contains record-only legacy rows whose raw was archived (0422, score.mk:75-85) and that a raw-reading adapter cannot rebuild. 0490 must resolve the legacy ingest source before this deletion is safe.
 2026-06-09T08:30Z HDMX-coding-agent note 0490 resolved as Option B (forensic snapshot). This PR deletes the LIVE measurements.jsonl + read interface but must RETAIN 0490's datestamped snapshot, and may only proceed once 0490's no-published-dep guard test is green (nothing published reads the snapshot). Re-scope reminder: delete the read stack (measurements.py loader, records_to_metrics, evaluate.py assemble, live measurements.jsonl) — NOT RunRecord, which the live collection path still emits.
 --- body ---
 ## Context
@@ -18,34 +18,37 @@ Run `make check` and a full grep audit before committing.
 
 ## Relevant files
 
-To delete:
-- `measurements.jsonl` (top-level, 669 records — data already in mart)
+To delete (the READ stack only):
+- `measurements.jsonl` (top-level, 669 exp1-benchmark records — migrated to the mart via 0476/0477)
+- `src/aedist/measurements.py` (`load`, `load_metrics`, `records_to_metrics` — replaced by the 0489 mart reader)
 - `src/aedist/evaluate.py` `assemble` subcommand (the only path that writes measurements.jsonl)
-- `src/aedist/schema.py` `RunRecord` class and associated infrastructure
-- `src/aedist/measurements.py` (entire module — replaced by mart reader)
 - `experiments/derived/score.mk` targets that build measurements.jsonl
 
+NOT deleted here (write-path — separate epic):
+- `src/aedist/schema.py` `RunRecord` / `MethodParams` / `ResourceUse` / `ResultSummary` — still
+  constructed by the live collection path (adapters, `query_*`, `worker`). Deleting them now
+  breaks collection at import time. Retiring the write path is its own tracked epic.
+
 Tests to delete/replace:
-- `tests/test_measurements.py`
-- `tests/test_measurements_agent_fields.py`
-- Any test that imports from `aedist.measurements` or `aedist.schema.RunRecord`
+- `tests/test_measurements.py`, `tests/test_measurements_agent_fields.py` (read-interface tests)
+- Any test importing from `aedist.measurements` (the deleted read module).
+  Tests importing `aedist.schema.RunRecord` STAY — RunRecord is not deleted here.
 
 ## Actions
 
-1. Grep audit: `grep -rn "measurements.jsonl\|RunRecord\|records_to_metrics" --include="*.py" --include="*.mk" --include="Makefile" .`
-   Confirm zero hits (excluding archive/ and worktrees/).
-2. Delete `measurements.jsonl` from git.
-3. Delete `src/aedist/measurements.py`.
-4. Remove `RunRecord`, `Method`, `MethodParams`, `ResourceUse`, `ResultSummary` from `schema.py`
-   (or delete `schema.py` if nothing else uses it).
-5. Remove `assemble` subcommand from `evaluate.py`.
-6. Remove `measurements.jsonl` target from `score.mk`.
-7. Delete or rewrite `tests/test_measurements.py` and `tests/test_measurements_agent_fields.py`.
-8. Run `make check` — must pass clean.
+1. Grep audit: `grep -rn "measurements\.jsonl\|records_to_metrics\|from aedist.measurements\|import measurements" --include="*.py" --include="*.mk" --include="Makefile" .`
+   Confirm zero hits (excluding archive/, worktrees/, and 0490's forensic snapshot).
+   NOTE: do NOT grep for `RunRecord` here — it stays (write-path epic).
+2. Delete `measurements.jsonl` from git — only AFTER 0490's snapshot is committed and its guard test is green.
+3. Delete `src/aedist/measurements.py` (read module).
+4. Remove the `assemble` subcommand from `evaluate.py` (leave other verbs intact).
+5. Remove the `measurements.jsonl` target from `score.mk`.
+6. Delete or rewrite the read-interface tests (`test_measurements.py`, `test_measurements_agent_fields.py`).
+7. Run `make check` — must pass clean. `schema.py`/`RunRecord` are untouched.
 
 ## Verification
 
-- [ ] `grep -rn "measurements.jsonl\|RunRecord\|records_to_metrics" src/ tests/ experiments/` → zero hits.
+- [ ] `grep -rn "measurements\.jsonl\|records_to_metrics\|aedist.measurements" src/ tests/ experiments/` → zero hits (RunRecord intentionally still present).
 - [ ] `make check` passes.
 - [ ] No report figure or table value changed (verify against golden outputs from 0477).
 - [ ] Tracking ticket 0297 closes after this PR merges.
@@ -54,7 +57,8 @@ Tests to delete/replace:
 
 - Deletion is LAST — only after all consumers are ported and green (0477 done).
 - Do not delete `evaluate.py` subcommands other than `assemble` — other verbs remain.
-- `schema.py` may retain non-RunRecord classes (Plant, FuelType, PlantStatus, etc.).
+- `schema.py` is NOT touched: `RunRecord` and all classes stay. Their retirement belongs to
+  the write-path epic, gated on porting the adapters / `query_*` / `worker` off RunRecord.
 
 ## Exit criteria
 

--- a/tickets/0478-mart-v2-delete-old-stack.erg
+++ b/tickets/0478-mart-v2-delete-old-stack.erg
@@ -7,7 +7,8 @@ Blocked-by: 0490
 
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created
-2026-06-09T08:12Z HDMX-coding-agent note Added Blocked-by 0490. Deletion target (measurements.jsonl) holds exp1+exp2+exp3, but exp3 is record-only (raw deleted post-edda724b) and no adapter can rebuild it from raw. 0490 must resolve the exp3/legacy ingest source (record.json ingest or retained snapshot) before this deletion is safe.
+2026-06-09T08:12Z HDMX-coding-agent note Added Blocked-by 0490. Deletion target (measurements.jsonl) holds exp1+exp2+exp3, but exp3 is record-only (raw deleted post-edda724b) and no adapter can rebuild it from raw. 0490 must resolve the exp3/legacy ingest source before this deletion is safe.
+2026-06-09T08:30Z HDMX-coding-agent note 0490 resolved as Option B (forensic snapshot). This PR deletes the LIVE measurements.jsonl + read interface but must RETAIN 0490's datestamped snapshot, and may only proceed once 0490's no-published-dep guard test is green (nothing published reads the snapshot). Re-scope reminder: delete the read stack (measurements.py loader, records_to_metrics, evaluate.py assemble, live measurements.jsonl) — NOT RunRecord, which the live collection path still emits.
 --- body ---
 ## Context
 

--- a/tickets/0489-mart-read-path-shim-mart-to-metrics-flat.erg
+++ b/tickets/0489-mart-read-path-shim-mart-to-metrics-flat.erg
@@ -1,0 +1,110 @@
+%erg 0.1
+Title: Mart read-path shim: mart_to_metrics() flattener + golden equivalence test (tracker: 0297)
+Created: 2026-06-09
+Author: HDMX-coding-agent
+Blocked-by: 0475
+
+--- log ---
+2026-06-09T08:12Z HDMX-coding-agent created
+2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the migration is a shape change (flat dict per run -> 3 nested mart records joined by parent_record_id), not a rename. This ticket builds the one shim that turns the irreversible 17/27-script rewrite (0477) into a one-line loader swap, and is the real cutover gate the exp2-only parity check (check_exp2_mart_parity.py) only pretends to be.
+
+--- body ---
+## Context
+
+`records_to_metrics()` (`measurements.py:75-248`) emits **one flat dict per run** — the
+metrics dict that ADR-7 calls "the complete scientific record." Every reporting consumer
+(27 scripts via `load_metrics()`) reads from this flat shape. The mart stores the same
+information as **three nested records** (`run` / `probe` / `score`) joined by
+`parent_record_id`, with metrics split across typed sub-models.
+
+If 0477 ports consumers by making each script walk nested mart records and join
+run⋈score itself, that is 27 new join sites and 27 new failure modes — for an
+**irreversible** cutover. This ticket eliminates that risk with a single shim.
+
+The actual read surface is small (verified by consumer audit, 2026-06-09): the 27 scripts
+collectively read only ~11 metrics-dict keys — `label`, `f1`, `coverage`, `precision`,
+`n_matched`, `n_missed`, `n_hallucinated`, `cost_usd`, `method`, `prompt_version`, `model`.
+So the shim only has to reproduce those exactly; the rest of the metrics dict is projected
+for ADR-7 completeness but read by nobody.
+
+## Deliverable
+
+`mart_to_metrics(records: list[MartRecord]) -> list[dict]` — re-flattens the mart's
+run⋈score graph back into the **identical** dict shape `records_to_metrics()` emits,
+so 0477 becomes a loader-import swap (`from aedist.measurements import load_metrics`
+→ a mart-backed `load_metrics`) rather than a rewrite.
+
+This is the keystone: with the shim + its golden test, the cutover is reversible
+(revert one import) and gated (row-for-row field equality), where today the exp2-only
+parity check covers ~20% of the rows being deleted and says nothing about exp1/exp3.
+
+## The join is the hazard
+
+The flat dict has cost/tokens (run-level) and f1 (score-level) on ONE row. In the mart
+they live on a `record_kind="run"` record and a separate `record_kind="score"` record.
+Cost-vs-quality consumers (`exp1_cost_quality.py`, `tabulate_cost_quality.py`) need both.
+The shim must define the join semantics explicitly:
+
+- **left join on the run record** by `parent_record_id`;
+- **null/None metrics when a run has no score row** (unscored generations, refusals) —
+  never drop the run;
+- output **row count == run-record count** (no fan-out, no drop).
+
+## Relevant files
+
+- `src/aedist/measurements.py` — `records_to_metrics()` is the reference shape to match.
+- `src/aedist/exp2_mart.py` (or `mart.py` post-0475) — mart record types.
+- `experiments/derived/exp2_mart.jsonl` — current exp2 mart (80 run + 80 score).
+
+## Actions
+
+1. Add `mart_to_metrics()` next to the mart schema (`mart.py` post-0475), mirroring the
+   key set and omit-when-None discipline of `records_to_metrics()`.
+2. Implement the documented left-join + null-on-unscored + no-fan-out contract.
+3. Write the golden equivalence test (below).
+
+## Test (write first — TDD red step)
+
+```python
+# tests/test_mart_to_metrics_equivalence.py
+import pytest
+
+@pytest.mark.adherence
+def test_mart_to_metrics_field_equals_records_to_metrics_on_shared_raw():
+    """Same raw inputs -> records_to_metrics() == mart_to_metrics(), field by field,
+    on the ~11 keys consumers actually read. The cutover gate for 0477."""
+    # Build both from the SAME raw artifacts (exp2 to start; exp1 lands with 0476,
+    # exp3/legacy with 0490). For each run, assert the read-surface keys are equal:
+    #   label, f1, coverage, precision, n_matched, n_missed, n_hallucinated,
+    #   cost_usd, method, prompt_version, model
+    # Numeric tol < 1e-4; identity fields exact.
+    pass
+
+@pytest.mark.adherence
+def test_mart_to_metrics_row_count_equals_run_count():
+    """Left join must not fan out or drop: one output row per run record,
+    None metrics on unscored runs."""
+    pass
+```
+
+## Verification
+
+- [ ] `mart_to_metrics()` exists and returns the same dict shape as `records_to_metrics()`
+      for the ~11 consumer-read keys.
+- [ ] Golden equivalence test passes on the exp2 mart (the only experiment in the mart today).
+- [ ] Row-count test passes (output rows == run records; unscored runs kept with None metrics).
+- [ ] `make check` passes.
+- [ ] `measurements.jsonl`, `RunRecord`, `records_to_metrics()` are NOT modified or deleted.
+
+## Invariants
+
+- This PR adds the shim + tests only; it ports no consumer and deletes nothing.
+- The shim's key set tracks `records_to_metrics()`; if 0475's field audit adds keys to
+  the mart, surface them here too (ADR-7).
+
+## Exit criteria
+
+- `mart_to_metrics()` lands with a passing golden equivalence test against
+  `records_to_metrics()` on shared raw inputs.
+- 0476 (exp1) and 0490 (exp3/legacy) instantiate this golden test for their subsets.
+- 0477 can cut over by swapping the loader import, with the golden test as the gate.

--- a/tickets/0489-mart-read-path-shim-mart-to-metrics-flat.erg
+++ b/tickets/0489-mart-read-path-shim-mart-to-metrics-flat.erg
@@ -6,22 +6,23 @@ Blocked-by: 0475
 
 --- log ---
 2026-06-09T08:12Z HDMX-coding-agent created
-2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the migration is a shape change (flat dict per run -> 3 nested mart records joined by parent_record_id), not a rename. This ticket builds the one shim that turns the irreversible 17/27-script rewrite (0477) into a one-line loader swap, and is the real cutover gate the exp2-only parity check (check_exp2_mart_parity.py) only pretends to be.
+2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the migration is a shape change (flat dict per run -> 3 nested mart records joined by parent_record_id), not a rename. This ticket builds the one shim that turns the irreversible consumer rewrite (0477) into a one-line loader swap, and is the real cutover gate the exp2-only parity check (check_exp2_mart_parity.py) only pretends to be.
 
 --- body ---
 ## Context
 
 `records_to_metrics()` (`measurements.py:75-248`) emits **one flat dict per run** — the
 metrics dict that ADR-7 calls "the complete scientific record." Every reporting consumer
-(27 scripts via `load_metrics()`) reads from this flat shape. The mart stores the same
+in the `load_metrics()` reader set (the 0297 inventory lists ~17; a 2026-06-09 grep found
+~13–14 that actually call `load_metrics()`/`load()`) reads from this flat shape. The mart stores the same
 information as **three nested records** (`run` / `probe` / `score`) joined by
 `parent_record_id`, with metrics split across typed sub-models.
 
 If 0477 ports consumers by making each script walk nested mart records and join
-run⋈score itself, that is 27 new join sites and 27 new failure modes — for an
-**irreversible** cutover. This ticket eliminates that risk with a single shim.
+run⋈score itself, that is one new join site per ported script and as many new failure
+modes — for an **irreversible** cutover. This ticket eliminates that risk with a single shim.
 
-The actual read surface is small (verified by consumer audit, 2026-06-09): the 27 scripts
+The actual read surface is small (verified by consumer audit, 2026-06-09): those scripts
 collectively read only ~11 metrics-dict keys — `label`, `f1`, `coverage`, `precision`,
 `n_matched`, `n_missed`, `n_hallucinated`, `cost_usd`, `method`, `prompt_version`, `model`.
 So the shim only has to reproduce those exactly; the rest of the metrics dict is projected
@@ -36,7 +37,8 @@ so 0477 becomes a loader-import swap (`from aedist.measurements import load_metr
 
 This is the keystone: with the shim + its golden test, the cutover is reversible
 (revert one import) and gated (row-for-row field equality), where today the exp2-only
-parity check covers ~20% of the rows being deleted and says nothing about exp1/exp3.
+parity check covers only the exp2 mart (80 score rows; ~12% of measurements.jsonl's 669)
+and says nothing about the exp1 benchmark that measurements.jsonl actually holds.
 
 ## The join is the hazard
 
@@ -74,7 +76,7 @@ def test_mart_to_metrics_field_equals_records_to_metrics_on_shared_raw():
     """Same raw inputs -> records_to_metrics() == mart_to_metrics(), field by field,
     on the ~11 keys consumers actually read. The cutover gate for 0477."""
     # Build both from the SAME raw artifacts (exp2 to start; exp1 lands with 0476,
-    # exp3/legacy with 0490). For each run, assert the read-surface keys are equal:
+    # record-only legacy rows with 0490). For each run, assert the read-surface keys are equal:
     #   label, f1, coverage, precision, n_matched, n_missed, n_hallucinated,
     #   cost_usd, method, prompt_version, model
     # Numeric tol < 1e-4; identity fields exact.
@@ -106,5 +108,5 @@ def test_mart_to_metrics_row_count_equals_run_count():
 
 - `mart_to_metrics()` lands with a passing golden equivalence test against
   `records_to_metrics()` on shared raw inputs.
-- 0476 (exp1) and 0490 (exp3/legacy) instantiate this golden test for their subsets.
+- 0476 (exp1) and 0490 (record-only legacy rows) instantiate this golden test for their subsets.
 - 0477 can cut over by swapping the loader import, with the golden test as the gate.

--- a/tickets/0490-mart-exp3-legacy-ingest-source-record-js.erg
+++ b/tickets/0490-mart-exp3-legacy-ingest-source-record-js.erg
@@ -1,100 +1,89 @@
 %erg 0.1
-Title: Mart exp3/legacy ingest source: .record.json vs frozen snapshot (tracker: 0297)
+Title: Mart exp3/legacy: forensic snapshot of measurements.jsonl, Option B (tracker: 0297)
 Created: 2026-06-09
 Author: HDMX-coding-agent
-Blocked-by: 0489
+Blocked-by: 0477
 
 --- log ---
 2026-06-09T08:12Z HDMX-coding-agent created
-2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the child chain (0475-0478) builds an exp1 adapter only, but measurements.jsonl = exp1 + exp2 + exp3 (669 rows). exp3 = experiments/archive/outputs, record-only, raw replies deleted post-edda724b. An adapter that reads raw JSON (0476's design) physically cannot reconstruct exp3. 0478's "delete measurements.jsonl" is unsafe until this is resolved. Reverses the earlier "fold into 0476" recommendation per author steer (discrete ticket, distinct blocker on 0478).
+2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the child chain (0475-0478) builds an exp1 adapter only, but measurements.jsonl = exp1 + exp2 + exp3 (669 rows). exp3 legacy = experiments/archive/outputs, record-only. A raw-reading adapter cannot rebuild record-only rows. 0478's "delete measurements.jsonl" is unsafe until this is resolved.
+2026-06-09T08:30Z haduong decided Option B: snapshot measurements.jsonl as a single-phase deliverable rather than ingesting record-only rows into the mart. HARD CONSTRAINT: nothing in the published report/manuscript may depend on the snapshot — it is forensic retention only. The standing liability is lingering consumers of old results; the deliverable must forbid new ones, not merely document the rule.
+2026-06-09T08:30Z HDMX-coding-agent note Re-pointed Blocked-by 0489 -> 0477. Under Option B there is no mart ingest of exp3, so 0489's golden test is not reused; the binding work is the post-port audit, which only means anything once consumers point at the mart (0477).
 
 --- body ---
-## Context
+## Decision: Option B — forensic snapshot, no published dependency
 
-The 0297 retirement deletes `measurements.jsonl`. That file holds **exp1 + exp2 + exp3**
-(669 rows). The mart is exp2-only; the child chain builds an **exp1** adapter (0476) and
-ports consumers (0477). **exp3 has no adapter and no home in the plan.**
+Author chose Option B (2026-06-09): retain a datestamped, immutable snapshot of
+`measurements.jsonl` as a single-phase deliverable, instead of ingesting record-only
+legacy rows into the mart. The snapshot is **forensic only**.
 
-Consumer audit (2026-06-09) confirmed exp3 = `experiments/archive/outputs/` — **record-only**:
-the raw model replies were archived/removed post-`edda724b` (ticket 0421/0422). Only the
-baked `*.record.json` score pointers survive. `evaluate.py assemble` rebuilds
-`measurements.jsonl` from these surviving `.record.json` files (`score.mk:112-115`), but an
-adapter that reads **raw** JSON (the 0476 design, `exp1_batch2/*.json`) **cannot reconstruct
-exp3** — there is no raw to read. These rows back published numbers.
+The binding acceptance criterion is therefore not "the snapshot exists" (trivial) but
+**"the published surface is provably independent of the snapshot."** Option B only stays
+clean if that independence is enforced by a test — otherwise it degrades into a second
+live source of truth, which is exactly the liability the author flagged ("eventually
+having consumers for old results is the problem").
 
-This is the single sharpest risk in the retirement: 0478 would orphan exp3 (and any other
-record-only legacy row) the moment `measurements.jsonl` is deleted.
+## Preliminary evidence (hypothesis to confirm, not assert)
 
-## Decision required
+A first-pass check (2026-06-09) supports the no-published-dep claim:
 
-Pick the ingest source for record-only experiments (exp3 + any pre-0122/archived legacy):
+- `report/` contains no `exp3` / `cross_eval` / `sota_cross` references — published
+  tables/figures enter as generated includes, not by data name.
+- `tabulate_exp3_fn_triage.py` does not read `measurements.jsonl` (`load`/`load_metrics`).
+- The published render DAG (`experiments/render.mk`) sources exp1/exp2/exp3 tables from
+  `sota_cross_eval.csv`, `*_view.csv` (mart-derived), and `exp1_cross_eval.csv` — not the
+  legacy rows.
+- Live exp3 (`experiments/outputs/sota_exp3_arm*_batch1`) carries raw `*.raw.json`, so its
+  published numbers are reproducible without the record-only rows.
 
-- **Option A — adapter ingests `.record.json`.** Extend the mart builder to read scored
-  `*.record.json` pointers (not just raw), so legacy/exp3 scores flow into the mart like
-  every other row. Cleanest end state (mart is genuinely the single source of truth), more
-  builder work, must preserve the exact baked scores.
-- **Option B — frozen snapshot.** Datestamp an immutable `measurements.jsonl` snapshot
-  (per the raw-snapshot policy, 0430) that 0478 must **not** delete; exp3/legacy reporting
-  reads the snapshot, fresh experiments read the mart. Less builder work, but leaves a
-  second source of truth alive — partial retirement, not full.
+This is a hypothesis to verify mechanically below, per the project rule: agent-surveyed
+counts are hypotheses, not facts.
 
-Author chooses A or B in the ticket log before work starts. Default recommendation: **A**,
-because 0297's stated goal is "single source of truth for all experiments"; B contradicts it.
+## Actions
 
-## Relevant files
-
-- `experiments/archive/outputs/` — record-only exp3/legacy `*.record.json`.
-- `experiments/derived/score.mk:112-115` — `assemble` rebuilds measurements.jsonl from
-  all surviving `*.record.json`; the dropped-entries note (`score.mk:75-85`, ticket 0422)
-  enumerates the record-only dirs.
-- `src/aedist/build_exp1_mart.py` (from 0476) — the adapter to extend (Option A).
-- `mart_to_metrics()` (from 0489) — the equivalence harness this ticket reuses.
-
-## Actions (Option A path)
-
-1. Identify every record-only row in `measurements.jsonl` (no recoverable raw): grep
-   `result_file` against surviving raw; cross-check the 0422 dropped-entries list.
-2. Extend the mart builder to ingest `.record.json` for those rows (map score payload →
-   `ScoreSummary`, including `tp/fp/fn` from 0475).
-3. Reuse 0489's golden test for the exp3/legacy subset:
-   `mart_to_metrics(exp3) == records_to_metrics(exp3)` run-for-run.
-
-## Actions (Option B path)
-
-1. Write a datestamped immutable snapshot of `measurements.jsonl` under the 0430 policy.
-2. Document in 0478 that the snapshot is retained, not deleted; route exp3/legacy consumers
-   to it; record that retirement is partial.
+1. **Snapshot.** Write a datestamped, immutable `measurements.jsonl` snapshot under the
+   raw-snapshot policy (0430) — e.g. `experiments/snapshots/measurements-YYYY-MM-DD.jsonl`
+   with a recorded SHA-256. It is an archival artifact, never a build prerequisite.
+2. **No-published-dep audit.** After 0477 ports consumers to the mart, enumerate every
+   record-only row in the snapshot (no recoverable raw; cross-check the 0422 dropped-entries
+   list) and prove no published artifact (`report/`, `publications/`, any `report/inputs/
+   generated/*` macro/table/figure) traces its provenance to one.
+3. **Guard test (the deliverable that makes B safe).** Add a CI test asserting the snapshot
+   path is referenced by nothing in the render DAG, the `load_metrics` consumer set, or the
+   report build — so no new consumer of old results can creep in.
 
 ## Test (write first — TDD red step)
 
 ```python
-# tests/test_mart_exp3_legacy_ingest.py
+# tests/test_snapshot_is_forensic_only.py
 import pytest
 
-@pytest.mark.slow
-def test_every_measurements_row_has_a_mart_home_or_documented_snapshot():
-    """No row in measurements.jsonl may be orphaned by 0478: each exp3/legacy
-    row is either reproduced in the mart (Option A) or covered by the retained
-    snapshot (Option B). Enumerate record-only rows and assert coverage."""
+@pytest.mark.adherence
+def test_no_published_artifact_depends_on_the_snapshot():
+    """The retained measurements.jsonl snapshot is forensic-only: nothing in the
+    render DAG, the load_metrics consumer set, or the report/publications build may
+    reference its path. Grep src/, experiments/*.mk, report/ for the snapshot path
+    and assert zero hits outside the archival writer itself."""
     pass
 ```
 
 ## Verification
 
-- [ ] Author has chosen Option A or B (written in ticket log).
-- [ ] Every record-only `measurements.jsonl` row is accounted for (mart record or snapshot).
-- [ ] Option A: exp3/legacy golden equivalence (`mart_to_metrics == records_to_metrics`) passes.
-- [ ] Option B: immutable snapshot committed; 0478 body amended to retain it.
+- [ ] Immutable datestamped snapshot committed with a recorded SHA-256.
+- [ ] Record-only rows enumerated; none is the provenance of a published number.
+- [ ] Guard test passes: no render/consumer/report reference to the snapshot path.
 - [ ] `make check` passes.
-- [ ] `measurements.jsonl` is NOT deleted by this PR (that is 0478).
+- [ ] `measurements.jsonl` (live) is NOT deleted by this PR — that is 0478.
 
 ## Invariants
 
-- No published number loses its source. Record-only rows are first-class, not collateral.
-- This PR does not delete the old stack; it closes the exp3/legacy gap that makes 0478 safe.
+- The snapshot is read by nothing in the build; it exists for forensics only.
+- No published number loses its source: any that would have depended on a record-only
+  row is a blocking finding (re-source from live raw, or drop from the publication)
+  before 0478 deletes the live file.
 
 ## Exit criteria
 
-- The exp3/legacy ingest question is resolved and tested.
-- 0478 can delete `measurements.jsonl` (Option A) or knowingly retain a snapshot (Option B)
-  with zero orphaned rows.
+- Forensic snapshot exists and is provably inert (guard test green).
+- 0478 can delete the live `measurements.jsonl` knowing the published surface is
+  snapshot-independent and zero rows are orphaned in a way that matters.

--- a/tickets/0490-mart-exp3-legacy-ingest-source-record-js.erg
+++ b/tickets/0490-mart-exp3-legacy-ingest-source-record-js.erg
@@ -1,14 +1,15 @@
 %erg 0.1
-Title: Mart exp3/legacy: forensic snapshot of measurements.jsonl, Option B (tracker: 0297)
+Title: Mart legacy ingest: forensic snapshot of measurements.jsonl, Option B (tracker: 0297)
 Created: 2026-06-09
 Author: HDMX-coding-agent
 Blocked-by: 0477
 
 --- log ---
 2026-06-09T08:12Z HDMX-coding-agent created
-2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the child chain (0475-0478) builds an exp1 adapter only, but measurements.jsonl = exp1 + exp2 + exp3 (669 rows). exp3 legacy = experiments/archive/outputs, record-only. A raw-reading adapter cannot rebuild record-only rows. 0478's "delete measurements.jsonl" is unsafe until this is resolved.
+2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the child chain (0475-0478) builds an exp1 adapter only. measurements.jsonl (669 rows) is the exp1 benchmark (methods direct 380 / rag 143 / frontier 101 / direct+multiturn 41 / rag+verification 4); exp2 lives only in the mart, SOTA exp3 only as raw under experiments/outputs. Some of those 669 are record-only (raw archived per 0422, score.mk:75-85), so a raw-reading adapter cannot rebuild them. 0478's "delete measurements.jsonl" is unsafe until this is resolved.
+2026-06-09T09:00Z HDMX-coding-agent note Review fixup: corrected an earlier mischaracterisation that measurements.jsonl held "exp1+exp2+exp3". Ground truth is the method histogram above (exp1 benchmark). The gap is record-only LEGACY rows, not exp3.
 2026-06-09T08:30Z haduong decided Option B: snapshot measurements.jsonl as a single-phase deliverable rather than ingesting record-only rows into the mart. HARD CONSTRAINT: nothing in the published report/manuscript may depend on the snapshot — it is forensic retention only. The standing liability is lingering consumers of old results; the deliverable must forbid new ones, not merely document the rule.
-2026-06-09T08:30Z HDMX-coding-agent note Re-pointed Blocked-by 0489 -> 0477. Under Option B there is no mart ingest of exp3, so 0489's golden test is not reused; the binding work is the post-port audit, which only means anything once consumers point at the mart (0477).
+2026-06-09T08:30Z HDMX-coding-agent note Re-pointed Blocked-by 0489 -> 0477. Under Option B there is no mart ingest of the legacy rows, so 0489's golden test is not reused; the binding work is the post-port audit, which only means anything once consumers point at the mart (0477).
 
 --- body ---
 ## Decision: Option B — forensic snapshot, no published dependency
@@ -23,21 +24,25 @@ clean if that independence is enforced by a test — otherwise it degrades into 
 live source of truth, which is exactly the liability the author flagged ("eventually
 having consumers for old results is the problem").
 
-## Preliminary evidence (hypothesis to confirm, not assert)
+## What measurements.jsonl actually holds (verified 2026-06-09)
 
-A first-pass check (2026-06-09) supports the no-published-dep claim:
+By `method` histogram, the 669 rows are the **exp1 benchmark**: direct 380, rag 143,
+frontier 101, direct+multiturn 41, rag+verification 4. exp2 (the arms) lives only in the
+mart; SOTA exp3 lives only as raw under `experiments/outputs/sota_exp3_arm*_batch1`. So the
+record-only gap is about **legacy exp1 rows** whose raw was archived (0422, `score.mk:75-85`),
+not "exp3" — an earlier draft mislabelled it.
 
-- `report/` contains no `exp3` / `cross_eval` / `sota_cross` references — published
-  tables/figures enter as generated includes, not by data name.
+The no-published-dep claim holds on a first pass:
+
+- `report/` contains no `exp3` / `cross_eval` / `sota_cross` references; the published
+  report carries no exp3 results at all (only exp1/exp2 figures).
 - `tabulate_exp3_fn_triage.py` does not read `measurements.jsonl` (`load`/`load_metrics`).
-- The published render DAG (`experiments/render.mk`) sources exp1/exp2/exp3 tables from
+- The published render DAG (`experiments/render.mk`) sources its tables from
   `sota_cross_eval.csv`, `*_view.csv` (mart-derived), and `exp1_cross_eval.csv` — not the
   legacy rows.
-- Live exp3 (`experiments/outputs/sota_exp3_arm*_batch1`) carries raw `*.raw.json`, so its
-  published numbers are reproducible without the record-only rows.
 
-This is a hypothesis to verify mechanically below, per the project rule: agent-surveyed
-counts are hypotheses, not facts.
+The audit below verifies this mechanically, per the project rule: agent-surveyed counts are
+hypotheses, not facts.
 
 ## Actions
 
@@ -46,11 +51,12 @@ counts are hypotheses, not facts.
    with a recorded SHA-256. It is an archival artifact, never a build prerequisite.
 2. **No-published-dep audit.** After 0477 ports consumers to the mart, enumerate every
    record-only row in the snapshot (no recoverable raw; cross-check the 0422 dropped-entries
-   list) and prove no published artifact (`report/`, `publications/`, any `report/inputs/
-   generated/*` macro/table/figure) traces its provenance to one.
-3. **Guard test (the deliverable that makes B safe).** Add a CI test asserting the snapshot
+   note, `score.mk:75-85`) and prove no published artifact (`report/`, `publications/`, any
+   `report/inputs/generated/*` macro/table/figure) traces its provenance to one.
+3. **Guard test (the deliverable that makes B safe).** Add a CI test asserting (a) the snapshot
    path is referenced by nothing in the render DAG, the `load_metrics` consumer set, or the
-   report build — so no new consumer of old results can creep in.
+   report build, AND (b) no ported consumer retains a residual read of — or silent fallback to —
+   the live `measurements.jsonl` path. Both are how a new consumer of old results creeps in.
 
 ## Test (write first — TDD red step)
 
@@ -62,8 +68,9 @@ import pytest
 def test_no_published_artifact_depends_on_the_snapshot():
     """The retained measurements.jsonl snapshot is forensic-only: nothing in the
     render DAG, the load_metrics consumer set, or the report/publications build may
-    reference its path. Grep src/, experiments/*.mk, report/ for the snapshot path
-    and assert zero hits outside the archival writer itself."""
+    reference its path, AND no ported consumer may still read or fall back to the live
+    measurements.jsonl. Grep src/, experiments/*.mk, report/ for BOTH the snapshot path
+    and any residual measurements.jsonl read; assert zero hits outside the archival writer."""
     pass
 ```
 

--- a/tickets/0490-mart-exp3-legacy-ingest-source-record-js.erg
+++ b/tickets/0490-mart-exp3-legacy-ingest-source-record-js.erg
@@ -1,0 +1,100 @@
+%erg 0.1
+Title: Mart exp3/legacy ingest source: .record.json vs frozen snapshot (tracker: 0297)
+Created: 2026-06-09
+Author: HDMX-coding-agent
+Blocked-by: 0489
+
+--- log ---
+2026-06-09T08:12Z HDMX-coding-agent created
+2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: the child chain (0475-0478) builds an exp1 adapter only, but measurements.jsonl = exp1 + exp2 + exp3 (669 rows). exp3 = experiments/archive/outputs, record-only, raw replies deleted post-edda724b. An adapter that reads raw JSON (0476's design) physically cannot reconstruct exp3. 0478's "delete measurements.jsonl" is unsafe until this is resolved. Reverses the earlier "fold into 0476" recommendation per author steer (discrete ticket, distinct blocker on 0478).
+
+--- body ---
+## Context
+
+The 0297 retirement deletes `measurements.jsonl`. That file holds **exp1 + exp2 + exp3**
+(669 rows). The mart is exp2-only; the child chain builds an **exp1** adapter (0476) and
+ports consumers (0477). **exp3 has no adapter and no home in the plan.**
+
+Consumer audit (2026-06-09) confirmed exp3 = `experiments/archive/outputs/` — **record-only**:
+the raw model replies were archived/removed post-`edda724b` (ticket 0421/0422). Only the
+baked `*.record.json` score pointers survive. `evaluate.py assemble` rebuilds
+`measurements.jsonl` from these surviving `.record.json` files (`score.mk:112-115`), but an
+adapter that reads **raw** JSON (the 0476 design, `exp1_batch2/*.json`) **cannot reconstruct
+exp3** — there is no raw to read. These rows back published numbers.
+
+This is the single sharpest risk in the retirement: 0478 would orphan exp3 (and any other
+record-only legacy row) the moment `measurements.jsonl` is deleted.
+
+## Decision required
+
+Pick the ingest source for record-only experiments (exp3 + any pre-0122/archived legacy):
+
+- **Option A — adapter ingests `.record.json`.** Extend the mart builder to read scored
+  `*.record.json` pointers (not just raw), so legacy/exp3 scores flow into the mart like
+  every other row. Cleanest end state (mart is genuinely the single source of truth), more
+  builder work, must preserve the exact baked scores.
+- **Option B — frozen snapshot.** Datestamp an immutable `measurements.jsonl` snapshot
+  (per the raw-snapshot policy, 0430) that 0478 must **not** delete; exp3/legacy reporting
+  reads the snapshot, fresh experiments read the mart. Less builder work, but leaves a
+  second source of truth alive — partial retirement, not full.
+
+Author chooses A or B in the ticket log before work starts. Default recommendation: **A**,
+because 0297's stated goal is "single source of truth for all experiments"; B contradicts it.
+
+## Relevant files
+
+- `experiments/archive/outputs/` — record-only exp3/legacy `*.record.json`.
+- `experiments/derived/score.mk:112-115` — `assemble` rebuilds measurements.jsonl from
+  all surviving `*.record.json`; the dropped-entries note (`score.mk:75-85`, ticket 0422)
+  enumerates the record-only dirs.
+- `src/aedist/build_exp1_mart.py` (from 0476) — the adapter to extend (Option A).
+- `mart_to_metrics()` (from 0489) — the equivalence harness this ticket reuses.
+
+## Actions (Option A path)
+
+1. Identify every record-only row in `measurements.jsonl` (no recoverable raw): grep
+   `result_file` against surviving raw; cross-check the 0422 dropped-entries list.
+2. Extend the mart builder to ingest `.record.json` for those rows (map score payload →
+   `ScoreSummary`, including `tp/fp/fn` from 0475).
+3. Reuse 0489's golden test for the exp3/legacy subset:
+   `mart_to_metrics(exp3) == records_to_metrics(exp3)` run-for-run.
+
+## Actions (Option B path)
+
+1. Write a datestamped immutable snapshot of `measurements.jsonl` under the 0430 policy.
+2. Document in 0478 that the snapshot is retained, not deleted; route exp3/legacy consumers
+   to it; record that retirement is partial.
+
+## Test (write first — TDD red step)
+
+```python
+# tests/test_mart_exp3_legacy_ingest.py
+import pytest
+
+@pytest.mark.slow
+def test_every_measurements_row_has_a_mart_home_or_documented_snapshot():
+    """No row in measurements.jsonl may be orphaned by 0478: each exp3/legacy
+    row is either reproduced in the mart (Option A) or covered by the retained
+    snapshot (Option B). Enumerate record-only rows and assert coverage."""
+    pass
+```
+
+## Verification
+
+- [ ] Author has chosen Option A or B (written in ticket log).
+- [ ] Every record-only `measurements.jsonl` row is accounted for (mart record or snapshot).
+- [ ] Option A: exp3/legacy golden equivalence (`mart_to_metrics == records_to_metrics`) passes.
+- [ ] Option B: immutable snapshot committed; 0478 body amended to retain it.
+- [ ] `make check` passes.
+- [ ] `measurements.jsonl` is NOT deleted by this PR (that is 0478).
+
+## Invariants
+
+- No published number loses its source. Record-only rows are first-class, not collateral.
+- This PR does not delete the old stack; it closes the exp3/legacy gap that makes 0478 safe.
+
+## Exit criteria
+
+- The exp3/legacy ingest question is resolved and tested.
+- 0478 can delete `measurements.jsonl` (Option A) or knowingly retain a snapshot (Option B)
+  with zero orphaned rows.


### PR DESCRIPTION
## What

Planning-only PR (tickets, no production code) that derisks the `measurements.jsonl` → mart retirement tracked by **0297**. The existing child chain (0475→0478) treated the migration as a rename of an exp1-shaped problem; in reality it is a **shape change** (one flat dict per run → three nested mart records joined by `parent_record_id`). Two gaps were closed by inserting two children and re-threading blockers.

**What `measurements.jsonl` actually is** (verified by `method` histogram, 669 rows): the **exp1 benchmark** — direct 380 / rag 143 / frontier 101 / direct+multiturn 41 / rag+verification 4. exp2 (the arms) lives only in the mart; SOTA exp3 lives only as raw under `experiments/outputs/`. The record-only concern is about **legacy exp1 rows** whose raw was archived (0422), not "exp3".

## New tickets

- **0489 — read-path shim.** `mart_to_metrics()` flattener + golden equivalence test against `records_to_metrics()` on shared raw inputs. Turns 0477's irreversible consumer rewrite into a one-line loader swap, and is the real cutover gate (`check_exp2_mart_parity.py` covers only the exp2 mart — 80 score rows, ~12% of the 669). Read surface is ~11 fields. `Blocked-by: 0475`.
- **0490 — legacy rows, Option B.** Some of the 669 rows are record-only (raw archived), so a raw-reading adapter can't rebuild them. Author chose **Option B**: retain a datestamped immutable snapshot (forensic-only) rather than ingest them. Hard constraint — **nothing published may depend on the snapshot** — enforced by a guard test forbidding render DAG / `load_metrics` consumers / report build from referencing the snapshot path *or retaining a fallback read of live `measurements.jsonl`*. `Blocked-by: 0477`.

## Re-threaded existing tickets

- **0475** — field-audit step (the condition vector, `validation`, justification + token/agent-mode fields have no mart home; audit is over the full projected key set).
- **0476** — `Blocked-by: 0475 → 0489` (its exp1 equivalence test is the golden test applied to exp1).
- **0478** — gained `Blocked-by: 0490`; re-scoped to delete the **read** stack only. `RunRecord` and `schema.py` are **not** touched here — they're still constructed by the live collection path (the adapters + `query_*` + `worker`); their retirement is a separate epic. Retitled accordingly.
- **0297 tracker** — child table + DAG (a fork-join: `0477 → {0490, 0478}`, `0490 → 0478`) + note.

## Review (2026-06-09) — addressed in `4378f2e`

A multi-perspective agent review + a Copilot review ran against this PR. Fixes applied:
- **Factual** (per the repo's derive-from-artifacts rule): corrected `exp1+exp2+exp3` → exp1 benchmark; `27 scripts` → ~17 inventory / ~13–14 actual; parity `~20%` → ~12%; `5 adapters` → the adapters.
- **0478 self-contradiction** (body said delete `RunRecord` while the note said keep it) → reconciled to read-stack-only.
- **Nits**: 0297 log actor token; `records_to_metrics` ref `130-247`→`75-248`; cite `score.mk:75-85` for the 0422 list; DAG shown as fork-join.
- Two Copilot comments were **incorrect** (`0430` and the `0422` list both exist — in `tickets/closed/` and `score.mk:75-85` respectively); noted on-thread.

## Validation

- `erg validate` PASS; `erg check` corpus-clean (3 pre-existing unrelated warnings)

https://claude.ai/code/session_01VHQJjf1sJvfAzv9H9wSad8