### PR TITLE
reference(boundary): a potential site is not a project — policy + removal/handover tickets

### DIFF
--- a/data/reference/PROVENANCE.md
+++ b/data/reference/PROVENANCE.md
@@ -4,6 +4,8 @@
 
 **The frozen reference is `vietnam_thermal_plants_v2_classified.csv` at 180 plants**: v2.2 (176) plus four potential coal sites from PDP planning documents — Kim Sơn (Ninh Bình, 3000 MW), Rạng Đông (Nam Định, 2400 MW, distinct from the existing Rang Dong cogeneration entry), Yên Hưng (Quảng Ninh, 1200 MW, PDP7 planned), and Phú Thọ (Phú Thọ, 600 MW). All four are status "1 announced". Primary sources: Study E542 Table PL9.2 (PDP8 draft 3, Institute of Energy, 2020-11) for Kim Sơn, Rạng Đông, and Phú Thọ; PDP7 Annex 1 + Annex 2 for Yên Hưng. Added via XML surgery on the ODS snapshot (`add_plants_0395.py`), re-extracted through the standard pipeline. The Exp2 FP audit `reference_hole` bucket drops from 95 occurrences (v1 baseline) to 8 occurrences (91.6% reduction).
 
+**Boundary correction (ticket 0497, 2026-06-09).** Three of these four — Kim Sơn, Rạng Đông, Phú Thọ — are **potential sites** from a draft planning study (Study E542 Table PL9.2, *"tổng hợp các vị trí tiềm năng"* / summary of *potential* coal-power locations, PDP8 draft 3), not projects, and violate the scope boundary below. They are scheduled for removal (180 → 177) and re-aliasing onto the corresponding PDP7 northern entries. Yên Hưng is **retained**: PDP7 Annex 1 + Annex 2 attest it as a planned 1200 MW (2×600) coal project genuinely missing from the gold list (absent in both v2.1/173 and v2.2/176) — a project, not a potential site.
+
 Not added (needs-human, no primary source in RAG corpus): Hòa Phát Dung Quất captive power (operating BFG/coal ~240 MW); the RAG corpus only documents "NĐ khí dư Hòa Phát II" (300 MW, announced, PDP8 Table 4) which is already in the reference.
 
 Status distribution (v1-compat projection): operational 56, proposed 71, planned 21, constructing 10, cancelled 20, retired 2. (Note: 0 exploring = 4, 1 announced = 24, 2 proposed = 43, 3 added to PDP = 16, 4 permitted = 5, 5 construction = 10, 6 operating = 56, 9 cancelled = 20, 10 retired = 2.)
@@ -164,6 +166,38 @@ Where sources disagreed during compilation, the following priority applied:
 - **Status reclassifications between cycles:** the latest PDP wins
   (PDP8 > PDP7A > PDP7), even when EVN annual reports list an interim
   status that has since been superseded.
+
+## Scope boundary: a project is not a potential site
+
+**A reference plant is a project.** It has a committed entry in an approved
+power development plan (PDP7 / PDP7A / PDP8 project annexes) — a named asset with
+a developer, a location, and a planned or actual commissioning — at any lifecycle
+status from `proposed` through `operating` to `retired` or `cancelled`. The
+status records *where in its lifecycle a project sits*, including projects that
+were planned and then cancelled.
+
+**A potential site is not a project and is not counted.** Potential sites are
+candidate *locations* identified in planning **studies** (e.g. Study E542 Table
+PL9.2, *"tổng hợp các vị trí tiềm năng"* — summary of potential coal-power
+locations, PDP8 draft 3) that carry no committed plan entry, no developer, and no
+schedule — often at feasibility-study stage, sometimes flagged for fuel
+conversion. Counting them would inflate the forward-looking pipeline with
+speculative capacity and conflate *"where a plant might one day go"* with
+*"a planned plant."* This matters doubly because the pipeline bucket is exactly
+where the reference claims coverage that external sources (GEM, Wikipedia) lack;
+that claim must rest on planned projects, not draft candidate sites.
+
+**Traceability without counting (aliases).** When a planning study names a
+candidate location that corresponds to an existing planned or anonymous reference
+entry — e.g. the PDP7 *"NĐ Miền Bắc 1/2/3"* northern slots already in the gold
+list — record the study reference as an **alias or note on that entry**, not as a
+new row. This keeps the PL9.2 cross-reference findable without double-counting a
+candidate as a project.
+
+**Enforcement.** Repo-side removal of the three v2.3 potential sites (Kim Sơn,
+Rạng Đông, Phú Thọ) is ticket 0497; the master-side rule (do not replay them onto
+the authoritative master; record them as aliases) is folded into the reverse-sync
+handover, ticket 0458.
 
 ## Residual uncertainty (top-3 disputed cases)
 

--- a/tickets/0458-replay-the-8-cell-standalone-extensions.erg
+++ b/tickets/0458-replay-the-8-cell-standalone-extensions.erg
@@ -1,5 +1,5 @@
 %erg 0.1
-Title: Replay the 8-cell standalone-extensions edit on the master pipeline.ods
+Title: Master reverse-sync handover (doudou): replay validated edits + apply the project-vs-potential-site boundary
 Created: 2026-06-06
 Author: HDMX-coding-agent
 Label: needs-human
@@ -8,6 +8,7 @@ Label: deferred
 --- log ---
 2026-06-06T13:56Z HDMX-coding-agent created
 2026-06-06T13:57Z claude note protect the 0445 standalone adoption: the pinned snapshot carries an edit the master does not
+2026-06-09T11:00Z HDMX-coding-agent note SCOPE EXPANDED to the full master reverse-sync. The pinned snapshot now carries THREE un-replayed edit-sets (extensions 0445, Kiên Lương 0472, ticket 0395), not just the extensions. Author ruled a potential site is not a project (boundary in PROVENANCE.md): when replaying 0395, replay ONLY Yên Hưng (PDP7 project); do NOT replay Kim Sơn / Rạng Đông / Phú Thọ (E542 PL9.2 potential sites) — record them as aliases instead. Repo side is ticket 0497.
 
 --- body ---
 ## Context
@@ -39,16 +40,46 @@ clear `Unit` (row-is-the-plant semantics):
 Also log the change in the master's own `Change log` sheet (master
 discipline; the analysis-side edit could not touch it meaningfully).
 
+## Edit-set 2 — Kiên Lương complex (ticket 0472)
+
+Replay the 4-row Kiên Lương insertion (`add_kien_luong.py`): Kiên Lương 1/2/3
+(Kiên Giang, coal, ~4400 MW complex, cancelled) — distinct from the existing
+"TBKHH Kiên Giang I, II" gas entry. These are committed-plan projects; replay
+verbatim.
+
+## Edit-set 3 — ticket 0395 additions, WITH the boundary applied
+
+The 0395 script added four rows. Under the project-vs-potential-site boundary
+(PROVENANCE.md "Scope boundary"), replay only the one that is a project:
+
+- **REPLAY: Yên Hưng** — Quảng Ninh, 1200 MW (2×600), coal, "1 announced".
+  PDP7 Annex 1 + Annex 2 attest it; a planned project, genuinely missing from
+  the gold list (absent in v2.1 and v2.2).
+- **DO NOT REPLAY: Kim Sơn, Rạng Đông, Phú Thọ** — Study E542 PL9.2 draft
+  *potential sites*, not projects. Instead, on the master, record each as an
+  **alias/note** against the corresponding PDP7 `NĐ Miền Bắc` northern entry
+  (boundary §"Traceability without counting"). The repo-side removal is ticket
+  0497; the master must converge to the same 177-plant result.
+
+After all three edit-sets, the master `Power plants` sheet should extract to
+**177 plants** (173 extensions-adopted + 4 Kiên Lương + 1 Yên Hưng − 0 potential
+sites), not 180.
+
 ## Exit criteria
 
-- [ ] Master pipeline.ods carries the 4-row standalone-extensions edit
-- [ ] Fresh `import.sh` snapshot extracts to 173 plants byte-identical to
-      `vietnam_thermal_plants_v2_classified.csv` (modulo later master edits)
+- [ ] Master pipeline.ods carries: the 4-row standalone-extensions edit, the
+      4-row Kiên Lương insertion, and the **Yên Hưng** row only from 0395
+- [ ] Kim Sơn / Rạng Đông / Phú Thọ are NOT replayed as rows; recorded as aliases
+- [ ] Fresh `import.sh` snapshot extracts to **177 plants** byte-identical to the
+      post-0497 `vietnam_thermal_plants_v2_classified.csv`
 - [ ] `config.VN_THERMAL_MASTER_SNAPSHOT_ODS` re-pinned to the new datestamped
       snapshot; the 0445 exception comment removed
-- [ ] PROVENANCE.md "Snapshot provenance exception" paragraph resolved
+- [ ] PROVENANCE.md "Snapshot provenance exception" paragraph resolved (all three
+      edit-sets replayed)
 
 ## Related
 
-- 0445 (the adoption this protects)
+- 0445 (extensions adoption), 0472 (Kiên Lương), 0395 (the four additions)
+- 0497 (repo-side removal of the three potential sites — keep in lockstep)
+- PROVENANCE.md "Scope boundary: a project is not a potential site"
 - `data/reference/extensions_standalone_vs_absorbed.md` (measurement + edit spec)

--- a/tickets/0497-remove-potential-sites-from-reference.erg
+++ b/tickets/0497-remove-potential-sites-from-reference.erg
@@ -1,0 +1,88 @@
+%erg 0.1
+Title: Remove the 3 E542 potential sites from the reference (apply the project-vs-potential-site boundary)
+Created: 2026-06-09
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-09T11:00Z HDMX-coding-agent created — from the 0486 reference-audit dialogue. Author ruled: a potential site is not a project (boundary now in PROVENANCE.md "Scope boundary"). Three v2.3 additions (Kim Sơn, Rạng Đông, Phú Thọ) are E542 PL9.2 draft potential sites and must be removed; Yên Hưng is retained (PDP7-planned project, genuine gap).
+
+--- body ---
+
+## Context
+
+The new scope boundary (PROVENANCE.md "Scope boundary: a project is not a
+potential site") excludes draft candidate *locations* from the reference. The
+v2.3 release (ticket 0395) added four rows; three of them violate the boundary:
+
+| Plant | Capacity | Source | Verdict |
+|---|---|---|---|
+| Kim Sơn (Ninh Bình) | 3000 MW | Study E542 PL9.2 (draft, "potential coal sites") | **remove** |
+| Rạng Đông (Nam Định) | 2400 MW | Study E542 PL9.2 (draft) | **remove** |
+| Phú Thọ (Phú Thọ) | 600 MW | Study E542 PL9.2 (draft; was not even FP-flagged) | **remove** |
+| Yên Hưng (Quảng Ninh) | 1200 MW | PDP7 Annex 1+2 (planned project, 2029 tranche) | **keep** |
+
+Removing the three brings the reference **180 → 177**.
+
+## Why a re-score is required
+
+Exp1–3 were re-scored **against the 180-plant reference** (`exp1_cross_eval.csv`
+last scored at `4f8c0bc4`, after the CSV hit 180 at `47a91957`). Dropping three
+reference rows changes the recall/precision denominators, so the experiment
+scoring must be regenerated. (No new API calls — re-score from existing outputs.)
+Effect is small and favourable: three obscure "announced" plants leave the
+false-negative pool, nudging recall up slightly.
+
+## Actions
+
+1. **Reverse the ODS surgery** for the three rows in
+   `data/reference/raw/pipeline+0395-2026-06-09.ods` (the inverse of
+   `add_plants_0395.py`; stdlib ET on content.xml + byte-identical rezip per the
+   ODS-surgery pattern). Keep Yên Hưng. Produce a new dated snapshot.
+2. **Aliases (boundary §"Traceability without counting").** Record the three
+   PL9.2 candidate names as aliases/notes against the existing PDP7
+   `NĐ Miền Bắc 1/2/3` northern entries (or a dedicated PL9.2 note), so the
+   cross-reference stays findable without a counted row. (Mechanism: a note/alias
+   column or PROVENANCE note — pick the lightest that survives extraction.)
+3. **Regenerate** `vietnam_thermal_plants_v2_classified.csv` through the standard
+   pipeline; confirm 177 rows; Yên Hưng present, the three absent.
+4. **Re-score Exp1–3** against the 177 reference; regenerate `exp1_cross_eval.csv`
+   and the Exp2/3 scored artifacts.
+5. **Cascade the count:** `tests/test_reference_count.py` (180 → 177),
+   `N_REFERENCE_PLANTS` in every figure module, regenerate affected figures.
+6. **PROVENANCE.md:** add a v2.4 adoption record; resolve the boundary-correction note.
+7. Coordinate with **0458** (master reverse-sync must also exclude the three) and
+   note the interaction with the manuscript count (currently a stale "173";
+   tracked separately).
+
+## Test
+
+First (red): extend `tests/test_reference_count.py` —
+```python
+def test_potential_sites_absent():
+    names = {p.name for p in load_plants_csv(VN_THERMAL_PLANTS_RELEASE_CSV)}
+    assert {"Kim Sơn", "Rạng Đông", "Phú Thọ"}.isdisjoint(names)
+    assert "Yên Hưng" in names            # the PDP7 project stays
+    assert reference_plant_count() == 177
+```
+Red now (the three are present, count is 180); green after removal.
+
+## Verification
+
+- [ ] Reference is 177 plants; Kim Sơn/Rạng Đông/Phú Thọ absent, Yên Hưng present
+- [ ] PL9.2 names preserved as aliases/notes (not counted rows)
+- [ ] Exp1–3 re-scored against 177; `exp1_cross_eval.csv` regenerated
+- [ ] `test_reference_count.py` asserts 177; all `N_REFERENCE_PLANTS` = 177; figures regenerated
+- [ ] PROVENANCE.md v2.4 record added; boundary-correction note resolved
+- [ ] `make check` passes
+
+## Invariants
+
+- Do NOT remove Yên Hưng (PDP7-attested project)
+- Denominator stays derived via `reference_plant_count()` — never hardcode 177
+- The ODS edit chain stays replayable; coordinate the master side via 0458
+
+## Exit criteria
+
+- The reference counts only projects (177); the three potential sites survive as aliases; experiments and figures are consistent at 177
+
+Related: 0395 (the additions), 0458 (master reverse-sync), 0486 (GEM concordance), 0494 (Wikipedia bar)


### PR DESCRIPTION
From the 0486 reference audit. Author ruling: **a draft "potential site" is not a project** and must not be counted as a reference plant.

## What this PR lands (policy + tickets only — no data change yet)
- **PROVENANCE.md** — new **"Scope boundary: a project is not a potential site"** section: projects (committed PDP entry) count; potential sites (E542 PL9.2 draft candidate *locations*) do not; planning-study names are preserved as **aliases/notes**, not rows. The v2.3 record is annotated to flag the violation.
- **Ticket 0497 (new)** — repo-side removal of the three E542 PL9.2 potential sites (**Kim Sơn, Rạng Đông, Phú Thọ**, 180→177), **keeping Yên Hưng** (PDP7 Annex 1+2 attest a planned 1200 MW project genuinely missing from the gold list). Includes the **Exp1–3 re-score** required because scoring is currently against 180.
- **Ticket 0458 (expanded)** — the **doudou reverse-sync handover** now covers all three un-replayed edit-sets (extensions 0445, Kiên Lương 0472, 0395) and bakes in the boundary: replay Yên Hưng, **do not replay** the three potential sites (alias them), converge the master to **177**.

## Verified during the audit
- All four 0395 additions have real primary-source citations (not fabricated).
- The three removed are E542 PL9.2 *"vị trí tiềm năng"* (potential locations) from **PDP8 draft 3** — speculative, "1 announced". Phú Thọ wasn't even FP-flagged.
- Yên Hưng: confirmed in PDP7 Annex 1 **and** 2 (1200 MW, 2×600 coal); absent from v2.1/173 and v2.2/176 → genuine gap.

Ticket-ref: tickets/0497-remove-potential-sites-from-reference.erg
Ticket-ref: tickets/0458-replay-the-8-cell-standalone-extensions.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)