### PR TITLE
fix(0499): guard remaining greedy-glob-class consumers + register in standing test

### DIFF
--- a/scripts/audit_lp_mismatched.py
+++ b/scripts/audit_lp_mismatched.py
@@ -35,6 +35,14 @@ _REPO = Path(__file__).parent.parent
 _EXP1_DIR = _REPO / "experiments" / "outputs" / "exp1_batch2"
 _DEFAULT_OUT = _REPO / "experiments" / "derived" / "exp1_mismatched_audit.csv"
 
+# Colocated non-run outputs that the greedy *-run*.csv glob would otherwise
+# capture as spurious models (ticket 0499; matches the established pattern in
+# tabulate_coherence). reconciliation_* is the real decoy in exp1_batch2;
+# *_filtered.csv (query_verification, retains plant schema) is the decoy in a
+# verification dir if --exp1-dir is pointed there.
+_SKIP_PREFIXES = ("reconciliation_", "filtered_")
+_SKIP_SUFFIXES = ("_filtered.csv",)
+
 _OUTPUT_COLS = [
     "model",
     "run",
@@ -77,6 +85,10 @@ def sweep(ref_csv: Path, exp1_dir: Path) -> list[dict]:
         return rows
 
     for csv_path in csv_files:
+        if any(csv_path.name.startswith(p) for p in _SKIP_PREFIXES) or any(
+            csv_path.name.endswith(s) for s in _SKIP_SUFFIXES
+        ):
+            continue
         model, run = _run_label(csv_path)
         sys_plants = load_plants_csv(csv_path)
         if not sys_plants:

--- a/src/aedist/score_provenance.py
+++ b/src/aedist/score_provenance.py
@@ -22,6 +22,22 @@ from .verify import classify_source_by_text, score_evidence
 
 log = logging.getLogger(__name__)
 
+# Colocated non-run outputs to skip by filename (ticket 0499).
+#
+# The content filter alone (_has_provenance_columns) excludes reconciliation_*
+# files because their match_type schema has no source_1 column. The real leak it
+# misses is *_filtered.csv: query_verification writes both {stem}.csv and
+# {stem}_filtered.csv into the same output dir, and the filtered copy RETAINS
+# source_1, so the content filter passes it and it would be scored as a spurious
+# second run alongside its base run. The suffix skip closes that.
+#
+# _SKIP_PREFIXES mirrors the sibling consumers for class-consistency. The
+# reconciliation_ prefix is redundant with the content filter here; "filtered_"
+# is a defensive prefix that matches no current artifact (the real filtered files
+# use the _filtered.csv suffix above), kept only to match the shared pattern.
+_SKIP_PREFIXES = ("reconciliation_", "filtered_")
+_SKIP_SUFFIXES = ("_filtered.csv",)
+
 # Epistemic markers that signal intellectual honesty in notes
 _EPISTEMIC_PATTERNS = [
     r"uncertain",
@@ -161,9 +177,19 @@ def _has_provenance_columns(csv_path: Path) -> bool:
 def score_directory(input_dir: Path) -> dict:
     """Score all CSVs in a directory and produce aggregate summary.
 
-    Skips CSVs that lack provenance columns (e.g. reconciliation files).
+    Skips CSVs that lack provenance columns, plus colocated non-run outputs by
+    filename: *_filtered.csv (which retains source_1 and would otherwise be scored
+    as a spurious run alongside its base {stem}.csv — query_verification emits
+    both into the same dir) and reconciliation_*/filtered_* prefixes for
+    class-consistency with the sibling consumers (ticket 0499).
     """
-    csv_files = sorted(f for f in input_dir.glob("*.csv") if _has_provenance_columns(f))
+    csv_files = sorted(
+        f
+        for f in input_dir.glob("*.csv")
+        if not any(f.name.startswith(p) for p in _SKIP_PREFIXES)
+        and not any(f.name.endswith(s) for s in _SKIP_SUFFIXES)
+        and _has_provenance_columns(f)
+    )
     if not csv_files:
         raise SystemExit(f"No sourced CSV files (with source_1 column) in: {input_dir}")
 

--- a/tests/test_no_colocated_output_leak.py
+++ b/tests/test_no_colocated_output_leak.py
@@ -1,7 +1,11 @@
 """Standing class test: every exp1_batch2 CSV consumer ignores colocated non-run outputs.
 
-Ticket 0496 — guards the greedy-glob anti-pattern class (0492/0495).
-Seeded with genuine + reconciliation_* + filtered_* decoys; asserts decoys ignored.
+Tickets 0496/0499 — guards the greedy-glob anti-pattern class (0492/0495).
+Batch2 consumers are seeded with reconciliation_*/filtered_* PREFIX decoys; the
+two source-aware consumers (score_provenance, audit_lp_mismatched) are also
+seeded with the real *_filtered.csv SUFFIX decoy that retains source_1.
+Registered consumers: score_exp1, screen_validation_within_model, tabulate_coherence,
+score_provenance, scripts.audit_lp_mismatched, and the 0492 test path.
 """
 
 import pytest
@@ -86,6 +90,66 @@ class TestNoColocatedOutputLeak:
         for model_slug in groups:
             assert not model_slug.startswith("reconciliation_")
             assert not model_slug.startswith("filtered_")
+
+    def test_score_provenance(self, tmp_path):
+        """score_provenance.score_directory ignores the *_filtered.csv suffix
+        decoy that RETAINS source_1 — the content filter alone would score it as
+        a spurious run alongside its base run (query_verification emits both)."""
+        from aedist.score_provenance import score_directory
+
+        input_dir = tmp_path / "runs"
+        input_dir.mkdir()
+        # genuine + reconciliation_ prefix + the real _filtered.csv suffix decoy,
+        # all carrying source_1 so the content filter cannot distinguish them.
+        for name in [
+            "model-a-run1.csv",
+            "model-b-run1.csv",
+            "reconciliation_model-a-run1.csv",
+            "model-a-run1_filtered.csv",
+        ]:
+            (input_dir / name).write_text(_SAMPLE_CSV, encoding="utf-8")
+
+        result = score_directory(input_dir)
+        runs = result["runs"]
+        assert len(runs) == 2, f"Expected 2 genuine runs, got {len(runs)} — decoys leaked"
+        for stem in runs:
+            assert not stem.startswith("reconciliation_")
+            assert not stem.endswith("_filtered")
+
+    def test_audit_lp_mismatched(self, tmp_path):
+        """scripts.audit_lp_mismatched.sweep ignores reconciliation_ prefix and
+        _filtered.csv suffix decoys."""
+        from scripts.audit_lp_mismatched import sweep
+
+        # A run whose single plant force-matches the reference under a low
+        # similarity → a Mismatched pair, so genuine runs produce output.
+        run_csv = (
+            "name,fuel,status,status_as_of,cod,province,capacity_mwe,"
+            "confidence,source_1,source_2,note\n"
+            "Zzz Unrelated Plant,coal,operating,2024-01-01,2020,Hanoi,600,"
+            "HIGH,http://a,http://b,ok\n"
+        )
+        input_dir = tmp_path / "runs"
+        input_dir.mkdir()
+        for name in [
+            "model-a-run1.csv",
+            "model-b-run1.csv",
+            "reconciliation_model-a-run1.csv",
+            "model-a-run1_filtered.csv",
+        ]:
+            (input_dir / name).write_text(run_csv, encoding="utf-8")
+        ref = tmp_path / "reference.csv"
+        ref.write_text(_SAMPLE_REF, encoding="utf-8")
+
+        rows = sweep(ref, input_dir)
+        # Assert on (model, run) pairs, not just models: the _filtered.csv decoy
+        # parses to model="model-a", run="run1_filtered" — a leak that a
+        # model-only check would miss because it reuses a genuine model name.
+        pairs = {(r["model"], r["run"]) for r in rows}
+        # Genuine runs must have been processed (sanity: not vacuously green).
+        assert pairs == {("model-a", "run1"), ("model-b", "run1")}, (
+            f"Expected only genuine (model, run) pairs, got {pairs}"
+        )
 
     def test_variability_screen_regression_guard(self):
         """The 0492 test glob also skips colocated outputs (source inspection)."""

--- a/tickets/closed/0499-greedy-glob-class-audit-lp-mismatched-sc.erg
+++ b/tickets/closed/0499-greedy-glob-class-audit-lp-mismatched-sc.erg
@@ -2,10 +2,14 @@
 Title: Greedy-glob class: audit_lp_mismatched + score_provenance filtered_ gap (0495/0496 sweep)
 Created: 2026-06-09
 Author: HDMX-coding-agent
+Closed: implemented: prefix skips in audit_lp_mismatched + score_provenance, registered in standing test
 
 --- log ---
 2026-06-09T11:32Z HDMX-coding-agent created
+2026-06-09T11:50Z claude note premise refined empirically: reconciliation_* files have a match_type schema (no source_1) so score_provenance's content-filter already excludes them; real "filtered" outputs use a _filtered.csv SUFFIX (query_verification), not a filtered_ prefix.
+2026-06-09T12:05Z claude note advisor caught a real gap: a prefix-only skip protects nothing new for score_provenance — query_verification writes BOTH {stem}.csv and {stem}_filtered.csv into the same dir, the _filtered copy RETAINS source_1, so the content-filter passes it and it is scored as a spurious second run. Added _SKIP_SUFFIXES=("_filtered.csv",) to score_provenance AND audit_lp_mismatched, seeded the real _filtered.csv suffix decoy (with source_1) in the standing test, and made the audit assertion check (model,run) pairs (the suffix decoy parses to model="model-a",run="run1_filtered" so a model-only check missed it). Prefix and suffix mutations both proven RED independently for both consumers. Honest docstrings: the filtered_ PREFIX is defensive-only (matches no current artifact).
 
+2026-06-09T11:42Z HDMX-coding-agent closed — implemented: prefix+suffix skips in audit_lp_mismatched + score_provenance, registered in standing test
 --- body ---
 ## Context
 
@@ -61,11 +65,11 @@ case (or source-inspection guard) proving the skip is present.
 
 ## Verification
 
-- [ ] `audit_lp_mismatched.sweep` ignores colocated `reconciliation_*`/`filtered_*`
-- [ ] `score_provenance.score_directory` excludes a `filtered_*` file that has `source_1`
-- [ ] Both registered in the 0496 standing test (or source-guarded if not importable)
-- [ ] Reverting either guard turns the standing test RED (mutation-proven)
-- [ ] `make check` green
+- [x] `audit_lp_mismatched.sweep` ignores colocated `reconciliation_*`/`filtered_*`
+- [x] `score_provenance.score_directory` excludes a `filtered_*` file that has `source_1`
+- [x] Both registered in the 0496 standing test (both importable: `scripts` is a package)
+- [x] Reverting either guard turns the standing test RED (mutation-proven, both consumers)
+- [x] `make check` green
 
 ## Invariants
 


### PR DESCRIPTION
## Summary
Closes the greedy-glob anti-pattern class (third instance set, after 0495/0496). Two more run-dir consumers found by the /roar sweep now skip colocated non-run outputs by filename **prefix AND suffix**:

- **`scripts/audit_lp_mismatched.py`** — `reconciliation_*` (exp1_batch2) was safe-by-accident (`load_plants_csv` returns `[]` for the recon schema); `*_filtered.csv` (verification-dir output, retains the plant schema) parses to `run="runN_filtered"` and leaks as a spurious row. Skip both.
- **`src/aedist/score_provenance.py`** — the content filter excludes `reconciliation_*` (no `source_1`) but **not** `*_filtered.csv`: `query_verification` writes `{stem}.csv` and `{stem}_filtered.csv` into the same dir, and the filtered copy **retains `source_1`**, so it was scored as a spurious second run. Added `_SKIP_SUFFIXES=("_filtered.csv",)` alongside the content filter.

## Premise refinement (verified empirically, advisor-caught)
The original ticket premise (and a prefix-only first pass) was wrong about the artifact name. Verified against `query_verification.py`: the real colocated decoy is `*_filtered.csv` (**suffix**, retains `source_1`), not a `filtered_` prefix. A prefix-only skip would have protected nothing new while the real `_filtered.csv` leaked. The `filtered_` prefix is kept defensively for class-consistency only, and the docstrings say so.

## Test plan
- [x] `test_score_provenance` / `test_audit_lp_mismatched` seed the real `_filtered.csv` suffix decoy (carrying `source_1`)
- [x] Audit assertion checks `(model, run)` pairs (the suffix decoy reuses a genuine model name)
- [x] Mutation-proven: reverting either the prefix **or** the suffix skip turns the test RED, independently, for both consumers
- [x] `make check` green (full suite)

**Ticket:** tickets/0499-greedy-glob-class-audit-lp-mismatched-sc.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)