### PR TITLE
tickets(0495,0496): greedy-glob fix + standing class test

### DIFF
--- a/src/aedist/score_exp1.py
+++ b/src/aedist/score_exp1.py
@@ -25,6 +25,7 @@ from .score_mechanical import (
 log = logging.getLogger(__name__)
 
 _FILENAME_RE = re.compile(r"^(?P<model>.+)-run(?P<run>\d+)\.csv$")
+_SKIP_PREFIXES = ("reconciliation_", "filtered_")
 _CAPACITY_KEYS = ("capacity_mwe", "total_mwe", "total_mw", "capacity")
 _SOURCE_DIVERSITY_CLIP = 20
 _SOURCE_NOT_FOUND = frozenset({"not found", "n/a", "unknown", ""})
@@ -291,6 +292,8 @@ def main(argv: list[str] | None = None) -> None:
 
     out_rows: list[dict[str, str]] = []
     for csv_path in files:
+        if any(csv_path.name.startswith(p) for p in _SKIP_PREFIXES):
+            continue
         model, run = _parse_model_run(csv_path)
         row = score_file(csv_path, args.reference, args.prompt_version)
         out_rows.append(row)

--- a/src/aedist/screen_validation_within_model.py
+++ b/src/aedist/screen_validation_within_model.py
@@ -113,7 +113,7 @@ def _load_raw_runs(exp1_dir: Path, f1_map: dict[tuple[str, int], float | None]) 
     runs = []
     for csv_path in sorted(exp1_dir.glob("*-run*.csv")):
         stem = csv_path.stem
-        if stem.startswith("reconciliation_"):
+        if stem.startswith(("reconciliation_", "filtered_")):
             continue
         parts = stem.rsplit("-run", 1)
         if len(parts) != 2:

--- a/tests/test_no_colocated_output_leak.py
+++ b/tests/test_no_colocated_output_leak.py
@@ -1,0 +1,88 @@
+"""Standing class test: every exp1_batch2 CSV consumer ignores colocated non-run outputs.
+
+Ticket 0496 — guards the greedy-glob anti-pattern class (0492/0495).
+Seeded with genuine + reconciliation_* + filtered_* decoys; asserts decoys ignored.
+"""
+
+import pytest
+
+_SAMPLE_CSV = (
+    "name,fuel,status,status_as_of,cod,province,capacity_mwe,"
+    "confidence,source_1,source_2,note\n"
+    "Plant A,coal,operating,2024-01-01,2020,Hanoi,600,"
+    "HIGH,http://a,http://b,ok\n"
+)
+
+_SAMPLE_REF = (
+    "name,fuel,status,province,cod,capacity_mwe\n"
+    "Plant A,coal,operating,Hanoi,2020,600\n"
+)
+
+GENUINE_NAMES = ["model-a-run1.csv", "model-b-run1.csv"]
+DECOY_NAMES = [
+    "reconciliation_model-a-run1.csv",
+    "filtered_model-b-run1.csv",
+]
+
+
+def _seed_dir(tmp_path):
+    """Create a tmp dir with genuine + decoy CSVs, return (input_dir, ref_path)."""
+    input_dir = tmp_path / "runs"
+    input_dir.mkdir()
+    for name in GENUINE_NAMES + DECOY_NAMES:
+        (input_dir / name).write_text(_SAMPLE_CSV, encoding="utf-8")
+    ref = tmp_path / "reference.csv"
+    ref.write_text(_SAMPLE_REF, encoding="utf-8")
+    return input_dir, ref
+
+
+@pytest.mark.adherence
+class TestNoColocatedOutputLeak:
+    """Each registered consumer must ignore reconciliation_*/filtered_* decoys."""
+
+    def test_score_exp1(self, tmp_path):
+        import csv
+
+        from aedist.score_exp1 import main
+
+        input_dir, ref = _seed_dir(tmp_path)
+        out = tmp_path / "out.csv"
+        main([
+            "--input-dir", str(input_dir),
+            "--output", str(out),
+            "--reference", str(ref),
+        ])
+        with out.open(encoding="utf-8") as fh:
+            rows = list(csv.DictReader(fh))
+        models = {r["model"] for r in rows}
+        assert len(rows) == len(GENUINE_NAMES), (
+            f"Expected {len(GENUINE_NAMES)} rows, got {len(rows)} — decoys leaked"
+        )
+        for m in models:
+            assert not m.startswith("reconciliation_")
+            assert not m.startswith("filtered_")
+
+    def test_screen_validation_within_model(self, tmp_path):
+        from aedist.screen_validation_within_model import _load_raw_runs
+
+        input_dir, _ = _seed_dir(tmp_path)
+        runs = _load_raw_runs(input_dir, f1_map={})
+        models = {r["model"] for r in runs}
+        assert len(runs) == len(GENUINE_NAMES), (
+            f"Expected {len(GENUINE_NAMES)} runs, got {len(runs)} — decoys leaked"
+        )
+        for m in models:
+            assert not m.startswith("reconciliation_")
+            assert not m.startswith("filtered_")
+
+    def test_tabulate_coherence(self, tmp_path):
+        from aedist.tabulate_coherence import load_extractions
+
+        input_dir, _ = _seed_dir(tmp_path)
+        groups = load_extractions([input_dir])
+        assert len(groups) == len(GENUINE_NAMES), (
+            f"Expected {len(GENUINE_NAMES)} models, got {len(groups)} — decoys leaked"
+        )
+        for model_slug in groups:
+            assert not model_slug.startswith("reconciliation_")
+            assert not model_slug.startswith("filtered_")

--- a/tests/test_no_colocated_output_leak.py
+++ b/tests/test_no_colocated_output_leak.py
@@ -86,3 +86,16 @@ class TestNoColocatedOutputLeak:
         for model_slug in groups:
             assert not model_slug.startswith("reconciliation_")
             assert not model_slug.startswith("filtered_")
+
+    def test_variability_screen_regression_guard(self):
+        """The 0492 test glob also skips colocated outputs (source inspection)."""
+        from pathlib import Path
+
+        src = Path(__file__).parent / "test_score_mechanical.py"
+        text = src.read_text(encoding="utf-8")
+        assert '"reconciliation_"' in text or "'reconciliation_'" in text, (
+            "test_score_mechanical.py lost its reconciliation_ skip guard"
+        )
+        assert '"filtered_"' in text or "'filtered_'" in text, (
+            "test_score_mechanical.py lost its filtered_ skip guard"
+        )

--- a/tests/test_score_exp1.py
+++ b/tests/test_score_exp1.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from aedist.score_exp1 import _CSV_COLUMNS, _parse_model_run, score_file
+from aedist.score_exp1 import _CSV_COLUMNS, _parse_model_run, main, score_file
 
 
 def test_parse_model_run() -> None:
@@ -37,3 +37,50 @@ def test_score_file_emits_expected_columns(tmp_path: Path) -> None:
     assert row["model"] == "toy-model"
     assert row["run"] == "1"
     assert row["prompt_version"] == "exp1"
+
+
+_SAMPLE_ROW = (
+    "name,fuel,status,status_as_of,cod,province,capacity_mwe,"
+    "confidence,source_1,source_2,note\n"
+    "Plant A,coal,operating,2024-01-01,2020,Hanoi,600,"
+    "HIGH,http://a,http://b,ok\n"
+)
+
+_SAMPLE_REF = (
+    "name,fuel,status,province,cod,capacity_mwe\n"
+    "Plant A,coal,operating,Hanoi,2020,600\n"
+)
+
+
+def test_main_skips_colocated_outputs(tmp_path: Path) -> None:
+    """score_exp1 main() ignores reconciliation_* and filtered_* CSVs."""
+    ref = tmp_path / "reference.csv"
+    ref.write_text(_SAMPLE_REF, encoding="utf-8")
+
+    input_dir = tmp_path / "runs"
+    input_dir.mkdir()
+    (input_dir / "model-a-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+    (input_dir / "model-b-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+    (input_dir / "reconciliation_model-a-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+    (input_dir / "filtered_model-b-run1.csv").write_text(_SAMPLE_ROW, encoding="utf-8")
+
+    out = tmp_path / "out.csv"
+    main([
+        "--input-dir", str(input_dir),
+        "--output", str(out),
+        "--reference", str(ref),
+    ])
+
+    import csv
+
+    with out.open(encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2
+    models = {r["model"] for r in rows}
+    assert models == {"model-a", "model-b"}
+
+
+def test_parse_model_run_still_rejects_malformed() -> None:
+    """Skip prefixes don't swallow genuinely malformed filenames."""
+    with pytest.raises(ValueError):
+        _parse_model_run(Path("no-run-number.csv"))

--- a/tests/test_score_mechanical.py
+++ b/tests/test_score_mechanical.py
@@ -649,7 +649,7 @@ def test_variability_screen_regression_exp1_batch2() -> None:
         # These are untracked 0374-era artifacts that linger in some working trees
         # (ticket 0492); the == 70 assertion below still guards against any OTHER
         # unexpected colocated file.
-        if fpath.name.startswith("reconciliation_"):
+        if fpath.name.startswith(("reconciliation_", "filtered_")):
             continue
         m = run_re.match(fpath.name)
         if not m:


### PR DESCRIPTION
## Summary
- Add standing adherence test (`test_no_colocated_output_leak.py`) verifying every exp1_batch2 CSV consumer ignores `reconciliation_*` and `filtered_*` decoys
- Fix `screen_validation_within_model._load_raw_runs` which only skipped `reconciliation_` but not `filtered_` — caught by the new test on first run
- Fix `test_score_mechanical.py` 0492 regression test to also skip `filtered_*` (was only skipping `reconciliation_*`)
- Covers: `score_exp1`, `screen_validation_within_model`, `tabulate_coherence`, `test_variability_screen_regression`

## Test plan
- [x] Test seeds genuine + decoy CSVs against each consumer, asserts decoys ignored
- [x] Mutation verified: removing any consumer's guard turns the test RED
- [x] `make check-fast` green

**Ticket:** tickets/0495-score-exp1-greedy-glob-matches-reconciliation.erg
**Ticket:** tickets/0496-standing-class-test-colocated-output-globs.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)