### PR TITLE
close(0500): diacritic-folding confound is a non-finding

### DIFF
--- a/tickets/closed/0500-audit-matcher-diacritic-folding-tp-undercount.erg
+++ b/tickets/closed/0500-audit-matcher-diacritic-folding-tp-undercount.erg
@@ -3,11 +3,13 @@ Title: Audit: matcher's missing diacritic-folding may undercount Exp1/2/3 TP (co
 Created: 2026-06-09
 Author: HDMX-coding-agent
 Label: needs-human
+Closed: Non-finding: premise refuted — production reconcile() folds diacritics on both sides via cleaner.clean_text; A/B shows folding is load-bearing (~+0.12 F1/model) AND already applied, so IMMATERIAL to reported Exp1/2/3 numbers. No re-score, no regression guard (fold is not a bug). Audit in experiments/derived/matcher_fold_audit.md (PR #905).
 
 --- log ---
 2026-06-09T13:00Z HDMX-coding-agent created — roar sweep from the 0486 GEM-coverage review.
 
 2026-06-09T12:26Z haduong note AUDIT steps 1-2 done (branch audit/0500-matcher-fold): premise REFUTED — production reconcile() folds diacritics on BOTH sides via cleaner.clean_text (NFD+Mn+d-bar). GEM 67/88 was the throwaway 0486 prototype bypassing the cleaner. A/B fold-vs-folding-disabled on Exp1 (70 runs): folding load-bearing ~+0.12 F1/model AND already applied -> IMMATERIAL to reported numbers, no re-score. Zero folding-induced FP collisions; combined-grain cases are 0498. Recommend close as non-finding + regression guard for the existing fold. Artifacts in experiments/derived/matcher_fold_audit.md. NOT setting Closed — author decision.
+2026-06-09T14:20Z Claude closed — Non-finding: premise refuted — production reconcile() folds diacritics on both sides via cleaner.clean_text; A/B shows folding is load-bearing (~+0.12 F1/model) AND already applied, so IMMATERIAL to reported Exp1/2/3 numbers. No re-score, no regression guard (fold is not a bug). Audit in experiments/derived/matcher_fold_audit.md (PR #905).
 --- body ---
 
 ## Context (observation, cause not yet established)


### PR DESCRIPTION
## What

Closes ticket 0500 as a **non-finding** per author decision (follow-up to the audit-only PR #905, which intentionally left the step-3 decision to the author).

- Moves `tickets/0500-...erg` → `tickets/closed/` via `erg close` + `erg archive`
- Sets the `Closed:` header and appends a log entry

## Why a non-finding

The ticket's premise — *the LP matcher doesn't fold Vietnamese diacritics, so ASCII-emitting models get TP-undercounted* — is **false for the production path**. `reconcile()` routes both reference and system through `cleaner.clean_text` (NFD + drop combining marks + `đ→d`), folding **both sides** before LP matching. The 67%→88% GEM gap that motivated the ticket came from the throwaway 0486 prototype that bypassed the cleaner.

The A/B (PR #905, Exp1, 70 runs) confirms the fold is **load-bearing** (~+0.12 F1/model) **and already applied in production** → **immaterial** to the reported Exp1/2/3 numbers. No re-score.

## Per author

- **No regression guard** — the existing fold is not a bug.

Audit artifacts (already on `main` via #905): `experiments/derived/matcher_fold_audit.md`.

Ticket-ref: tickets/closed/0500-audit-matcher-diacritic-folding-tp-undercount.erg

https://claude.ai/code/session_012nMMytSw4Z1BHwNyo3xWcQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012nMMytSw4Z1BHwNyo3xWcQ)_