### PR TITLE
fix(0495): score_exp1 skips colocated reconciliation/filtered CSVs

### DIFF
--- a/src/aedist/score_exp1.py
+++ b/src/aedist/score_exp1.py
@@ -25,6 +25,7 @@ from .score_mechanical import (
 log = logging.getLogger(__name__)
 
 _FILENAME_RE = re.compile(r"^(?P<model>.+)-run(?P<run>\d+)\.csv$")
+_SKIP_PREFIXES = ("reconciliation_", "filtered_")
 _CAPACITY_KEYS = ("capacity_mwe", "total_mwe", "total_mw", "capacity")
 _SOURCE_DIVERSITY_CLIP = 20
 _SOURCE_NOT_FOUND = frozenset({"not found", "n/a", "unknown", ""})
@@ -291,6 +292,8 @@ def main(argv: list[str] | None = None) -> None:
 
     out_rows: list[dict[str, str]] = []
     for csv_path in files:
+        if any(csv_path.name.startswith(p) for p in _SKIP_PREFIXES):
+            continue
         model, run = _parse_model_run(csv_path)
         row = score_file(csv_path, args.reference, args.prompt_version)
         out_rows.append(row)

--- a/tests/test_score_exp1.py
+++ b/tests/test_score_exp1.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from aedist.score_exp1 import _CSV_COLUMNS, _parse_model_run, score_file
+from aedist.score_exp1 import _CSV_COLUMNS, _parse_model_run, main, score_file
 
 
 def test_parse_model_run() -> None:
@@ -37,3 +37,50 @@ def test_score_file_emits_expected_columns(tmp_path: Path) -> None:
     assert row["model"] == "toy-model"
     assert row["run"] == "1"
     assert row["prompt_version"] == "exp1"
+
+
+_SAMPLE_ROW = (
+    "name,fuel,status,status_as_of,cod,province,capacity_mwe,"
+    "confidence,source_1,source_2,note\n"
+    "Plant A,coal,operating,2024-01-01,2020,Hanoi,600,"
+    "HIGH,http://a,http://b,ok\n"
+)
+
+_SAMPLE_REF = (
+    "name,fuel,status,province,cod,capacity_mwe\n"
+    "Plant A,coal,operating,Hanoi,2020,600\n"
+)
+
+
+def test_main_skips_colocated_outputs(tmp_path: Path) -> None:
+    """score_exp1 main() ignores reconciliation_* and filtered_* CSVs."""
+    ref = tmp_path / "reference.csv"
+    ref.write_text(_SAMPLE_REF, encoding="utf-8")
+
+    input_dir = tmp_path / "runs"
+    input_dir.mkdir()
+    (input_dir / "model-a-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+    (input_dir / "model-b-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+    (input_dir / "reconciliation_model-a-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+    (input_dir / "filtered_model-b-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+
+    out = tmp_path / "out.csv"
+    main([
+        "--input-dir", str(input_dir),
+        "--output", str(out),
+        "--reference", str(ref),
+    ])
+
+    import csv
+
+    with out.open(encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2
+    models = {r["model"] for r in rows}
+    assert models == {"model-a", "model-b"}
+
+
+def test_parse_model_run_still_rejects_malformed() -> None:
+    """Skip prefixes don't swallow genuinely malformed filenames."""
+    with pytest.raises(ValueError):
+        _parse_model_run(Path("no-run-number.csv"))


### PR DESCRIPTION
## Summary
- Add `_SKIP_PREFIXES = ("reconciliation_", "filtered_")` to `score_exp1.py`, matching the established pattern in `tabulate_coherence.py`
- Skip colocated non-run outputs in the glob loop before `_parse_model_run` is called
- Add test proving exactly 2 genuine runs are scored when decoys are present

## Test plan
- [x] `test_main_skips_colocated_outputs` — seeds genuine + reconciliation + filtered CSVs, asserts only genuine scored
- [x] `test_parse_model_run_still_rejects_malformed` — malformed non-prefixed filenames still raise
- [x] `make check-fast` green

**Ticket:** tickets/0495-score-exp1-greedy-glob.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)