### PR TITLE
Insert mart-migration discovery phase (0493) gating execution

### DIFF
--- a/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
+++ b/tickets/0297-retire-measurements-jsonl-to-mart-v2.erg
@@ -40,19 +40,28 @@ single source of truth for all experiments (exp1 through exp3+), and the old sta
 
 ## Tracking: child tickets
 
-This is a tracking ticket. Children must land in dependency order:
+This is a tracking ticket. A **discovery phase (0493)** gates execution: it produces the
+provenance map and answers four open questions, and may reshape the children below before any
+irreversible work starts. Children then land in dependency order:
 
-DAG (fork-join at the tail): `0475 → 0489 → 0476 → 0477 → 0490 → 0478`, where 0478 also
-gates directly on 0477 — i.e. `0477 → {0490, 0478}` and `0490 → 0478`.
+DAG (discovery gates the head; fork-join at the tail):
+`0493 → 0475 → 0489 → 0476 → 0477 → 0490 → 0478`, where 0478 also gates directly on 0477 —
+i.e. `0477 → {0490, 0478}` and `0490 → 0478`.
 
 | ID | Title | Status |
 |----|-------|--------|
-| 0475 | Architect question: generalize vs shoehorn + schema design + field audit | open |
+| 0493 | DISCOVERY: provenance map + four open questions (Q1 0476 scope, Q2 record-only set, Q3 exp2 raw survival, Q4 write-path epic) | open (gates 0475) |
+| 0475 | Architect question: generalize vs shoehorn + schema design + field audit | blocked on 0493 |
 | 0489 | Read-path shim: `mart_to_metrics()` flattener + golden equivalence test | blocked on 0475 |
 | 0476 | Exp1 adapter + mart equivalence test | blocked on 0489 |
 | 0477 | Port reporting consumers from measurements.jsonl to mart | blocked on 0476 |
 | 0490 | Legacy rows: forensic snapshot (Option B) + no-published-dep guard | blocked on 0477 |
 | 0478 | Delete old stack (read interface; RunRecord write-path is a separate epic) | blocked on 0477, 0490 |
+
+Discovery note (2026-06-09): inserted after #881 merged ("too many bumps, need more plan
+review"). The derisk pass fixed a wrong premise and a self-contradiction, but the plan still
+assumes a data provenance nobody has enumerated. 0493 produces that artifact first; its Q4
+also creates the missing RunRecord write-path epic that 0478 forward-references.
 
 Tracker closes only after 0478 merges and a final `make check` confirms no old-stack references remain.
 

--- a/tickets/0475-mart-v2-architecture-schema-design.erg
+++ b/tickets/0475-mart-v2-architecture-schema-design.erg
@@ -2,11 +2,13 @@
 Title: Mart v2 architecture decision + schema extension (tracker: 0297)
 Created: 2026-06-08
 Author: HDMX-coding-agent
+Blocked-by: 0493
 
 --- log ---
 2026-06-08T12:00Z HDMX-coding-agent created
 2026-06-08T23:00Z haduong decided Generalize: rename exp2_mart.py → mart.py, schema name "mart"; no shoehorn; raw counts (tp/fp/fn) as int|None on ScoreSummary directly
 2026-06-09T08:12Z HDMX-coding-agent note Derisk pass on 0297: added a field-audit step (§Field audit) — 0297's "fields to absorb" list is incomplete vs what records_to_metrics() actually projects. The whole controlled-condition vector (temperature, seed, num_ctx, provider_order, max_tokens, no_think, system_instruction, reasoning_effort), plus validation and the justification scalars, has no mart home today. Read by no current consumer (so not a blast-radius risk) but required for ADR-7 completeness if the mart is to be the single scientific record.
+2026-06-09T09:42Z HDMX-coding-agent note Gated on 0493 (discovery phase). Execution waits until the provenance map answers Q1-Q4; discovery may reshape this ticket (e.g. Q3 affects whether the field audit can be validated against surviving raw).
 --- body ---
 ## Context
 

--- a/tickets/0493-mart-migration-discovery-phase-provenanc.erg
+++ b/tickets/0493-mart-migration-discovery-phase-provenanc.erg
@@ -1,0 +1,92 @@
+%erg 0.1
+Title: Mart migration DISCOVERY phase: provenance map + four open questions (tracker: 0297)
+Created: 2026-06-09
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-06-09T09:42Z HDMX-coding-agent created
+2026-06-09T09:42Z HDMX-coding-agent note Gate inserted by author after PR #881 merged ("too many bumps, need more plan review"). The derisk pass corrected a wrong premise (measurements.jsonl was mislabelled exp1+exp2+exp3; it is the exp1 benchmark) and a self-contradiction in 0478. Before any irreversible execution (0475+), four data-provenance questions must be answered from artifacts, not enumerated. Execution chain gated: 0475 Blocked-by 0493.
+
+--- body ---
+## Why this phase exists
+
+PR #881 derisked the `measurements.jsonl` → mart plan (0297 chain) but the review found
+the plan rested on an *unverified* picture of the data: one premise was outright wrong
+(`exp1+exp2+exp3` → actually the exp1 benchmark) and 0478 contradicted itself on whether
+`RunRecord` is deleted. The plan is now internally consistent, but it still assumes a data
+provenance that **nobody has enumerated**. This is a Plan-phase **discovery** ticket: produce
+the provenance artifact and answer four questions *from the artifacts*, then decide whether
+0475–0490 need reshaping. **No production-pipeline code.** A throwaway analysis script is fine.
+
+This ticket follows the project rule: agent-surveyed counts are hypotheses; the deliverable
+is a generated provenance map an independent parse can re-derive — not prose enumeration.
+
+## Deliverable
+
+1. A committed **provenance map** of every row in `measurements.jsonl` (e.g.
+   `docs/mart-migration-provenance.md` plus a CSV/JSONL it is derived from): one entry per
+   row keyed by `result_file`, with — source directory, `method`, raw-present? (does the
+   raw reply still exist under `experiments/outputs|derived|archive`?), rebuildable-from-raw?,
+   and which mart adapter (0476 exp1 / 0490 legacy snapshot) is responsible for it.
+2. Written answers to the four questions below, recorded in this ticket's log.
+3. A go / reshape decision on the 0297 children, with concrete edits named if reshape.
+
+## The four questions
+
+### Q1 — 0476 scope vs reality
+0476 scopes the exp1 adapter to read `exp1_batch2/*.json`. But `measurements.jsonl` is 669
+rows across `direct 380 / rag 143 / frontier 101 / direct+multiturn 41 / rag+verification 4`
+— far more than `exp1_batch2`. **Find:** for each non-`exp1_batch2` cohort (rag, frontier,
+multiturn, verification), which source directory produces it and does the 0476 adapter cover
+it or not? Output: the cohort→source→covered? table. If 0476 covers only a fraction, that is
+a reshape (widen 0476, or add sibling adapters).
+
+### Q2 — record-only / legacy boundary
+0490 (Option B) assumes a clean split between rebuildable rows and record-only legacy rows
+whose raw was archived (0422, `score.mk:75-85`). **Find:** the exact set — for each of the
+669 rows, is the raw reply still present, or only the `*.record.json` score pointer? Output:
+the count and the enumerated list of record-only rows. This is the set Option B's snapshot
+must cover and the no-published-dep guard (0490) must clear.
+
+### Q3 — exp2 mart provenance
+0489's golden test needs to run `mart_to_metrics()` and `records_to_metrics()` on **shared
+raw**. **Find:** is the existing `exp2_mart.jsonl` built from raw that still survives, or is
+it itself partly record-only (raw archived)? If the mart's own inputs are partly gone, the
+golden equivalence test cannot run on those rows and 0489's gate needs a fallback (e.g. pin a
+frozen mart + frozen measurements subset as the test fixture). Output: exp2 raw-survival count.
+
+### Q4 — the write-path epic does not exist
+0478 now defers `RunRecord` retirement to "a separate epic" that has **no ticket**. A dangling
+forward reference is a plan hole. **Find:** enumerate the live `RunRecord` constructors
+(adapters, `query_*`, `worker`) and what each would need to emit instead (mart records direct,
+or raw-only + adapter). Output: **create the write-path epic ticket** (tracker or first child)
+and point 0478's "separate epic" at its real ID.
+
+## Method (read-only / throwaway)
+
+- Parse `measurements.jsonl` for `result_file` per row; classify by source dir + `method`.
+- For each `result_file`, test raw presence under `experiments/{outputs,derived,archive}`.
+- Cross-check the 0422 dropped-entries note (`experiments/derived/score.mk:75-85`).
+- Grep `from aedist.schema import RunRecord` / `RunRecord(` for Q4's constructor list.
+
+## Verification
+
+- [ ] Provenance map committed; its row count equals `measurements.jsonl`'s (669).
+- [ ] Q1 cohort→source→covered table recorded; 0476 coverage gap (if any) named.
+- [ ] Q2 record-only set enumerated with a count.
+- [ ] Q3 exp2 raw-survival recorded; 0489 fixture strategy stated if any inputs are gone.
+- [ ] Q4 write-path epic ticket created; 0478's "separate epic" updated to its ID.
+- [ ] Go / reshape decision recorded for 0475–0490 (named edits if reshape).
+
+## Exit criteria
+
+- The four questions are answered from the committed provenance artifact, not enumeration.
+- Any required reshape of 0475–0490 is ticketed or applied; the write-path epic exists.
+- Execution (0475) is unblocked only once this ticket closes.
+
+## Invariants
+
+- No production-pipeline code, no schema change, no `measurements.jsonl` mutation — this is
+  measurement and decision only. A throwaway analysis script may live under `experiments/`
+  or be deleted after the map is generated.


### PR DESCRIPTION
## What

Inserts a **discovery phase (0493)** that gates the `measurements.jsonl` → mart migration (tracker 0297) before any irreversible execution. Planning-only — one new ticket + two edits, no production code.

After #881 merged, the plan was internally consistent but still rested on a data provenance nobody had enumerated. 0493 produces that artifact first and answers four open questions, deriving from artifacts (not enumeration) per the repo rule:

- **Q1 — 0476 scope vs reality:** `measurements.jsonl` is 669 rows (direct 380 / rag 143 / frontier 101 / multiturn 41 / verification 4), far more than the `exp1_batch2` the 0476 adapter scopes — map each cohort to its source and coverage.
- **Q2 — record-only boundary:** enumerate exactly which rows have no recoverable raw (the set Option B's snapshot must cover).
- **Q3 — exp2 mart raw survival:** can 0489's golden test run on shared raw, or are the mart's own inputs partly archived (→ frozen-fixture fallback)?
- **Q4 — write-path epic:** enumerate live `RunRecord` constructors and **create the epic ticket** that 0478 forward-references but that doesn't exist.

**Deliverable:** a committed provenance map (one entry per row, keyed by `result_file`) + recorded answers + a go/reshape decision on 0475–0490.

## Gating

`0475 Blocked-by 0493`, so the chain becomes `0493 → 0475 → 0489 → 0476 → 0477 → 0490 → 0478`. `erg ready` confirms 0475 left the workable set and 0493 is the only entry point. 0493 is tagged `needs-human`.

## Validation

- `erg validate` PASS; `erg check` corpus-clean (6 pre-existing unrelated warnings)

https://claude.ai/code/session_01VHQJjf1sJvfAzv9H9wSad8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHQJjf1sJvfAzv9H9wSad8)_