### PR TITLE
fix(boundary): speculative tail is wanted — discriminator is project identity, not status

### DIFF
--- a/data/reference/PROVENANCE.md
+++ b/data/reference/PROVENANCE.md
@@ -169,23 +169,26 @@ Where sources disagreed during compilation, the following priority applied:
 
 ## Scope boundary: a project is not a potential site
 
-**A reference plant is a project.** It has a committed entry in an approved
-power development plan (PDP7 / PDP7A / PDP8 project annexes) — a named asset with
-a developer, a location, and a planned or actual commissioning — at any lifecycle
-status from `proposed` through `operating` to `retired` or `cancelled`. The
-status records *where in its lifecycle a project sits*, including projects that
-were planned and then cancelled.
+**A reference plant is a project.** A project is a *specific named development*
+with a developer/proponent and a location — whether it appears in a PDP annex or
+is tracked by a project tracker (GEM) — at **any** lifecycle status from
+`proposed` / `announced` through `operating` to `retired` or `cancelled`.
 
-**A potential site is not a project and is not counted.** Potential sites are
-candidate *locations* identified in planning **studies** (e.g. Study E542 Table
-PL9.2, *"tổng hợp các vị trí tiềm năng"* — summary of potential coal-power
-locations, PDP8 draft 3) that carry no committed plan entry, no developer, and no
-schedule — often at feasibility-study stage, sometimes flagged for fuel
-conversion. Counting them would inflate the forward-looking pipeline with
-speculative capacity and conflate *"where a plant might one day go"* with
-*"a planned plant."* This matters doubly because the pipeline bucket is exactly
-where the reference claims coverage that external sources (GEM, Wikipedia) lack;
-that claim must rest on planned projects, not draft candidate sites.
+**Lifecycle status is not the discriminator.** A cancelled, shelved, or merely
+announced *developer-led project* is still a project and **is counted** — the
+speculative and cancelled tail is part of the inventory's value (the full
+lifecycle, including the dead and the not-yet-built). Comprehensiveness across
+status is a feature, not a leak.
+
+**A potential site is not a project and is not counted.** The test is the absence
+of project identity — **no developer/proponent**, no specific named development.
+Potential sites are candidate *locations* a planning **study** lists as
+capacity placeholders (e.g. Study E542 Table PL9.2, *"tổng hợp các vị trí tiềm
+năng"* — summary of potential coal-power *locations*, PDP8 draft 3): a region is
+allotted X MW and a few candidate places are named, with no developer attached.
+Counting them conflates *"where capacity could one day be sited"* with *"a project
+someone is developing."* (This is orthogonal to status: a cancelled developer-led
+project is counted; a developer-less study location is not, even if "announced".)
 
 **Traceability without counting (aliases).** When a planning study names a
 candidate location that corresponds to an existing planned or anonymous reference

--- a/tickets/0498-postarxiv-full-gem-reconciliation.erg
+++ b/tickets/0498-postarxiv-full-gem-reconciliation.erg
@@ -6,22 +6,30 @@ Label: deferred
 
 --- log ---
 2026-06-09T11:30Z HDMX-coding-agent created — spun out of 0486. The arXiv coverage table uses light-reviewed (ASCII-fold) numbers; this is the rigorous per-plant HITL concordance for the journal version.
-2026-06-09T12:00Z HDMX-coding-agent note author HITL on the 11 GEM-only: Ka Ga = transcription of Kê Gà + grain (GEM's 3600 MW = ref's 3×1200 Mũi Kê Gà) → matcher miss, NOT a gap; Embark-Quantum = an old project renamed several times → unverifiable because the GEM import dropped aliases; Phu Yen = real GEM-only (cancelled, author confused it with Yên Hưng). Added the alias-preservation prerequisite and the "superset modulo the boundary" goal below. Author agreed to defer all of this post-arXiv.
+2026-06-09T12:00Z HDMX-coding-agent note author HITL on the 11 GEM-only: Ka Ga = transcription of Kê Gà + grain (GEM's 3600 MW = ref's 3×1200 Mũi Kê Gà) → matcher miss, NOT a gap; Embark-Quantum = an old project renamed several times → unverifiable because the GEM import dropped aliases; Phu Yen = real GEM-only (cancelled, author confused it with Yên Hưng). Added the alias-preservation prerequisite and the superset goal below. Author agreed to defer all of this post-arXiv.
+2026-06-09T12:15Z HDMX-coding-agent note CORRECTION (author): "speculative tail is what we want, not a ground for dismissal." Reframed the goal from "superset of GEM's committed projects (exclude speculative)" to "superset of GEM's PROJECTS, any status — ADD the speculative/cancelled tail." Discriminator is project identity (named development + developer), NOT lifecycle status; only developer-less capacity-placeholder locations (E542 PL9.2) are excluded. (The GEM-only LNG/gas tail tracks the US LNG-supply-chain push into Vietnam — context, not a paper claim.)
 
 --- body ---
 
-## Goal (author decision): superset of GEM's *committed* projects
+## Goal (author decision): superset of GEM's *projects* (any lifecycle status)
 
-The author wants the reference to be a **superset of GEM modulo the
-project-vs-potential-site boundary**: contain every GEM **committed** plant
-(operating / construction / permitted / committed-announced) and extend it with
-the PDP8 pipeline GEM lacks, while **legitimately excluding GEM's own speculative
-tier** (`pre-permit` / `shelved` / speculative-cancelled). A *literal* strict
-superset is rejected: it would force GEM's speculative megaprojects (Embark-
-Quantum 6000 MW cancelled, Millenium 9600 MW announced) into the reference,
-re-admitting exactly the "potential sites" the boundary excludes. The claim to
-earn: *"the reference reproduces GEM's committed fleet and extends it; GEM-only
-residue is GEM's speculative tail, excluded by documented policy."*
+The author wants the reference to be a **superset of GEM's projects** —
+**including** GEM's speculative/cancelled tier (`announced` / `pre-permit` /
+`shelved` / cancelled). **Speculative status is NOT a ground for dismissal**:
+a cancelled or proposed *developer-led project* is exactly what the reference
+should carry — comprehensiveness across the full lifecycle is its value, and the
+speculative LNG/gas tail is real (it tracks the US LNG-supply-chain push into
+Vietnam — context, not a paper claim). So the GEM-only tail (Embark-Quantum,
+Millenium, Phu Yen, and the cancelled coal projects) is to be **added**, not
+excluded, once matcher misses are stripped (Ka Ga was one).
+
+**The discriminator is project identity, not lifecycle status.** A *project* has
+a specific named development and a developer/proposal (which GEM tracks at any
+status). A *potential site* is a planning study's capacity-placeholder **location
+with no developer** (E542 PL9.2 "vị trí tiềm năng"). Only the latter is excluded
+(per PROVENANCE.md, already enforced by 0497). The claim to earn:
+*"the reference is a superset of every project GEM tracks — built, planned, and
+cancelled — and extends it with the PDP8 pipeline GEM lacks."*
 
 ## Context
 
@@ -45,14 +53,18 @@ not for the journal:
        + grain (GEM aggregates 3600 MW; ref splits 3×1200 "Mũi Kê Gà"). NOT a gap.
      - **Embark-Quantum** (6000 MW cancelled) = an old project **renamed several
        times**; unverifiable from the repo because the GEM import carries no
-       aliases (see prerequisite). Likely a rename miss; if so, GEM's speculative
-       tail anyway → boundary-excluded.
-     - **Phu Yen** (2400 MW cancelled) = **real GEM-only**, confirmed absent under
-       any name/province/capacity. GEM's cancelled tail → boundary-excluded.
+       aliases (see prerequisite). Resolve via aliases: if it folds into an
+       existing reference row → matcher miss; if it is a distinct project → **add**
+       (it is a developer-led project, cancelled status notwithstanding).
+     - **Phu Yen** (2400 MW cancelled) = **real GEM-only**, confirmed absent. A
+       cancelled developer-led project → **add** (cancelled is a lifecycle status,
+       not a dismissal ground).
      - **Millenium** (9600 MW announced) and the remaining cancelled rows
        (Cai Trap Island, Ganh Dau, Than An Giang, Can Duoc, Hon Chong, Nhon Hoi):
-       adjudicate each vs PDP8 — committed project → add; GEM speculative /
-       `pre-permit` / `shelved` / cancelled → document the boundary exclusion.
+       each is a GEM-tracked project → **add**, recording source + status. The
+       only rows NOT added are confirmed matcher misses (Ka Ga) and any genuine
+       capacity-placeholder location with no developer (none seen so far in the
+       GEM tail — that pattern is the E542 study, not GEM).
 
 ## Actions
 
@@ -71,8 +83,10 @@ not for the journal:
    grain before scoring coverage — e.g. Ka Ga ↔ 3× Mũi Kê Gà).
 2. HITL-adjudicate every residual on both sides (the 21 + 11): real gap, naming
    variant, grain artifact, or deliberate scope exclusion — record the verdict.
-3. Decide Millenium / Ka Ga (and any other committed GEM-only) → add to the
-   reference (via the master ODS + 0458 discipline) or document the exclusion.
+3. **Add** every genuine GEM-only project (Millenium, Phu Yen, Embark-Quantum if
+   distinct, the cancelled coal rows) to the reference via the master ODS + 0458
+   discipline, recording source + status. Exclude only confirmed matcher misses
+   and (if any) capacity-placeholder locations with no developer.
 4. Replace 0486's light-reviewed numbers with the adjudicated ones for the journal.
 
 ## Test
@@ -86,8 +100,8 @@ under reference vs GEM (already in `tabulate_reconciliation.py`) is reported.
 - [ ] GEM re-exported with its alias/other-names column; aliases reach the matcher
 - [ ] Per-plant adjudicated GEM↔reference concordance at resolved grain
 - [ ] All 21 reference-only + 11 GEM-only residuals carry a recorded verdict
-- [ ] Every GEM **committed** plant is in the reference (committed-superset achieved); GEM-only residue is documented speculative-tail exclusions
-- [ ] Millenium + the cancelled tail adjudicated (added or boundary-excluded); Ka Ga folded into Mũi Kê Gà
+- [ ] Every GEM **project** (any lifecycle status, speculative/cancelled included) is in the reference — superset of GEM's projects achieved; residue is only matcher misses or developer-less capacity-placeholder locations
+- [ ] Millenium, Phu Yen, the cancelled tail (and Embark-Quantum if distinct) added with source + status; Ka Ga folded into Mũi Kê Gà
 - [ ] Journal-version numbers supersede 0486's light-reviewed figures
 - [ ] `make check` passes
 


### PR DESCRIPTION
Author correction: **"speculative tail is what we want, not a ground for dismissal."**

My previous 0498 update wrongly framed GEM's speculative/cancelled tier as boundary-excludable. The discriminator is **project identity, not lifecycle status**:

- **PROVENANCE "Scope boundary"** sharpened: a *project* is any developer-led named development at **any** status (proposed/announced/operating/cancelled/retired); the exclusion test is the **absence of a developer** — a planning study's capacity-placeholder *location* (E542 PL9.2). A cancelled developer-led project **is** counted; comprehensiveness across the lifecycle is a feature.
- **0498 goal reframed**: superset of GEM's **projects** (any status) — **add** the GEM-only speculative/cancelled tail (Millenium 9600 MW, Phu Yen, Embark-Quantum if distinct, the cancelled coal rows), not exclude it. Only confirmed matcher misses (Ka Ga = Mũi Kê Gà) and developer-less locations stay out.

(The GEM-only LNG/gas tail tracks the US LNG-supply-chain push into Vietnam — noted as context, not a paper claim. The 0497 removal of the 3 E542 *locations* still stands — they're developer-less study placeholders.)

Ticket-ref: tickets/0498-postarxiv-full-gem-reconciliation.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)