### PR TITLE
ticket(0458): master reverse-sync prep — convergence verifier + handover checklist

### DIFF
--- a/data/reference/MASTER_REVERSE_SYNC_0458.md
+++ b/data/reference/MASTER_REVERSE_SYNC_0458.md
@@ -1,0 +1,93 @@
+# Master reverse-sync handover (ticket 0458)
+
+Apply this at the **master machine** (where `pipeline.ods` lives). It replays the
+three edit-sets currently applied only on the analysis side, so a fresh
+`import.sh` snapshot regenerates the **177-plant v2.4 reference** instead of
+silently reverting it (`config.VN_THERMAL_MASTER_SNAPSHOT_ODS` re-pin would
+otherwise drop the adoption — see the guard comment at that pin and PROVENANCE.md
+§ v2.4 / § v2.3).
+
+Target state (verified against the committed `vietnam_thermal_plants_v2_classified.csv`,
+2026-06-09): **177 plants** — the 4 extension rows + 3 Kiên Lương + 1 Yên Hưng
+below are present; Kim Sơn / Rạng Đông / Phú Thọ are absent.
+
+## Edit-set 1 — standalone extensions (0445)
+
+For each extension row in the master `Power plants` sheet: set `Plant` to the
+full extension name and **clear** `Unit` (row-is-the-plant). Resulting plant
+rows must match:
+
+| Plant | Province | Fuel | MWe | Status |
+|---|---|---|---|---|
+| `Duyen Hai 3 extension` | Tra Vinh | coal | 660 | 6 operating |
+| `Uong Bi I extension` | Quảng Ninh | coal | 300 | 6 operating |
+| `Uong Bi II extension` | Quảng Ninh | coal | 330 | 6 operating |
+| `Vinh Tan 4 extension` | Bình Thuận | coal | 600 | 6 operating |
+
+Also log the change in the master's own `Change log` sheet (master discipline —
+the analysis-side edit could not touch it meaningfully).
+
+## Edit-set 2 — Kiên Lương complex (0472)
+
+Replay the 4-row insertion (`add_kien_luong.py` is the analysis-side source).
+Distinct from the existing "TBKHH Kiên Giang I, II" gas entry; replay verbatim:
+
+| Plant | Province | Fuel | MWe | Status |
+|---|---|---|---|---|
+| `Kiên Lương 1` | Kiên Giang | coal | 1200 | 9 cancelled |
+| `Kiên Lương 2` | Kiên Giang | coal | 1200 | 9 cancelled |
+| `Kiên Lương 3` | Kiên Giang | coal | 2000 | 9 cancelled |
+
+## Edit-set 3 — the 0395 additions, **with the project-vs-potential-site boundary**
+
+The 0395 script added four rows. Under the PROVENANCE.md scope boundary
+("a project is not a potential site"), replay **only the project**:
+
+- **REPLAY as a row — Yên Hưng**:
+
+  | Plant | Province | Fuel | MWe | Status |
+  |---|---|---|---|---|
+  | `Yên Hưng` | Quảng Ninh | coal | 1200 | 1 announced |
+
+  PDP7 Annex 1 + Annex 2 attest it; a planned project genuinely missing from the
+  gold list.
+
+- **DO NOT replay as rows — Kim Sơn, Rạng Đông, Phú Thọ**: Study E542 PL9.2 draft
+  *potential sites* (candidate locations, not projects). Record each as an
+  **alias / note** against the corresponding PDP7 northern entry — the three
+  `NĐ Miền Bắc 1 / 2 / 3` rows (status `9 cancelled`) — under PROVENANCE.md
+  "Traceability without counting".
+
+  ⚠ **Name collision**: an existing plant `Rang Dong cogeneration` is already in
+  the reference and is a *different* asset. Alias the E542 "Rạng Đông" potential
+  site against the `NĐ Miền Bắc` entry, **not** against `Rang Dong cogeneration`.
+
+After all three edit-sets the master `Power plants` sheet extracts to **177**
+plants (173 extensions-adopted + 4 Kiên Lương + 1 Yên Hưng − 0 potential sites),
+not 180.
+
+## Convergence gate (run before re-pinning config)
+
+Produce a fresh `import.sh` snapshot, then:
+
+```sh
+python data/reference/verify_master_convergence.py \
+    --snapshot data/reference/raw/pipeline+0458-YYYY-MM-DD.ods
+```
+
+- **`OK: … byte-identical (177 plants)`** → safe to proceed.
+- **`DIVERGENCE`** → the diff lists exactly which plant rows are extra (un-applied
+  removal / spurious add) or missing (un-replayed edit-set). Fix the master and
+  re-run; do not re-pin until it prints OK.
+
+The gate also runs in CI against the currently pinned snapshot
+(`tests/test_master_convergence_0458.py`), so the released reference cannot drift
+from its snapshot source unnoticed.
+
+## After convergence
+
+1. Re-pin `config.VN_THERMAL_MASTER_SNAPSHOT_ODS` to the new dated snapshot.
+2. Remove the 0445 snapshot-exception comment block at that pin.
+3. Resolve the PROVENANCE.md "Snapshot provenance exception" paragraph (all three
+   edit-sets now replayed).
+4. Tick the 0458 exit criteria.

--- a/data/reference/verify_master_convergence.py
+++ b/data/reference/verify_master_convergence.py
@@ -1,0 +1,129 @@
+"""Verify a candidate master snapshot converges to the post-0497 reference (ticket 0458).
+
+The master ``pipeline.ods`` lives on the author's other machine; the analysis
+repo pins a re-imported snapshot in ``config.VN_THERMAL_MASTER_SNAPSHOT_ODS``.
+Three edit-sets applied on the analysis side are NOT yet replayed on the master
+(0445 standalone-extensions, 0472 Kiên Lương, 0395-with-boundary: Yên Hưng only —
+Kim Sơn / Rạng Đông / Phú Thọ recorded as aliases, not rows). Until they are,
+a fresh ``import.sh`` snapshot regenerates a DIFFERENT reference and re-pinning
+``config`` to it silently reverts the adoption (177 → 170).
+
+This script is the convergence gate for that handover. It runs the reference
+pipeline (``extract_ods`` → ``aggregate_units`` → ``add_classifications``) on a
+candidate snapshot into a temp dir and byte-compares the regenerated classified
+CSV against the committed post-0497 artifact. On mismatch it prints a
+plant-name-level diff (rows only the candidate has, rows only the reference has)
+to localise which edit-set is missing or wrong, then exits non-zero.
+
+Usage:
+    # Self-test: the currently pinned snapshot must regenerate the committed CSV.
+    python data/reference/verify_master_convergence.py
+
+    # Gate a fresh master re-import BEFORE re-pinning config to it:
+    python data/reference/verify_master_convergence.py \\
+        --snapshot data/reference/raw/pipeline+0458-YYYY-MM-DD.ods
+
+Exit status: 0 = byte-identical convergence (safe to re-pin); 1 = divergence.
+"""
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent
+
+# Committed target the master must converge to (post-0497, 177 plants).
+_DEFAULT_REFERENCE = _HERE / "vietnam_thermal_plants_v2_classified.csv"
+
+
+def _pinned_snapshot() -> Path:
+    """The snapshot currently pinned in config (used when --snapshot is omitted)."""
+    from aedist.config import VN_THERMAL_MASTER_SNAPSHOT_ODS
+
+    return Path(VN_THERMAL_MASTER_SNAPSHOT_ODS)
+
+
+def regenerate_classified(snapshot: Path, workdir: Path) -> Path:
+    """Run extract → aggregate → classify on ``snapshot``; return the classified CSV.
+
+    Each stage is invoked as its own subprocess (same interpreter, so it inherits
+    the project venv), mirroring the ``reference-pipeline`` recipe in acquire.mk.
+    Any stage's hard-fail guard (dirty ODS, duplicate plant key, …) surfaces here.
+    """
+    units = workdir / "units.csv"
+    plants = workdir / "plants.csv"
+    classified = workdir / "classified.csv"
+
+    stages = [
+        (_HERE / "extract_ods.py", ["--input", str(snapshot), "--output", str(units)]),
+        (_HERE / "aggregate_units.py", ["--input", str(units), "--output", str(plants)]),
+        (
+            _HERE / "add_classifications.py",
+            ["--input", str(plants), "--output", str(classified), "--fuel-col", "fuel"],
+        ),
+    ]
+    for script, args in stages:
+        subprocess.run([sys.executable, str(script), *args], check=True)
+    return classified
+
+
+def _plant_names(csv_path: Path) -> set[str]:
+    """First column ('name') of a classified CSV, excluding the header."""
+    lines = csv_path.read_text(encoding="utf-8").splitlines()
+    return {line.split(",", 1)[0] for line in lines[1:] if line}
+
+
+def verify(snapshot: Path, reference: Path) -> bool:
+    """True iff ``snapshot`` regenerates a byte-identical copy of ``reference``."""
+    with tempfile.TemporaryDirectory() as tmp:
+        regenerated = regenerate_classified(snapshot, Path(tmp))
+        regenerated_bytes = regenerated.read_bytes()
+        reference_bytes = reference.read_bytes()
+
+        if regenerated_bytes == reference_bytes:
+            n = len(_plant_names(reference))
+            print(f"OK: {snapshot.name} regenerates {reference.name} byte-identically ({n} plants).")
+            return True
+
+        got = _plant_names(regenerated)
+        want = _plant_names(reference)
+        only_candidate = sorted(got - want)
+        only_reference = sorted(want - got)
+        print(f"DIVERGENCE: {snapshot.name} does not regenerate {reference.name}.")
+        print(f"  candidate plants: {len(got)}    reference plants: {len(want)}")
+        if only_candidate:
+            print("  only in candidate (extra rows — un-applied removal / spurious add):")
+            for name in only_candidate:
+                print(f"    + {name}")
+        if only_reference:
+            print("  only in reference (missing rows — un-replayed edit-set):")
+            for name in only_reference:
+                print(f"    - {name}")
+        if not only_candidate and not only_reference:
+            print("  plant SETS match but bytes differ — column/ordering/whitespace drift.")
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=None,
+        help="Candidate master ODS snapshot (default: config.VN_THERMAL_MASTER_SNAPSHOT_ODS).",
+    )
+    parser.add_argument(
+        "--reference",
+        type=Path,
+        default=_DEFAULT_REFERENCE,
+        help="Committed classified CSV the snapshot must converge to.",
+    )
+    args = parser.parse_args(argv)
+    snapshot = args.snapshot if args.snapshot is not None else _pinned_snapshot()
+    return 0 if verify(snapshot, args.reference) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/acquire.mk
+++ b/experiments/acquire.mk
@@ -196,6 +196,7 @@ CORPUS_REF     ?= ../report/inputs/README.md
 
 .PHONY: pdf2md build-corpus preflight help extract-reference-ods \
         aggregate-reference-plants classify-reference-plants reference-pipeline \
+        verify-master-convergence \
         aggregate-gem-plants classify-gem-plants gem-pipeline
 
 pdf2md:
@@ -294,6 +295,14 @@ classify-reference-plants:
 # snapshot is absent from CI by design).
 reference-pipeline: extract-reference-ods aggregate-reference-plants classify-reference-plants
 
+# Convergence gate (ticket 0458): re-run the reference pipeline on the pinned
+# (or a candidate --snapshot) master ODS and byte-compare against the committed
+# classified CSV. The master-reverse-sync handover gate — run before re-pinning
+# config.VN_THERMAL_MASTER_SNAPSHOT_ODS to a fresh import. A .PHONY verb (reads a
+# snapshot, writes nothing tracked); also wrapped by tests/test_master_convergence_0458.py.
+verify-master-convergence:
+	$(UV_RUN) python ../data/reference/verify_master_convergence.py
+
 # Aggregate the GEM unit-grain CSV up to plant grain (ticket 0429). A utility
 # verb (.PHONY): Phase-aware groupby on GEM's data model, with output uniqueness
 # guard (no duplicate plant Name). Replaces the lost GEM.csv -> GEM_aggregate.py
@@ -342,6 +351,7 @@ help:
 	@echo "  make aggregate-reference-plants  Roll units up to plants (validated)"
 	@echo "  make classify-reference-plants   Add IRES/ISIC/PyPSA columns (in->out)"
 	@echo "  make reference-pipeline    extract -> aggregate -> classify (full regen)"
+	@echo "  make verify-master-convergence  Gate: pinned snapshot regenerates the 177-plant CSV byte-identically (0458)"
 	@echo "  make aggregate-gem-plants  Aggregate GEM units to plants (uniqueness guard)"
 	@echo "  make classify-gem-plants   Add IRES/ISIC/PyPSA columns to GEM plants"
 	@echo "  make gem-pipeline          aggregate -> classify GEM cross-check data"

--- a/tests/test_master_convergence_0458.py
+++ b/tests/test_master_convergence_0458.py
@@ -1,0 +1,46 @@
+"""Snapshot↔reference lockstep guard (ticket 0458).
+
+The committed ``vietnam_thermal_plants_v2_classified.csv`` (177 plants, v2.4) is a
+*generated* artifact: the reference pipeline (extract → aggregate → classify)
+applied to the master snapshot pinned in ``config.VN_THERMAL_MASTER_SNAPSHOT_ODS``.
+This guard re-runs that pipeline via ``verify_master_convergence.py`` and asserts
+the regenerated CSV is byte-identical to the committed one — i.e. the released
+reference has not drifted from its snapshot source (hand-edit, partial re-pin, or
+a master re-import that skipped one of the un-replayed edit-sets would break it).
+
+This is also the gate ticket 0458 hands to the master-machine operator: once the
+three edit-sets are replayed and a fresh ``import.sh`` snapshot is produced,
+running the verifier against it must pass before re-pinning ``config``.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "data" / "reference" / "verify_master_convergence.py"
+
+
+def test_pinned_snapshot_regenerates_reference_byte_identically():
+    """The pinned master snapshot regenerates the committed classified CSV exactly."""
+    from aedist.config import VN_THERMAL_MASTER_SNAPSHOT_ODS
+
+    snapshot = Path(VN_THERMAL_MASTER_SNAPSHOT_ODS)
+    if not snapshot.exists():
+        pytest.skip(
+            f"pinned snapshot {snapshot} absent — "
+            "reference-pipeline source not available in this checkout"
+        )
+    result = subprocess.run(
+        [sys.executable, str(VERIFIER)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "pinned snapshot no longer regenerates the committed reference "
+        f"byte-identically:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
**Ticket:** tickets/0458-replay-the-8-cell-standalone-extensions.erg (master reverse-sync, doudou)

## Why

The 0497 merge took the repo reference to **177**, but the master `pipeline.ods` (on doudou) still carries three un-replayed edit-sets (0445 extensions, 0472 Kiên Lương, 0395-with-boundary). A fresh `import.sh` re-pin would silently revert 177 → 170. This lands everything that can be done *off* the master machine; the physical master edit + `config` re-pin stay a human step (ticket remains `needs-human`).

## What

- **`data/reference/verify_master_convergence.py`** — runs the reference pipeline (extract → aggregate → classify) on a candidate snapshot into a temp dir and byte-compares against the committed post-0497 classified CSV. On divergence it prints a plant-name diff (extra rows = un-applied removal; missing rows = un-replayed edit-set). Self-tested: pinned snapshot → `OK … 177 plants byte-identical`; pre-0497 snapshot → `DIVERGENCE` flagging Kim Sơn / Rạng Đông / Phú Thọ as extras.
- **`tests/test_master_convergence_0458.py`** (`@pytest.mark.adherence`) — guards that the pinned snapshot regenerates the committed reference byte-identically, so the released CSV cannot drift from its snapshot source. Skips if the snapshot is absent.
- **`data/reference/MASTER_REVERSE_SYNC_0458.md`** — operator checklist with the exact target rows (4 extensions + 3 Kiên Lương + 1 Yên Hưng, all values verified against the committed reference), the alias targets for the three potential sites (`NĐ Miền Bắc 1/2/3`) with the `Rang Dong cogeneration` name-collision warning, the convergence gate, and post-replay config steps.
- **`experiments/acquire.mk`** — discoverable `.PHONY` verb `verify-master-convergence`.

## Turns the handover into

Apply checklist on doudou → `import.sh` → run the convergence gate (must print OK) → re-pin `config` → resolve PROVENANCE exception.

https://claude.ai/code/session_01UW5z7sCnfAm5saPuxBESzW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW5z7sCnfAm5saPuxBESzW)_