### PR TITLE
fix(0492): skip colocated reconciliation_*.csv in variability regression test

### DIFF
--- a/tests/test_score_mechanical.py
+++ b/tests/test_score_mechanical.py
@@ -644,6 +644,13 @@ def test_variability_screen_regression_exp1_batch2() -> None:
     vetoed_runs: set[tuple[str, str]] = set()
 
     for fpath in sorted(exp1_dir.glob("*.csv")):
+        # Skip colocated reconciliation outputs (reconciliation_<model>-run<N>.csv);
+        # the greedy run_re would otherwise capture them as model="reconciliation_...".
+        # These are untracked 0374-era artifacts that linger in some working trees
+        # (ticket 0492); the == 70 assertion below still guards against any OTHER
+        # unexpected colocated file.
+        if fpath.name.startswith("reconciliation_"):
+            continue
         m = run_re.match(fpath.name)
         if not m:
             continue

--- a/tickets/0492-variability-test-regex-matches-reconciliation.erg
+++ b/tickets/0492-variability-test-regex-matches-reconciliation.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-06-09T09:45Z HDMX-coding-agent created — surfaced during the 483/486/487/488 raid wrap-up `make check` on padme primary working tree.
 
+2026-06-09T10:23Z fixed: prefix-skip reconciliation_*.csv before run_re; red(71)->green(70) proven with dummy; 50/50 test_score_mechanical pass; ruff clean
 --- body ---
 ## Context
 
@@ -61,9 +62,9 @@ touching a dummy `reconciliation_x-run1.csv` in that dir.
 
 ## Verification
 
-- [ ] Test passes whether or not `reconciliation_*.csv` files are present locally
-- [ ] Count assertion still pins exactly 70 genuine run files
-- [ ] `make check` passes on a working tree that retains the reconciliation outputs
+- [x] Test passes whether or not `reconciliation_*.csv` files are present locally
+- [x] Count assertion still pins exactly 70 genuine run files
+- [x] `make check` passes on a working tree that retains the reconciliation outputs
 
 ## Invariants
 


### PR DESCRIPTION
## Summary

`test_variability_screen_regression_exp1_batch2` globbed `experiments/outputs/exp1_batch2/*.csv` and matched filenames with a greedy `run_re = ^(?P<model>.+)-run(\d+)\.csv$`. That regex also captured colocated `reconciliation_<model>-run<N>.csv` artifacts, double-counting runs (71/140) and tripping `make check` on working trees that still hold the untracked 2026-05-26 reconciliation outputs (e.g. padme primary). Fresh checkouts and CI stay green, so this is a latent test fragility, not a regression.

## Fix

Skip the `reconciliation_` prefix before the regex. Chosen over anchoring to a model roster because the `== 70` assertion then remains the **loud** guard against any *other* unexpected colocated file, rather than silently swallowing it.

## Proof

- RED: with a dummy `reconciliation_*.csv` present → `71 != 70` failure reproduced.
- GREEN: same dummy present, fix applied → passes (70).
- `tests/test_score_mechanical.py`: 50/50 pass; ruff clean; pre-commit suite green.
- The ρ ≥ 0.85 screen and the exact 23-veto set invariants are untouched.

**Ticket:** tickets/0492-variability-test-regex-matches-reconciliation.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)