### PR TITLE
chore(0486): integrate stranded Wikipedia wikitext + prototypes onto main

### DIFF
--- a/data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext
+++ b/data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext
@@ -1,0 +1,728 @@
+{{short description|None}}
+{{Update|type=|date=October 2020|reason=Power Development Plan-VIII}}
+{{EngvarB|date=July 2022}}
+{{Use dmy dates|date=July 2022}}
+
+About 20 GW of [[List of power stations in Vietnam|power stations in Vietnam]] are coal-fired.<ref>{{Cite web|date=2020-08-06|title=Vietnam prepares to rein in coal-power growth|url=https://www.argusmedia.com/en/news/2129998-vietnam-prepares-to-rein-in-coalpower-growth|access-date=2020-10-02|website=www.argusmedia.com|language=en}}</ref> In 2019 [[coal-fired power station]]s were generated almost 40% of [[Vietnam]]s electricity and was about a quarter of the coal was imported.<ref>{{Cite web|url=https://www.bangkokpost.com/business/1874664/powering-vietnam|title=Powering Vietnam|website=Bangkok Post|access-date=2020-03-21}}</ref>
+
+Source: Initial query from Coal Tracker,<ref>{{Cite web|url=https://endcoal.org/tracker/|title=Global Coal Plant Tracker {{!}} End Coal|website=endcoal.org}}{{dead link|date=December 2024|bot=medic}}{{cbignore|bot=medic}}</ref> updated with data from MOIT 2019 Report 58/BC-CBT,<ref>{{Cite web|url=http://vepg.vn/legal_doc/moit-report-58-bc-cbt-on-the-implementation-progress-of-power-projects-in-the-revised-pdp7/|title=MOIT Report 58/BC-CBT on the Implementation Progress of Power Projects in the Revised PDP7|last=Hoàng|first=Quốc Vượng|date=2019-06-04|website=vepg.vn|language=en}}</ref> updated using press released, updated from PDP 7A <ref>{{Cite web|url=http://vepg.vn/legal_doc/pm-decision-428-qd-ttg-on-the-approval-of-the-revised-national-power-development-master-plan-for-the-period-of-2011-2020-with-the-vision-to-2030/|title=PM Decision 428/QĐ-TTg on the Approval of the Revised National Power Development Master Plan for the Period of 2011–2020 with the Vision to 2030|last=Nguyễn|first=Tấn Dũng|date=2016-03-18|website=vepg.vn|language=en}}</ref>
+{| class="wikitable sortable"
+!Power plants (with units)
+!Other names
+!Sponsor
+!Capacity ([[megawatt|MW]])
+!Status
+!Province
+!Commission date
+!Source
+!Note
+|-
+|An Khanh – Bac Giang 
+|Luc Nam power station
+|An Khanh – Bac Giang Thermoelectric Joint Stock Company
+|650
+|pre-permit
+|Bac Giang
+|2023
+|MOIT Report 58/BC-CBT annex row V.4
+|
+|-
+|An Khanh 1
+|Khanh Hoa power station
+|An Khanh Electricity JSC
+|2x58
+|operating
+|Thai Nguyen
+|2015
+|<ref name=":7">{{Cite web|url=https://www.gem.wiki/An_Khanh_power_station|title=An Khanh power station|website=[[Global Energy Monitor]]|access-date=2020-10-02}}</ref>
+|
+|-
+|Cam Pha Phase I-II
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x340
+|operating
+|Quang Ninh
+|2011
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Cam_Pha_power_station|title=Cam Pha power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Cao Ngan 
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x57.5
+|operating
+|Thai Nguyen
+|2006
+|<ref>{{Cite web|url=https://www.evn.com.vn/userfile/files/2017/3/AnnualReport2016.pdf|title=Vietnam Electricity Annual Report 2016|last=EVN|date=2016|website=evn.com.vn}}</ref>
+|
+|-
+|Cong Thanh 
+|
+|Cong Thanh Thermal Power Joint Stock Company
+|600
+|permitted
+|Thanh Hoa
+|2024
+|MOIT Report 58/BC-CBT annex row V.3
+|
+|-
+|Dong Nai Formosa Unit 1–2
+|
+|Hung Nghiep Formosa
+|2x150
+|operating
+|Dong Nai
+|2004
+|<ref>{{Cite web|url=http://www.moit.gov.vn/CmsView-EcoIT-portlet/html/print_cms.jsp?articleId=108005|title=Giải quyết khó khăn của Formosa theo đúng quy định của Chính phủ|last=Phương Thảo|date=2016-10-26|website=moit.gov.vn}}</ref>
+|
+|-
+|Dong Nai Formosa Unit 3
+|
+|Hung Nghiep Formosa
+|150
+|operating
+|Dong Nai
+|2018
+|<ref>{{Cite web|url=http://www.erav.vn/userfile/User/anhnpn/files/2018/2018-67-PD-NM%C4%90%20Formosa%20Dong%20Nai.pdf|title=Giấy phép hoạt động điện lực|last=Nguyễn|first=Anh Tuấn|date=2018-04-02|website=erav.vn}}</ref>
+|
+|-
+|Duc Giang – Lao Cai Chemical 
+|
+|Duc Giang – Lao Cai Chemicals Joint Stock Company
+|2x50
+|pre-permit
+|Lao Cai
+|2020
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Duc_Giang_-_Lao_Cai_Chemicals_power_station|title=Duc Giang – Lao Cai Chemicals power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Dung Quat Special Economic Zone (J-Power) Phase I-II
+|
+|J-Power
+|2400 & 2000
+|announced
+|Quang Ngai
+|2028–2030
+|<ref>{{Cite web|url=https://english.vov.vn/content/MTk4MDE4.vov|title=Japan company proposes building a power plant in Quang Ngai|date=2017-04-14|website=VOV – VOV Online Newspaper|access-date=2019-07-01}}</ref>
+|
+|-
+|Duyen Hai 1 
+|
+|Electricity of Vietnam
+|2x622
+|operating
+|Tra Vinh
+|2015
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Duyen_Hai_Power_Generation_Complex|title=Duyen Hai Power Generation Complex – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Duyen Hai 2 
+|
+|Janakuasa SDN BHD
+|2x600
+|construction
+|Tra Vinh
+|2021–2022
+|MOIT Report 58/BC-CBT annex row IV.3
+|
+|-
+|Duyen Hai 3 Extension
+|
+|Electricity of Vietnam
+|660
+|construction
+|Tra Vinh
+|2019
+|MOIT Report 58/BC-CBT annex row I.9
+|
+|-
+|Duyen Hai 3 
+|
+|Electricity of Vietnam
+|2x622
+|operating
+|Tra Vinh
+|2016
+|MOIT Report 58/BC-CBT annex row I.4
+|
+|-
+|Ha Tinh Formosa Plastics Steel Complex Unit 1,2,5,6,7,10
+|Formosa Ha Tinh
+|Hung Nghiep Formosa Ha Tinh
+|6x150
+|operating: Unit 1,2,5
+pre-permit: Unit 6,7,10
+|Ha Tinh
+|2015–2020
+|<ref>{{Cite web|url=https://thoibaokinhdoanh.vn/kinh-doanh-xanh/formosa-da-nhap-gan-668000-tan-than-1021474.html|title=Formosa đã nhập gần 668.000 tấn than|last=Lê Thuý|date=2016-11-08|website=thoibaokinhdoanh.vn}}</ref>
+|
+|-
+|Hai Duong 
+|Hai Duong BOT plant
+|JAKS Resources, China Power Engineering Consulting Group
+|2x600
+|construction
+|Hai Duong
+|2021
+|MOIT Report 58/BC-CBT annex row IV.2
+|
+|-
+|Hai Ha CHP 1–4
+|Dong Phat Hai Ha (CHP)
+|Texhong Hai Ha Industrial Park Co.
+|2100
+|pre-permit
+|Quang Ninh
+|2019–2030
+|MOIT Report 58/BC-CBT annex row V.2
+|
+|-
+|Hai Phong 1–2 
+|
+|EVN Genco No 2
+|4x300
+|operating
+|Hai Phong
+|2011–2014
+|<ref name=":1">{{Cite web|url=https://www.sourcewatch.org/index.php/Hai_Phong_Thermal_Power_Station#cite_note-talk-3|title=Hai Phong Thermal Power Station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Hai Phong 3 Unit 1–2
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x600
+|pre-permit
+|Hai Phong
+|2028–2029
+|MOIT Report 58/BC-CBT annex row III.4
+|
+|-
+|Lee & Man 
+|
+|Lee & Man Vietnam Paper Limited Company
+|50 & 75
+|operating
+|Hau Giang
+|2018
+|<ref>{{Cite news|url=https://tuoitre.vn/nha-may-nhiet-dien-lee-man-su-dung-than-chu-khong-phai-nhiet-dien-sinh-khoi-20190403162858207.htm|title=Nhà máy nhiệt điện Lee & Man sử dụng than chứ không phải 'nhiệt điện sinh khối'|last=Lê Dân|date=2019-04-03|work=tuoitre.vn}}</ref>
+|
+|-
+|Long An Phase I 
+|
+|no investor
+|2x600
+|announced
+|Long An
+|
+|MOIT Report 58/BC-CBT annex row VI.1
+|
+|-
+|Long An Phase II 
+|
+|no investor
+|2x800
+|announced
+|Long An
+|
+|MOIT Report 58/BC-CBT annex row VI.2
+|
+|-
+|Long Phu 1
+|
+|PetroVietnam Power Corp
+|2x600
+|construction
+|Soc Trang
+|2023–2024
+|MOIT Report 58/BC-CBT annex row II.2
+|
+|-
+|Long Phu 2
+|
+|Tata Group
+|2x660
+|pre-permit
+|Soc Trang
+|2029–2030
+|MOIT Report 58/BC-CBT annex row IV.8
+|
+|-
+|Long Phu 3 
+BANPU – THAILAND
+|Soc Trang
+|announced
+|2x600
+|
+|
+|
+|MOIT Report 58/BC-CBT annex row II.4
+|
+|-
+|Mao Khe 
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x220
+|operating
+|Quang Ninh
+|2013
+|<ref>{{Citation|title=Nhà máy nhiệt điện Mạo Khê|date=2017-04-23|url=https://vi.wikipedia.org/w/index.php?title=Nh%C3%A0_m%C3%A1y_nhi%E1%BB%87t_%C4%91i%E1%BB%87n_M%E1%BA%A1o_Kh%C3%AA&oldid=26513659|work=Wikipedia tiếng Việt|language=vi|access-date=2019-07-01}}</ref>
+|
+|-
+|Mong Duong 1
+|
+|Electricity of Vietnam
+|2x540
+|operating
+|Quang Ninh
+|2015
+|<ref name=":3">{{Cite web|url=https://www.sourcewatch.org/index.php/Mong_Duong_power_station|title=Mong Duong power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Mong Duong 2 
+|
+|AES-VCM Mong Dong Power Co Ltd
+|2x620
+|operating
+|Quang Ninh
+|2015
+|<ref name=":3" />
+|
+|-
+|Na Duong 1 
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x55
+|operating
+|Lang Son
+|2005
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Na_Duong_power_station|title=Na Duong power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Na Duong 2
+|
+|Vietnam National Coal and Mineral Industries Group
+|110
+|construction
+|Lang Son
+|2022
+|MOIT Report 58/BC-CBT annex row III.1
+|
+|-
+|Nam Dinh 1 
+|Hai Hau power station
+|Taekwang Vina Industry Joint Stock Company, First National Operation & Maintenance Co. (NOMAC)
+|2x600
+|permitted
+|Nam Dinh
+|2024–2025
+|MOIT Report 58/BC-CBT annex row IV.4
+|
+|-
+|Nghi Son 1 
+|
+|EVN Genco No 1
+|2x300
+|operating
+|Thanh Hoa
+|2013–2014
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Nghi_Son_power_station|title=Nghi Son power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Nghi Son 2 
+|
+|Korean Electric Power Corporation and Marubeni Group
+|2x600
+|construction
+|Thanh Hoa
+|2022
+|MOIT Report 58/BC-CBT annex row IV.5
+|
+|-
+|Ninh Binh 
+|
+|Ninh Binh Thermal Power JSC
+|4x25
+|operating
+|Ninh Binh
+|1974
+|<ref>{{Citation|title=Nhà máy nhiệt điện Ninh Bình|date=2018-04-13|url=https://vi.wikipedia.org/w/index.php?title=Nh%C3%A0_m%C3%A1y_nhi%E1%BB%87t_%C4%91i%E1%BB%87n_Ninh_B%C3%ACnh&oldid=39480046|work=Wikipedia tiếng Việt|language=vi|access-date=2019-07-01}}</ref>
+|
+|-
+|Nong Son 1
+|
+|Vietnam National Coal and Mineral Industries Group
+|30
+|operating
+|Quang Nam
+|2014
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Nong_Son_power_station|title=Nong Son power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|[[Phả Lại Power Station|Pha Lai 1]]
+|
+|Pha Lai Thermal Power JSC
+|4x110
+|operating
+|Hai Duong
+|1986
+|
+|
+|-
+|[[Phả Lại Power Station|Pha Lai 2]]
+|
+|Pha Lai Thermal Power JSC
+|2x300
+|operating
+|Hai Duong
+|2001
+|
+|
+|-
+|Quang Ninh 1–2 
+|
+|Quang Ninh Thermal Power JSC
+|2x300
+|operating
+|Quang Ninh
+|2009–2014
+|<ref name=":5">{{Cite web|url=https://www.sourcewatch.org/index.php/Quang_Ninh_power_station|title=Quang Ninh power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Quang Ninh 3 
+|
+|no investor
+|2x600
+|announced
+|Quang Ninh
+|
+|MOIT Report 58/BC-CBT annex row VI.4
+|
+|-
+|Quang Trach 1 
+|
+|Electricity of Vietnam
+|2x600
+|permitted
+|Quang Binh
+|2022–2023
+|MOIT Report 58/BC-CBT annex row I.17
+|
+|-
+|Quang Trach 2 
+|
+|Electricity of Vietnam
+|2x600
+|announced
+|Quang Binh
+|2026
+|MOIT Report 58/BC-CBT annex row I.18
+|
+|-
+|Quang Tri 1 
+|
+|EGAT International (EGATi)
+|2x660
+|pre-permit
+|Quang Tri
+|2026–2027
+|MOIT Report 58/BC-CBT annex row IV.11
+|
+|-
+|Quang Tri 2 
+|
+|Korea Western Power Co
+|2x600
+|announced
+|Quang Tri
+|2024
+|<ref>{{Cite web|url=http://icon.com.vn/vn-s83-131604-626/Han-Quoc-xay-nha-may-nhiet-dien-chay-than-tai-Quang-Tri.aspx|title=Hàn Quốc xây nhà máy nhiệt điện chạy than tại Quảng Trị|last=Nhịp cầu đầu tư|date=2017-01-20|website=icon.com.vn}}</ref>
+|
+|-
+|Quynh Lap 1 
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x600
+|permitted
+|Nghe An
+|2026
+|MOIT Report 58/BC-CBT annex row III.3
+|
+|-
+|Quynh Lap 2 
+|
+|POSCO
+|2x600
+|announced
+|Nghe An
+|2027–2028
+|MOIT Report 58/BC-CBT annex row IV.14
+|
+|-
+|Rang Dong cogeneration
+|
+|
+|100
+|announced
+|
+|2025
+|PDP 7A Decision 428/QD-TTg annex 1 Table 2, "Projects in operation from 2025" row 4
+|
+|-
+|Son Dong 
+|
+|Vietnam National Coal and Mineral Industries Group
+|2x110
+|operating
+|Bac Giang
+|2009
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Son_Dong_power_station#cite_note-GreenID-5|title=Son Dong power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Song Hau 1 
+|
+|PetroVietnam Power Corp
+|2x600
+|construction
+|Hau Giang
+|2021
+|MOIT Report 58/BC-CBT annex row II.3
+|
+|-
+|Song Hau 2 
+|
+|Toyo Engineering & Construction
+|2x1000
+|permitted
+|Hau Giang
+|2024
+|MOIT Report 58/BC-CBT annex row IV.7
+|
+|-
+|Tan Phuoc 1 
+|
+|Electricity of Vietnam
+|2x600
+|announced
+|Tien Giang
+|
+|MOIT Report 58/BC-CBT annex row I.15
+|
+|-
+|Tan Phuoc 2 
+|
+|Electricity of Vietnam
+|2x600
+|announced
+|Tien Giang
+|
+|MOIT Report 58/BC-CBT annex row I.16
+|
+|-
+|Thai Binh 1 
+|
+|Electricity of Vietnam
+|2x300
+|operating
+|Thai Binh
+|2017
+|MOIT Report 58/BC-CBT annex row I.5
+|
+|-
+|Thai Binh 2 
+|
+|PetroVietnam Power Corp
+|2x600
+|construction
+|Thai Binh
+|2021–2022
+|MOIT Report 58/BC-CBT annex row II.1
+|
+|-
+|Thai Binh 3
+|
+|Vietnam National Coal and Mineral Industries Group
+|440
+|announced
+|Thai Binh
+|
+|<ref>{{Cite web|url=http://www.vinacomin.vn/tin-tuc-vinacomin/chinh-thuc-trien-khai-dau-tu-xay-dung-nha-may-nhiet-dien-tai-thai-binh-201807201513463374.htm|title=Chính thức triển khai đầu tư xây dựng Nhà máy nhiệt điện tại Thái Bình|last=H.H|date=2018-07-20|website=VINACOMIN}}</ref>
+|
+|-
+|Thang Long 
+|Le Loi power station
+|Hanoi Export-Import Company
+|2x300
+|operating
+|Quang Ninh
+|2017–2018
+|MOIT Report 58/BC-CBT annex row V.1
+|
+|-
+|Uong Bi I extension
+|
+|EVN Genco No 1
+|300
+|operating
+|Quang Ninh
+|2007
+|<ref name=":6">{{Cite web|url=https://www.sourcewatch.org/index.php/Uong_Bi_power_station|title=Uong Bi power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Uong Bi I 
+|
+|EVN Genco No 1
+|50 & 55
+|operating
+|Quang Ninh
+|1975–1976
+|<ref name=":6" />
+|retired in 2021
+|-
+|Uong Bi II extension
+|
+|EVN Genco No 1
+|330
+|operating
+|Quang Ninh
+|2014
+|<ref name=":6" />
+|
+|-
+|Van Phong 1 
+|
+|Sumitomo Corporation
+|2x660
+|permitted
+|Khanh Hoa
+|2023–2024
+|MOIT Report 58/BC-CBT annex row IV.10
+|
+|-
+|Vedan Vietnam Cogeneration 
+|
+|Vedan Vietnam JSC
+|60
+|operating
+|Dong Nai
+|2015
+|<ref>{{Cite web|url=https://moit.gov.vn/web/guest/tin-chi-tiet/-/chi-tiet/vedan-can-31-500-tan-than-moi-thang-cho-nha-may-%C4%91ien-108325-23.html|title=Vedan cần 31.500 tấn than mỗi tháng cho Nhà máy điện|last=Quyên Lưu|date=2016-11-10|website=moit.gov.vn}}</ref>
+|
+|-
+|Vinh Tan 1 
+|
+|China Southern Power Grid, Vinacomin
+|2x600
+|operating
+|Binh Thuan
+|2018–2019
+|MOIT Report 58/BC-CBT annex row IV.1
+|
+|-
+|Vinh Tan 2 
+|
+|EVN Genco No 3
+|2x622
+|operating
+|Binh Thuan
+|2014
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Vinh_Tan_power_station|title=Vinh Tan power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Vinh Tan 3 
+|
+|OneEnergy, EVN, and Pacific Group
+|3x660
+|pre-permit
+|Binh Thuan
+|2024–2025
+|MOIT Report 58/BC-CBT annex row IV.9
+|
+|-
+|Vinh Tan 4 extension
+|Vinh Tan 4 extension
+|Electricity of Vietnam
+|600
+|construction
+|Binh Thuan
+|2019
+|MOIT Report 58/BC-CBT annex row I.12
+|
+|-
+|Vinh Tan 4 
+|
+|Electricity of Vietnam
+|2x600
+|operating
+|Binh Thuan
+|2017–2018
+|MOIT Report 58/BC-CBT annex row I.6
+|
+|-
+|Vung Ang 1 
+|
+|PetroVietnam Power Corp
+|2x600
+|operating
+|Ha Tinh
+|2014–2015
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Vung_Ang_power_station|title=Vung Ang power station – SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|
+|-
+|Vung Ang 2 
+|
+|OneEnergy Co.
+|2x600
+|permitted
+|Ha Tinh
+|2023–2024
+|MOIT Report 58/BC-CBT annex row IV.6
+|
+|-
+|Vung Ang 3
+|
+|Samsung Construction & Trading Corporation
+|2x600
+|shelved
+|Ha Tinh
+|2031
+|MOIT Report 58/BC-CBT annex row IV.13
+|
+|-
+|Vung Ang 3
+|
+|
+|2x600
+|announced
+|
+|
+|PDP 7A: Reserve power plants for renewable energy power stations' failure of schedule and output expected
+|
+|}
+
+== Notes ==
+
+* '''Announced:''' Projects that are in the planning decision of the government or companies but have not yet obtained a permit or permission for land use rights, coal supply rights...<ref name=":0">{{Cite web|url=https://endcoal.org/global-coal-plant-tracker/about-the-tracker/|archive-url=https://web.archive.org/web/20150919205943/http://endcoal.org/global-coal-plant-tracker/about-the-tracker/|url-status=usurped|archive-date=19 September 2015|title=End Coal {{!}} Frequently Asked Questions|website=End Coal|language=en-US|access-date=2019-08-06}}</ref>
+* '''Pre-permit development:''' Projects have started to implement one of the following items: environmental licenses, land and water use rights, financial security, transmission contract guarantees, etc.<ref name=":0" />
+* '''Permitted:''' Projects that have been licensed for environmental licenses but have not yet begun to break ground.<ref name=":0" />
+* '''Construction:''' Projects are being built after the groundbreaking ceremony.<ref name=":0" />
+* '''Shelved:''' Projects do not have specific information on the project's progress but do not have enough information to declare the project cancelled.<ref name=":0" />
+* '''Operating:''' Projects with an official commercial operation date (COD).<ref name=":0" />
+
+== Sources ==
+*{{Cite report
+|date=2021-04-05
+|title=Boom and Bust 2021: Tracking The Global Coal Plant Pipeline
+|url=https://globalenergymonitor.org/report/boom-and-bust-2021-tracking-the-global-coal-plant-pipeline-2/
+|publisher=[[Global Energy Monitor]]
+}}
+
+== References ==
+{{reflist}}
+
+{{World topic|prefix=List of coal-fired power stations in|title=List of coal-fired power stations by country|noredlinks=yes|state=expanded}}
+
+{{DEFAULTSORT:Vietnam}}
+[[Category:Coal-fired power stations in Vietnam|*]]
+[[Category:Lists of buildings and structures in Vietnam|Power stations, coal]]
+[[Category:Lists of coal-fired power stations]]

--- a/data/reference/raw/wikipedia_power_vietnam-2026-06-09.wikitext
+++ b/data/reference/raw/wikipedia_power_vietnam-2026-06-09.wikitext
@@ -1,0 +1,6146 @@
+{{Short description|None}}
+The following page lists some of the [[power station]]s in [[Vietnam]].
+
+== Coal ==
+{{Main|List of coal-fired power stations in Vietnam}}
+Source: Initial query Coal Tracker,<ref>{{Cite web|url=https://endcoal.org/tracker/|title=Global Coal Plant Tracker {{!}} End Coal|website=endcoal.org}}{{dead link|date=December 2024|bot=medic}}{{cbignore|bot=medic}}</ref> updated with data from MOIT 2019 Report 58/BC-CBT,<ref>{{Cite web|url=http://vepg.vn/legal_doc/moit-report-58-bc-cbt-on-the-implementation-progress-of-power-projects-in-the-revised-pdp7/|title=MOIT Report 58/BC-CBT on the Implementation Progress of Power Projects in the Revised PDP7|last=Hoàng|first=Quốc Vượng|date=2019-06-04|website=vepg.vn|language=en}}</ref> updated using press releases, updated from PDP 7A <ref>{{Cite web|url=http://vepg.vn/legal_doc/pm-decision-428-qd-ttg-on-the-approval-of-the-revised-national-power-development-master-plan-for-the-period-of-2011-2020-with-the-vision-to-2030/|title=PM Decision 428/QĐ-TTg on the Approval of the Revised National Power Development Master Plan for the Period of 2011-2020 with the Vision to 2030|last=Nguyễn|first=Tấn Dũng|date=2016-03-18|website=vepg.vn|language=en}}</ref>
+
+{| class="wikitable sortable"
+!width=100|Station
+! width="60" |Province
+! width="60" |Capacity (MW)
+! width="60" |Commission date
+!width=200|Sponsor/owner
+!width=60|Status
+! width="60" |Note
+!width=150|{{Tooltip|Ref|References}}
+|-
+|An Khanh 1 (Khanh Hoa power station)
+|[[Thái Nguyên Province|Thai Nguyen]]
+|120 (2x60)
+|2015
+|An Khanh Electricity JSC
+|Operating
+|
+|<ref name=":74">{{Cite web|url=https://www.sourcewatch.org/index.php/An_Khanh_power_station|title=An Khanh power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Cam Pha Phase I-II
+|[[Quảng Ninh Province|Quang Ninh]]
+|680 (2x340)
+|2011
+|VINACOMIN
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Cam_Pha_power_station|title=Cam Pha power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Cao Ngan
+|[[Thái Nguyên Province|Thai Nguyen]]
+|115 (2x57.5)
+|2006
+|VINACOMIN
+|Operating
+|
+|<ref>{{Cite web|url=https://www.evn.com.vn/userfile/files/2017/3/AnnualReport2016.pdf|title=Vietnam Electricity Annual Report 2016|last=EVN|date=2016|website=evn.com.vn}}</ref> 428/QĐ-TTg, BCĐQGĐ-VP
+|-
+|Dong Nai Formosa Unit 1–2
+|[[Đồng Nai Province|Dong Nai]]
+|300 (2x150)
+|2004
+|Hung Nghiep Formosa
+|Operating
+|
+|<ref>{{Cite web|url=http://www.moit.gov.vn/CmsView-EcoIT-portlet/html/print_cms.jsp?articleId=108005|title=Giải quyết khó khăn của Formosa theo đúng quy định của Chính phủ|last=Phương Thảo|date=2016-10-26|website=moit.gov.vn}}</ref>
+|-
+|Dong Nai Formosa Unit 3
+|Dong Nai
+|150
+|2018
+|Hung Nghiep Formosa
+|Operating
+|
+|<ref>{{Cite web|url=http://www.erav.vn/userfile/User/anhnpn/files/2018/2018-67-PD-NM%C4%90%20Formosa%20Dong%20Nai.pdf|title=Giấy phép hoạt động điện lực|last=Nguyễn|first=Anh Tuấn|date=2018-04-02|website=erav.vn}}</ref> 428/QĐ-TTg
+|-
+|Duyen Hai 1
+|[[Trà Vinh Province|Tra Vinh]]
+|1245
+|2015
+|EVN
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Duyen_Hai_Power_Generation_Complex|title=Duyen Hai Power Generation Complex - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Duyen Hai 3
+|Tra Vinh
+|1245
+|2017
+|EVN
+|Operating
+|
+|57/BCĐQGĐL-VP
+|-
+|Formosa Ha Tinh
+|Ha Tinh
+|650
+|2015
+|Hung Nghiep Formosa Ha Tinh
+|Operating
+|
+|428/QĐ-TTg
+|-
+|Formosa Ha Tinh Phase 2
+|[[Hà Tĩnh Province|Ha Tinh]]
+|650
+|2020
+|Hung Nghiep Formosa Ha Tinh
+|
+|
+|<ref name="Lê Thuý">{{Cite web|url=https://thoibaokinhdoanh.vn/kinh-doanh-xanh/formosa-da-nhap-gan-668000-tan-than-1021474.html|title=Formosa đã nhập gần 668.000 tấn than|last=Lê Thuý|date=2016-11-08|website=thoibaokinhdoanh.vn}}</ref>
+|-
+|Hai Phong 1–2
+|[[Hai Phong Province|Hai Phong]]
+|1200 (4x300)
+|2011-2014
+|EVNGENCO2 TPC Hai Phong
+|Operating
+|
+|<ref name=":17">{{Cite web|url=https://www.sourcewatch.org/index.php/Hai_Phong_Thermal_Power_Station#cite_note-talk-3|title=Hai Phong Thermal Power Station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Lee & Man
+|[[Hậu Giang Province|Hau Giang]]
+|125 (1x50, 1x75)
+|2018
+|Lee & Man Vietnam Paper LLC
+|Operating
+|
+|<ref>{{Cite news|url=https://tuoitre.vn/nha-may-nhiet-dien-lee-man-su-dung-than-chu-khong-phai-nhiet-dien-sinh-khoi-20190403162858207.htm|title=Nhà máy nhiệt điện Lee & Man sử dụng than chứ không phải 'nhiệt điện sinh khối'|last=Lê Dân|date=2019-04-03|work=tuoitre.vn}}</ref>
+|-
+|Mao Khe
+|[[Quảng Ninh Province|Quang Ninh]]
+|440 (2x220)
+|2013
+|[[Vinacomin|VINACOMIN]]
+|Operating
+|
+|{{CN|date=May 2024}}
+|-
+|Mong Duong 1
+|Quang Ninh
+|1120
+|2015
+|EVNGENCO3 TPC Mong Duong
+|Operating
+|
+|<ref name=":33">{{Cite web|url=https://www.sourcewatch.org/index.php/Mong_Duong_power_station|title=Mong Duong power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Mong Duong 2
+|Quang Ninh
+|1245
+|2015
+|AES-VCM Mong Dong Power Co Ltd
+|Operating
+|
+|<ref name=":33" />
+|-
+|Na Duong 1
+|[[Lạng Sơn Province|Lang Son]]
+|110 (2x55)
+|2005
+|VINACOMIN
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Na_Duong_power_station|title=Na Duong power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Nghi Son 1
+|[[Thanh Hóa Province|Thanh Hoa]]
+|600 (2x300)
+|2013-2014
+|EVNGENCO No 1
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Nghi_Son_power_station|title=Nghi Son power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Ninh Binh
+|[[Ninh Bình Province|Ninh Binh]]
+|100 (4x25)
+|1976
+|Ninh Binh Thermal Power JSC
+|Operating
+|
+|{{CN|date=May 2024}}
+|-
+|Nong Son 1
+|[[Quảng Nam Province|Quang Nam]]
+|30
+|2015
+|VINACOMIN
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Nong_Son_power_station|title=Nong Son power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|[[Phả Lại Power Station|Pha Lai 1]]
+|[[Hải Dương Province|Hai Duong]]
+|440 (4x110)
+|1986
+|Pha Lai Thermal Power JSC
+|Operating
+|
+|{{CN|date=May 2024}}
+|-
+|[[Phả Lại Power Station|Pha Lai 2]]
+|Hai Duong
+|600 (2x300)
+|2001
+|Pha Lai Thermal Power JSC
+|Operating
+|
+|{{CN|date=May 2024}}
+|-
+|Quang Ninh 1–2
+|[[Quảng Ninh Province|Quang Ninh]]
+|1200 (4x300)
+|2009-2014
+|Quang Ninh Thermal Power JSC
+|Operating
+|
+|<ref name=":52">{{Cite web|url=https://www.sourcewatch.org/index.php/Quang_Ninh_power_station|title=Quang Ninh power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Son Dong
+|[[Bắc Giang Province|Bac Giang]]
+|220 (2x110)
+|2009
+|VINACOMIN
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Son_Dong_power_station#cite_note-GreenID-5|title=Son Dong power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Thai Binh 1
+|[[Thái Bình Province|Thai Binh]]
+|600 (2x300)
+|2018
+|EVN
+|Operating
+|
+|57/BCĐQGĐL-VP
+|-
+|Thang Long (Le Loi power station)
+|[[Quảng Ninh Province|Quang Ninh]]
+|620 (2x310)
+|2017-2018
+|Hanoi Export-Import Company
+|Operating
+|
+|57/BCĐQGĐL-VP
+|-
+|Uong Bi I extension
+|Quang Ninh
+|300
+|2009
+|EVNGENCO No 1
+|Operating
+|
+|<ref name=":62">{{Cite web|url=https://www.sourcewatch.org/index.php/Uong_Bi_power_station|title=Uong Bi power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Uong Bi I
+|Quang Ninh
+|105 (1x50, 1x55)
+|1975-1976
+|EVNGENCO No 1
+|Operating
+|Retired in 2021
+|<ref name=":62" />
+|-
+|Uong Bi II extension
+|Quang Ninh
+|330
+|2014
+|EVNGENCO No 1
+|Operating
+|
+|<ref name=":62" />
+|-
+|Vedan Vietnam Cogeneration
+|[[Đồng Nai Province|Dong Nai]]
+|60
+|2015
+|Vedan Vietnam JSC
+|Operating
+|
+|<ref>{{Cite web|url=https://moit.gov.vn/web/guest/tin-chi-tiet/-/chi-tiet/vedan-can-31-500-tan-than-moi-thang-cho-nha-may-%C4%91ien-108325-23.html|title=Vedan cần 31.500 tấn than mỗi tháng cho Nhà máy điện|last=Quyên Lưu|date=2016-11-10|website=moit.gov.vn}}</ref> EVN Annual Report 2016
+|-
+|Vinh Tan 1
+|[[Bình Thuận Province|Binh Thuan]]
+|1240 (2x620)
+|2018-2019
+|China Southern Power Grid, Vinacomin
+|Operating
+|
+|57/BCDQGDL-VP
+|-
+|Vinh Tan 2
+|Binh Thuan
+|1245
+|2014
+|EVNGENCO3
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Vinh_Tan_power_station|title=Vinh Tan power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Vinh Tan 4
+|Binh Thuan
+|1200 (2x600)
+|2017-2018
+|EVN
+|Operating
+|
+|57/BCDQGDL-VP
+|-
+|Vung Ang 1
+|Ha Tinh
+|1200 (2x600)
+|2014-2015
+|PetroVietnam Power Corp
+|Operating
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Vung_Ang_power_station|title=Vung Ang power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref> 1208/QĐ-TTg
+|-
+|Duyen Hai 2
+|[[Trà Vinh|Tra Vinh]]
+|1200 (2x600)
+|2021
+|Janakuasa SDN BHD
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Duyen Hai 3 Extension
+|Tra Vinh
+|660
+|2019
+|EVN
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Hai Duong (Hai Duong BOT plant)
+|[[Hải Dương|Hai Duong]]
+|1200 (2x600)
+|2020
+|JAKS Resources, China Power Engineering Consulting Group
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Long Phu 1
+|[[Sóc Trăng|Soc Trang]]
+|1200 (2x600)
+|2023
+|PetroVietnam Power Corp
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Na Duong 2
+|[[Lạng Sơn|Lang Son]]
+|110
+|2024
+|VINACOMIN
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Nghi Son 2
+|Thanh Hoa
+|1200 (2x600)
+|2022
+|Korean Electric Power Corporation and Marubeni Group
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Song Hau 1
+|[[Hậu Giang Province|Hau Giang]]
+|1200 (2x600)
+|2021
+|PetroVietnam Power Corp
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Thai Binh 2
+|Thai Binh
+|1200 (2x600)
+|2022
+|PetroVietnam Power Corp
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Vinh Tan 4 extension
+|Binh Thuan
+|600
+|2019
+|EVN
+|Construction
+|
+|57/BCDQGDL-VP
+|-
+|Vung Ang 3
+|Ha Tinh
+|1200 (2x600)
+|2024-2025
+|Samsung Construction & Trading Corporation
+|Shelved
+|
+|57/BCDQGDL-VP
+|-
+|An Khanh 2
+|[[Thái Nguyên|Thai Nguyen]]
+|300 (2x150)
+|
+|An Khanh Electricity JSC
+|Cancelled
+|
+|<ref name=":74"/>
+|-
+|Bac Lieu (Cai Cung power station)
+|[[Bạc Liêu|Bac Lieu]]
+|1200 (2x600)
+|
+|EVN, Sojitz Kyushu Corporation
+|Cancelled
+|switch to gas
+|<ref>{{Cite web|url=https://www.thesaigontimes.vn/284599/du-an-dien-khi-43-ti-do-la-duoc-ky-vong-giup-bac-lieu-thoat-ngheo.html|title=Dự án điện khí 4,3 tỉ đô la được kỳ vọng giúp Bạc Liêu thoát nghèo|last=Trung Chánh|date=2019-01-23|website=thesaigontimes.vn}}</ref>
+|-
+|Binh Dinh 1-2 (Than Binh Dinh power station)
+|Binh Dinh
+|2400 (2x1200)
+|
+|Electricity Generating Authority of Thailand and possibly other Thai companies
+|Cancelled
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Binh_Dinh_power_station#cite_note-PDP-3|title=Binh Dinh power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Cam Pha Phase III
+|Quang Ninh
+|440 (2x220)
+|
+|VINACOMIN
+|Cancelled
+|
+|<ref>{{Cite web|url=https://vietnambiz.vn/hang-loat-du-an-dien-bi-dung-trien-khai-59680.htm|title=Hàng loạt dự án điện bị dừng triển khai|last=Đức Quỳnh|date=2018-07-12|website=vietnambiz.vn}}</ref>
+|-
+|Dung Quat 1–2
+|Quang Ngai
+|1200 (2x600)
+|
+|Sembcorp Utilities Vietnam
+|Cancelled
+|switch to gas
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Dung_Quat_power_station|title=Dung Quat power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Ganh Dau (Phu Quoc power station)
+|Kien Giang
+|200 (2x100)
+|
+|VINACOMIN
+|Cancelled
+|switch to gas
+|<ref>{{Cite web|url=https://www.pvpower.vn/kien-giang-dua-luoi-dien-quoc-gia-ra-hai-huyen-dao/|title=Kiên Giang đưa lưới điện quốc gia ra hai huyện đảo|last=TTXVN|date=2013-04-22|website=pvpower.vn}}</ref>
+|-
+|Hai Phong 3 Unit 3–4
+|[[Haiphong|Hai Phong]]
+|1200 (2x600)
+|
+|VINACOMIN
+|Cancelled
+|
+|<ref name=":17"/>
+|-
+|Hoa Dau Long Son
+|Vung Tau
+|225 (3x75)
+|
+|Hoa Dau Son LLC
+|Cancelled
+|switch to gas
+|<ref>{{Cite web|url=https://baodautu.vn/to-hop-hoa-dau-long-son-go-bo-nut-that-cuoi-cung-d96622.html|title=Tổ hợp hóa dầu Long Sơn: Gỡ bỏ nút thắt cuối cùng|last=Hoàng Nam|date=2019-03-12|website=baodautu.vn}}</ref>
+|-
+|Kien Luong 1–2
+|Kien Giang
+|2400 (4x600)
+|
+|Tan Tao Energy Corp.
+|Cancelled
+|
+|<ref name=":23">{{Cite web|url=https://www.researchgate.net/publication/310411343|title=PHÁT TRIỂN NHIỆT ĐIỆN THAN Ở ĐỒNG BẰNG SÔNG CỬU LONG: NHỮNG ĐIỀU CẦN LÀM RÕ|website=ResearchGate|language=en|access-date=2019-07-01}}</ref>
+|-
+|Kien Luong 3
+|[[Kiên Giang Province|Kien Giang]]
+|2000 (2x1000)
+|
+|Tan Tao Energy Corp.
+|Cancelled
+|
+|<ref name=":23" />
+|-
+|Nam Dinh 2 (Hai Hau power station)
+|Nam Dinh
+|1200 (2x600)
+|
+|Taekwang Vina Industry JSC
+|Cancelled
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Nam_Dinh_power_station|title=Nam Dinh power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Ninh Binh II Expansion
+|Ninh Binh
+|300
+|
+|Ninh Binh Thermal Power JSC
+|Cancelled
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Ninh_Binh_power_station|title=Ninh Binh power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Phu Tho
+|Phu Tho
+|600
+|
+|EVN
+|Cancelled
+|switch to solid wastes
+|<ref>{{Cite news|url=https://baomoi.com/phu-tho-muon-xay-nha-may-dien-rac-hon-2-000-ty-bo-cong-thuong-chap-thuan-bo-tai-chinh-nghi-ngo/c/29324708.epi|title=Phú Thọ muốn xây nhà máy điện rác hơn 2.000 tỷ: Bộ Công Thương chấp thuận, Bộ Tài chính nghi ngờ|last=Tào Minh|date=2019-01-12|work=baomoi.com}}</ref>
+|-
+|Phu Yen
+|[[Phú Yên Province|Phu Yen]]
+|2400 (4x600)
+|
+|EVN
+|Cancelled
+|switch to gas
+|<ref>{{Cite news|url=http://www.baophuyen.com.vn/82/200833/j-power-tim-hieu-de-xay-dung-nha-may-dien-khi-tai-phu-yen.html|title=J - POWER tìm hiểu để xây dựng nhà máy điện khí tại Phú Yên|last=Thủy Tiên|date=2018-06-07|work=Phú Yên Online}}</ref>
+|-
+|Son  My 1–6
+|Binh  Thuan
+|3600 (6x600)
+|
+|Son  My Electricity Centre
+|Cancelled
+|switch to gas
+|<ref>{{Cite web|url=https://petrovietnam.petrotimes.vn/mo-hi-nh-lng-cho-to-ho-p-khi-die-n-ta-i-son-my-bi-nh-thua-n-521254.html|title=Mô hình LNG cho tổ hợp khí-điện tại Sơn Mỹ – Bình Thuận|date=2018-11-12|website=PetroTimes}}</ref>
+|-
+|Song  Hau 3
+|Hau  Giang
+|2000 (2x1000)
+|
+|no  investor
+|Cancelled
+|
+|<ref name=":23" />
+|-
+|Tan  Thanh
+|Ba  Ria-Vung Tau
+|2400 (4x600)
+|
+|J-Power
+|Cancelled
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Tan_Thanh_power_station|title=Tan Thanh power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Than  An Giang
+|An  Giang
+|2000
+|
+|no  investor
+|Cancelled
+|
+|<ref name=":23" />
+|-
+|Van  Phong 2
+|Khanh  Hoa
+|1320 (2x660)
+|
+|Hanoi  Industrial Construction and Investment, Keangnam Enterprises
+|Cancelled
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Van_Phong_power_station#cite_note-PDP-16|title=Van Phong power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Cong Thanh
+|[[Thanh Hóa|Thanh Hoa]]
+|600
+|2024
+|Cong Thanh Thermal Power JSC
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|Nam Dinh 1 (Hai Hau power station)
+|Nam  Dinh
+|1200 (2x600)
+|2024-2025
+|Taekwang  Vina Industry JSC, First National Operation & Maintenance  Co. (NOMAC)
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|Quang Trach 1
+|Quang  Binh
+|1200 (2x600)
+|2022-2023
+|EVN
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|Quynh Lap 1
+|Nghe  An
+|1200 (2x600)
+|2026
+|VINACOMIN
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|Song Hau 2
+|Hau  Giang
+|2000 (2x1000)
+|2024
+|Toyo Engineering & Construction
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|Van Phong 1
+|Khanh  Hoa
+|1320 (2x660)
+|2023-2024
+|Sumitomo Corporation
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|Vung Ang 2
+|Ha  Tinh
+|1200 (2x600)
+|2023-2024
+|OneEnergy Co.
+|Permitted
+|
+|57/BCDQGDL-VP
+|-
+|An Khanh - Bac Giang (Luc Nam power station)
+|Bac  Giang
+|650
+|2023
+|An  Khanh - Bac Giang Thermoelectric JSC
+|Pre-permit
+|
+|57/BCDQGDL-VP
+|-
+|Duc Giang - Lao Cai Chemical
+|Lao Cai
+|100 (2x50)
+|2020
+|Duc Giang - Lao Cai Chemicals JSC
+|Pre-permit
+|
+|<ref>{{Cite web|url=https://www.sourcewatch.org/index.php/Duc_Giang_-_Lao_Cai_Chemicals_power_station|title=Duc Giang - Lao Cai Chemicals power station - SourceWatch|website=www.sourcewatch.org|access-date=2019-07-01}}</ref>
+|-
+|Hai Ha CHP 1-4 (Dong Phat Hai Ha (CHP))
+|Quang  Ninh
+|2100
+|2019-2030
+|Texhong Hai Ha Industrial Park Co.
+|Preparation
+|
+|57/BCDQGDL-VP
+|-
+|Hai Phong 3 Unit 1–2
+|Hai Phong
+|1200 (2x600)
+|2028-2029
+|VINACOMIN
+|Pre-permit
+|
+|57/BCDQGDL-VP
+|-
+|Long Phu 2
+|Soc Trang
+|1320 (2x660)
+|2029-2030
+|Tata Group
+|Pre-permit
+|
+|57/BCDQGDL-VP
+|-
+|Quang Tri 1
+|Quang Tri
+|1320 (2x660)
+|2026-2027
+|EGAT International (EGATi)
+|Pre-permit
+|
+|57/BCDQGDL-VP
+|-
+|Vinh Tan 3
+|Binh  Thuan
+|1980 (3x660)
+|2024-2025
+|OneEnergy,  EVN, and Pacific Group
+|Pre-permit
+|
+|57/BCDQGDL-VP
+|-
+|Dung Quat Special Economic Zone (J-Power) Phase I-II
+|Quang  Ngai
+|4400 (1x2000, 1x2400)
+|2028-2030
+|J-Power
+|Announced
+|
+|<ref>{{Cite web|url=https://english.vov.vn/content/MTk4MDE4.vov|title=Japan company proposes building a power plant in Quang Ngai|date=2017-04-14|website=VOV - VOV Online Newspaper|access-date=2019-07-01}}</ref>
+|-
+|Long  An Phase I
+|Long  An
+|1200 (2x600)
+|
+|no  investor
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Long  An Phase II
+|Long  An
+|1600 (2x800)
+|
+|no  investor
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Long Phu 3
+|Soc Trang
+|1800 (3x600)
+|
+|PVN  proposed to transfer
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Quang Ninh 3
+|Quang  Ninh
+|1200 (2x600)
+|
+|no  investor
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Quang Trach 2
+|Quang  Binh
+|1200 (2x600)
+|2026
+|EVN
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Quang Tri 2
+|Quang  Tri
+|1200 (2x600)
+|2024
+|Korea  Western Power Co
+|Announced
+|
+|<ref>{{Cite web|url=http://icon.com.vn/vn-s83-131604-626/Han-Quoc-xay-nha-may-nhiet-dien-chay-than-tai-Quang-Tri.aspx|title=Hàn Quốc xây nhà máy nhiệt điện chạy than tại Quảng Trị|last=Nhịp cầu đầu tư|date=2017-01-20|website=icon.com.vn}}</ref>
+|-
+|Quynh Lap 2
+|Nghe  An
+|1200 (2x600)
+|2027-2028
+|POSCO
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Rang Dong cogeneration
+|Nam Dinh
+|100
+|2025
+|
+|Announced
+|
+|Decision 428/QD-TTg annex 1 Table 2, "Projects in operation from  2025" row 4
+|-
+|Tan Phuoc 1
+|Tien Giang
+|1200 (2x600)
+|
+|EVN
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Tan Phuoc 2
+|Tien Giang
+|1200 (2x600)
+|
+|EVN
+|Announced
+|
+|57/BCDQGDL-VP
+|-
+|Thai Binh 3
+|Thai Binh
+|440
+|
+|VINACOMIN
+|Announced
+|
+|<ref>{{Cite web|url=http://www.vinacomin.vn/tin-tuc-vinacomin/chinh-thuc-trien-khai-dau-tu-xay-dung-nha-may-nhiet-dien-tai-thai-binh-201807201513463374.htm|title=Chính thức triển khai đầu tư xây dựng Nhà máy nhiệt điện tại Thái Bình|last=H.H|date=2018-07-20|website=VINACOMIN}}</ref>
+|-
+|Vung Ang 3
+|
+|1200 (2x600)
+|
+|
+|Announced
+|
+|Decision 428/QD-TTg: Reserve power plants for  renewable energy power stations’ failure of schedule and output expected
+|}
+
+==Gas turbines==
+{{Further|Natural gas in Vietnam}}
+Source: updated with data from [[Ministry of Industry and Trade (Vietnam)|Ministry of Industry and Trade]] (MOIT) 2019 Report 58/BC-CBT, updated with Decision 125/QD-DTDL,<ref>{{Cite web|url=http://www.erav.vn/userfile/files/2015/6/QD_125_2014_DTDL.pdf|title=Decision 125/QD-DTDL on Issuing List of power plants participating in the Competitive Generation Market 2015|last=Nguyễn|first=Anh Tuấn|date=2014-12-29|website=erav.vn}}</ref> updated using press releases.
+
+{| class="wikitable sortable"
+!width=100|Station
+! width="60" |Province
+! width="60" |Capacity (MW)
+! width="60" |Commission date
+!width=200|Sponsor/owner
+!width=60|Status
+! width="60" |Note
+!width=150|{{Tooltip|Ref|References}}
+|-
+|Ca Mau 1&2 gas power plant
+|Ca  Mau
+|2x750
+|2008
+|PetroVietnam Power Ca Mau
+|Operating
+|
+|<ref>{{Cite web|url=https://www.pvpower.vn/du_an/nhiet-dien-khi-ca-mau-1-2/|title=Nhiệt điện khí Cà Mau 1&2|last=PetroVietnam Power|date=2017-05-05|website=pvpower.vn}}</ref> and decision 125/QD-DTDL annex 3 row 22–23
+|-
+|Nhon Trach 1 gas power plant
+|Dong  Nai
+|450
+|2009
+|PetroVietnam  Power Nhon Trach
+|Operating
+|
+|<ref>{{Cite web|url=https://www.pvpower.vn/du_an/nhiet-dien-khi-nhon-trach-1/|title=Nhiệt điện khí Nhơn Trạch 1|last=PetroVietnam Power|date=2017-05-05|website=pvpower.vn}}</ref>
+|-
+|Nhon Trach 2 Combined Cycle Gas Turbine Plant
+|Dong  Nai
+|750
+|2011
+|PetroVietnam  Power Nhon Trach 2
+|Operating
+|
+|<ref>{{Cite web|url=https://www.pvpnt2.vn/gioi-thieu/gioi-thieu-chung|title=Nhà máy điện Nhơn Trạch 2 hiện tại vận hành rất ổn định, an toàn, cung cấp sản lượng điện hiệu quả, góp phần đảm bảo an ninh năng lượng quốc gia và phát triển kinh tế xã hội.|last=PetroVietnam PVPower NT2|website=pvpnt2.vn}}</ref>
+|-
+|Phu My 2.1
+|Vung  Tau
+|477
+|1997
+|Phu  My Thermal Power Company, GENCO3
+|Operating
+|
+|<ref>{{Cite web|url=https://www.nhandan.com.vn/kinhte/item/14661502-.html%20%20and%20%20https://moit.gov.vn/tin-chi-tiet/-/chi-tiet/nhiet-%C4%91ien-phu-my-gop-phan-bao-%C4%91am-an-ninh-nang-luong-quoc-gia-109954-23.html|title=Phú Mỹ - Trung tâm điện lực lớn nhất nước|last=Theo Thể thao và Văn hóa|date=2010-09-17|website=nhandan.com.vn}}</ref> and Decision 125/QD-DTDL annex 1 row 15
+|-
+|Ba Ria
+|Vung  Tau
+|340
+|1992-2002
+|Ba  Ria Thermal Power Company, GENCO 3
+|Operating
+|
+|<ref>{{Cite web|url=http://www.btp.com.vn/vnn/index.asp?uid=1120&TopID=15&catID=2&page=1|title=Tóm tắt quá trình hình thành và phát triển của Công ty Cổ phần Nhiệt điện Bà Rịa|last=Công Ty Cổ Phần Nhiệt Điện Bà Rịa|date=2011-09-15|website=btp.com.vn}}</ref> and Decision 125/QD-DTDL annex 3 row 21
+|-
+|Phu My 2.1 extension
+|Vung  Tau
+|468
+|1999
+|Phu  My Thermal Power Company, GENCO 3
+|Operating
+|
+|<ref name=":04">{{Cite web|url=https://moit.gov.vn/tin-chi-tiet/-/chi-tiet/nhiet-%C4%91ien-phu-my-gop-phan-bao-%C4%91am-an-ninh-nang-luong-quoc-gia-109954-23.html|title=Nhiệt điện Phú Mỹ góp phần bảo đảm an ninh năng lượng quốc gia|last=MOIT|date=2017-05-16|website=moit.gov.vn}}</ref> and Decision 125/QD-DTDL annex 1 row 15
+|-
+|Phu My 4
+|Vung  Tau
+|477
+|2004
+|Phu  My Thermal Power Company, GENCO 3
+|Operating
+|
+|<ref name=":04"/> and Decision 125/QD-DTDL annex 1 row 16
+|-
+|O Mon
+|Can  Tho
+|2x330
+|2009-2015
+|EVNGENCO2
+|Operating
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-luc-viet-nam/nhiet-dien-o-mon-1-se-chuyen-sang-chay-khi-thay-dau-fo.html|title=Nhiệt điện Ô Môn 1 sẽ chuyển sang chạy khí thay dầu FO|last=NANGLUONGVIETNAM|date=2017-09-22|website=Năng Lượng Việt Nam}}</ref><ref>{{Cite web|url=https://www.evn.com.vn/d6/news/To-may-2-Nha-may-Nhiet-dien-O-Mon-I-Hoa-dien-lan-dau-vao-luoi-dien-quoc-gia-6-13-15584.aspx|title=Tổ máy 2 Nhà máy Nhiệt điện Ô Môn I: Hòa điện lần đầu vào lưới điện quốc gia|last=Nhã Uyên|date=2015-06-15|website=evn.com.vn}}</ref>
+|-
+|Phu My 1
+|Vung  Tau
+|1118
+|a
+|Phu  My Thermal Power Company, GENCO 3
+|Operating
+|
+|<ref>{{Cite web|url=https://nld.com.vn/thoi-su-trong-nuoc/nha-may-nhiet-dien-phu-my-1-phat-dien-to-may-cuoi-cung-81826.htm|title=Nhà máy Nhiệt điện Phú Mỹ 1 phát điện tổ máy cuối cùng|last=N. Hữu|date=2001-12-31|website=nld.com.vn}}</ref><ref name=":04"/>  and Decision 125/QD-DTDL annex 1 row 14
+|-
+|Phu My 3
+|Vung  Tau
+|720
+|2004
+|Phu  My 3 Bot Power Company LTD, BP Holdings BV (England), SempCorp Utilities  company (Singapore), Kyushu and Nissho Iwai (Japan)
+|Operating
+|
+|<ref>{{Cite web|url=https://www.nhandan.com.vn/chinhtri/item/8169702-.html|title=Khánh thành Nhà máy điện Phú Mỹ 3|last=Theo|date=2010-09-15|website=nhandan.com.vn}}</ref><ref>{{Cite web|url=https://baodautu.vn/sembcorp-chi-dam-de-the-chan-bp-tai-nhiet-dien-phu-my-3-d27298.html|title=SembCorp chi đậm để thế chân BP tại nhiệt điện Phú Mỹ 3|last=Thanh Hương|date=2015-05-25|website=Đầu Tư Online}}</ref>  and Decision 125/QD-DTDL annex 3 row 18
+|-
+|Phu My 2.2
+|Vung  Tau
+|720
+|2005
+|Mekong  Energy Company LTD, Electricité De France (EDF), Sumitomo, [[Tokyo Electric Power Company|TEPCO]]
+|Operating
+|
+|<ref>{{Cite web|url=https://nld.com.vn/kinh-te/van-hanh-nha-may-dien-phu-my-22--cong-suat-715-mw-130605.htm|title=Vận hành Nhà máy điện Phú Mỹ 2.2, công suất 715 MW|last=P.D|date=2005-10-20|website=nld.com.vn}}</ref> and Decision 125/QD-DTDL annex 3 row 17
+|-
+|O Mon III Combined Cycle Gas Turbine Plant
+|Can Tho
+|1x750
+|2025
+|EVN (ODA)
+|Permitted/pre-permit
+|
+|Report 58/BC-CBT annex row I.13
+|-
+|O Mon IV Combined Cycle Gas Turbine Plant
+|Can  Tho
+|1x750
+|2023
+|EVN
+|Permitted/pre-permit
+|
+|Report 58/BC-CBT annex row I.14
+|-
+|Dung  Quat I Combined Cycle Gas Turbine Plant
+|Quang  Ngai
+|750
+|2024
+|EVN
+|Permitted/pre-permit
+|
+|Report 58/BC-CBT annex row I.19
+|-
+|DungQuat III Combined Cycle Gas Turbine Plant
+|Quang  Ngai
+|750
+|2025
+|EVN
+|Permitted/pre-permit
+|
+|Report 58/BC-CBT annex row I.20
+|-
+|Nhon Trach 3&4 Combined Cycle Gas Turbine Plant
+|Dong  Nai
+|2x750
+|2023-2024
+|PVN
+|Permitted/pre-permit
+|
+|Report 58/BC-CBT annex row II.5
+|-
+|Mien Trung 1,2 Combined Cycle Gas Turbine Plant
+|Quang Nam
+|2x750
+|2024-2025
+|PVN
+|Permitted/pre-permit
+|
+|Report 58/BC-CBT annex row II.7
+|-
+|Long Son Petrochemical Complex (Mien Nam Petrochemical Complex)
+|Vung  Tau
+|2x10
+|2023
+|SCG  Group (Thailand)
+|Permitted/pre-permit
+|
+|<ref>{{Cite web|url=https://baodautu.vn/to-hop-hoa-dau-long-son-go-bo-nut-that-cuoi-cung-d96622.html|title=Tổ hợp hóa dầu Long Sơn: Gỡ bỏ nút thắt cuối cùng|last=Hoàng Nam|date=2019-03-12|website=Đầu Tư Online}}</ref>
+|-
+|Kien Giang 1&2 Combined Cycle Gas Turbine Plant
+|Kien  Giang
+|2x750
+|After 2030
+|PVN
+|Announced
+|
+|Report 58/BC-CBT annex row II.6
+|-
+|Son My II Combined Cycle Gas Turbine Plant
+|Binh  Thuan
+|3x750
+|2026-2028
+|AES Corporation, PVGAS
+|Announced
+|
+|Report 58/BC-CBT annex row II.8 and <ref>{{Cite web|url=https://vietstock.vn/2018/05/them-mot-ong-lon-my-muon-trien-khai-du-an-nha-may-nhiet-dien-khi-tai-viet-nam-768-605846.htm|title=Thêm một "ông lớn" Mỹ muốn triển khai dự án nhà máy nhiệt điện khí tại Việt Nam|last=Ngọc Hà|date=2018-05-18|website=vietstock.vn}}</ref>
+|-
+|Dung Quat II Combined Cycle Gas Turbine Plant
+|Quang  Ngai
+|750
+|2026
+|BOT
+|Announced
+|
+|Report 58/BC-CBT annex row IV.12
+|-
+|Son My  Combined Cycle Gas Turbine Plant
+|Binh  Thuan
+|3x750
+|2028-2029
+|Electricité De France (EDF),  Kiushu, Sojitz, PAC
+|Announced
+|
+|Report 58/BC-CBT annex row IV.15 and <ref>{{Cite web|url=https://petrovietnam.petrotimes.vn/mo-hi-nh-lng-cho-to-ho-p-khi-die-n-ta-i-son-my-bi-nh-thua-n-521254.html|title=Mô hình LNG cho tổ hợp khí-điện tại Sơn Mỹ – Bình Thuận|last=P.V|date=2018-11-12|website=petrovietnam.petrotimes.vn}}</ref>
+|-
+|O Mon II  Combined Cycle Gas Turbine Plant
+|Can  Tho
+|750
+|2026
+|no  investor
+|Announced
+|
+|Report 58/BC-CBT annex row VI.3
+|-
+|Ca Na LNG gas power plant
+|Ninh  Thuan
+|4x1500
+|unknown
+|Gulf  Energy Development Group (Thailand)
+|Announced
+|
+|<ref>{{Cite web|url=https://baodautu.vn/tap-doan-gulf-thai-lan-nham-du-an-dien-khi-ca-na-78-ty-usd-d97160.html|title=Tập đoàn Gulf (Thái Lan) "nhắm" dự án điện khí Cà Ná 7,8 tỷ USD|last=Nguyên Đức|date=2019-03-21|website=Đầu Tư Online}}</ref>
+|-
+|Bac Lieu LNG gas power plant
+|Bac  Lieu
+|3200
+|unknown
+|Delta  Offshore Energy
+|Announced
+|
+|<ref>{{Cite web|url=https://www.thesaigontimes.vn/284599/du-an-dien-khi-43-ti-do-la-duoc-ky-vong-giup-bac-lieu-thoat-ngheo.html|title=Dự án điện khí 4,3 tỉ đô la được kỳ vọng giúp Bạc Liêu thoát nghèo|last=Trung Chánh|date=2019-01-23|website=Kinh Tế Sài Gòn Online}}</ref>
+|-
+|Phu Yen
+|Phu  Yen
+|
+|
+|J-Power
+|Announced
+|
+|<ref>{{Cite web|url=http://www.baophuyen.com.vn/82/200833/j-power-tim-hieu-de-xay-dung-nha-may-dien-khi-tai-phu-yen.html|title=J - POWER tìm hiểu để xây dựng nhà máy điện khí tại Phú Yên|last=Thủy Tiên|date=2018-06-07|website=baophuyen.com.vn}}</ref>
+|-
+|Long Son
+|Vung  Tau
+|3x1200
+|2019-2025
+|EVNGENCO3
+|Announced
+|
+|<ref>{{Cite web|url=http://ndh.vn/evn-va-genco-3-dau-tu-du-an-dien-khi-quy-mo-4-39-ty-usd-tai-ba-ria-vung-tau-201802231159289p4c147.news|title=EVN và GENCO 3 đầu tư dự án điện khí quy mô 4,39 tỷ USD tại Bà Rịa - Vũng Tàu|last=Thanh Thủy|date=2018-02-23|website=ndh.vn}}</ref>
+|}
+
+Updated with data from [[Ministry of Industry and Trade (Vietnam)|Ministry of Industry and Trade]] (MOIT) 2019 Report 58/BC-CBT,<ref>{{Cite web|url=http://vepg.vn/legal_doc/moit-report-58-bc-cbt-on-the-implementation-progress-of-power-projects-in-the-revised-pdp7/|title=Report 58/BC-CBT on the Implementation Progress of Power Projects in the Revised PDP7|last=Hoàng|first=Quốc Vượng|date=2019-06-04|website=vepg.vn|access-date=}}</ref> updated with Decision 125/QD-DTDL,<ref>{{Cite web|url=http://www.erav.vn/userfile/files/2015/6/QD_125_2014_DTDL.pdf|title=Decision 125/QD-DTDL on Issuing List of power plants participating in the Competitive Generation Market 2015|last=Nguyễn|first=Anh Tuấn|date=2014-12-29|website=erav.vn|access-date=}}</ref> updated using press releases.
+{| class="wikitable sortable"
+!Power  plants
+!style="width:80pt;"|Other names
+!width=100|Sponsors
+!Capacity (MW)
+!Status
+!Province
+!Commission date
+!Source
+!Note
+|-
+|O Mon  III Combined Cycle Gas Turbine Plant
+|
+|EVN (ODA)
+|1x750
+|Pre-permit/permitted
+|[[Cần Thơ|Can Tho]]
+|2025
+|MOIT  Report 58/BC-CBT annex row I.13
+|
+|-
+|O Mon IV  Combined Cycle Gas Turbine Plant
+|
+|EVN
+|1x750
+|Pre-permit/permitted
+|Can Tho
+|2023
+|MOIT  Report 58/BC-CBT annex row I.14
+|
+|-
+|Dung  Quat I Combined Cycle Gas Turbine Plant
+|
+|EVN
+|750
+|Pre-permit/permitted
+|[[Quảng Ngãi Province|Quang Ngai]]
+|2024
+|MOIT  Report 58/BC-CBT annex row I.19
+|
+|-
+|Dung  Quat III Combined Cycle Gas Turbine Plant
+|
+|EVN
+|750
+|Pre-permit/permitted
+|Quang  Ngai
+|2025
+|MOIT  Report 58/BC-CBT annex row I.20
+|
+|-
+|Nhon  Trach 3&4 Combined Cycle Gas Turbine Plant
+|
+|PVN
+|2x750
+|Pre-permit/permitted
+|[[Đồng Nai Province|Dong Nai]]
+|2023-2024
+|MOIT  Report 58/BC-CBT annex row II.5
+|
+|-
+|Kien  Giang 1&2 Combined Cycle Gas Turbine Plant
+|
+|PVN
+|2x750
+|Announced
+|[[Kiên Giang Province|Kien Giang]]
+|After 2030
+|MOIT  Report 58/BC-CBT annex row II.6
+|
+|-
+|Mien  Trung 1,2 Combined Cycle Gas Turbine Plant
+|
+|PVN
+|2x750
+|Pre-permit/permitted
+|[[Quảng Nam Province|Quang Nam]]
+|2024-2025
+|MOIT  Report 58/BC-CBT annex row II.7
+|
+|-
+|Son My  II Combined Cycle Gas Turbine Plant
+|
+|AES Corporation, PVGAS
+|3x750
+|Announced
+|[[Bình Thuận Province|Binh Thuan]]
+|2026-2028
+|MOIT  Report 58/BC-CBT annex row II.8 and <ref>{{Cite web|url=https://vietstock.vn/2018/05/them-mot-ong-lon-my-muon-trien-khai-du-an-nha-may-nhiet-dien-khi-tai-viet-nam-768-605846.htm|title=Thêm một "ông lớn" Mỹ muốn triển khai dự án nhà máy nhiệt điện khí tại Việt Nam|last=Ngọc Hà|first=|date=2018-05-18|website=vietstock.vn|access-date=}}</ref>
+|
+|-
+|Dung  Quat II Combined Cycle Gas Turbine Plant
+|
+|BOT
+|750
+|Announced
+|Quang  Ngai
+|2026
+|MOIT  Report 58/BC-CBT annex row IV.12
+|
+|-
+|Son My  Combined Cycle Gas Turbine Plant
+|
+|Electricité De France (EDF),  Kiushu, Sojitz, PAC
+|3x750
+|Announced
+|Binh  Thuan
+|2028-2029
+|MOIT  Report 58/BC-CBT annex row IV.15 and <ref>{{Cite web|url=https://petrovietnam.petrotimes.vn/mo-hi-nh-lng-cho-to-ho-p-khi-die-n-ta-i-son-my-bi-nh-thua-n-521254.html|title=Mô hình LNG cho tổ hợp khí-điện tại Sơn Mỹ – Bình Thuận|last=P.V|first=|date=2018-11-12|website=petrovietnam.petrotimes.vn|access-date=}}</ref>
+|
+|-
+|O Mon II  Combined Cycle Gas Turbine Plant
+|
+|no  investor
+|750
+|Announced
+|Can  Tho
+|2026
+|MOIT  Report 58/BC-CBT annex row VI.3
+|
+|-
+|Ca Na LNG gas power plant
+|
+|Gulf  Energy Development Group (Thailand)
+|4x1500
+|Announced
+|[[Ninh Thuận Province|Ninh Thuan]]
+|unknown
+|<ref>{{Cite web|url=https://baodautu.vn/tap-doan-gulf-thai-lan-nham-du-an-dien-khi-ca-na-78-ty-usd-d97160.html|title=Tập đoàn Gulf (Thái Lan) "nhắm" dự án điện khí Cà Ná 7,8 tỷ USD|last=Nguyên Đức|first=|date=2019-03-21|website=Đầu Tư Online|access-date=}}</ref>
+|
+|-
+|Ca Mau 1&2 gas power plant
+|
+|PetroVietnam  Power Ca Mau
+|2x750
+|Operating
+|[[Cà Mau|Ca Mau]]
+|2008
+|<ref>{{Cite web|url=https://www.pvpower.vn/du_an/nhiet-dien-khi-ca-mau-1-2/|title=Nhiệt điện khí Cà Mau 1&2|last=PetroVietnam Power|first=|date=2017-05-05|website=pvpower.vn|access-date=}}</ref> and decision 125/QD-DTDL annex 3 row 22–23
+|
+|-
+|Nhon Trach 1 gas power plant
+|
+|PetroVietnam  Power Nhon Trach
+|450
+|Operating
+|Dong  Nai
+|2009
+|<ref>{{Cite web|url=https://www.pvpower.vn/du_an/nhiet-dien-khi-nhon-trach-1/|title=Nhiệt điện khí Nhơn Trạch 1|last=PetroVietnam Power|first=|date=2017-05-05|website=pvpower.vn|access-date=}}</ref>
+|
+|-
+|Nhon Trach 2 Combined Cycle Gas Turbine Plant
+|
+|PetroVietnam  Power Nhon Trach 2
+|750
+|Operating
+|[[Đồng Nai Province|Dong Nai]]
+|2011
+|<ref>{{Cite web|url=https://www.pvpnt2.vn/gioi-thieu/gioi-thieu-chung|title=Nhà máy điện Nhơn Trạch 2 hiện tại vận hành rất ổn định, an toàn, cung cấp sản lượng điện hiệu quả, góp phần đảm bảo an ninh năng lượng quốc gia và phát triển kinh tế xã hội.|last=PetroVietnam PVPower NT2|first=|date=|website=pvpnt2.vn|access-date=}}</ref>
+|
+|-
+|Bac Lieu LNG gas power plant
+|
+|Delta  Offshore Energy
+|3200
+|Announced
+|[[Bạc Liêu Province|Bac Lieu]]
+|unknown
+|<ref>{{Cite web|url=https://www.thesaigontimes.vn/284599/du-an-dien-khi-43-ti-do-la-duoc-ky-vong-giup-bac-lieu-thoat-ngheo.html|title=Dự án điện khí 4,3 tỉ đô la được kỳ vọng giúp Bạc Liêu thoát nghèo|last=Trung Chánh|first=|date=2019-01-23|website=Kinh Tế Sài Gòn Online|access-date=}}</ref>
+|
+|-
+|Phu My 2.1
+|
+|Phu  My Thermal Power Company, GENCO3
+|477
+|Operating
+|Vung  Tau
+|1997
+|<ref>{{Cite web|url=https://www.nhandan.com.vn/kinhte/item/14661502-.html%20%20and%20%20https://moit.gov.vn/tin-chi-tiet/-/chi-tiet/nhiet-%C4%91ien-phu-my-gop-phan-bao-%C4%91am-an-ninh-nang-luong-quoc-gia-109954-23.html|title=Phú Mỹ - Trung tâm điện lực lớn nhất nước|last=Theo Thể thao và Văn hóa|first=|date=2010-09-17|website=nhandan.com.vn|access-date=}}</ref> and Decision 125/QD-DTDL annex 1 row 15
+|
+|-
+|Ba Ria
+|
+|Ba  Ria Thermal Power Company, GENCO 3
+|340
+|Operating
+|[[Vũng Tàu|Vung Tau]]
+|1992-2002
+|<ref>{{Cite web|url=http://www.btp.com.vn/vnn/index.asp?uid=1120&TopID=15&catID=2&page=1|title=Tóm tắt quá trình hình thành và phát triển của Công ty Cổ phần Nhiệt điện Bà Rịa|last=Công Ty Cổ Phần Nhiệt Điện Bà Rịa|first=|date=2011-09-15|website=btp.com.vn|access-date=}}</ref> and Decision 125/QD-DTDL annex 3 row 21
+|
+|-
+|Phu My 2.1 extension
+|
+|Phu  My Thermal Power Company, GENCO 3
+|468
+|Operating
+|Vung  Tau
+|1999
+|<ref name=":0">{{Cite web|url=https://moit.gov.vn/tin-chi-tiet/-/chi-tiet/nhiet-%C4%91ien-phu-my-gop-phan-bao-%C4%91am-an-ninh-nang-luong-quoc-gia-109954-23.html|title=Nhiệt điện Phú Mỹ góp phần bảo đảm an ninh năng lượng quốc gia|last=MOIT|first=|date=2017-05-16|website=moit.gov.vn|access-date=}}</ref> and Decision 125/QD-DTDL annex 1 row 15
+|
+|-
+|Phu My 4
+|
+|Phu  My Thermal Power Company, GENCO 3
+|477
+|Operating
+|Vung  Tau
+|2004
+|<ref name=":0" /> and Decision 125/QD-DTDL annex 1 row 16
+|
+|-
+|Phu Yen
+|
+|J-Power
+|
+|Announced
+|[[Phú Yên Province|Phu Yen]]
+|
+|<ref>{{Cite web|url=http://www.baophuyen.com.vn/82/200833/j-power-tim-hieu-de-xay-dung-nha-may-dien-khi-tai-phu-yen.html|title=J - POWER tìm hiểu để xây dựng nhà máy điện khí tại Phú Yên|last=Thủy Tiên|first=|date=2018-06-07|website=baophuyen.com.vn|access-date=}}</ref>
+|
+|-
+|Long Son Petrochemical Complex
+|Mien  Nam Petrochemical Complex
+|SCG  Group (Thailand)
+|2x10
+|permitted
+|Vung  Tau
+|2023
+|<ref>{{Cite web|url=https://baodautu.vn/to-hop-hoa-dau-long-son-go-bo-nut-that-cuoi-cung-d96622.html|title=Tổ hợp hóa dầu Long Sơn: Gỡ bỏ nút thắt cuối cùng|last=Hoàng Nam|first=|date=2019-03-12|website=Đầu Tư Online|access-date=}}</ref>
+|
+|-
+|O Mon
+|
+|EVNGENCO2
+|2x330
+|operating
+|[[Cần Thơ|Can Tho]]
+|2009-2015
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-luc-viet-nam/nhiet-dien-o-mon-1-se-chuyen-sang-chay-khi-thay-dau-fo.html|title=Nhiệt điện Ô Môn 1 sẽ chuyển sang chạy khí thay dầu FO|last=NANGLUONGVIETNAM|first=|date=2017-09-22|website=Năng Lượng Việt Nam|access-date=}}</ref><ref>{{Cite web|url=https://www.evn.com.vn/d6/news/To-may-2-Nha-may-Nhiet-dien-O-Mon-I-Hoa-dien-lan-dau-vao-luoi-dien-quoc-gia-6-13-15584.aspx|title=Tổ máy 2 Nhà máy Nhiệt điện Ô Môn I: Hòa điện lần đầu vào lưới điện quốc gia|last=Nhã Uyên|first=|date=2015-06-15|website=evn.com.vn|access-date=}}</ref>
+|
+|-
+|Phu My 1
+|
+|Phu  My Thermal Power Company, GENCO 3
+|1118
+|operating
+|Vung  Tau
+|2001
+|<ref name=":0" /><ref>{{Cite web|url=https://nld.com.vn/thoi-su-trong-nuoc/nha-may-nhiet-dien-phu-my-1-phat-dien-to-may-cuoi-cung-81826.htm|title=Nhà máy Nhiệt điện Phú Mỹ 1 phát điện tổ máy cuối cùng|last=N. Hữu|first=|date=2001-12-31|website=nld.com.vn|access-date=}}</ref>  and Decision 125/QD-DTDL annex 1 row 14
+|
+|-
+|Phu My 3
+|
+|Phu  My 3 Bot Power Company LTD, BP Holdings BV (England), SempCorp Utilities  company (Singapore), Kyushu and Nissho Iwai (Japan)
+|720
+|operating
+|Vung  Tau
+|2004
+|<ref>{{Cite web|url=https://www.nhandan.com.vn/chinhtri/item/8169702-.html|title=Khánh thành Nhà máy điện Phú Mỹ 3|last=Theo|first=|date=2010-09-15|website=nhandan.com.vn|access-date=}}</ref><ref>{{Cite web|url=https://baodautu.vn/sembcorp-chi-dam-de-the-chan-bp-tai-nhiet-dien-phu-my-3-d27298.html|title=SembCorp chi đậm để thế chân BP tại nhiệt điện Phú Mỹ 3|last=Thanh Hương|first=|date=2015-05-25|website=Đầu Tư Online|access-date=}}</ref>  and Decision 125/QD-DTDL annex 3 row 18
+|
+|-
+|Phu My 2.2
+|
+|Mekong  Energy Company LTD, Electricité De France (EDF), Sumitomo, TEPCO
+|720
+|operating
+|Vung  Tau
+|2005
+|<ref>{{Cite web|url=https://nld.com.vn/kinh-te/van-hanh-nha-may-dien-phu-my-22--cong-suat-715-mw-130605.htm|title=Vận hành Nhà máy điện Phú Mỹ 2.2, công suất 715 MW|last=P.D|first=|date=2005-10-20|website=nld.com.vn|access-date=}}</ref> and Decision 125/QD-DTDL annex 3 row 17
+|
+|-
+|Long Son
+|
+|EVNGENCO3
+|3x1200
+|Announced
+|Vung  Tau
+|2019-2025
+|<ref>{{Cite web|url=http://ndh.vn/evn-va-genco-3-dau-tu-du-an-dien-khi-quy-mo-4-39-ty-usd-tai-ba-ria-vung-tau-201802231159289p4c147.news|title=EVN và GENCO 3 đầu tư dự án điện khí quy mô 4,39 tỷ USD tại Bà Rịa - Vũng Tàu|last=Thanh Thủy|first=|date=2018-02-23|website=ndh.vn|access-date=}}</ref>
+|
+|}
+
+== Solar power plants ==
+Source: Initial query from DEVI Renewable Energies,<ref name=":12">{{Cite web|url=https://devi-renewable.com/news/tinh-den-thang-6-2019-viet-nam-du-kien-co-4244mw-dien-mat-troi/|title=Tính đến tháng 6 năm 2019, Việt Nam dự kiến có 4.244MW điện mặt trời đưa vào lưới|last=DEVI Renewable Energies|date=2019-03-22|website=DEVI Renewable Energies}}</ref> updated using press releases
+
+Note: Construction start + COD date form: day/month/year
+
+{| class="wikitable sortable"
+! width="100" |Station
+! width="90" |Location
+! width="50" |Province
+! width="50" |Capacity (MW)
+! width="50" |Capacity (MWp)
+! width="60" |Construction start date
+! width="60" |COD date
+! width="100" |Sponsor/owner
+! width="60" |Status
+! width="150" |Note
+! width="40" |Source
+|-
+|[[TTC Phong Dien]]
+|Dien Loc commune, Phong Dien district, TT Hue province
+|Thua Thien Hue
+|35
+|48
+|01/01/2018
+|25/09/2018
+|GEC/TTC
+|Operation
+|EPC: Sharp-SSSA-NSN  partnership
+|<ref>{{Cite web|url=https://baodautu.vn/khanh-thanh-nha-may-dien-mat-troi-35-mw-dau-tien-tai-viet-nam-d88820.html|title=Khánh thành nhà máy điện mặt trời 35 MW đầu tiên tại Việt Nam|last=Thùy Vinh|date=2018-04-10|website=Đầu tư online}}</ref><ref name=":13">{{Cite web|url=https://baodautu.vn/mo-danh-tinh-87-nha-may-dien-mat-troi-da-van-hanh-truoc-ngay-3062019-d112210.html|title="Mở danh tính" 87 nhà máy điện mặt trời đã vận hành trước ngày 30/6/2019|last=Thanh|first=Hương|date=2019-12-04|website=baodautu.vn}}</ref>
+|-
+|[[TTC Krong Pa]]
+|Krong  Pa, Gia Lai
+|Gia  Lai
+|49
+|69
+|03/2018
+|4/11/2018
+|GEC/TTC
+|Operation
+|
+|<ref>{{Cite web|url=https://thanhnien.vn/tai-chinh-kinh-doanh/nha-may-dien-mat-troi-ttc-krong-pa-cong-suat-49-mw-69-mwp-1029256.html|title=Nhà máy điện mặt trời TTC Krông Pa công suất 49 MW (69 MWp)|last=Nam Bình|date=2018-02-12|website=Báo Thanh Niên online}}</ref><ref name=":13" />
+|-
+|[[BP Solar 1 (Vietnamese power plant)]]
+|Huu Phuoc  commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|37.5
+|46
+|06/2018
+|20/01/2019
+|Bac Phuong JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|{{ill|Srepok 1|vi|Điện mặt trời Srêpôk 1|vertical-align=sup}}
+|Ea  Wer commune, Buon Don district, Dak Lak province
+|Dak  Lak
+|42.1
+|50
+|19/10/2018
+|31/01/2019
+|Dai Hai Investment and Development JSC
+|Operation
+|
+|<ref name=":02">{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khanh-thanh-cum-nha-may-dien-mat-troi-srepok-1-va-quang-minh.html|title=Khánh thành cụm Nhà máy điện mặt trời Srêpốk 1 và Quang Minh|last=TẠP CHÍ NĂNG LƯỢNG VIỆT NAM|date=2019-03-09|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|Long Thanh 1 |vi|Điện mặt trời Long Thành|vertical-align=sup}}
+|Cu M'Lan commune, Ea Sup district, Dak Lak province
+|Dak  Lak
+|43.8
+|50
+|
+|05/2019
+|Long Thanh Infrastructure Investment and Development JS
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nha-may-dien-mat-troi-long-thanh-1-giai-doan-1-di-vao-hoat-dong.html|title=Nhà máy điện mặt trời Long Thành 1 (giai đoạn 1) đi vào hoạt động|last=NANGLUONGVIETNAM|date=2019-05-30|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|Quang Minh solar power|vi|Điện mặt trời Srêpôk 1|vertical-align=sup}}
+|Village 9, Ea Wer commune, Buon Don district, Dak Lak
+|Dak  Lak
+|40.9
+|50
+|19/10/2018
+|31/01/2019
+|Dai Hai Power + Srepok Solar
+|Operation
+|
+|<ref name=":02" /><ref name=":13" />
+|-
+|{{ill|TTC 1 solar power |vi|Điện mặt trời TTC An Hòa|vertical-align=sup}}
+|Thanh Thanh Cong port warehouse in An Hoa commune, Trang Bang district, Tay Ninh
+|Tay  Ninh
+|48
+|68.8
+|25/05/2018
+|06/03/2019
+|TTC Green Energy
+|Operation
+|
+|<ref name=":14">{{Cite web|url=https://tuoitre.vn/khanh-thanh-nha-may-dien-mat-troi-ttc-so-01-va-02-20190619190855633.htm|title=Khánh thành nhà máy điện mặt trời TTC số 01 và 02|last=K.H.|date=2019-06-19|website=Báo Tuổi Trẻ online}}</ref><ref name=":13" />
+|-
+|{{ill|TTC 2  solar power |vi|Điện mặt trời TTC An Hòa|vertical-align=sup}}
+|Trang  Bang District, Tay Ninh Province
+|Tay Ninh
+|40.8
+|50
+|10/08/2018
+|19/4/2019
+|TTC Green Energy
+|Operation
+|
+|<ref name=":14" /><ref name=":13" />
+|-
+|{{ill|BIM 1|vi|Điện mặt trời BIM Ninh Thuận|vertical-align=sup}}
+|Phuoc  Minh commune, Thuan Nam district, Ninh Thuan
+|Ninh  Thuan
+|25
+|30
+|01/2018
+|27/03/2019
+|Bim Group
+|Operation
+|BIM - AC Renewable partnership
+|<ref>{{Cite web|url=https://vtv.vn/vtv8/ninh-thuan-nha-may-dien-mat-troi-bim-1-chinh-thuc-phat-dien-20190329084535052.htm|title=Ninh Thuận: Nhà máy điện mặt trời BIM 1 chính thức phát điện|last=Hữu Tầm|date=2019-03-29|website=VTV News}}</ref><ref name=":22">{{Cite web|url=https://baodautu.vn/bim-group-khanh-thanh-cum-3-nha-may-dien-mat-troi-tong-cong-suat-330-mwp-d99383.html|title=BIM Group khánh thành cụm 3 nhà máy điện mặt trời, tổng công suất 330 MWP|last=Như Loan|date=2019-04-27|website=Đầu Tư Online}}</ref><ref name=":13" />
+|-
+|{{ill|BIM 2|vi|Điện mặt trời BIM Ninh Thuận|vertical-align=sup}}
+|Phuoc  Minh commune, Thuan Nam district, Ninh Thuan
+|Ninh  Thuan
+|199.3
+|250
+|01/2018
+|05/2019
+|Bim Group
+|Operation
+| rowspan="2" |Powerway Mounting structure. 
+Sungrow Inverter. AC  Energy – the subsidiaries of Ayala Corporation (Philippines) is the owner and  Bouygues Energies & Services (France) is the EPC contractor.
+BIM - AC Renewable partnership. 
+|<ref name=":22" /><ref name=":32">{{Cite web|url=https://vtv.vn/kinh-te/bim-group-van-hanh-nha-may-dien-mat-troi-lon-nhat-dong-nam-a-20190502164742236.htm|title=BIM Group vận hành nhà máy điện mặt trời lớn nhất Đông Nam Á|last=Trung tâm Tin tức VTV24|date=2019-05-02|website=VTV.vn}}</ref><ref name=":13" />
+|-
+|{{ill|BIM 3|vi|Điện mặt trời BIM Ninh Thuận|vertical-align=sup}}
+|Phuoc  Minh commune, Thuan Nam district, Ninh Thuan
+|Ninh  Thuan
+|41.2
+|50
+|01/2018
+|05/2019
+|Bim Group
+|Operation
+|<ref name=":22" /><ref name=":32" /><ref name=":13" />
+|-
+|{{ill|Yen Dinh solar power|vi|Điện mặt trời Yên Định|vertical-align=sup}}
+|Yen  Thai commune, Yen Dinh district, Thanh Hoa province
+|Thanh Hoa
+|30
+|38
+|10/2017
+|22/3/2019
+|Song  Lam Son La Energy JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://truyenhinhthanhhoa.vn/kinh-te/201905/nha-may-dien-mat-troi-yen-dinh-cung-cap-nguon-nang-luong-sach-cho-dien-luoi-quoc-gia-8202724/|title=Nhà máy điện mặt trời Yên Định cung cấp nguồn năng lượng sạch cho điện lưới quốc gia|last=TTV|date=2019-05-23|website=TTV Thanh Hóa}}</ref><ref>{{Cite web|url=http://antt.vn/dau-tu-nha-may-dien-mat-troi-hon-700-ty-dong-dau-tien-tai-thanh-hoa--261249.htm|title=Đầu tư nhà máy điện mặt trời hơn 700 tỷ đồng đầu tiên tại Thanh Hóa|last=Lương Diễn|date=2018-12-04|website=Báo An Ninh Tiền Tệ - Truyền Thông}}</ref><ref name=":13" />
+|-
+|{{ill|Vinh Tan Power Center  Phase 1|vi|Điện mặt trời Vĩnh Tân|vertical-align=sup}}
+|Vinh Tan commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|6.2
+|
+|12/2018
+|23/01/2019
+|EVNPECC2
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/du-an-dien-mat-troi-vinh-tan-hoa-luoi-dien-quoc-gia.html|title=Dự án điện mặt trời Vĩnh Tân hòa lưới điện quốc gia|last=NANGLUONGVIETNAM|date=2019-02-12|website=Năng lượng Việt Nam}}</ref>
+|-
+|{{ill|Vinh Tan Power Center  Phase 2|vi|Điện mặt trời Vĩnh Tân|vertical-align=sup}}
+|Vinh Tan commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|34.9
+|42.7
+|12/2018
+|22/06/2019
+|EVNGENCO 3
+|Operation
+|
+|<ref>{{Cite web|url=https://tuoitre.vn/nha-may-dien-mat-troi-vinh-tan-2-phat-dien-thuong-mai-20190622200009439.htm|title=Nhà máy điện mặt trời Vĩnh Tân 2 phát điện thương mại|last=Ngọc Hiến|date=2019-06-22|website=Báo Tuổi Trẻ online}}</ref><ref name=":13" />
+|-
+|TTC Ham Phu II
+|Ham  Phu, Ham Thuan Bac district, Binh Thuan province
+|Binh Thuan
+|40.8
+|49
+|31/07/2018
+|12/04/2019
+|GEC/TTC
+|Operation
+|
+|<ref>{{Cite web|url=https://thanhnien.vn/tai-chinh-kinh-doanh/nha-may-dien-mat-troi-ttc-ham-phu-2-cong-suat-49-mwp-1085060.html|title=Nhà máy điện mặt trời TTC - Hàm Phú 2 công suất 49 MWp|last=Minh Quân|date=2019-05-24|website=Thanh Niên Online}}</ref><ref name=":13" />
+|-
+|{{ill|Da Mi Floating|vi|Điện mặt trời Đa Mi|vertical-align=sup}}
+|Tanh  Linh and Ham Thuan Bac districts, Binh Thuan province
+|Binh Thuan
+|42.5
+|47.5
+|2017
+|13/05/2019
+|DHD - Da Nhim Hydropower Plant - Ham Thuan - Da Mi (EVNGENCO 1)
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/du-an-dien-mat-troi-noi-tren-ho-da-mi-hoa-luoi-thanh-cong.html|title=Dự án điện mặt trời nổi trên hồ Đa Mi hòa lưới thành công|last=Kim Oanh|date=2019-05-14|website=Năng Lượng Việt Nam}}</ref><ref>{{Cite web|url=https://www.evn.com.vn/d6/news/Du-an-dien-mat-troi-noi-tai-ho-Da-Mi-Them-nguon-nang-luong-sach-141-17-20615.aspx|title=Dự án điện mặt trời nổi tại hồ Đa Mi: Thêm nguồn năng lượng sạch|last=TCĐL chuyên đề Quản lý & Hội nhập|date=2017-09-20|website=EVN}}</ref>
+|-
+|{{ill|Sao Mai Solar PV1|vi|Điện mặt trời Sao Mai|vertical-align=sup}} Phase 1&2
+|Tinh Bien district, An Giang
+|An Giang
+|174
+|210
+|02/2019
+|06/07/2019
+|Sao Mai Group
+|Operation
+|
+|<ref name=":72">{{Cite web|url=https://thanhnien.vn/tai-chinh-kinh-doanh/tap-doan-sao-mai-khanh-thanh-nha-may-dien-nang-luong-mat-troi-sao-mai-solar-pv1-1100618.html|title=Tập đoàn Sao Mai khánh thành Nhà máy điện năng lượng mặt trời Sao Mai Solar PV1|last=Tuyết Nga|date=2019-07-06|website=Thanh Niên Online}}</ref><ref name=":13" />
+|-
+|{{ill|Mui Ne|vi|Điện mặt trời Mũi Né|vertical-align=sup}}
+|Mui  Ne ward, Phan Thiet city, Binh Thuan province
+|Binh Thuan
+|32.5
+|40
+|12/10/2018
+|04/06/2019
+|Duc Thanh Mui Ne JSC
+(Pacifico Energy + Duc Long Gia Lai)
+|Operation
+|EPC: TTCL Vietnam LLC, Battery of [[Jinko Solar]]. TVGS is Mott Macdonald
+|<ref>{{Cite web|url=https://nhandan.com.vn/kinhte/item/40512702-khanh-thanh-nha-may-dien-mat-troi-mui-ne.html|title=Khánh thành Nhà máy điện mặt trời Mũi Né|last=Đình Châu|date=2019-06-12|website=Nhân Dân News}}</ref><ref name=":13" />
+|-
+|{{ill|Hong Phong 4|vi|Điện mặt trời Hồng Phong|vertical-align=sup}}
+|Hong  Phong commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|40
+|48
+|10/2018
+|30/5/2019
+|Ha Do Group (HDG)
+|Operation
+|Sunpower  panels, Inverter SMA, Transformer ABB, Tractebel: OE
+|<ref>{{Cite web|url=https://hado.com.vn/48-mwp-dien-mat-troi-du-an-hong-phong-4-sap-hoa-luoi-dien-quoc-gia|title=48 MWp điện mặt trời dự án Hồng Phong 4 đã hòa lưới điện quốc gia|last=Tập đoàn Hà Đô|date=2019-05-30|website=HA DO GROUP}}</ref><ref name=":13" />
+|-
+|{{ill|LIG Quang Tri|vi|Điện mặt trời LIG Quảng Trị|vertical-align=sup}}
+|Gio Hai commune  and Gio Thanh commune, Gio Linh district, Quang Tri
+|Quang Tri
+|40.8
+|49.5
+|10/2018
+|18/05/2019
+|LICOGI 13 JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://congthuong.vn/khanh-thanh-du-an-dien-mat-troi-lon-nhat-quang-tri-von-dau-tu-gan-12-ngan-ty-dong-121761.html|title=Khánh thành dự án Điện mặt trời lớn nhất Quảng Trị, vốn đầu tư gần 1,2 ngàn tỷ đồng|last=Thành Long & Nguyễn Tuấn|date=2019-06-30|website=congthuong.vn}}</ref><ref name=":13" />
+|-
+|Hau Giang
+|Hoa An commune, Phung Hiep district, Hau Giang province
+|Hau Giang
+|29
+|
+|
+|15/12/2020
+|VKT Hoa An JSC
+|Operation
+|
+|<ref name=":0c">{{Cite web|title=Công văn 4614/BCT-ĐL 2018 tình hình phát triển điện mặt trời|url=https://thukyluat.vn/cv/cong-van-4614-bct-dl-2018-tinh-hinh-phat-trien-dien-mat-troi-60adb.html|access-date=2021-07-14|website=thukyluat.vn}}</ref>
+|-
+|Hong Phong 1A
+|Hong Phong commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|150
+|195
+|
+|01/06/2019
+|Hong Phong 1 Energy JSC
+|Operation
+|Sinohydro Corporation  Limited belongs to Power Chi Group
+|<ref name=":18" /><ref name=":13" />
+|-
+|Hong Phong 1B
+|Hong Phong commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|100
+|130
+|
+|02/06/2019
+|Hong Phong 1 Energy JSC
+|Operation
+|Sinohydro Corporation  Limited belongs to Power Chi Group
+|<ref name=":18">{{Cite web|url=https://theleader.vn/cong-ty-trung-quoc-ban-pin-cho-hai-nha-may-dien-mat-troi-lon-tai-viet-nam-1562286069356.htm|title=Công ty Trung Quốc bán pin cho hai nhà máy điện mặt trời lớn tại Việt Nam|last=Duy Kiên|date=2019-07-05|website=theleader.vn}}</ref><ref name=":13" />
+|-
+|Hong Liem 3
+|Hong Liem commune, Ham Thuan Bac district, Binh Thuan province
+|Binh Thuan
+|42
+|
+|
+|18/12/2020
+|Truong Loc Binh Thuan Solar Company
+|Operation
+|
+|
+|-
+|{{ill|Cu Jut solar power |vi|Điện mặt trời Cư Jút|vertical-align=sup}}
+|Ea T’ling town, Cu Jut district, Dak Nong province
+|Dak Nong
+|50
+|62
+|06/2017
+|20/04/2019
+|Mien Trung Hydropower JSC (CHP)
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nha-may-dien-mat-troi-cu-jut-phat-dien-thuong-mai.html|title=Nhà máy điện mặt trời Cư Jút phát điện thương mại|last=Dương Anh Minh|date=2019-04-22|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|Nhi Ha - Thuan Nam 13 |vi|Điện mặt trời Nhị Hà|vertical-align=sup}}
+|Nhi Ha commune, Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|40
+|50
+|05/2018
+|20/06/2019
+|Solar Power Ninh Thuan One Member LLC
+|Operation
+|
+|<ref name=":8">{{Cite web|url=https://baodautu.vn/diem-mat-loat-du-an-nha-may-dien-mat-troi-tai-ninh-thuan-d87063.html|title="Điểm mặt" loạt dự án Nhà máy điện mặt trời tại Ninh Thuận|last=Việt Hương|date=2018-08-30|website=Đầu Tư Online}}</ref><ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nang-luong-tai-tao/khanh-thanh-nha-may-dien-mat-troi-nhi-ha-thuan-nam-13.html|title=Khánh thành Nhà máy điện mặt trời Nhị Hà - Thuận Nam 13|last=Quyền Thịnh & Văn Hải|date=2019-07-08|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|CMX Renewable Energy Vietnam
+|My  Son commune, Ninh Son district, Ninh Thuan province
+|Ninh Thuan
+|131.3
+|168
+|09/06/2018
+|18/06/2019
+|CMX Re Sunseap Vietnam
+|Operation
+|JV: Sunseap, InfraCo  Asia and CMX Renewable Energy Canada Inc
+|<ref>{{Cite web|url=https://baomoi.com/khoi-cong-nha-may-dien-mat-troi-cmx-renewable-energy-viet-nam/c/26350224.epi|title=Khởi công Nhà máy điện mặt trời CMX Renewable Energy Việt Nam|last=Thảo Anh|date=2018-06-09|website=Báo Mới News}}</ref><ref>{{Cite web|url=https://devi-renewable.com/news/sunseap-khanh-thanh-du-an-cmx-renewable-energy-168mwp-tai-ninh-thuan/|title=Sunseap khánh thành dự án CMX Renewable Energy 168MWp tại Ninh Thuận|last=DEVI Renewable Energies|date=2019-06-19|website=DEVI Renewable Energies}}</ref><ref name=":13" />
+|-
+|{{ill|Thuan Nam 19|vi|Điện mặt trời Thuận Nam 19|vertical-align=sup}}
+|Phuoc  Minh commune, Thuan Nam district, Ninh Thuan
+|Ninh Thuan
+|49
+|61.1
+|01/04/2018
+|24/6/2019
+|Tasco Energy
+|Operation
+|EPC: Risen Energy.  Risen holds 70% equity
+|<ref>{{Cite web|url=http://tietkiemnangluong.vn/d6/news/Nha-may-dien-mat-troi-Thuan-Nam-19-hoa-luoi-dien-quoc-gia-111-136-12141.aspx|title=Nhà máy điện mặt trời Thuận Nam 19 hòa lưới điện quốc gia|last=Huỳnh|first=Quang Tuấn|date=2019-06-25|website=tietkiemnangluong.vn}}</ref><ref name=":13" />
+|-
+|Ninh Phuoc 6.1, 6.2
+|Phuoc  Huu commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|49
+|58.3
+|12/06/2018
+|06/2019
+|NITSA (Ninh Thuan Renewable Energy & Agriculture JSC)
+|Operation
+|EPC: EVNPECC2
+|<ref name="PECC2">{{Cite web|url=http://www.pecc2.com/Detail.aspx?newsID=50960|title=Khởi công xây dựng Nhà máy Điện mặt trời Ninh Phước 6.1 và Ninh Phước 6.2|last=PECC2|date=2018-06-25|website=EVNPECC2}}</ref><ref name=":13" />
+|-
+|Dam Tra O
+|My Chau commune, Phu My district, Binh Dinh province
+|Binh Dinh
+|41.7
+|
+|
+|18/12/2020
+|Vietnam Renewable Energy JSC
+|Operation
+|
+|<ref name=":0" />
+|-
+|Dohwa Le Thuy
+|Ngu Thuy Bac and Hung Thuy commune, Le Thuy district, Quang Binh province
+|Quang Binh
+|47.6
+|
+|
+|24/12/2020
+|Green Energy Dohwa Company Ltd
+|Operation
+|
+|<ref name=":0" />
+|-
+|Cam Hung
+|Cam Hung commune, Cam Xuyen district, Ha Tinh province
+|Ha Tinh
+|23.2
+|
+|
+|25/12/2020
+|GA POWER SOLAR PARK CAM XUYEN LTD
+|Operation
+|
+|
+|-
+|{{ill|Cat Hiep|vi|Điện mặt trời Cát Hiệp|vertical-align=sup}}
+|Hoi Van village, Cat  Hiep commune, Phu Cat district, Binh Dinh province
+|Binh Dinh
+|42
+|49.5
+|29/10/2018
+|06/06/2019
+|Truong Thanh (TTVN Group)
+|Operation
+|Powerway Mounting system.
+EPC: Juwi. JV:  Quadran International (owned by Lucia Holding – France Republic)
+|<ref>{{Cite web|url=http://tietkiemnangluong.vn/d6/news/Nha-may-dien-mat-troi-Cat-Hiep-hoa-luoi-dien-quoc-gia-111-136-12033.aspx|title=Nhà máy điện mặt trời Cát Hiệp hòa lưới điện quốc gia|last=Hưng Việt|date=2019-05-21|website=tietkiemnangluong.vn}}</ref><ref name=":13" />
+|-
+|Ha Do Ninh Phuoc
+|Phuoc Thai commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|40
+|50
+|
+|01/09/2020
+|Ha Do Group
+|Operation
+|
+|<ref>{{Cite web|title=TẬP ĐOÀN HÀ ĐÔ KHÁNH THÀNH NHÀ MÁY ĐIỆN MẶT TRỜI HÀ ĐÔ NINH PHƯỚC TẠI NINH THUẬN|url=http://hado.com.vn/tap-doan-ha-do-khanh-thanh-nha-may-dien-mat-troi-ha-do-ninh-phuoc-tai-ninh-thuan|access-date=2021-07-12|website=Tập đoàn Hà Đô|language=vi}}</ref>
+|-
+|{{ill|Phuoc Huu |vi|Điện mặt trời Phước Hữu|vertical-align=sup}}
+|Phuoc  Huu commune, Ninh Phuoc district, Ninh Thuan
+|Ninh Thuan
+|50
+|65
+|30/06/2018
+|20/06/2019
+|Nha Trang Bay Investment JSC
+|Operation
+|Module:JA Solar,  Inverter:SMA, Mounting:Schletter Solar Mounting Group, Transformers:Siemens
+|<ref>{{Cite web|url=https://dantri.com.vn/kinh-doanh/khoi-cong-du-an-nha-may-dien-mat-troi-phuoc-huu-20180701075355212.htm|title=Khởi công Dự án Nhà máy Điện mặt trời Phước Hữu|last=dantri.com.vn|date=2018-07-01}}</ref><ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khanh-thanh-nha-may-dien-mat-troi-phuoc-huu.html|title=Khánh thành Nhà máy điện mặt trời Phước Hữu|last=NANGLUONGVIETNAM|date=2019-07-08|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|Song Luy 1 |vi|Điện mặt trời Sông Lũy|vertical-align=sup}}
+|Song  Luy commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|39
+|46.7
+|23/09/2018
+|05/2019
+|Binh Thuan Optoelectronics Investment JSC
+|Operation
+|Design consultant  Sigma Energy (Spain) - Electrical Consultant 4 (Vietnam), Supervision  Consultant Tractebel (Belgium). Equipment suppliers are ABB (Sweden), TMEIC  (Japan), JA Solar (China); Contractor of construction and installation  PowerChina (China) -AIT (Vietnam). The project also has credit support by SHB  bank.
+|<ref>{{Cite web|url=http://baochinhphu.vn/Doanh-nghiep/Phat-dien-nha-may-dien-mat-troi-dau-tien-lap-dat-tren-mat-ho/367038.vgp|title=Phát điện nhà máy điện mặt trời đầu tiên lắp đặt trên mặt hồ|last=BT|date=2019-05-28|website=Chính Phủ Việt Nam News}}</ref><ref name=":13" />
+|-
+|{{ill|SP – Infra Ninh Thuan|vi|Điện mặt trời SP - Infra Ninh Thuận|vertical-align=sup}}
+|Phuoc  Vinh commune, Ninh Phuoc district, Ninh Thuan
+|Ninh Thuan
+|
+|50
+|04/2018
+|09/2020
+|Surya Prakash Energy Ltd. Vietnam
+|Operation
+|
+|<ref name=":8" />
+|-
+|{{ill|Bau Ngu Lake |vi|Điện mặt trời Bàu Ngứ|vertical-align=sup}}
+|Phuoc  Dinh commune, Thuan Nam district, Ninh Thuan
+|Ninh Thuan
+|37.4
+|45.8
+|31/03/2018
+|06/2019
+|Truong Thanh Investment and Construction JSC
+|Operation
+|OCA: transformer
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nha-may-dien-mat-troi-bau-ngu-hoa-luoi-dien-quoc-gia.html|title=Nhà máy điện mặt trời Bàu Ngứ hoà lưới điện quốc gia|last=Quyền Trịnh & Văn Hải|date=2019-07-01|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|Gelex Ninh Thuan|vi|Điện mặt trời Gelex Ninh Thuận|vertical-align=sup}}
+|Phuoc  Dinh commune, Thuan Nam district, Ninh Thuan
+|Ninh Thuan
+|42
+|50
+|04/06/2018
+|02/07/2019
+|Gelex Ninh Thuan Energy JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://devi-renewable.com/news/dien-mat-troi-gelex-ninh-thuan-50mwp-dung-thiet-bi-sma-da-dong-dien-thanh-cong/|title=Điện mặt trời GELEX Ninh Thuận 50MWp dùng thiết bị SMA đã đóng điện thành công|last=DEVI Renewable Energies|date=2019-07-02|website=DEVI Renewable Energies}}</ref><ref name=":13" />
+|-
+|{{ill|Xuan Tho 1|vi|Điện mặt trời Xuân Thọ|vertical-align=sup}}
+|Xuan  Tho 1 and Xuan Tho 2 communes, Song Cau town, Phu Yen province
+|Phu Yen
+|45.9
+|49.6
+|08/01/2019
+|27/06/2019
+|Phu Khanh Solar JSC
+|Operation
+|
+|<ref name=":19">{{Cite web|url=https://baodautu.vn/nha-may-dien-mat-troi-xuan-tho-1-va-xuan-tho-2-hoa-luoi-dien-quoc-gia-d102835.html|title=Nhà máy điện mặt trời Xuân Thọ 1 và Xuân Thọ 2 hoà lưới điện quốc gia|last=Hoàng Anh|date=2019-06-27|website=Đầu Tư Online}}</ref><ref name=":13" />
+|-
+|{{ill|Xuan Tho 2|vi|Điện mặt trời Xuân Thọ|vertical-align=sup}}
+|Xuan  Tho 1 and Xuan Tho 2 communes, Song Cau town, Phu Yen province
+|Phu Yen
+|45.9
+|49.6
+|08/01/2019
+|27/06/2019
+|Phu Khanh Solar JSC
+|Operation
+|
+|<ref name=":19" /><ref name=":13" />
+|-
+|{{ill|BCG Bang Duong/BCG-CME Long An 1|vi|Điện mặt trời BCG Băng Dương|vertical-align=sup}}
+|Thanh  An commune, Thanh Hoa district, Long An province
+|Long An
+|31.25
+|40.6
+|16/09/2018
+|23/06/2019
+|Bamboo Capital Group
+|Operation
+|
+|<ref>{{Cite web|url=https://tinnhanhchungkhoan.vn/doanh-nghiep/bamboo-capital-bcg-khanh-thanh-nha-may-dien-mat-troi-tai-long-an-270290.html|title=Bamboo Capital (BCG) khánh thành nhà máy điện mặt trời tại Long An|last=Thu Hương|date=2019-06-24|website=tinnhanhchungkhoan.vn}}</ref><ref name=":13" />
+|-
+|Cam Lam VN
+|Cam  An Bac commune, Cam Lam district - Khanh Hoa
+|Khanh Hoa
+|45
+|49.6
+|
+|25/06/2019
+|Cam Lam Solar Ltd.
+|Operation
+|Equity: Golf Long  Thanh
+|<ref name=":10">{{Cite web|url=http://nangluongsachvietnam.vn/d6/vi-VN/news2/Khanh-thanh-nha-may-dien-mat-troi-KN-Cam-Lam-va-Cam-Lam-VN--6-165-4204|title=Khánh thành nhà máy điện mặt trời KN Cam Lâm và Cam Lâm VN|last=Nhã Quyên|date=2019-07-22|website=Đầu Tư Online}}</ref><ref name=":13" />
+|-
+|KN Cam Lam
+|2  communes of Cam An Bac and Cam Phuoc Tay, Cam Lam district, Khanh Hoa
+|Khanh Hoa
+|45
+|49.5
+|
+|25/06/2019
+|Cam Lam Solar Ltd.
+|Operation
+|Equity: Golf Long  Thanh
+|<ref name=":10" /><ref name=":13" />
+|-
+|{{ill|Hoa Hoi (power station)|Hoa Hoi|vi|Điện mặt trời Hòa Hội|vertical-align=sup}}
+|Hoa Hoi commune, Phu Hoa district, Phu Yen province
+|Phu Yen
+|214.2
+|257
+|17/11/2018
+|10/06/2019
+|B.Grimm Phu Yen + Truong Thanh Vietnam Group JSC (TTVN)
+|Operation
+|
+|<ref>{{Cite web|url=https://thanhnien.vn/tai-chinh-kinh-doanh/nha-may-dien-mat-troi-dau-tien-o-phu-yen-di-vao-hoat-dong-1096425.html|title=Nhà máy điện mặt trời đầu tiên ở Phú Yên đi vào hoạt động|last=Đức Huy|date=2019-06-25|website=Thanh Niên Online}}</ref><ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/dong-tho-nha-may-dien-mat-troi-dau-tien-tai-phu-yen.html|title=Động thổ nhà máy điện mặt trời đầu tiên tại Phú Yên|last=NANGLUONGVIETNAM|date=2018-11-18|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|Truc Son
+|5 hamlet, Truc Son commune, Cu Jut district, Dak Nong province
+|Dak Nong
+|36.5
+|44.4
+|02/2018
+|14/06/2019
+|GEC/TTC
+|Operation
+|
+|<ref>{{Cite web|url=http://cafef.vn/gec-van-hanh-thuong-mai-nha-may-dien-mat-troi-truc-son-chiem-12-thi-phan-dien-mat-troi-ca-nuoc-20190629113037125.chn|title=GEC vận hành thương mại nhà máy điện mặt trời Trúc Sơn, chiếm 12% thị phần điện mặt trời cả nước|last=Ánh Dương|date=2019-06-29|website=cafef.vn}}</ref><ref>{{Cite web|url=http://truyenhinhdaknong.vn/tin-tuc/3-nha-dau-tu-chuan-bi-trien-khai-du-an-nha-may-dien-mat-troi-truc-son-2329.html|title=3 nhà đầu tư chuẩn bị triển khai Dự án nhà máy điện mặt trời Trúc Sơn|last=H'Loan|date=2018-04-03|website=truyenhinhdaknong.vn}}</ref><ref name=":13" />
+|-
+|Phong Phu
+|Phong Phu commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|38
+|42
+|08/2018
+|27/04/2019
+|Solarcom
+|Operation
+|
+|<ref>{{Cite web|url=https://nhandan.com.vn/kinhte/item/40006502-nha-may-dien-mat-troi-phong-phu-hoa-luoi-dien-quoc-gia.html|title=Nhà máy điện mặt trời Phong Phú hòa lưới điện quốc gia|last=Đình Châu|date=2019-04-27|website=Nhân Dân Online}}</ref><ref name=":13" />
+|-
+|{{ill|BMT Solar farm Dak Lak |vi|Điện mặt trời BMT Krông Pắk|vertical-align=sup}}
+|Ea Phe commune, Krong Pac district, Dak Lak province
+|Dak Lak
+|25
+|30
+|10/2018
+|25/04/2019
+|AMI and AC Energy
+|Operation
+|EPC general contractor unit (cooperation between Malaysia ERS Company and Vietnam IPC Group)
+|<ref>{{Cite web|url=https://congthuong.vn/du-an-dien-mat-troi-bmt-dak-lak-chinh-thuc-hoa-luoi-dien-quoc-gia-118923.html|title=Dự án điện mặt trời BMT Đắk Lắk chính thức hòa lưới điện quốc gia|last=Thái Hưng|date=2019-04-26|website=congthuong.vn}}</ref><ref>{{Cite web|url=http://tietkiemnangluong.vn/d6/news/Trang-trai-dien-mat-troi-BMT-Dak-Lak-cong-suat-30-MWp-di-vao-hoat-dong-111-136-11953.aspx|title=Trang trại điện mặt trời BMT Đắk Lắk công suất 30 MWp đi vào hoạt động|last=Bùi Long|date=2019-05-02|website=tietkiemnangluong.vn}}</ref><ref name=":13" />
+|-
+|Jang Pong Solar farm Dak Lak
+|Ea Huar commune, Buon Don district, Dak Lak province
+|Dak Lak
+|24
+|30
+|
+|21/11/2020
+|Cao Nguyen IE JSC
+|Operation
+|The plant is connected to the 35kVA grid, after going into operation, the commercial electricity supply will provide 17.5 million kWh of electricity per year.
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/du-an-dien-mat-troi-thu-tu-tai-dak-lak-di-vao-hoat-dong.html|title=Dự án điện mặt trời thứ tư tại Đắk Lắk đi vào hoạt động|last=NANGLUONGVIETNAM|date=2019-05-09|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|Mo Duc solar farm |vi|Điện mặt trời Mộ Đức|vertical-align=sup}}
+|Duc Minh commune, Mo Duc district, Quang Ngai province
+|Quang Ngai
+|19.2
+|
+|08/2015
+|26/04/2019
+|Thien Tan Group
+|Operation
+|FTC Solar Tracking
+|<ref>{{Cite web|url=https://vnexpress.net/kinh-doanh/quang-ngai-khanh-thanh-nha-may-dien-mat-troi-900-ty-dong-3915630.html|title=Quảng Ngãi khánh thành nhà máy điện mặt trời 900 tỷ đồng|last=Phạm Linh|date=2019-04-26|website=vnexpress.net}}</ref><ref name=":13" />
+|-
+|{{ill|Binh Nguyen solar farm |vi|Điện mặt trời Bình Nguyên|vertical-align=sup}}
+|Nam Binh village, Binh Nguyen commune, Binh Son district, Quang Ngai
+|Quang Ngai
+|40.8
+|49.6
+|20/09/2018
+|18/05/2019
+|Truong Thanh Quang Ngai High Technology and Energy JSC
+|Operation
+|General contractors are Sharp Corporation (Japan) and Hawee Construction and Industry JSC (Vietnam). Truong Thanh Quang Ngai High Technology and Energy JSC was established by Vietnam Joint Venture Group and Sermsang Power Corporation (Kingdom of Thailand).
+|<ref>{{Cite web|url=http://baoquangngai.vn/channel/2025/201906/nha-may-dien-mat-troi-binh-nguyen-chinh-thuc-di-vao-van-hanh-2948927/|title=Nhà máy Điện mặt trời Bình Nguyên: Chính thức đi vào vận hành|last=Thanh Nhị|date=2019-06-03|website=Quảng Ngãi News}}</ref><ref name=":13" />
+|-
+|AMI Khanh Hoa
+|Cam An Nam commune, Cam Lam district, Khanh Hoa province
+|Khanh Hoa
+|47.5
+|49.9
+|24/08/2018
+|30/05/2019
+|AMI Khanh Hoa Energy JSC
+|Operation
+|
+|<ref>{{Cite web|url=http://tinhuykhanhhoa.vn/tin-chi-tiet/id/4264/Cac-du-an-dien-mat-troi--Dong-luc-moi-cho-phat-trien-kinh-te|title=Các dự án điện mặt trời: Động lực mới cho phát triển kinh tế|last=Khánh Hòa News|date=2019-05-31|website=tinhuykhanhhoa.vn}}</ref><ref name=":13" />
+|-
+|KN Van Ninh
+|Van Hung commune, Van Ninh district, Khanh Hoa province
+|Khanh Hoa
+|86.7
+|100
+|
+|07/12/2020
+|KN Van Ninh Solar Development and Investment Company Limited
+|Operation
+|
+|<ref>{{Cite web|last=VnExpress|title=KN Vạn Ninh khánh thành dự án nhà máy điện mặt trời|url=https://vnexpress.net/kn-van-ninh-khanh-thanh-du-an-nha-may-dien-mat-troi-4214932.html|access-date=2021-07-14|website=vnexpress.net|language=vi}}</ref>
+|-
+|Krong Pa 2
+|Chu Gu commune, Krong Pa district, Gia Lai province
+|Gia Lai
+|39
+|49
+|
+|2019
+|Thanh Nguyen Development and Investment Company Limited
+|Operation
+|
+|
+|-
+|Loc Ninh 1
+|Loc Tan commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc 
+|187.5
+|
+|
+|19/12/2020
+|Loc Ninh Energy JSC
+|Operation
+|
+|
+|-
+|Loc Ninh 2
+|Loc Tan commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc 
+|187.5
+|
+|
+|19/12/2020
+|Loc Ninh Energy JSC
+|Operation
+|
+|
+|-
+|Loc Ninh 3
+|Loc Tan commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc 
+|125
+|
+|
+|22/12/2020
+|Loc Ninh Energy JSC
+|Operation
+|
+|
+|-
+|Loc Ninh 4
+|Loc Tan commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc 
+|162
+|
+|
+|21/12/2020
+|Loc Ninh 4 Energy JSC
+|Operation
+|
+|
+|-
+|Loc Ninh 5
+|Loc Tan commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc 
+|40
+|
+|
+|21/12/2020
+|Loc Ninh 4 Energy JSC
+|Operation
+|
+|
+|-
+|Long Son
+|Ninh Son commune, Ninh Hoa district, Khanh Hoa province
+|Khanh Hoa
+|140
+|
+|
+|02/12/2020
+|Long Son Energy JSC
+|Operation
+|
+|
+|-
+|My Hiep
+|My Hiep commune, Phu My district, Binh Dinh province
+|Binh Dinh
+|40.8
+|
+|
+|11/12/2020
+|Vietnam Renewable Energy JSC
+|Operation
+|
+|<ref>{{Cite web|title=Khánh thành Nhà máy điện mặt trời Mỹ Hiệp|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khanh-thanh-nha-may-dien-mat-troi-my-hiep.html|access-date=2021-07-15|website=Nangluongvietnam.vn}}</ref>
+|-
+|Phu My 1
+|My Thang and My An commune, Phu My district, Binh Dinh province
+|Bình Dinh
+|100
+|144
+|
+|14/12/2020
+|Clean Energy Vision Development JSC
+|Operation
+|
+|
+|-
+|Phu My 2
+|My Thang and My An commune, Phu My district, Binh Dinh province
+|Bình Dinh
+|93.8
+|110
+|
+|27/12/2020
+|Clean Energy Vision Development JSC
+|Operation
+|
+|
+|-
+|Phu My 3
+|My Thang and My An commune, Phu My district, Binh Dinh province
+|Bình Dinh
+|81.3
+|
+|
+|18/12/2020
+|Clean Energy Vision Development JSC
+|Operation
+|
+|
+|-
+|Phuoc Ninh
+|Phuoc Ninh and Phuoc Minh commune, Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|36.9
+|45
+|
+|12/06/2020
+|Ninh Thuan Energy Industry JSC
+|Operation
+|
+|<ref>{{Cite web|title=Khánh thành Nhà máy điện mặt trời Phước Ninh|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khanh-thanh-nha-may-dien-mat-troi-phuoc-ninh.html|access-date=2021-07-14|website=Nangluongvietnam.vn}}</ref>
+|-
+|Phuoc Thai 1
+|Phuoc Thai commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|42
+|50
+|
+|04/07/2020
+|EVN
+|Operation
+|
+|<ref>{{Cite web|last=Thương|first=Báo Công|date=2020-08-12|title=Nhà máy điện mặt trời Phước Thái 1 chính thức hoạt động {{!}} Báo Công Thương|url=https://congthuong.vn/nha-may-dien-mat-troi-phuoc-thai-1-chinh-thuc-hoat-dong-142026.html|access-date=2021-07-14|website=Báo Công Thương điện tử, kinh tế, chính trị, xã hội|language=vi}}</ref>
+|-
+|{{ill|Song Giang |vi|Điện mặt trời Sông Giang|vertical-align=sup}}
+|Cam Thinh Dong and Cam Thinh Tay communes, Cam Ranh city, Khanh Hoa province
+|Khanh Hoa
+|42
+|50
+|11/2018
+|15/04/2019
+|Song Giang Solar Power JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://baokhanhhoa.vn/kinh-te/201905/khanh-thanh-nha-may-dien-mat-troi-song-giang-8116002/|title=Khánh thành Nhà máy Điện mặt trời Sông Giang|last=Đình Lâm|date=2019-05-25|website=Khánh Hòa Online}}</ref><ref name=":13" />
+|-
+|Tan Chau 1
+|Tan Thanh commune, Tam Chau district, Tay Ninh province
+|Tay Ninh
+|41.2
+|50
+|
+|24/09/2020
+|Tan Chau Energy JSC
+|Operation
+|
+|<ref name=":0" />
+|-
+|Thac Mo
+|Thac Mo commune, Phuoc Long district, Binh Phuoc province
+|Binh Phuoc
+|40.8
+|50
+|
+|05/12/2020
+|Thac Mo Hydropower JSC
+|Operation
+|
+|<ref>{{Cite web|title=Nhà máy điện mặt trời Thác Mơ hòa lưới điện quốc gia|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nang-luong-tai-tao/nha-may-dien-mat-troi-thac-mo-hoa-luoi-dien-quoc-gia.html|access-date=2021-07-14|website=Nangluongvietnam.vn}}</ref>
+|-
+|Thanh Long Phu Yen
+|Son Thanh Dong commune, Tay Hoa district, Phu Yen province
+|Phu Yen
+|32.8
+|50
+|
+|02/12/2020
+|Thanh Long Phu Yen Solar JSC
+|Operation
+|
+|<ref>{{Cite web|last=|title=Đóng điện Nhà máy điện mặt trời Thành Long Phú Yên|url=https://nangluongsachvietnam.vn/d6/vi-VN/news/Dong-dien-Nha-may-dien-mat-troi-Thanh-Long-Phu-Yen-6-165-8577|access-date=2021-07-14|website=nangluongsachvietnam.vn}}</ref>
+|-
+|Thien Tan 1.2
+|Phuoc Ha commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|85.4
+|100
+|
+|31/12/2020
+|Ninh Thuan Energy Industry JSC
+|Operation
+|
+|<ref name=":16">{{Cite web|title=T&T Group đồng loạt hòa lưới ba nhà máy điện mặt trời|url=https://nhandan.vn/thong-tin-doanh-nghiep/t-t-group-dong-loat-hoa-luoi-ba-nha-may-dien-mat-troi-630616/|access-date=2021-07-14|website=Báo Nhân Dân|language=en}}</ref>
+|-
+|Thien Tan 1.3
+|Phuoc Vinh commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|43
+|50
+|
+|28/12/2020
+|Ninh Thuan Energy Industry JSC
+|Operation
+|
+|<ref name=":16" />
+|-
+|Thien Tan Solar
+|Phuoc Trung commune, Bac Ai district,  Ninh Thuan province
+|Ninh Thuan
+|43
+|50
+|
+|07/03/2020
+|Thien Tan Group
+|Operation
+|
+|
+|-
+|Thuan Nam Duc Long
+|Phuoc Minh commune, Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|43
+|50
+|
+|24/12/2019
+|DLG Ninh Thuan Solar JSC
+|Operation
+|
+|
+|-
+|Trung Nam Thuan Nam
+|Phuoc Minh commune, Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|450
+|630
+|
+|30/09/2020
+|Trung Nam Thuan Nam Solar Power Company Limited 
+|Operation
+|
+|<ref>{{Cite web|date=2020-10-12|title=Khánh thành dự án điện mặt trời lớn nhất Đông Nam Á tại Ninh Thuận|url=https://tuoitre.vn/news-20201012144659039.htm|access-date=2021-07-14|website=TUOI TRE ONLINE|language=vi}}</ref>
+|-
+|Trung Son
+|Cam An Bac commune, Cam Lam district, Khanh Hoa province
+|Khanh Hoa
+|29.6
+|35
+|
+|20/12/2020
+|Trung Son Energy Development JSC
+|Operation
+|
+|<ref>{{Cite web|last=ELECTRIC|first=TRUONG GIANG|title=Đóng điện thành công nhà máy điện mặt trời Trung Sơn|url=http://www.tg-electric.com.vn/tin-tuc/tin-nganh/dong-dien-thanh-cong-nha-may-dien-mat-troi-trung-son-1064.html|access-date=2021-07-14|website=TRƯỜNG GIANG ELECTRIC|language=vi}}</ref>
+|-
+|VNECO
+|Trung Nghia commune, Vung Liem district, Vinh Long province
+|Vinh Long
+|42
+|50
+|
+|29/12/2020
+|Vneco - Vinh Long Solar Power One Member Limited Company
+|Operation
+|
+|<ref>{{Cite web|date=2020-12-30|title=Nhà máy điện mặt trời đầu tiên tại Vĩnh Long hòa lưới|url=https://tuoitre.vn/news-20201230143759492.htm|access-date=2021-07-14|website=TUOI TRE ONLINE|language=vi}}</ref>
+|-
+|Xuan Thien - Ea Sup 1
+|Ia Lop and Ia Rve commune, Ea Sup district, Dak Lak province
+|Dak Lak
+|600
+|831
+|
+|08/12/2020
+|Xuan Thien Group
+|Operation
+|
+|<ref>{{Cite web|title=Nhà máy điện mặt trời Xuân Thiện - Ea Súp đóng điện thành công giai đoạn I - Chi tiết tin - Trang chủ|url=https://daklak.gov.vn/-/nha-may-ien-mat-troi-xuan-thien-ea-sup-ong-ien-thanh-cong-giai-oan-i|access-date=2021-07-14|website=daklak.gov.vn}}</ref>
+|-
+|Chu Ngoc - EVNLICOGI 16
+|B’Lang village, Chu Ngọc commune, Krong Pa district, Gia Lai province
+|Gia Lai
+|12.8
+|15
+|01/2019
+|28/05/2019
+|LICOGI 16 Gia Lai Renewable Energy Investment JSC
+|Operation
+|
+|<ref>{{Cite web|url=http://licogi16.vn/vi/news/51/nha-may-dien-mat-troi-chu-ngoc-%E2%80%93evnlicogi-16-hoa-luoi-dien-231.html|title=Nhà máy điện mặt trời Chư Ngọc –EVNLICOGI 16 hòa lưới điện|last=licogi16.vn|date=2019-05-30}}</ref><ref name=":13" />
+|-
+|Vinh Hao solar farm
+|Vinh Hao commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|30
+|34.2
+|
+|16/05/2019
+|Vinh Hao Solar Power JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Vinh Hao 4 solar farm
+|Vinh Hao commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|36.8
+|39
+|
+|28/05/2019
+|Quynh Quang Real Estate Company
+|Operation
+|
+|<ref name=":13" />
+|-
+|{{ill|Vinh Hao 6 solar farm |vi|Điện mặt trời Vĩnh Hảo 6|vertical-align=sup}}
+|Vinh Hao commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|40.6
+|50
+|25/10/2018
+|18/06/2019
+|Vinh Hao 6 Energy JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://fecon.com.vn/tin-tuc-fecon/tin-tuc-du-an/nha-may-dien-mat-troi-vinh-hao-6-chinh-thuc-dong-tho.html|title=Nhà máy Điện mặt trời Vĩnh Hảo 6 chính thức động thổ|last=FECON|date=2018-10-30|website=fecon.com.vn}}</ref><ref>{{Cite web|url=https://baodautu.vn/fecon-chinh-thuc-van-hanh-thuong-mai-nha-may-dien-mat-troi-vinh-hao-6-d102674.html|title=FECON chính thức vận hành thương mại Nhà máy Điện mặt trời Vĩnh Hảo 6|last=Minh Hải|date=2019-06-25|website=Đầu Tư Online}}</ref><ref name=":13" />
+|-
+|Van Giao 2 solar power
+|An Cu commune, Tinh Bien district, An Giang province
+|An Giang
+|40
+|50
+|
+|16/06/2019
+|Van Giao Solar Energy JSC
+|Operation
+| rowspan="2" |TrinaSolar. 0.38 / 22kV pressure lifting station, 22kV medium voltage cable and working road to each solar array; operator area; 22kV distribution area, 22 / 110kV pressure lifting station. 110 kV transmission line of solar power plant Van Giao - Tinh Bien connected to Van Giao 2 solar power plant into 110 kV Tinh Bien substation. Powerchina Zhongnan Corporation Limited (China) is the EPC general contractor
+|<ref name=":13" />
+|-
+|Van Giao 1 solar power
+|An Cu commune, Tinh Bien district, An Giang province
+|An Giang
+|40
+|50
+|
+|17/06/2019
+|Van Giao Solar Energy JSC
+|Operation
+|<ref name=":13" />
+|-
+|Solar Park 01
+|Hamlet 3, Binh Hoa Nam Commune, Duc Hue District, Long An Province
+|Long An
+|40.8
+|50
+|
+|18/06/2019
+|Hoan Cau Long An
+|Operation
+|
+|<ref name=":13" />
+|-
+|Solar Park 02 
+|Hamlet 3, Binh Hoa Nam Commune, Duc Hue District, Long An Province
+|Long An
+|40.8
+|50
+|
+|19/06/2019
+|Vietnamsolar JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|[[Cam Hoa solar farm]]
+|Cam Hoa commune, Cam Xuyen district, Ha Tinh province
+|Ha Tinh
+|43.8
+|50
+|15/01/2019
+|01/07/2019
+|Hoanh Son Group JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://baotainguyenmoitruong.vn/kinh-te/ha-tinh-khanh-thanh-nha-may-dien-mat-troi-cong-suat-50-mwp-1271332.html|title=Hà Tĩnh: Khánh thành nhà máy điện mặt trời công suất 50 MWp|last=Đức Cảnh|date=2019-07-01|website=Tài Nguyên Môi Trường News}}</ref><ref name=":13" />
+|-
+|Eco Seido Tuy Phong
+|Phong Phu commune and Phu Lac commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|40
+|51
+|28/03/2018
+|12/06/2019
+|Green Energy LLC
+|Operation
+|
+|<ref>{{Cite web|url=https://vtv.vn/kinh-te/khanh-thanh-nha-may-nang-luong-mat-troi-tai-binh-thuan-20190616202906578.htm|title=Khánh thành nhà máy năng lượng mặt trời tại Bình Thuận|last=Đức Phú|date=2019-06-16|website=vtv.vn}}</ref><ref name=":13" />
+|-
+|{{ill|TTC Duc Hue 1|vi|Điện mặt trời Đức Huệ|vertical-align=sup}}
+|My  Thanh Bac commune, Duc Hue district, Long An province
+|Long An
+|40.8
+|49
+|31/08/2018
+|2020
+|GEG/TTC
+|Operation
+|
+|<ref>{{Cite web|url=https://www.dag.vn/article/geg-se-vay-638-ty-dong-cho-nha-may-dien-mat-troi-ttc-duc-hue-1-737-656355-733.da|title=GEG sẽ vay 638 tỷ đồng cho Nhà máy Điện Mặt Trời TTC Đức Huệ 1|last=Minh Nhật|date=2019-02-28|website=Dong A Securities}}</ref><ref>{{Cite web|url=http://hawee-idc.com/hawee-idc-dong-tho-nha-may-dien-nang-luong-mat-troi-tcc-duc-hue-01-long.html|title=HAWEE IDC động thổ Nhà máy điện năng lượng mặt trời TCC Đức Huệ 01- Long An|last=HAWEE IDC|date=2018-09-05|website=hawee-idc.com}}</ref><ref name=":13" />
+|-
+|{{ill|Trung Nam Ninh Thuan solar power |vi|Điện mặt trời Trung Nam Ninh Thuận|vertical-align=sup}}
+|Bac  Phong commune and Loi Hai commune, Thuan Bac district, Ninh Thuan province
+|Ninh Thuan
+|204
+|258
+|07/07/2018
+|13/04/2019
+|Trung Nam JSC
+|Operation
+|Siemens Inverter
+|<ref>{{Cite web|url=https://vnexpress.net/kinh-doanh/ninh-thuan-hut-cac-du-an-dien-mat-troi-3909955.html|title=Ninh Thuận hút các dự án điện mặt trời|last=Hoài Phong|date=2019-04-17|website=VNEXPRESS News}}</ref><ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khoi-cong-du-an-nha-may-dien-mat-troi-trung-nam.html|title=Khởi công dự án Nhà máy điện mặt trời Trung Nam|last=NANGLUONGVIETNAM|date=2018-07-08|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|Da Bac solar power
+|Da  Bac Industrial Area, Da Bac Commune, Chau Duc District, Ba Ria Vung Tau  Province
+|Ba Ria-Vung Tau
+|48
+|61
+|12/2018
+|14/05/2019
+|Dong A JSC
+|Operation
+|
+|<ref name=":432">{{Cite web|url=http://ptc4.npt.evn.vn/d6/vi-VN/news/Dau-noi-tram-220kV-Nha-may-dien-mat-troi-Da-Bac-vao-luoi-truyen-tai-dien-Quoc-gia--6-191-378|title=Đấu nối trạm 220kV Nhà máy điện mặt trời Đá Bạc vào lưới truyền tải điện Quốc gia|last=Lê Thanh Hòa & Tạ Hoàng Nam|date=2019-04-26|website=EVNNPT PTC4}}</ref><ref name=":532">{{Cite web|url=http://www.baobariavungtau.com.vn/kinh-te/201906/uu-tien-dau-tu-dien-nang-luong-mat-troi-858554/|title=Ưu tiên đầu tư điện năng lượng mặt trời|last=Đông Hiếu|date=2019-06-13|website=Bà Rịa-Vũng Tàu News}}</ref><ref name=":13" />
+|-
+|Da Bac 2 solar power
+|Da  Bac Industrial Area, Da Bac Commune, Chau Duc District, Ba Ria Vung Tau  Province
+|Ba Ria-Vung Tau
+|48
+|61
+|12/2018
+|01/05/2019
+|Tai Tien Limited Liability Company
+|Operation
+|
+|<ref name=":432" /><ref name=":13" />
+|-
+|Da Bac 3 solar power
+|Da  Bac Industrial Area, Da Bac Commune, Chau Duc District, Ba Ria Vung Tau  Province
+|Ba Ria-Vung Tau
+|42
+|50
+|12/2018
+|8/5/2019
+|Green HC Limited Liability Company
+|Operation
+|
+|<ref name=":432" /><ref name=":13" />
+|-
+|Da Bac 4 solar power
+|Da  Bac Industrial Area, Da Bac Commune, Chau Duc District, Ba Ria Vung Tau  Province
+|Ba Ria-Vung Tau
+|42
+|50
+|12/2018
+|11/6/2019
+|Dong A Chau Duc JSC
+|Operation
+|
+|<ref name=":432" /><ref name=":532" /><ref name=":13" />
+|-
+|{{ill|Dau Tieng 1, 2|vi|Điện mặt trời Dầu Tiếng|vertical-align=sup}}
+|Duong  Minh Chau and Tan Chau districts, Tay Ninh province
+|Tay Ninh
+|350
+|420
+|23/06/2018
+|2019
+|B. Grimm Power + Xuan Cau LLC
+|Operation
+|EPC:Power Huadong  Engineering, PCC1 and PECC2: Substation
+|<ref name=":20" /><ref name=":21" /><ref name=":13" />
+|-
+|{{ill|Dau Tieng 3|vi|Điện mặt trời Dầu Tiếng|vertical-align=sup}}
+|Duong  Minh Chau and Tan Chau districts, Tay Ninh province
+|Tay Ninh
+|60
+|72
+|23/06/2018
+|2019
+|B. Grimm Power + Xuan Cau LLC
+|Operation
+|EPC:Power Huadong  Engineering, PCC1 and PECC2: Substation
+|<ref name=":20">{{Cite web|url=https://congthuong.vn/tay-ninh-danh-thuc-tiem-nang-nang-luong-tai-tao-121715.html|title=Tây Ninh: "Đánh thức" tiềm năng năng lượng tái tạo|last=Thế Vĩnh|date=2019-06-29|website=Công Thương Online}}</ref><ref name=":21">{{Cite web|url=https://baomoi.com/xay-dung-nha-may-dien-mat-troi-lon-nhat-chau-a-tai-tay-ninh/c/26607260.epi|title=Xây dựng nhà máy điện mặt trời lớn nhất châu Á tại Tây Ninh|last=Phùng Nguyên|date=2018-06-21|website=Báo Mới Online}}</ref><ref name=":13" />
+|-
+|VSP Binh Thuan II
+|Vinh Hao, Tuy Phong, Binh Thuan
+|Binh Thuan
+|26.5
+|33.1
+|
+|2019
+|VSP Binh Thuan JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Binh Hoa
+|Binh Hoa commune, Chau Thanh district, An Giang province
+|An Giang
+|10
+|12
+|
+|22/06/2019
+|Pacific Energy Network Viet Nam Company Limited
+|Operation
+|
+|<ref name=":13" />
+|-
+|Dien Luc Mien Trung
+|Cam An Bac commune, Cam Lam district, Khanh Hoa province
+|Khanh Hoa
+|50
+|
+|
+|14/06/2019
+|EVNCPC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Ham Kiem
+|Ham Kiem commune, Ham Thuan Nam district, Binh Thuan province
+|Binh Thuan
+|45
+|49
+|
+|16/05/2019
+|Truong Thanh Binh Thuan Solar JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|KCN Chau Duc
+|Nghia Thanh commune, Chau Duc district, Ba Ria - Vung Tau province
+|Ba Ria - Vung Tau
+|58
+|70
+|
+|29/05/2019
+|Hoang Viet Hung Company Limited
+|Operation
+|
+|<ref name=":13" />
+|-
+|Thuan Minh 2
+|Thuan Minh commune, Ham Thuan district, Binh Thuan province
+|Binh Thuan
+|42.5
+|50
+|
+|20/06/2019
+|TRUONG THANH CONSTRUCTION JOINT STOCK COMPANY
+|Operation
+|
+|<ref name=":13" />
+|-
+|Thinh Long - AAA Phu Yen
+|Son Thanh Dong commune, Tay Hoa district, Phu Yen province
+|Phu Yen
+|43.8
+|50
+|
+|22/06/2019
+|Thinh Long Phu Yen Solar JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Tuan An
+|Cam Thinh Tay commune, Cam Ranh district, Khanh Hoa province
+|Khanh Hoa
+|10
+|11.7
+|
+|01/06/2019
+|Tuan An Solar JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Phong Dien 2
+|Luong Mai village, Phong  Chuong commune, Phong Dien district, Thua Thien Hue province
+|Thua Thien Hue
+|40
+|50
+|
+|10/12/2020
+|Doan  Son Thuy JSC
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/ky-hop-dong-mua-ban-dien-nm-dien-mat-troi-phong-dien-2.html|title=Ký hợp đồng mua bán điện NM điện mặt trời Phong Điền 2|last=NANGLUONGVIETNAM|date=2018-11-04|website=Năng Lượng Việt Nam}}</ref>
+|-
+|{{ill|Fujiwara Binh Dinh|vi|Điện mặt trời và điện gió Fujiwara Bình Định|vertical-align=sup}}
+|Nhon  Hoi Economic Zone, Quy Nhon City, Binh Dinh Province
+|Binh Dinh
+|40
+|50
+|04/2018
+|20/06/2019
+|Fujiwara Binh Dinh Ltd.
+|Operation
+|
+|<ref>{{Cite web|url=https://moitruong.net.vn/binh-dinh-nha-may-dien-mat-troi-fujiwara-sap-dua-vao-thu-nghiem-ket-noi-luoi-dien-quoc-gia/|title=Bình Định: Nhà máy điện mặt trời Fujiwara sắp đưa vào thử nghiệm kết nối lưới điện quốc gia|last=Bình Minh|date=2019-03-27|website=moitruong.net.vn}}</ref><ref name=":13" />
+|-
+|{{ill|My Son|vi|Điện mặt trời Mỹ Sơn|vertical-align=sup}}
+|My  Son commune, Ninh Son district, Ninh Thuan
+|Ninh Thuan
+|50
+|62
+|27/06/2019
+|2020
+|My Son 1 Solar Power JSC
+|Operation
+|EPC: LICOGI 16
+|<ref name=":92">{{Cite web|url=http://licogi16.vn/vi/news/51/khoi-cong-2-du-an-dien-mat-troi-licogi-16-lam-tong-thau-epc-240.html|title=Khởi công 2 dự án điện mặt trời LICOGI 16 làm tổng thầu EPC|last=licogi16.vn|date=2019-06-28}}</ref>
+|-
+|{{ill|My Son 2|vi|Điện mặt trời Mỹ Sơn|vertical-align=sup}}
+|My  Son commune, Ninh Son district, Ninh Thuan
+|Ninh Thuan
+|40
+|50
+|27/06/2019
+|2020
+|My Son 2 Solar Power JSC
+|Operation
+|EPC: LICOGI 16
+|<ref name=":92" />
+|-
+|Sinenergy Ninh Thuan 1
+|Tan Duc village, Phuoc Huu commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|42.5
+|50
+|10/12/2018
+|16/10/2019
+|Sinenergy  Holdings Singapore
+|Operation
+|
+|<ref>{{Cite web|url=https://devi-renewable.com/news/du-an-nha-may-dien-mat-troi-sinenergy-ninh-thuan-1-vuong-ve-giai-toa-mat-bang/|title=Dự án nhà máy Điện mặt trời Sinenergy Ninh Thuận 1 vướng về giải tỏa mặt bằng|last=DEVI Renewable Energies|date=2019-07-02|website=DEVI Renewable Energies}}</ref>
+|-
+|Hacom Solar
+|Phuoc  Minh commune, Thuan Nam district, Ninh Thuan
+|Ninh Thuan
+|46
+|50
+|08/04/2019
+|25/10/2019
+|Hacom Holdings
+|Operation
+|EPC: Sharp Solar Solution Asia partnership
+|<ref>{{Cite web|url=https://tuoitre.vn/dan-dat-hang-tram-da-tang-chan-xe-du-an-nha-may-dien-mat-troi-20190620154643373.htm|title=Dân đặt hàng trăm đá tảng chặn xe dự án nhà máy điện mặt trời|last=Minh Trân|date=2019-06-20|website=Tuổi Trẻ Online}}</ref><ref>{{Cite web|url=http://hawee-idc.com/hawee-idc-khoi-cong-du-nha-may-dien-mat-troi-hacom-solar.html|title=Hawee IDC khởi công dự án Nhà máy Điện mặt trời Hacom Solar|last=Hawee IDC|date=2019-04-22|website=hawee-idc.com}}</ref>
+|-
+|{{ill|Tuy Phong|vi|Điện mặt trời Tuy Phong|vertical-align=sup}}
+|Vinh Hao commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|30
+|39
+|19/09/2018
+|25/06/2019
+|Power Plus Vietnam LLC
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nang-luong-tai-tao/khoi-cong-du-an-dien-mat-troi-tuy-phong.html|title=Khởi công dự án điện Mặt Trời Tuy Phong|last=NANGLUONGVIETNAM|date=2018-09-20|website=Năng Lượng Việt Nam}}</ref><ref>{{Cite web|url=http://cafef.vn/binh-thuan-sap-co-nha-may-dien-mat-troi-dau-tien-tong-von-dau-tu-1000-ty-dong-20180919170158609.chn|title=Bình Thuận sắp có nhà máy điện mặt trời đầu tiên, tổng vốn đầu tư 1.000 tỷ đồng|last=T.Công|date=2018-09-19|website=cafef.vn}}</ref><ref name=":13" />
+|-
+|{{ill|EuroPlast Long An |vi|Điện mặt trời Europlast Long An|vertical-align=sup}}
+|My Thanh Bac commune, Duc Hue district, Long An province
+|Long An
+|40.8
+|50
+|21/09/2018
+|30/05/2019
+|Europlast Long An JSC
+|Operation
+|
+|<ref>{{Cite web|url=http://baolongan.vn/khoi-cong-nha-may-dien-mat-troi-europlast-long-an-50mw-a63176.html|title=Khởi công nhà máy điện mặt trời Europlast Long An 50MW|last=Mai Hương|date=2018-09-21|website=Long An Online}}</ref><ref name=":13" />
+|-
+|EuroPlast Phu Yen
+|Hoa Quang Nam and Hoa Hoi communes, Phu Hoa district, Phu Yen province
+|Phu Yen
+|40.6
+|50
+|11/2018
+|21/06/2019
+|Europlast Phu Yen JSC
+|Operation
+|
+|<ref>{{Cite web|url=http://techgel.com/ja/nha-may-dien-mat-troi-europlast-phu-yen-52-mwp-.html|title=NHÀ MÁY ĐIỆN MẶT TRỜI EUROPLAST, PHÚ YÊN (52 MWp)|last=techgel.com|date=2018-11-08}}</ref><ref name=":13" />
+|-
+|Solar Park 03, Solar Park 04 (Long An)
+|Hamlet 3, Binh Hoa Nam Commune, Duc Hue District, Long An Province
+|Long An
+|83
+|100
+|
+|7/2020
+|Long An Solar Park JSC
+|Operation
+|
+|
+|-
+|Bach Khoa A Chau 1
+|Hamlet 5, Suoi Day Commune, Tan Chau District, Tay Ninh Province
+|Tay Ninh
+|24.2
+|30
+|
+|13/05/2019
+|Tay Ninh Bach Khoa A Chau JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Tri Viet 1
+|Hamlet 5, Suoi Day Commune, Tan Chau District, Tay Ninh Province
+|Tay Ninh
+|24.2
+|30
+|
+|20/05/2019
+|Tri Viet Tay Ninh JSC
+|Operation
+|
+|<ref name=":122">{{Cite web|last=Giang Phương|date=2018-06-13|title=Hơn 14.000 tỉ đồng đầu tư vào các dự án điện mặt trời|url=https://baomoi.com/hon-14-000-ti-dong-dau-tu-vao-cac-du-an-dien-mat-troi/c/26397499.epi|website=baomoi.com}}</ref><ref name=":13" />
+|-
+|{{ill|HCG (power station)|lt=HCG|vi|Điện mặt trời HCG và HTG|vertical-align=sup}}
+|Tien Thuan and Loi Thuan communes, Ben Cau district, Tay Ninh province
+|Tay Ninh
+|40
+|50
+|11/2018
+|23/05/2019
+|Hoang Thai Gia Trust and Investment Management LLC, HCG Tay Ninh solar power JSC
+|Operation
+| rowspan="2" |This project was initiated and developed by Hai Dang JSC and is invested by Reonyuan Power Singapore
+|<ref name=":132">{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khoi-cong-du-an-dien-mat-troi-hcg-va-htg-tai-tay-ninh.html|title=Khởi công dự án điện mặt trời HCG và HTG tại Tây Ninh|last=NANGLUONGVIETNAM|date=2018-11-27|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|{{ill|HTG (power station)|lt=HTG|vi|Điện mặt trời HCG và HTG|vertical-align=sup}}
+|Tien Thuan and Loi Thuan communes, Ben Cau district, Tay Ninh province
+|Tay Ninh
+|40
+|50
+|11/2018
+|24/05/2019
+|Hoang Thai Gia Trust and Investment Management LLC, HCG Tay Ninh solar power JSC
+|Operation
+|<ref name=":132" /><ref name=":13" />
+|-
+|{{ill|Phan Lam 1 solar power |vi|Điện mặt trời Phan Lâm|vertical-align=sup}}
+|Phan Lam commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|30
+|36.7
+|11/01/2019
+|17/06/2019
+|Nam Viet Phan Lam Company is a joint venture with Thailand's Super Energy Corporation
+|Operation
+|
+|<ref>{{Cite web|url=http://dinhtan.vn/khoi-cong-nha-may-dien-mat-troi-phan-lam/|title=Khởi công nhà máy điện mặt trời Phan Lâm|date=2019-01-11|website=dinhtan.vn}}</ref><ref name=":13" />
+|-
+|{{ill|Phan Lam 2 solar power |vi|Điện mặt trời Phan Lâm|vertical-align=sup}}
+|Phan Lam commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|
+|49
+|10/2018
+|12/14/2020
+|Phan Lam Energy LLC
+|Operation
+|
+|
+|-
+|{{ill|Gio Thanh 1,2 |vi|Điện mặt trời Gio Thành|vertical-align=sup}}
+|Gio Thanh and Gio Hai communes, Gio Linh district, Quang Tri
+|Quang Tri
+|83.5
+|100
+|26/06/2019
+|28/11/2020
+|Gio Thanh Energy JSC, Seco JSC
+|Operation
+|Gio Thanh 1 and 2 solar power plants will install approximately 3,000 battery panels, 20 stations with inverter and medium voltage transformer, connected by 110kV voltage to Quan Ngang 110kV substation and expected to complete finished after 6 months of construction.
+|<ref>{{Cite web|url=https://baodautu.vn/quang-tri-khoi-cong-nha-may-dien-mat-troi-gio-thanh-1-va-gio-thanh-2-d102786.html|title=Quảng Trị: Khởi công Nhà máy điện mặt trời Gio Thành 1 và Gio Thành 2|last=Tiến Nhất|date=2019-06-26|website=Đầu Tư Online}}</ref>
+|-
+|Thuan Nam 12
+|Phuoc Ha commune, Thuan Nam district, Ninh Thuan province
+|[[Ninh Thuận Province|Ninh Thuan]]
+|46
+|50
+|
+|07/08/2020
+|Thanh Vinh Solar JSC
+|Operation
+|
+|
+|-
+|Thuan Nam 19
+|Phuoc Minh commune, Thuan Nam district, Ninh Thuan province
+|[[Ninh Thuận Province|Ninh Thuan]]
+|49
+|60
+|
+|24/06/2020
+|Tasco Energy JSC
+|Operation
+|Annex 2, 4614/BCT-DL
+|
+|-
+|Nui Mot Lake solar power plant
+|Phuoc Dinh commune, Thuan Nam district, Ninh Thuan province
+|[[Ninh Thuận Province|Ninh Thuan]]
+|42.5
+|71
+|
+|05/12/2020
+|Truong Thanh Construction And Development Investment JSC
+|Operation
+|
+|
+|-
+|{{ill|Trung Nam Tra Vinh solar power|vi|Điện mặt trời Trung Nam Trà Vinh|vertical-align=sup}}
+|Dan Thanh commune, Duyen Hai town, Tra Vinh province
+|Tra Vinh
+|140.8
+|165
+|19/01/2019
+|20/06/2019
+|Trungnam Tra Vinh Solar Power
+|Operation
+|
+|<ref>{{Cite web|url=https://www.baogiaothong.vn/dong-tho-xay-dung-du-an-nha-may-dien-mat-troi-hon-3500-ti-o-tra-vinh-d408222.html|title=Động thổ xây dựng dự án Nhà máy Điện mặt trời hơn 3500 tỉ ở Trà Vinh|last=Lê An|date=2019-01-20|website=Giao Thông News}}</ref><ref name=":13" />
+|-
+|{{ill|Binh An |vi|Điện mặt trời Bình An|vertical-align=sup}}
+|Binh An commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|42.5
+|50
+|
+|19/06/2019
+|Everich Binh Thuan Energy LLC
+|Operation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/chap-thuan-dau-tu-du-an-dien-mat-troi-binh-an.html|title=Chấp thuận đầu tư dự án điện mặt trời Bình An|last=NANGLUONGVIETNAM|date=2018-07-13|website=Năng Lượng Việt Nam}}</ref><ref name=":13" />
+|-
+|Se San 4
+|Se San river, Ia O commune, Ia Grai district, Gia Lai province
+|Gia Lai
+|40.6
+|49
+|
+|01/12/2019
+|EVNPMB2
+|Operation
+|EVN signs 24.2 million EUR loan agreement for the 49 MW Se San 4 solar project with AFD.
+|
+|-
+|Bau Zon
+|Phuoc Huu commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|20
+|
+|
+|05/08/2020
+|Sunglim.tt Solar Power Company Limited
+|Operation
+|
+|<ref name=":0" />
+|-
+|Nhon Hai Solar Farm
+|Khanh Phuoc hamlet, Nhon Hai commune, Ninh Hai district, Ninh Thuan province
+|Ninh Thuan
+|28
+|35
+|07/2019
+|27/06/2020
+|Licogi 16 Ninh Thuan RE JSC
+|Operation
+|free land use, NOT  allowed to transfer to other investor
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/trao-giay-phep-dau-tu-du-an-dien-mat-troi-solar-farm-nhon-hai.html|title=Trao giấy phép đầu tư dự án điện mặt trời Solar Farm Nhơn Hải|last=NANGLUONGVIETNAM|date=2019-04-08|website=Năng Lượng Việt Nam}}</ref>
+|-
+|Hong Phong 5.2
+|In  Hong Phong commune, Bac Binh district, Binh Thuan province, Binh Thuan  province
+|Binh Thuan
+|38.4
+|48
+|
+|26/12/2020
+|Thien Nien Ky Energy JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://vietstock.vn/2019/05/dien-mat-troi-binh-thuan-kho-ve-dich-dung-han-768-677930.htm|title=Điện mặt trời Bình Thuận khó về đích đúng hạn|last=Việt Khánh|date=2019-05-11|website=vietstock.vn}}</ref>
+|-
+|{{ill|Phuoc  Huu - Dien luc 1|vi|Điện mặt trời Phước Hữu|vertical-align=sup}}
+|Phuoc Huu commune, Ninh Phuoc district, Ninh Thuan
+|Ninh Thuan
+|28.1
+|30.2
+|07/2018
+|09/05/2019
+|Phuoc Huu Power JSC
+|Operation
+|
+|<ref>{{Cite web|url=https://bnews.vn/nha-may-dien-mat-troi-phuoc-huu-dien-luc-1-chinh-thuc-khanh-thanh/125409.html|title=Nhà máy điện mặt trời Phước Hữu - Điện lực 1 chính thức khánh thành|last=Công Thử|date=2019-06-16|website=bnews.vn}}</ref><ref name=":13" />
+|-
+|My  Son - Hoan Loc Viet
+|My  Son commune, Ninh Son district, Ninh Thuan
+|Ninh Thuan
+|37.5
+|50
+|01/07/2018
+|13/06/2019
+|My  Son - Hoan Loc Viet Solar JSC
+|Operation
+|
+|<ref name=":13" />
+|-
+|Adani Phuoc Minh
+|Phuoc  Minh commune and Phuoc Ninh commune, Thuan Nam district, Ninh Thuan
+|Ninh Thuan
+|38
+|50
+|01/10/2018
+|01/12/2019
+|Adani Phuoc Minh Ltd.
+|Operation
+|
+|
+|-
+|Xuan Thien Thuan Bac - 1
+|Bac Phong commune, Thuan Bac district, Ninh Thuan
+|Ninh Thuan
+|125
+|
+|01/09/2018
+|02/04/2020
+|Xuan  Thien Ninh Thuan JSC
+|Operation
+|
+|<ref name=":0" />
+|-
+|Xuan Thien Thuan Bac - 2
+|Bac Phong commune, Thuan Bac district, Ninh Thuan
+|Ninh Thuan
+|75
+|
+|01/09/2018
+|31/03/2020
+|Xuan Thien Ninh  Thuan JSC
+|Operation
+|
+|<ref name=":0" />
+|-
+|Gia Hoet 1
+|Gia Hoet 1 lake, Chau Duc district, Ba Ria - Vung Tau province
+|Ba Ria - Vung Tau
+|27.5
+|35
+|
+|10/12/2020
+|DTD Natural Energy Investment LLC
+|Operation
+|
+|<ref name=":112">{{Cite web|url=http://ndh.vn/ba-ria-vung-tau-chap-thuan-2-nha-may-dien-mat-troi-hon-1-500-ty-dong-20190318095635651p145c151.news|title=Bà Rịa - Vũng Tàu chấp thuận 2 nhà máy điện mặt trời hơn 1.500 tỷ đồng|last=Nam Anh|date=2019-03-18|website=ndh.vn}}</ref>
+|-
+|Tam Bo
+|Tam Bo lake, Chau Duc district, Ba Ria - Vung Tau province
+|Ba Ria - Vung Tau
+|27.5
+|35
+|
+|10/12/2020
+|Energy Development LLC
+|Operation
+|
+|<ref name=":112" />
+|-
+|Sơn My 3.1
+|Son My commune, Ham Tan district, Binh Thuan province
+|Binh Thuan
+|43
+|50
+|
+|05/12/2019
+|Son My Renewable Energy JSC, EVNPECC2
+|Operation
+|
+|<ref>{{Cite web|url=https://www.24h.com.vn/kinh-doanh/dien-mat-troi-cuoc-dua-dang-nong-cua-cac-dai-gia-viet-c161a1044084.html|title=Điện mặt trời: cuộc đua đang "nóng" của các đại gia Việt|last=Quang Sơn|date=2019-04-18|website=24h.com.vn}}</ref><ref name=":13" />
+|-
+|GAIA
+|Thanh An commune, Thanh Hoa district, Long An province
+|Long An
+|75
+|
+|
+|
+|BCG Bang Duong & Hanwha Energy JSC
+|Implementation
+|
+|<ref>{{Cite web|title=NHÀ MÁY NĂNG LƯỢNG MẶT TRỜI GAIA|url=https://www.tracodi.com.vn/du-an/danh-sach-du-an/danh-sach-du-an/nha-may-nang-luong-mat-troi-gaia|access-date=2021-07-19|website=By Tracodi|language=vi}}</ref>
+|-
+|Xuan Thien - Ea Sup 2
+|Ia Lop and Ia Rve commune, Ea Sup district, Dak Lak province
+|Dak Lak
+|683
+|843
+|
+|
+|Xuan Thien Group
+|Implementation
+|
+|
+|-
+|Xuan Thien - Ea Sup 3
+|Ia Lop and Ia Rve commune, Ea Sup district, Dak Lak province
+|Dak Lak
+|683
+|843
+|
+|
+|Xuan Thien Group
+|Implementation
+|
+|
+|-
+|Xuan Thien - Ea Sup 4
+|Ia Lop and Ia Rve commune, Ea Sup district, Dak Lak province
+|Dak Lak
+|1400
+|
+|
+|
+|Xuan Thien Group
+|Implementation
+|
+|
+|-
+|Xuan Thien - Ea Sup 5
+|Ia Lop and Ia Rve commune, Ea Sup district, Dak Lak province
+|Dak Lak
+|600
+|831
+|
+|
+|Xuan Thien Group
+|Implementation
+|
+|
+|-
+|Phuoc Trung solar power project
+|Ninh Thuan
+|[[Ninh Thuận Province|Ninh Thuan]]
+|40
+|50
+|
+|
+|
+|Preparation
+|
+|
+|-
+|Ngoc Lac
+|Kien Tho commune, Ngoc Lac district, Thanh Hoa province
+|Thanh Hoa
+|36
+|
+|
+|
+|Hoang Son JSC
+|Preparation
+|
+|<ref>{{Cite web|last=VietnamFinance|date=2021-06-03|title=Thanh Hóa: Dự án nhà máy điện mặt trời 2.600 tỷ tại huyện Ngọc Lặc sẽ khởi công vào quý III/2021|url=https://vietnamfinance.vn/news-20180504224253922.htm|access-date=2021-07-19|website=VietnamFinance|language=vi}}</ref>
+|-
+|An Cu (An Giang) solar power project
+|An Giang
+|An Giang
+|40
+|50
+|
+|
+|
+|Preparation
+|
+|
+|-
+|Phong Hoa solar power project
+|Thua Thien Hue
+|Thua Thien Hue
+|40
+|50
+|
+|
+|
+|Preparation
+|
+|
+|-
+|Ia Rsuom - Bitexco - To Na solar power project
+|Gia Lai
+|Gia Lai
+|12
+|15
+|
+|
+|Bitexco Group (Solar Power Ninh Thuan LLC)
+|Preparation
+|
+|
+|-
+|MT 1, MT 2 solar power project
+|Loc Thanh commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc
+|48
+|60
+|
+|
+|
+|Preparation
+|
+|
+|-
+|Loc Thach 1-1 solar power project
+|Loc Thanh commune, Loc Ninh district, Binh Phuoc province
+|Binh Phuoc
+|40
+|50
+|
+|
+|
+|Preparation
+|
+|
+|-
+|{{ill|TTC Duc Hue 2|vi|Điện mặt trời Đức Huệ|vertical-align=sup}}
+|Duc Hue district, Long An province
+|Long An
+|40
+|49
+|
+|
+|GEG/TTC
+|Preparation
+|
+|
+|}
+
+== Wind power plants ==
+Source: Initial query from DEVI Renewable Energies,<ref name=":12" />  795/TTG-CN<ref name=":25">{{Cite web|title=Công văn 795/TTg-CN 2020 bổ sung danh mục dự án điện gió vào quy hoạch phát triển điện lực|url=https://thuvienphapluat.vn/cong-van/Dau-tu/Cong-van-795-TTg-CN-2020-bo-sung-danh-muc-du-an-dien-gio-vao-quy-hoach-phat-trien-dien-luc-446039.aspx|access-date=2021-07-15|website=thuvienphapluat.vn}}</ref>
+
+Note: Construction start + COD date form: day/month/year
+{| class="wikitable sortable"
+!width=100|Station
+! width="90" |Location
+! width="50" |Province
+! width="50" |Capacity (MW)
+! width="60" |Construction start date
+! width="60" |COD date
+!width=100|Sponsor/owner
+! width="60" |Status
+!width=150|Note
+! width="40" |Source
+|-
+|{{ill|Tuy Phong Phase 1 |vi|Điện gió Tuy Phong|vertical-align=sup}}
+|Tuy Phong district, Binh Thuan province
+|Binh  Thuan
+|30
+|2008
+|05/2011
+|REVN - Vietnam Renewable  Energy JSC
+|Operation
+|Fuhrländer  turbines
+|<ref>{{Cite web|url=http://tietkiemnangluong.com.vn/tin-tuc/pho-bien-kien-thuc/t11498/dien-gio-tuy-phong-hoan-thanh-hoa-luoi-dien-quoc-gia-giai-doan-1.html|title=Điện gió Tuy Phong hoàn thành hòa lưới điện quốc gia giai đoạn 1|last=Minh Châu|date=2011-05-31|website=tietkiemnangluong.com.vn}}</ref>
+|-
+|{{ill|Phu Lac wind farm |vi|Điện gió Phú Lạc|vertical-align=sup}}
+|Phu Lac commune, Tuy Phong district, Binh Thuan province
+|Binh  Thuan
+|24
+|27/07/2015
+|19/09/2016
+|EVN - Thuan Binh Wind Power
+|Operation
+|funded by  KfW, 12x2MW Vestas turbines
+|
+|-
+|{{ill|Mui Dinh |vi|Điện gió Mũi Dinh|vertical-align=sup}}
+|Phuoc Dinh commune, Thuan Nam district, Ninh Thuan province
+|Ninh  Thuan
+|37.6
+|08/2016
+|01/2019
+|EAB - Germany
+|Operation
+|Enercon  turbines E-103 EP02 2.35MW. First turbine erected in August/2018
+|<ref>{{Cite web|url=http://thoibaotaichinhvietnam.vn/pages/kinh-doanh/2019-04-10/khanh-thanh-nha-may-dien-gio-mui-dinh-ninh-thuan-69965.aspx|title=Khánh thành Nhà máy điện gió Mũi Dinh - Ninh Thuận|last=TTXVN|date=2019-04-10|website=thoibaotaichinhvietnam.vn}}</ref>
+|-
+|Dong Hai 1
+|Long Dien Dong, Dong Hai district, Bac Lieu province
+|Bac Lieu
+|50
+|16/04/2019
+|
+|Bac Phuong Energy JSC
+|Operation
+|12 turbines; 22/110kV booster lift station - 1x63MVA; The 110kV line connects the plant with Hoa Binh - Dong Hai 110kV line
+|<ref>{{Cite web|last=Đình Tú|date=2019-04-16|title=Khởi công dự án Nhà máy điện gió Đông Hải 1tại Bạc Liêu|url=http://nangluongsachvietnam.vn/d6/vi-VN/news/Khoi-cong-du-an-Nha-may-dien-gio-Dong-Hai-1tai-Bac-Lieu-6-164-3680|website=nangluongsachvietnam.vn}}</ref>
+|-
+|{{ill|Phu Quy|vi|Điện gió Phú Quý|vertical-align=sup}}
+|Phu Quy island district, Binh Thuan province
+|Binh  Thuan
+|6
+|26/11/2010
+|12/2012
+|PV Power
+|Operation
+|Vestas turbines 3x2MW
+|<ref>{{Cite web|url=https://www.evn.com.vn/d6/news/Khanh-thanh-Nha-may-Dien-gio-tai-huyen-dao-Phu-Quy-141-17-6584.aspx|title=Khánh thành Nhà máy Điện gió tại huyện đảo Phú Quý|last=TTXVN|date=2013-01-25|website=evn.com.vn}}</ref>
+|-
+|Bac Lieu (phase I, II) ({{ill|VN version|vi|Điện gió Bạc Liêu|vertical-align=sup}})
+|Vinh Trach Dong commune, Bac Lieu city
+|Bac  Lieu
+|99.2
+|09/2010
+|01/2016
+|Construction-Trade-Tourism Ltd.
+|Operation
+|62 x 16 GE  (1.6-82.5) turbines
+|<ref>{{Cite web|url=https://www.voatiengviet.com/a/nang-luong-tai-tao-me-kong-cuu-long/4201877.html|title=Từ điện gió Bạc Liêu, tới nhà máy điện than Sóc Trăng, Trà Vinh|last=Ngô Thế Vinh|date=2018-01-11|website=voatiengviet.com}}</ref>
+|-
+|Dam Nai (phase I) ({{ill|VN version|vi|Điện gió Đầm Nại|vertical-align=sup}})
+|Bac Son commune, Thuan Bac district, Ninh Thuan
+|Ninh  Thuan
+|7.8
+|01/04/2017
+|22/09/2017
+|Blue Circle +TSV Vietnam
+|Operation
+|16x 2,625  MW Gamesa turbines.Phase 1: TC 22kV Ninh Hai station
+|<ref>{{Cite web|url=http://ninhthuan.tintuc.vn/tin-tuc/cong-trinh-dien-gio-dam-nai-ninh-thuan-da-hoa-luoi-dien-quoc-gia.html|title=Công trình điện gió Đầm Nại - Ninh Thuận đã hòa lưới điện quốc gia|last=Minh Tuấn & Đình Hùng|date=2017-09-25|website=ninhthuan.tintuc.vn}}</ref>
+|-
+|Dam Nai (phase II) ({{ill|VN version|vi|Điện gió Đầm Nại|vertical-align=sup}})
+|Bac Son commune, Thuan Bac district, Ninh Thuan
+|Ninh  Thuan
+|30
+|20/01/2018
+|08/09/2018
+|Blue Circle +TSV Vietnam
+|Operation
+|Phase 2: transit 110kV Thap Cham - Ninh Hai (AC300, 0.9&nbsp;km)
+|<ref>{{Cite web|url=http://congtycophantuvandien1.com.vn/du-an-nha-may-dien-gio-dam-nai-giai-doan-2-hoan-thanh-vuot-truoc-tien-do/|title=Dự án: NHÀ MÁY ĐIỆN GIÓ ĐẦM NẠI – GIAI ĐOẠN 2 hoàn thành vượt trước tiến độ yêu cầu 05 tháng|last=congtycophantuvandien1.com.vn|date=2018-09-10}}</ref><ref>{{Cite web|url=https://baodautu.vn/khoi-cong-giai-doan-2-du-an-dien-gio-dam-nai---ninh-thuan-d76072.html|title=Khởi công giai đoạn 2 Dự án điện gió Đầm Nại - Ninh Thuận|last=Công Thử|date=2018-01-20|website=baodautu.vn}}</ref>
+|-
+|{{ill|Huong Linh 1 |vi|Điện gió Hướng Linh|vertical-align=sup}}
+|Huong Hoa district, Quang Tri province
+|Quang  Tri
+|30
+|
+|14/03/2020
+|Tan Hoan Cau Group
+|Operation
+|
+|
+|-
+|{{ill|Huong Linh 2 |vi|Điện gió Hướng Linh|vertical-align=sup}}
+|Huong Hoa district, Quang Tri province
+|Quang  Tri
+|30
+|
+|30/04/2017
+|Tan Hoan Cau Group
+|Operation
+|15x2 MW  Vestas turbines
+|<ref name=":1">{{Cite web|url=http://quangtri.tintuc.vn/tin-tuc/nha-may-dien-gio-huong-linh-2-chinh-thuc-phat-dien-dip-le-304.html|title=Nhà máy điện gió Hướng Linh 2 chính thức phát điện dịp lễ 30/4|last=Công Điền|date=2017-04-26|website=quangtri.tintuc.vn}}</ref>
+|-
+|Trung Nam Ninh  Thuan phase 1
+|Loi Hai and Bac Phong communes, Thuan Bac district, Ninh Thuan province
+|Ninh  Thuan
+|39.95
+|26/08/2016
+|27/04/2019
+|Trungnam Wind Power JSC
+|Operation
+|ENERCON  turbines, Siemens Inverter
+|<ref name=":2">{{Cite web|url=http://thoibaonganhang.vn/trung-nam-group-khanh-thanh-to-hop-dien-gio-dien-mat-troi-tai-ninh-thuan-87367.html|title=Trung Nam Group khánh thành tổ hợp điện gió, điện mặt trời tại Ninh Thuận|last=VPMT|date=2019-04-28|website=thoibaonganhang.vn}}</ref><ref name=":3">{{Cite web|url=https://www.trungnamgroup.com.vn/dien-gio-trung-nam|title=ĐIỆN GIÓ TRUNG NAM|website=trungnamgroup.com.vn}}</ref>
+|-
+|Trung Nam Ninh  Thuan phase 2
+|Loi Hai and Bac Phong communes, Thuan Bac district, Ninh Thuan province
+|Ninh  Thuan
+|64
+|
+|04/2020
+|Trungnam Wind Power JSC
+|Operation
+|ENERCON  turbines, Siemens Inverter
+|<ref name=":2" /><ref name=":3" /><ref name=":24">{{Cite web|title=Khánh thành Nhà máy điện gió Trung Nam|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khanh-thanh-nha-may-dien-gio-trung-nam.html|access-date=2021-07-14|website=Nangluongvietnam.vn}}</ref>
+|-
+|Trung Nam Ninh  Thuan phase 3
+|Loi Hai and Bac Phong communes, Thuan Bac district, Ninh Thuan province
+|Ninh  Thuan
+|48
+|
+|04/2020
+|Trungnam Wind Power JSC
+|Operation
+|ENERCON  turbines, Siemens Inverter
+|<ref name=":24" />
+|-
+|Dai Phong wind farm
+|Thien Nghiep commune, Mui Ne ward, Phan Thiet city
+|Binh Thuan
+|40
+|
+|23/07/2020
+|Dai Phong Development Investment JSC
+|Operation
+|AC Energy  accounts for over 62% of the economic ownership including its 50% direct  voting stake. Project completion of the first phase is expected in the First  Half of 2020, in time for the new wind feed-in-tariff deadline of November  2021.
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/du-an-dien-gio-dai-phong-duoc-cap-phep-dau-tu.html|title=Dự án điện gió Đại Phong được cấp phép đầu tư|last=NANG LUONG VIET NAM|date=2018-06-20|website=nangluongvietnam.vn}}</ref>
+|-
+|HBRE Tay Nguyen phase 1
+|Ea H'Leo district, Dak Lak province
+|Dak Lak
+|28.8
+|
+|31/12/2019
+|HBRE Wind Power Solution
+|Operation
+|
+|
+|-
+|Phuong Mai 3
+|Quy Nhon district, Binh Dinh province
+|Binh Dinh
+|20.8
+|
+|01/10/2020
+|Central Wind JSC
+|Operation
+|
+|
+|-
+|{{ill|Bac Lieu phase III |vi|Điện gió Bạc Liêu|vertical-align=sup}}
+|Vinh Trach Dong commune, Bac Lieu city
+|Bac Lieu
+|142
+|30/01/2018
+|
+|Super Wind Energy Cong Ly 1 JSC
+|Implementation
+|Super Wind Energy Cong Ly 1 JSC = Cong Ly + Thai Investor
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khoi-cong-du-an-dien-gio-bac-lieu-giai-doan-3.html|title=Khởi công dự án điện gió Bạc Liêu giai đoạn 3|last=NANG LUONG VIET NAM|date=2018-01-30|website=nangluongvietnam.vn}}</ref>
+|-
+|Lac Hoa 1
+|Lac Hoa commune, Vinh Chau district, Soc Trang
+|Soc Trang
+|30
+|
+|
+|Vinh Chau - TDC Renewable Energy JSC
+|Implementation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/nhan-dinh-phan-bien-kien-nghi/nhan-dinh-du-bao/tiem-nang-va-thach-thuc-phat-trien-nang-luong-tai-tao-o-viet-nam-ky-1.html|title=Tiềm năng và thách thức phát triển năng lượng tái tạo ở Việt Nam [Kỳ 1]|last=Võ Hồng Thái & Cao Thị Thu Hằng|date=2019-08-19|website=nangluongvietnam.vn}}</ref>
+|-
+|Lac Hoa 2
+|Lac Hoa commune, Vinh Chau district, Soc Trang
+|Soc Trang
+|130
+|
+|
+|Lac Hoa 2 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Lien Lap
+|Tan Lien and Tan Lap commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Lien Lap Wind Power JSC
+|Implementation
+|
+|
+|-
+|Loi Hai 2
+|Loi Hai commune, Thuan Bac district, Ninh Thuan province
+|Ninh Thuan
+|28.9
+|
+|
+|Thuan Binh Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Nam Binh 1
+|Dak Song district, Dak Nong province
+|Dak Nong
+|30
+|
+|
+|
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Nhon Hoa 1
+|Ia Phang and Nhon Hoa commune, Chu Puh district, Gia Lai province
+|Gia Lai
+|100
+|
+|
+|Nhon Hoa 1 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Nhon Hoa 2
+|Ia Phang and Nhon Hoa commune, Chu Puh district, Gia Lai province
+|Gia Lai
+|100
+|
+|
+|Nhon Hoa 2 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Phat trien mien nui
+|Chu Prong district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|Chu Prong Gia Lai Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Phong Huy
+|Tan Thanh and Huong Tan commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Phong Huy Wind Power JSC
+|Implementation
+|
+|
+|-
+|Phong Lieu
+|Huong Linh and Tan Thanh and Huong Tan commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Phong Lieu Wind Power JSC
+|Implementation
+|
+|
+|-
+|Phong Nguyen
+|Tan Thanh and Huong Tan commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Phong Nguyen Wind Power JSC
+|Implementation
+|
+|
+|-
+|Phu Lac phase 2
+|Phu Lac commune, Tuy Phong district, BInh Thuan province
+|Binh Thuan
+|25.2
+|
+|
+|Thuan Binh Wind Power JSC
+|Implementation
+|
+|
+|-
+|Cong Ly (3 phase)  ({{ill|VN version|vi|Điện gió Công Lý Sóc Trăng|vertical-align=sup}})
+|Lai Hoa commune, Vinh Chau district, Soc Trang
+|Soc Trang
+|90
+|30/01/2018
+|
+|Super Wind Energy Cong Ly 1 JSC
+|Implementation
+|15x2MW per unit.
+|<ref>{{Cite web|url=https://bnews.vn/khoi-cong-xay-dung-nha-may-dien-gio-dau-tien-tai-soc-trang/75073.html|title=Khởi công xây dựng Nhà máy điện gió đầu tiên tại Sóc Trăng|last=Trung Hiếu|date=2018-01-30|website=bnews.vn}}</ref>
+|-
+|Hoa Dong
+|Hoa Dong Commune, Vinh Chau District, Soc Trang
+|Soc Trang
+|30
+|
+|
+|Hoa Dong Wind Power Ltd
+|Implementation
+|
+|<ref>{{Cite web|url=http://hoangsonvietnam.vn/tin-cong-ty/1904/khao-sat-du-an-nha-may-dien-gio-lac-hoa-va-dien-gio-hoa-dong|title=Khảo sát dự án Nhà máy điện gió Lạc Hòa và điện gió Hòa Đông|last=Hoang Son Energy|date=2018-10-23|website=hoangsonvietnam.vn}}</ref>
+|-
+|Hoa Dong 2
+|Hoa Dong Commune, Vinh Chau District, Soc Trang
+|Soc Trang
+|72
+|
+|
+|Hoa Dong Wind Power Ltd
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Hoa Binh 1
+|Vinh Hau Commune, Hoa Binh District, Bac Lieu Province
+|Bac  Lieu
+|50
+|01/06/2019
+|
+|Hoa Binh 1 Wind Power Investment JSC
+|Implementation
+|
+|<ref>{{Cite web|last=Dương Anh Minh & Minh Đức|date=2019-06-02|title=Khởi công dự án Nhà máy điện gió Hòa Bình 1|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/nang-luong-tai-tao/khoi-cong-du-an-nha-may-dien-gio-hoa-binh-1.html|website=nangluongvietnam.vn}}</ref>
+|-
+|Hoa Binh 1 phase 2
+|Vinh Hau Commune, Hoa Binh District, Bac Lieu Province
+|Bac  Lieu
+|50
+|
+|
+|Hoa Binh 1 Wind Power Investment JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Hoa Binh 2
+|Vinh Hau Commune, Hoa Binh District, Bac Lieu Province
+|Bac  Lieu
+|50
+|
+|
+|Hoa Binh 2 Investment JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Hoa Thang 2.2
+|Hoa Thang commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|19.8
+|
+|
+|Win Energy JSC
+|Implementation
+|
+|
+|-
+|Hoang Hai
+|Huc commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|50
+|
+|
+|Hoang Hai Quang Tri Energy Investment JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Cau Dat
+|Xuan Truong and Tram Hanh communes, Da Lat city
+|Lam Dong
+|50
+|21/03/2019
+|
+|Dai Duong RE JSC
+|Implementation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khoi-cong-du-an-dien-gio-dau-tien-tai-lam-dong.html|title=Khởi công dự án điện gió đầu tiên tại Lâm Đồng|last=NANG LUONG VIET NAM|date=2019-03-23|website=nangluongvietnam.vn}}</ref>
+|-
+|Dong Hai 1 (V1-7)
+|Dong Hai commune, Duyen Hai district, Tra Vinh province
+|Tra Vinh
+|100
+|
+|
+|Trung Nam Tra Vinh 1 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Dong Hai 1 phase 2
+|Long Dien Dong commune, Dong Hai district, Bac Lieu province
+|Bac Lieu
+|50
+|
+|
+|Bac Phuong Energy JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ea Nam
+|Dlie Yang commune, Ea H'leo district, Dak Lak province
+|Dak Lak
+|400
+|
+|
+|Trung Nam Dak Lak 1 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ham Cuong 2
+|Ham Cuong commune, Ham Thuan Nam district, Binh Thuan province
+|Binh Thuan
+|20
+|
+|
+|HD Investment JSC
+|Implementation
+|
+|
+|-
+|Han Quoc Tra Vinh
+|Truong Long Hoa commune, Duyen Hai district, Tra Vinh province
+|Tra Vinh
+|48
+|
+|
+|Tra Vinh 1 Wind Power JSC
+|Implementation
+|
+|
+|-
+|HBRE Chu Prong phase 1
+|Ia Bang and Ia Phin commune, Chu Prong district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|HBRE Gia Lai Wind Power JSC
+|Implementation
+|
+|
+|-
+|HBRE Ha Tinh
+|Ky Anh district, Ha Tinh province
+|Ha Tinh
+|120
+|
+|
+|HBRE Wind Power Solution
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Hong Phong 1
+|Hong Phong commune, Bac Binh district, Binh Thuan province
+|Binh Thuan
+|40
+|
+|
+|Hong Phong 1 Wind Power JSC
+|Implementation
+|
+|
+|-
+|Hung Hai Gia Lai
+|Krong Cho district, Gia Lai province
+|Gia Lai
+|100
+|
+|
+|
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Huong Linh 4
+|Huong Linh commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|30
+|
+|
+|Huong Linh 4 Wind Power JSC
+|Implementation
+|
+|
+|-
+|Huong Linh 5
+|Huong Linh commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|30
+|
+|
+|
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Huong Linh 7
+|Huong Linh commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|30
+|
+|
+|Huong Linh 7 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Huong Linh 8
+|Huong Linh commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|25.2
+|
+|
+|Huong Linh 7 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ia Bang 1
+|Ia Bang commune, Chu Prong district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|Ia Bang Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ia Le 1
+|Ia Le commune, Chu Puh district, Gia Lai province
+|Gia Lai
+|100
+|
+|
+|Cao Nguyen 1 Investment and Development JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ia Pech
+|Ia Grai district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|Dien Xanh Gia Lai Investment Energy JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ia Pech 2
+|Ia Grai district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|Dien Xanh Gia Lai Investment Energy JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ia Pet Dak Doa 1
+|Ia Pet commune, Dak Doa district, Gia Lai province
+|Gia Lai
+|100
+|
+|
+|Ia Pet Dak Doa Wind Power Plant Number One JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Ia Pet Dak Doa 2
+|Ia Pet commune, Dak Doa district, Gia Lai province
+|Gia Lai
+|100
+|
+|
+|Ia Pet Dak Doa Wind Power Plant Number Two JSC
+|Implementation
+|
+|
+|-
+|{{ill|Huong Phung 1 |vi|Điện gió Hướng Phùng|vertical-align=sup}}
+|Huong Do Hamlet, Huong Phung commune, Huong Hoa district, Quang Tri
+|Quang Tri
+|30
+|29/06/2019
+|
+|EVNGENCO2
+|Implementation
+|The project is built of main items, with 10 turbine towers supporting 110m high, each for a turbine of 3.63MW; lifting stations 0.69/22kV-4,300kVA and internal 22kV electric network; Transformer station Huong Phung 1 22/110kV-1x40MVA; the 110kV line is about 21.5&nbsp;km long from Huong Phung 1 substation to Lao Bao 220kV substation; construction road system for management and operation, auxiliary area for construction; operation manager.
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khoi-cong-du-an-nha-may-dien-gio-huong-phung-1.html|title=Khởi công dự án Nhà máy điện gió Hướng Phùng 1|last=Dương|first=Anh Minh|date=2019-06-29|website=nangluongvietnam.vn}}</ref>
+|-
+|{{ill|Huong Phung 2 |vi|Điện gió Hướng Phùng|vertical-align=sup}}
+|Doa Cuoi Hamlet, Huong Phung commune, Huong Hoa district, Quang Tri
+|Quang Tri
+|20
+|27/06/2019
+|
+|Huong Phung Wind Power Ltd. Co.
+|Implementation
+|
+|<ref name=":4" />
+|-
+|{{ill|Huong Phung 3 |vi|Điện gió Hướng Phùng|vertical-align=sup}}
+|Huong Phung commune, Huong Hoa district, Quang Tri
+|Quang Tri
+|30
+|27/06/2019
+|
+|Huong Phung wind power Ltd. Co.
+|Implementation
+|
+|<ref name=":4">{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/quang-tri-khoi-cong-du-an-dien-gio-huong-phung-2-va-3.html|title=Quảng Trị: Khởi công dự án điện gió Hướng Phùng 2 và 3|last=Thành Ánh|date=2019-06-28|website=nangluongvietnam.vn}}</ref>
+|-
+|Khai Long Phase 1
+|Dat Mui commune, Ngoc Hien district, Ca Mau province
+|Ca  Mau
+|100
+|26/09/2016
+|
+|Super Wind Energy Cong Ly 1 JSC
+|Implementation
+|Delayed.  Changed investors from Cong Ly to JV Cong Ly+Super Wind Energy (Thailand)
+|<ref>{{Cite web|url=https://www.tienphong.vn/kinh-te/khoi-cong-du-an-dien-gio-khu-du-lich-khai-long-ca-mau-1055080.tpo|title=Khởi công dự án Điện gió Khu du lịch Khai Long- Cà Mau|last=Nguyễn|first=Tiến Hưng|date=2016-09-26|website=tienphong.vn}}</ref><ref>{{Cite web|url=https://plo.vn/do-thi/kien-nghi-thu-tuong-go-kho-cho-du-an-dien-gio-5500-ti-802663.html|title=Kiến nghị Thủ tướng gỡ khó cho dự án điện gió 5.500 tỉ|last=Gia Tuệ|date=2018-11-14|website=plo.vn}}</ref>
+|-
+|Binh Dai Phase I
+|Thua Duc commune, Binh Dai district, Ben Tre province
+|Ben  Tre
+|30
+|28/11/2017
+|
+|TTC-Mekong Wind JSC
+|Implementation
+|
+|<ref>{{Cite web|url=https://nongnghiep.vn/le-dong-tho-du-an-dien-gio-binh-dai-ben-tre-post207885.html|title=Lễ động thổ dự án điện gió Bình Đại Bến Tre|last=T.C|date=2017-11-28|website=nongnghiep.vn}}</ref>
+|-
+|{{ill|Huong Linh 3 |vi|Điện gió Hướng Linh|vertical-align=sup}}
+|Huong Hoa district, Quang Tri province
+|Quang  Tri
+|30
+|06/2019
+|
+|Huong Linh 3 JSC (Tan Hoan Cau Group)
+|Implementation
+|DZ110 double circuit, ACSR300 conductor, about 10.2&nbsp;km long into 110kV busbar of 220kV Lao Bao station
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/chap-thuan-dau-tu-du-an-dien-gio-huong-linh-3.html|title=Chấp thuận đầu tư dự án điện gió Hướng Linh 3|last=NANG LUONG VIET NAM|date=2019-04-11|website=nangluongvietnam.vn}}</ref>
+|-
+|KOSY Bac Lieu
+|Vinh Minh A commune, Hoa Binh district, Bac Lieu province
+|Bac Lieu
+|40
+|
+|
+|Kosy Bac Lieu Wind Power JSC
+|Implementation
+|
+|7201/BCT-DL
+|-
+|Quoc Vinh Soc Trang (Soc Trang 6)
+|Vinh Hai commune, Vinh Chau district, Soc Trang province
+|Soc Trang 
+|30
+|
+|
+|Quoc Vinh Wind Power Ltd
+|Implementation
+|
+|
+|-
+|Soc Trang 18
+|
+|Soc Trang
+|22.4
+|
+|
+|Trung Thinh Soc Trang Energy Company Limited
+|Implementation
+|
+|
+|-
+|Song An
+|An Khe district, Gia Lai province
+|Gia Lai
+|46.2
+|
+|
+|Song An Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Tai Tam
+|Huong Phung commune, Huong Hoa district, Quang Tri province
+|Quang Tri province
+|50
+|
+|
+|Tai Tam Quang Tri Energy Investment Company 
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Tan An 1
+|Tan An commune, Ngoc Hien district, Ca Mau province
+|Ca Mau
+|25
+|
+|
+|Song Lam Investment Hydropower JSC
+|Implementation
+|
+|<ref>{{Cite web|title=Cà Mau: Khởi công xây dựng Nhà máy điện gió Tân Ân 1 - giai đoạn 1|url=https://baodautu.vn/ca-mau-khoi-cong-xay-dung-nha-may-dien-gio-tan-an-1---giai-doan-1-d134775.html|access-date=2021-07-15|website=baodautu|language=vi}}</ref>
+|-
+|Tan Lien 1 phase 1 (AMACCAO Quang Tri 1)
+|Tan Lien and Huc commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|49.2
+|
+|
+|Khe Sanh Wind Power JSC
+|Implementation
+|
+|
+|-
+|Tan Linh
+|Huong Tan and Huong Linh commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Tan Linh Wind Power JSC
+|Implementation
+|
+|
+|-
+|Tan Phu Dong
+|Go Cong Dong district, Tien Giang province
+|Tieng Giang
+|150
+|
+|
+|Hoa Viet Corporation
+|
+|
+|<ref name=":25" />
+|-
+|Tan Tan Nhat - Dak Glei
+|Dak Glei commune, Dak Glei district, Kon Tum province
+|Kon Tum
+|50
+|
+|
+|Tan Tan Nhat JSC
+|
+|
+|<ref name=":25" />
+|-
+|Tan Thuan
+|Tan Thuan commune, Dam Doi district, Ca Mau province
+|Ca Mau
+|75
+|
+|
+|Ca Mau Renewable Energy Investment JSC
+|
+|
+|<ref>{{Cite web|last=|title=Lắp đặt thành công trụ tuabin đầu tiên dự án điện gió Tân Thuận|url=https://nangluongsachvietnam.vn/d6/vi-VN/news/Lap-dat-thanh-cong-tru-tuabin-dau-tien-du-an-dien-gio-Tan-Thuan-6-164-10169|access-date=2021-07-15|website=nangluongsachvietnam.vn}}</ref>
+|-
+|Hanbaram
+|Tan Hai commune, Ninh Hai district, Ninh Thuan province
+|Ninh Thuan
+|117
+|
+|
+|Hanbaram Wind Power JSC
+|
+|
+|
+|-
+|Thanh Phu
+|Thanh Phu district, Ben Tre province
+|Ben Tre
+|120
+|
+|
+|
+|
+|
+|<ref name=":25" />
+|-
+|Thien Phu
+|Thanh Phu district, Ben Tre province
+|Ben Tre
+|30
+|
+|
+|Thien Phu Energy Investment JSC
+|
+|
+|<ref name=":25" />
+|-
+|Thien Phu 2
+|Thanh Phu district, Ben Tre province
+|Ben Tre
+|30
+|
+|
+|Thien Phu Energy Investment JSC
+|
+|
+|<ref name=":25" />
+|-
+|TNC Quang Tri 1
+|Huong Hoa district, Quang Tri province
+|Quang Tri
+|50
+|
+|
+|TNC Quang Tri 1 Wind Power JSC 
+|
+|
+|<ref name=":25" />
+|-
+|TNC Quang Tri 2
+|Huong Hoa district, Quang Tri province
+|Quang Tri
+|50
+|
+|
+|
+|
+|
+|<ref name=":25" />
+|-
+|Soc Trang 2
+|Vinh Chau district, Soc Trang province
+|Soc  Trang
+|30
+|
+|
+|Dai Phong Development Investment JSC
+|Implementation
+|
+|
+|-
+|Soc Trang 3
+|Vinh Chau district, Soc Trang province
+|Soc  Trang
+|29.4
+|01/11/2019
+|
+|BanPu - Thailand Co., Ltd.
+|Implementation
+|Metmast  installed, FS underway
+|
+|-
+|Soc Trang 7
+|Vinh Hai commune, Vinh Chau district, Soc Trang province
+|Soc Trang
+|29.4
+|
+|
+|Xuan Cau LLC
+|Implementation
+|
+|
+|-
+|Tra Vinh 3
+|Hiep Thanh commune, Duyen Hai town, Tra Vinh province
+|Tra  Vinh
+|78
+|
+|
+|Ecotech Tra Vinh
+|Implementation
+|
+|
+|-
+|Phuoc Huu - Duyen Hai 1
+|Phuoc Huu commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh  Thuan
+|30
+|
+|
+|Phuoc Huu Duyen Hai 1 Wind Power Ltd
+|Implementation
+|
+|
+|-
+|Phuoc Minh wind farm
+|Phuoc Minh commune, Ninh Thuan province
+|Ninh  Thuan
+|27.3
+|Q1-2019
+|
+|Adani Phuoc Minh Wind  Power Ltd.(Adani+TVS)
+|Implementation
+|Transit 110kV Ninh Phuoc - Phan Ri (AC300, 1&nbsp;km)
+(Adani 80%, TVS 20%). Total capacity registered 48.3MW
+|<ref name=":6">{{Cite web|last=NANG LUONG VIET NAM|date=2018-08-31|title=Ninh Thuận kiên quyết thu hồi các dự án điện gió chậm tiến độ|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/ninh-thuan-kien-quyet-thu-hoi-cac-du-an-dien-gio-cham-tien-do.html|website=nangluongvietnam.vn}}</ref>
+|-
+|Thuan Nhien Phong
+|Hoa Thang commune, Bac Binh district, Binh Thuan province
+|Binh  Thuan
+|32
+|
+|
+|Thuan Nhien Phong Wind Power Ltd
+|Implementation
+|
+|<ref>{{Cite web|date=2018-11-08|title=Đầu tư dự án nhà máy điện gió Thuận Nhiên Phong|url=http://www.525.vn/index.php?option=com_content&view=article&id=573:2018-11-08-01-49-16&catid=34:tin-tuc-cong-ty-525&Itemid=70|website=525.vn}}</ref>
+|-
+|Huong Hiep 1
+|Huong Hiep commune, Dakrong district, Quang Tri province
+|Quang Tri
+|30
+|
+|
+|Huong Hiep 1 Wind Power JSC
+|Implementation
+|
+|
+|-
+|Gelex 1, 2, 3
+|Huong Linh and Huong Hiep communes, Dakrong district, Quang Tri province
+|Quang Tri
+|90
+|
+|
+|Quang Tri Gelex Energy company
+|Implementation
+|Equity Huong Phung wind power JSC 20%
+|<ref>{{Cite web|last=Cẩm Thư|date=2019-06-28|title=Gelex muốn bán công ty con ở Campuchia trong quý III|url=https://vietnamfinance.vn/gelex-muon-ban-cong-ty-con-o-campuchia-trong-quy-iii-20180504224225494.htm|website=vietnamfinance.vn}}</ref>
+|-
+|Thai Hoa
+|Hoa Thang commune, Bac Binh district, Binh Thuan province
+|Binh  Thuan
+|90
+|
+|
+|Pacific Energy - Binh Thuan JSC
+|Implementation
+|Metmast installed
+|<ref name=":9">{{Cite web|last=thaibinhduong.vn|date=2017-05-12|title=Chủ tịch HĐQT Tập đoàn Thái Bình Dương đến thăm và làm việc tại dự án Nhà máy điện gió Thái Hòa và Thái Phong|url=http://thaibinhduong.vn/tin-tuc/tin-cong-ty/chu-tich-hdqt-tap-doan-thai-binh-duong-den-tham-va-lam-viec-tai-du-an-nha-may-dien-gio-thai-hoa-va-thai-phong}}</ref>
+|-
+|Chinh Thang Wind Energy
+|Thuan Nam and Ninh Phuoc districts, Ninh Thuan
+|Ninh  Thuan
+|50
+|25/04/2019
+|
+|Chinh Thang Wind Power Ltd.
+|Implementation
+|Transit 110kV Thap Cham - Ninh Phuoc (ACSR 300, 0.1&nbsp;km)
+|<ref>{{Cite web|last=Lê Vân|date=2019-04-25|title=Khởi công điện gió Win Energy Chính Thắng|url=http://www.ninhthuan.gov.vn/chinhquyen/thuannam/Pages/Khoi-cong-dien-gio-Win-Energy-Chinh-Thang-.aspx|website=ninhthuan.gov.vn}}</ref>
+|-
+|7A Ninh Thuan
+|Phuoc Minh commune, Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|50
+|
+|
+|Ha do Thuan Nam Wind Energy One Member Company Limited
+|Implementation
+|
+|
+|-
+|BT 1
+|Gia Ninh and Hai Ninh commune, Quang Ninh district, Quang Binh province
+|Quang Binh
+|109
+|
+|
+|BT1 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|BT 2
+|Ngu Thuy Bac commune, Le Thuy district, Quang Binh province
+|Quang Binh
+|100
+|
+|
+|BT1 Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|V1-3 Ben Tre
+|An Thuy commune, Ba Tri district, Ben Tre province
+|Ben Tre
+|30
+|
+|
+|Ben Tre Renewable Energy JSC
+|Implementation
+|
+|
+|-
+|Phong Dien 1 - phase 2
+|Binh Thuan commune, Tuy Phong district, Binh Thuan province
+|Binh Thuan
+|30
+|
+|
+|Binh Thuan Renewable Energy No2 Company Limited
+|Implementation
+|
+|
+|-
+|Che bien Tay Nguyen
+|Chu Prong district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|Chu Prong Gia Lai Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Cho Long
+|Cho Long commune, Kong Chro district, Gia Lai province
+|Gia Lai
+|155
+|
+|
+|Cho Long Wind Power JSC 
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Cuu An
+|Cuu An commune, An Khe district, Gia Lai province
+|Gia Lai
+|46.2
+|
+|
+|Cuu An Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Dak N'Drung 1
+|Dak Song district, Dak Nong province
+|Dak Nong
+|100
+|
+|
+|Dak N'Drung Energy Company
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Dak N'Drung 2
+|Dak Song district, Dak Nong province
+|Dak Nong
+|100
+|
+|
+|Dak N'Drung 1 Energy Company
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Dak N'Drung 3
+|Dak Song district, Dak Nong province
+|Dak Nong
+|100
+|
+|
+|Dak N'Drung 2 Energy Company
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Number 5 Thanh Hai 1
+|Thanh Hai commune, Thanh Phu district, Ben Tre province
+|Ben Tre
+|30
+|
+|
+|Tan Hoan Cau Ben Tre JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|5 Ninh Thuan
+|Phuoc Huu commune, Ninh Phuoc district, Ninh Thuan province
+|Ninh Thuan
+|46.2
+|
+|
+|Phuoc Huu Trung Nam Wind Power JSC
+|Implementation
+|
+|<ref name=":25" />
+|-
+|Tra Vinh V1-2 (Duyen Hai phase 1)
+|Truong Long Hoa commune, Duyen Hai district, Tra Vinh province
+|Tra Vinh
+|48
+|
+|
+|Truong Thanh Group + Sermsang Power Corporation
+|
+|
+|
+|-
+|Tra Vinh V1-3
+|Truong Long Hoa commune, Duyen Hai district, Tra Vinh province
+|Tra Vinh
+|48
+|
+|
+|REE Corporation
+|
+|
+|7201/BCT-DL
+|-
+|Vien An
+|Ngoc Hien district, Ca Mau province
+|Ca Mau
+|50
+|
+|
+|
+|
+|
+|<ref name=":25" />
+|-
+|VPL
+|Binh Dai district, Ben Tre province
+|Ben Tre
+|30
+|
+|
+|VPL Energy JSC
+|
+|
+|<ref name=":25" />
+|-
+|Yang Trung
+|Kong Chro district, Gia Lai
+|Gia Lai
+|145
+|
+|
+|Yang Trung Wind Power JSC
+|
+|
+|<ref name=":25" />
+|-
+|Thanh Phong
+|Thanh Hai commune, Thanh Phu district, Ben Tre province
+|Ben Tre
+|29.7
+|
+|
+|ECOWIN Energy JSC
+|
+|
+|
+|-
+|Wind power plant number 7
+|Vinh Hai commune, Vinh Chau district, Soc Trang province
+|Soc Trang
+|30
+|
+|
+|Soc Trang Energy JSC
+|
+|
+|<ref>{{Cite web|date=2020-09-25|title=Khởi công nhà máy điện gió 1.500 tỷ ở Sóc Trăng|url=https://tienphong.vn/post-1277274.tpo|access-date=2021-07-15|website=Báo điện tử Tiền Phong|language=vi}}</ref>
+|-
+|HBRE Phu Yen
+|An Tho, An Hiep and An Linh communes, Tuy An district, Phu Yen province
+|Phu  Yen
+|200
+|
+|
+|Super Energy Corporation
+|Preparation
+|
+|<ref name=":5">{{Cite web|url=https://devi-renewable.com/news/super-energy-corp-mua-2-du-den-gio-hbre/|title=Super Energy Corp mua 2 dự án điện gió HBRE Phú Yên và HBRE Gia Lai 250MW với giá 17,5 triệu đô la|last=devi-renewable.com|date=2019-03-16}}</ref>
+|-
+|HBRE Gia Lai
+|Ia Bang and Ia Phin communes, Chu Prong district, Gia Lai province
+|Gia  Lai
+|50
+|
+|
+|Super Energy Corporation
+|Preparation
+|
+|<ref name=":5" />
+|-
+|Soc Trang 4
+|Vinh Chau district, Soc Trang province
+|Soc  Trang
+|350
+|
+|
+|General Trading Construction JSC
+|Preparation
+|
+|
+|-
+|Soc Trang 8
+|Vinh Chau district, Soc Trang province
+|Soc Trang
+|100
+|
+|
+|Trac Viet Renewable Energy Co., Ltd.
+|Preparation
+|
+|
+|-
+|Soc Trang 11
+|Cu Lao Dung district, Soc Trang province
+|Soc Trang
+|100
+|
+|
+|Xuan Thien Yen Bai LLC
+|Preparation
+|
+|
+|-
+|Soc Trang 16
+|Vinh Chau district, Soc Trang province
+|Soc Trang
+|40
+|
+|
+|Envision Energy LLC
+|Preparation
+|
+|
+|-
+|Hoa Thang 1.2
+|Hoa Thang commune and Cho Lau town (Bac Binh district, Binh Thuan province)
+|Binh  Thuan
+|100
+|
+|
+|Hoa Thang Energy JSC
+|Preparation
+|Transit 110kV Luong Son-Hoa Thang-Mui Ne, wire ACSR 240, 11&nbsp;km long
+|
+|-
+|Hiep Thanh - Tra Vinh
+|Duyen Hai town, Tra Vinh province
+|Tra  Vinh
+|78
+|
+|
+|
+|Preparation
+|
+|
+|-
+|Saigon - Binh  Thuan
+|Bac Binh district, Binh Thuan province
+|Binh  Thuan
+|200
+|
+|
+|Saigon-Binh Thuan power  investment JSC
+|Preparation
+|
+|
+|-
+|Phuong Mai 1
+|Nhon Hoi Economic Zone, Quy Nhon, Binh Dinh
+|Binh Dinh
+|30
+|
+|
+|Phuong Mai wind power JSC
+|Preparation
+|Applying to adjust the connection plan to 110kV, transfer Phuoc Son - Nhon Hoi (AC240-5&nbsp;km)
+|
+|-
+|Phuong Mai 2
+|Nhon Hoi Economic Zone, Quy Nhon, Binh Dinh
+|Binh Dinh
+|60
+|
+|
+|GGP Corp. (Germany)
+|Preparation
+|
+|
+|-
+|Bach Long Vi  island
+|Bach Long Vi island, Hai Phong province
+|Hai Phong
+|1
+|
+|
+|National Youth Union
+|Preparation
+|
+|
+|-
+|Phuoc Dan
+|Phuoc Hau, Phuoc Thai, Phuoc Huu communes and Phuoc Dan town, Ninh Phuoc district, Ninh Thuan province.
+|Ninh  Thuan
+|45
+|
+|
+|Thuong Tin Power company  (Sacomreal)
+|Preparation
+|
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/ninh-thuan-moi-goi-dau-tu-du-an-dien-gio-phuoc-dan.html|title=Ninh Thuận mời gọi đầu tư dự án điện gió Phước Dân|last=NANG LUONG VIET NAM|date=2019-03-29|website=nangluongvietnam.vn}}</ref>
+|-
+|Nhon Hoi
+|Phu Hau village, Cat Chanh commune, Phu Cat district
+|Binh  Dinh
+|30
+|
+|
+|Fico Investment JSC
+|Preparation
+|
+|
+|-
+|Cong Hai
+|Cong Hai commune, Thuan Bac district, Ninh Thuan province
+|Ninh  Thuan
+|29
+|
+|
+|Saigon Industry Corporation
+|Preparation
+|
+|<ref name=":6" />
+|-
+|Phuoc Thanh
+|Phuoc Thanh commune, Bac Ai district, Ninh Thuan province
+|Ninh  Thuan
+|18
+|
+|
+|Global Energy Investment  and Consultantcy
+|Preparation
+|
+|
+|-
+|UPC - Quang Binh 1,2,3,4
+|Le Thuy, Quang Binh
+|Quang  Binh
+|120
+|
+|
+|UPC Renewables Asia
+|Preparation
+|2/7/2018  first met Local authority
+|<ref>{{Cite web|url=http://nangluongvietnam.vn/news/vn/dien-hat-nhan-nang-luong-tai-tao/khoi-dong-du-an-dien-gio-12-nghin-ty-tai-quang-binh.html|title=Khởi động dự án điện gió 12 nghìn tỷ tại Quảng Bình|last=NANG LUONG VIET NAM|date=2018-01-22|website=nangluongvietnam.vn}}</ref>
+|-
+|Huong Hoa 1
+|Huong Loc, A Tuc and A Doi communes, Huong Hoa district, Quang Tri province
+|Quang Tri
+|64
+|
+|
+|Licogi 16
+|Preparation
+|Construction of 220kV double circuit line with a length of about 20&nbsp;km from the factory connected to the 220kV busbar of 220kV Lao Bao substation; Construction of 220kV distribution yard for wind power plant 2x80MVA; expanding 2 dividers on 220kV bus bar of 220kV Lao Bao substation to connect the line circuits from the factory
+|
+|-
+|Huong Son 2
+|Huong Son commune, Huong Hoa district, Quang Tri
+|Quang Tri
+|30
+|
+|
+|EVNGENCO2 (Song Bung hydroelectric management 2)
+|Preparation
+|Huong Son 2 wind power plant is expected to connect to the national electricity system with the plan to build a 22/110kV transformer station at Huong Son 2 wind power plant; construction of single circuit line, ACSR-185 wire with a length of about 6&nbsp;km; to build a new 110kV highway at 110kV Huong Phung 1 station.
+|
+|-
+|Ke Ga offshore wind farm
+|Tan Thanh commune, Ham Thuan Nam district, Binh Thuan province
+|Binh Thuan
+|3400
+|
+|
+|Enterprize Energy
+|Preparation
+|Pre-FS  underway
+|<ref>{{Cite web|url=https://congthuong.vn/viet-nam-co-the-tro-thanh-quoc-gia-co-cong-trinh-dien-gio-voi-cong-nghe-tan-tien-123318.html|title=Việt Nam có thể trở thành quốc gia có công trình điện gió với công nghệ tân tiến|last=Hoa Quỳnh|date=2019-08-03|website=congthuong.vn}}</ref>
+|-
+|Mang Yang wind farm
+|Mang Yang district, Gia Lai province
+|Gia Lai
+|200
+|
+|
+|Mirat Energy + HLP
+|Preparation
+|
+|<ref name=":7">{{Cite web|last=devi-renewable.com|date=2019-04-01|title=Mirat Energy ký hợp tác phát triển hai dự án điện gió 400MW ở Gia Lai|url=https://devi-renewable.com/news/mirat-energy-ky-hop-tac-phat-trien-hai/}}</ref>
+|-
+|Thai Phong
+|Chi Cong, Hoa Minh and Phong Phu communes, Tuy Phong district, Binh Thuan province
+|Binh  Thuan
+|52.5
+|
+|
+|Pacific Energy - Binh Thuan JSC
+|Preparation
+|Metmast installed
+|<ref name=":9" />
+|-
+|Nexif Energy Ben Tre Wind Power Plant
+|Thanh Phu district, Ben Tre province
+|Ben Tre
+|80
+|
+|
+|EVNEPTC, Nexif Energy (Singapore)
+|Preparation
+|Nexif Energy signs 30 MW PPA with Electric Power Trading Company (EPTC) for first phase of wind farm in Ben Tre Province.
+|<ref>{{Cite web|url=http://www.tietkiemnangluong.vn/d6/news/EPTC-ky-ket-hop-dong-mua-ban-dien-Nha-may-Dien-gio-Nexif-Energy-Ben-Tre-111-135-12753.aspx|title=EPTC ký kết hợp đồng mua bán điện Nhà máy Điện gió Nexif Energy Bến Tre|last=Huy P.|date=2019-11-21|website=tietkiemnangluong.vn}}</ref>
+|-
+|Asia Dak Song 1
+|Dak Song district, Dak Nong Province
+|Dak Nong
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Bao Thanh
+|Ba Tri district, Ben Tre province
+|Ben Tre
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|BCG Soc Trang 1
+|Hoa Dong commune, Vinh Chau district, Soc Trang province
+|Soc Trang
+|50
+|
+|
+|Bamboo Capital Group
+|Preparation
+|
+|<ref name=":25" />
+|-
+|19 Ben Tre
+|Thua Duc commune, Binh Dai district, Ben Tre province
+|Ben Tre
+|50
+|
+|
+|Bamboo Capital Group
+|Preparation
+|
+|<ref name=":25" />
+|-
+|20 Ben Tre
+|Thua Duc commune, Binh Dai district, Ben Tre province
+|Ben Tre
+|50
+|
+|
+|Bamboo Capital Group
+|Preparation
+|
+|<ref name=":25" />
+|-
+|BIM
+|Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|88
+|
+|
+|BIM Group
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Binh Dai 2
+|Thua Duc commune, Binh Dai district, Ben Tre province
+|Ben Tre
+|49
+|
+|
+|Me Kong Wind Power JSC
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Binh Dai 3
+|Thua Duc commune, Binh Dai district, Ben Tre province
+|Ben Tre
+|49
+|
+|
+|Me Kong Wind Power JSC
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Cong Hai 1 phase 2
+|Cong Hai commune, Thuan Bac district, Ninh Thuan province
+|Ninh Thuan
+|25
+|
+|
+|Saigon Industry Corporation
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Cong Ly Ba Ria - Vung Tau
+|Xuyen Moc district, Ba Ria Vung Tau province
+|Ba Ria Vung Tau
+|102
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Cu Ne 1
+|Krong Buk district, Dak Lak province
+|Dak Lak
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Cu Ne 2
+|Krong Buk district, Dak Lak province
+|Dak Lak
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Dak Hoa
+|Dak Song district, Dak Nong province
+|Dak Nong
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Dam Nai 3
+|Bac Son commune, Thuan Bac district, Ninh Thuan province
+|Ninh Thuan
+|39.4
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Dam Nai 4
+|Bac Son commune, Thuan Bac district, Ninh Thuan province
+|Ninh Thuan
+|27.6
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Dong Thanh 1
+|Dong Hai commune, Duyen Hai district, Tra Vinh province
+|Tra Vinh
+|80
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Dong Thanh 2
+|Dong Hai commune, Duyen Hai district, Tra Vinh province
+|Tra Vinh
+|120
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Ea H'Leo 1, 2
+|Ea H'Leo and Ea Wy commune, Ea H'Leo district, Dak Lak province
+|Dak Lak
+|57
+|
+|
+|Thuan Binh Wind Power JSC
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Hai Anh
+|Lao Bao commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|40
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Huong Hiep 2
+|Huong Hiep commune, Dakrong district, Quang Tri province
+|Quang Tri
+|30
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Huong Hiep 3
+|Huong Hiep commune, Dakrong district, Quang Tri province
+|Quang Tri
+|30
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Ia Boong - Chu Prong
+|Ia Boong and Ia Me commune, Chu Prong district, Gia Lai province
+|Gia Lai
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Khai Long phase 2
+|Dat Mui commune, Ngoc Hien district, Ca Mau province
+|Ca Mau
+|100
+|
+|
+|Super Wind Energy Cong Ly JSC
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Khai Long phase 3
+|Dat Mui commune, Ngoc Hien district, Ca Mau province
+|Ca Mau
+|100
+|
+|
+|Super Wind Energy Cong Ly JSC
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Kon Plong
+|Kon Plong district, Kon Tum province
+|Kon Tum
+|103.5
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Krong Buk 1
+|Krong Buk district, Dak Lak province
+|Dak Lak
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Krong Buk 2
+|Krong Buk district, Dak Lak province
+|Dak Lak
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|LIG Huong Hoa 1
+|Huong Loc and A Tuc commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Licogi 16
+|Preparation
+|
+|<ref name=":25" />
+|-
+|LIG Huong Hoa 2
+|Huong Loc and A Tuc commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|48
+|
+|
+|Licogi 16
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Loi Hai
+|Loi Hai commune, Thuan Bac district, Ninh Thuan province
+|Ninh Thuan
+|50
+|
+|
+|Thuan BInh Wind Power JSC
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Long My 1
+|Vinh Vien A commune, Long My district, Hau Giang province
+|Hau Giang
+|100
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Nexif Ben Tre phase 2, 3
+|Thanh Hai commune, Thanh Phu district, Ben Tre province
+|Ben Tre
+|50
+|
+|
+|NEXIF ENERGY BEN TRE ONE MEMBER COMPANY LIMITED
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Phu Cuong Soc Trang
+|Vinh Chau district, Soc Trang province
+|Soc Trang
+|200
+|
+|
+|Phu Cuong Group Corporation + Mainstream Renewable Power
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Soc Trang 11
+|Cu Lao Dung district, Soc Trang province
+|Soc Trang
+|101
+|
+|
+|Xuan Thien Yen Bai Company Limited
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Soc Trang 16
+|Vinh Chau district, Soc Trang province
+|Soc Trang
+|40
+|
+|
+|Envision Energy
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Soc Trang 4
+|Vinh Chau district, Soc Trang province
+|Soc Trang
+|350
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Soc Trang 7 phase 2
+|Vinh Hai commune, Vinh Chau district, Soc Trang province
+|Soc Trang
+|90
+|
+|
+|Xuan Cau Company Limited
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Song Hau
+|Long Phu and Tran De district, Soc Trang province
+|Soc Trang
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Tan Hop
+|Huc commune, Huong Hoa district, Quang Tri province
+|Quang Tri
+|38
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Tran De
+|Tran De district, Soc Trang province
+|Soc Trang
+|50
+|
+|
+|
+|Preparation
+|
+|<ref name=":25" />
+|-
+|Vietnam Power number 1
+|Thuan Nam district, Ninh Thuan province
+|Ninh Thuan
+|30
+|
+|
+|Palatial Global Inc
+|Preparation
+|
+|<ref name=":25" />
+|-
+|La Gan
+|
+|Binh Thuan
+|3500
+|
+|
+|Copenhagen Infrastructure Partners
+|Preparation
+|
+|<ref>{{Cite web|last=Đức -|first=Mạnh|date=2021-05-20|title=Việt Nam sắp có dự án điện gió ngoài khơi đầu tiên quy mô tới 3.500 MW|url=https://vneconomy.vn/viet-nam-sap-co-du-an-dien-gio-ngoai-khoi-dau-tien-quy-mo-toi-3-500-mw.htm|access-date=2021-07-15|website=Nhịp sống kinh tế Việt Nam & Thế giới|language=vi}}</ref>
+|}
+
+== Biomass ==
+This section mentions both plants using biomass products (bagasse,...) and [[municipal solid waste]] (MSW).
+
+Source: updated using press releases.
+{| class="wikitable sortable"
+!Plant  name
+!Location
+!Capacity (MW)
+!Operation time
+!Technology
+!Fuel type
+!Sponsor/owner
+!Note
+!{{Tooltip|Ref|References}}
+|-
+|KCP - Phu Yen Phase 1
+|Phu Yen
+|30
+|2017
+|Combustion
+|Bagasse
+|KCP Vietnam Industries Limited 
+|
+|<ref name=":11">{{Cite web|url=https://www.evn.com.vn/d6/news/Nha-may-dien-sinh-khoi-KCP-Phu-Yen-chinh-thuc-hoa-luoi-dien-quoc-gia-141-17-19796.aspx|title=Nhà máy điện sinh khối KCP - Phú Yên chính thức hòa lưới điện quốc gia|last=TTXVN|date=2017-04-04|website=evn.com.vn}}</ref>
+|-
+|Tuyen Quang
+|Tuyen Quang
+|25
+|2019
+|Combustion
+|Bagasse
+|
+|
+|<ref>{{Cite web|url=http://hamyen.org.vn/tin-tuc-su-kien/kinh-te/nha-may-dien-sinh-khoi-mia-duong-tuyen-quang-hoa-luoi-dien-quoc-gia-16536.html|title=Nhà máy Điện sinh khối mía đường Tuyên Quang hòa lưới điện quốc gia|last=TTV|date=2019-01-04|website=hamyen.org.vn}}</ref>
+|-
+|An Khe
+|Gia Lai
+|110
+|2017
+|Combustion
+|Bagasse
+|Quang Ngai Sugar JSC
+|
+|<ref>{{Cite web|url=http://tbdn.com.vn/nha-may-dien-sinh-khoi-an-khe-chinh-thuc-di-vao-hoat-dong_n33272.html|title=Nhà máy điện sinh khối An Khê chính thức đi vào hoạt động|last=Lam Anh|date=2017-11-29|website=tbdn.com.vn}}</ref>
+|-
+|Go Cat
+|Ho Chi Minh City
+|2.5
+|2017
+|Combustion
+|MSW
+|Hydraulic and Machine Co., Ltd
+|
+|<ref>{{Cite web|url=https://bnews.vn/khai-thac-nguon-dien-xanh-tu-rac-thai/115856.html|title=mua bán nguồn điện "xanh" từ nhà cung cấp|last=Nguyễn|first=Xuân Dự|date=2019-03-17|website=bnews.vn}}</ref>
+|-
+|Can Tho
+|Can Tho
+|7.5
+|2018
+|Combustion
+|MSW
+|EB Can Tho Environmental Energy LLC & China Everbright International Corporation
+|
+|<ref>{{Cite web|url=https://bnews.vn/khanh-thanh-nha-may-dot-rac-sinh-hoat-phat-dien-can-tho/104887.html|title=Khánh thành nhà máy đốt rác sinh hoạt phát điện Cần Thơ|last=Thanh Liêm|date=2018-12-08|website=bnews.vn}}</ref>
+|-
+|Nam Son
+|Hanoi
+|2
+|2017
+|Combustion
+|MSW
+|Urban Environment Company (URENCO) & Hitachi Zosen Company - Japan
+|
+|<ref>{{Cite web|url=https://baodautu.vn/khanh-thanh-nha-may-xu-ly-chat-thai-cong-nghiep-phat-dien-von-645-ty-dong-tai-soc-son-d62383.html|title=Khánh thành Nhà máy xử lý chất thải công nghiệp phát điện vốn 645 tỷ đồng tại Sóc Sơn|last=Thu Trang|date=2017-04-24|website=baodautu.vn}}</ref>
+|-
+|Sugar mills
+|
+|150
+|
+|CHP
+|
+|
+|
+|
+|-
+|Soc Son
+|Hanoi
+|90
+|2022
+|Combustion
+|MSW
+|
+|
+|
+|-
+|KCP - Phu Yen Phase 2
+|Phu Yen
+|30
+|
+|
+|
+|KCP Vietnam industries limited 
+|Announced
+|<ref name=":11" />
+|}
+
+== Hydroelectricity  ==
+This section mentions only medium and large hydro power plants (capacity >= 30 MW).
+
+Source: updated with data from [[Ministry of Industry and Trade (Vietnam)|Ministry of Industry and Trade]] (MOIT) 2019 Report 58/BC-CBT, updated using press releases.
+{| class="wikitable sortable"
+|-
+! Station !!Location!! Capacity (MW)
+!Commission time!! Sponsor/owner
+!Note!!{{Tooltip|Ref|References}}
+|-
+|[[Sơn La Dam]]
+|[[Mường La]]|| 6x400
+|  ||Son La Hydropower Company/EVN
+|
+|&nbsp;
+|-
+|[[Lai Châu Dam|Lai Chau]]
+|
+|1200
+|
+|Son La Hydropower Company/EVN
+|
+|
+|-
+|Lai Chau #2, 3
+|
+|2x400
+|2016
+|EVN
+|
+|Report 58/BC-CBT annex row I.2
+|-
+|Ban Chat
+|
+|220
+|
+|Huoi Quang-Ban Chat hydropower company/EVN
+|
+|
+|-
+|[[Huoi Quang Dam|Huoi Quang]]
+|
+|520
+|
+|Huoi Quang-Ban Chat hydropower company/EVN
+|
+|
+|-
+|Huoi Quang #2
+|
+|260
+|2016
+|EVN
+|
+|Report 58/BC-CBT annex row I.1
+|-
+|[[Hòa Bình Dam|Hoa Binh]]
+|
+|1960
+|
+|Hoa Binh Hydropower Company/EVN
+|2,400 by 2024
+|
+|-
+|Tuyen Quang
+|
+|342
+|
+|Tuyen Quang Hydropower Company/EVN
+|
+|
+|-
+|Pleikrong
+|
+|100
+|
+|Yaly Hydropower Company/EVN
+|
+|
+|-
+|Yaly
+|
+|720
+|
+|Yaly Hydropower Company/EVN
+|
+|
+|-
+|Se San 3
+|
+|260
+|
+|Yaly Hydropower Company/EVN
+|
+|
+|-
+|Se San 4
+|
+|360
+|
+|Se San Hydropower Development Company/EVN
+|
+|
+|-
+|[[Trị An Dam|Tri An]]
+|
+|400
+|
+|Tri An Hydropower Company/EVN
+|
+|
+|-
+|Thac Mo expansion
+|
+|75
+|2017
+|Thac Mo expansion hydropower plant project/EVN
+|
+|Report 58/BC-CBT annex row I.7
+|-
+|Ban Ve
+|
+|320
+|
+|Ban Ve Hydropower Company/EVNGENCO 1
+|
+|
+|-
+|Khe Bo
+|
+|100
+|
+|Khe Bo Hydropower Company/EVNGENCO 1
+|
+|
+|-
+|Trung Son
+|
+|4x65
+|2017
+|Trung Son Hydropower One Member LLC/EVNGENCO 2
+|
+|Report 58/BC-CBT annex row I.3
+|-
+|Quang Tri
+|
+|64
+|
+|Quang Tri Hydropower Company/EVNGENCO 2
+|
+|
+|-
+|A Vuong
+|
+|210
+|
+|A Vuong Hydropower JSC/EVNGENCO 2
+|
+|
+|-
+|Buon Tua Srah
+|
+|86
+|
+|Buon Kuop Hydropower Company/EVNGENCO 3
+|
+|
+|-
+|Buon Kuop
+|
+|280
+|
+|Buon Kuop Hydropower Company/EVNGENCO 3
+|
+|
+|-
+|Srepok 3
+|
+|220
+|
+|Buon Kuop Hydropower Company/EVNGENCO 3
+|
+|
+|-
+|Song Tranh 2
+|
+|190
+|
+|Song Tranh Hydropower Company/EVNGENCO 1
+|
+|
+|-
+|An Khe
+|
+|160
+|
+|Song Ba Ha Hydropower JSC/EVNGENCO 2
+|
+|
+|-
+|Song Ba Ha
+|
+|220
+|
+|Song Bung Hydropower Company/EVNGENCO 2
+|
+|
+|-
+|Bung River 2
+|
+|2x50
+|2018
+|EVNGENCO 2
+|
+|Report 58/BC-CBT annex row I.8
+|-
+|Song Bung 4
+|
+|156
+|
+|Dong Nai Hydropower Company/EVNGENCO 2
+|
+|
+|-
+|Dong Nai 3
+|
+|180
+|
+|Dong Nai Hydropower Company/EVNGENCO 1
+|
+|
+|-
+|Dong Nai 4
+|
+|340
+|
+|Thac Mo Hydropower JSC/EVNGENCO 1
+|
+|
+|-
+|Thac Mo
+|
+|150
+|
+|Da Nhim-Ham Thuan-Da Mi Hydropower JSC/EVNGENCO 2
+|
+|
+|-
+|Da Nhim
+|
+|160
+|
+|Da Nhim-Ham Thuan-Da Mi Hydropower JSC/EVNGENCO 1
+|
+|
+|-
+|Da Nhim expansion
+|
+|80
+|2019
+|Da Nhim-Ham Thuan-Da Mi Hydropower JSC/EVNGENCO 1
+|Generated 40MW
+|Report 58/BC-CBT annex row I.10
+|-
+|Thuong Kon Tum
+|
+|2x110
+|2019
+|EVN
+|
+|Report 58/BC-CBT annex row I.11
+|-
+|Ham Thuan
+|
+|300
+|
+|Da Nhim-Ham Thuan-Da Mi Hydropower JSC/EVNGENCO 1
+|
+|
+|-
+|Da Mi
+|
+|175
+|
+|Dai Ninh Hydropower Company/EVNGENCO 1
+|
+|
+|-
+|Dai Ninh
+|
+|300
+|
+|Hoang Anh-Gia Lai Hydropower JSC (Bitexco)/EVNGENCO 1
+|
+|
+|-
+|Ba Thuoc 1
+|
+|60
+|
+|Hoang Anh-Gia Lai Hydropower JSC (Bitexco)
+|
+|
+|-
+|Ba Thuoc 2
+|
+|80
+|
+|Bac Ha Hydropower JSC
+|
+|
+|-
+|Bac Ha
+|
+|90
+|
+|IPP
+|
+|
+|-
+|Bac Me
+|
+|45
+|
+|Construction Commercial Joint Stock Corporation (Vietracimex)
+|
+|
+|-
+|Bao Lam 3
+|
+|50.6
+|
+|Power Construction JSC No1 (PCC1)
+|
+|
+|-
+|Chiem Hoa
+|
+|48
+|
+|International Investment Construction and Trade JSC (ICT)
+|
+|
+|-
+|Chi Khe
+|
+|41
+|
+|Agrita Nghe Tinh energy JSC
+|
+|
+|-
+|Cua Dat
+|
+|97
+|
+|Vinaconex P&C JSC
+|
+|
+|-
+|Hua Na
+|
+|180
+|
+|Hua Na Hydropower JSC/PVN
+|
+|
+|-
+|Huong Son
+|
+|33
+|
+|Huong Son Hydropower JSC
+|
+|
+|-
+|Muong Hum
+|
+|32
+|
+|Muong Hum Hydropower JSC
+|
+|
+|-
+|Nam Chien 1
+|
+|200
+|
+|Nam Chien Hydropower JSC
+|
+|
+|-
+|Nam Chien 2
+|
+|32
+|
+|North-west Electric Investment And Development JSC
+|
+|
+|-
+|Nam Cun
+|
+|40
+|
+|299 Construction and Trading JSC
+|
+|
+|-
+|Nam Muc
+|
+|44
+|
+|Nam Muc Hydropower JSC (Bitexco)
+|
+|
+|-
+|Nam Na 2
+|
+|66
+|
+|Hung Hai Construction LLC
+|
+|
+|-
+|Nam Na 3
+|
+|84
+|
+|Hung Hai Construction LLC
+|
+|
+|-
+|Nam Phang
+|
+|36
+|
+|Bac Ha Energy JSC
+|
+|
+|-
+|Nam Toong
+|
+|34
+|
+|Sapa Hydropower One Member LLC
+|
+|
+|-
+|Ngoi Hut 2
+|
+|48
+|
+|Truong Thanh Construction and Development Investment JSC
+|
+|
+|-
+|Ngoi Hut 2A
+|
+|8.4
+|
+|Truong Thanh Construction and Development Investment JSC
+|
+|
+|-
+|Ngoi Phat
+|
+|72
+|
+|Northern Electricity Development Investment JSC 2 (NEDI 2)
+|
+|
+|-
+|Nhan Hac A
+|
+|55
+|
+|Za Hung JSC
+|
+|
+|-
+|Nhan Hac B
+|
+|4
+|
+|Za Hung JSC
+|
+|
+|-
+|Nho Que 1
+|
+|32
+|
+|Nho Que Hydropower JSC 1 (Bitexco)
+|
+|
+|-
+|Nho Que 2
+|
+|48
+|
+|Nho Que Investment and Power Development JSC (Bitexco)
+|
+|
+|-
+|Nho Que 3
+|
+|110
+|
+|Nho Que 3 One Member LLC (Bitexco)
+|
+|
+|-
+|Song Bac
+|
+|42
+|
+|Song Bac Hydropower JSC
+|
+|
+|-
+|Su Pan 2
+|
+|34.5
+|
+|Su Pan Hydropower JSC
+|
+|
+|-
+|Ta Thang
+|
+|60
+|
+|Vietracimex Lao Cai Electric JSC
+|
+|
+|-
+|Thac Ba
+|
+|120
+|
+|Thac Ba Hydropower JSC
+|
+|
+|-
+|Thai An
+|
+|82
+|
+|Thai An Hydropower JSC
+|
+|
+|-
+|Thuan Hoa
+|
+|42
+|
+|Thuan Hoa - Ha Giang Hydropower JSC
+|
+|
+|-
+|Van Chan
+|
+|57
+|
+|Van Chan Hydropower JSC (Bitexco)
+|
+|
+|-
+|A Luoi
+|
+|170
+|
+|Central Hydropower JSC (EVNCHP)
+|
+|
+|-
+|Binh Dien
+|
+|44
+|
+|Binh Dien Hydropower JSC (Bitexco)
+|
+|
+|-
+|Dakdrinh
+|
+|125
+|
+|Dakdrinh Hydropower JSC/PVN
+|
+|
+|-
+|Dak Mi 3
+|
+|63
+|
+|Dak Mi 3 IDICO Hydropower JSC
+|
+|
+|-
+|Dak Mi 4
+|
+|208
+|
+|Dak Mi Hydropower JSC (Bitexco)
+|
+|
+|-
+|Dak R'Tih
+|
+|144
+|
+|Dak R'Tih Hydropower JSC
+|
+|
+|-
+|Dong Nai 5
+|
+|150
+|
+|Dong Nai 5 Hydropower JSC/TKV
+|
+|
+|-
+|Huong Dien
+|
+|81
+|
+|Huong Dien Investment JSC
+|
+|
+|-
+|Krong H'nang
+|
+|64
+|
+|Song Ba JSC
+|
+|
+|-
+|Se San 3A
+|
+|108
+|
+|Se San 3A Power Investment and Development JSC
+|
+|
+|-
+|Se San 4A
+|
+|63
+|
+|Se San 4A Hydropower JSC
+|
+|
+|-
+|Song Bung 4A
+|
+|49
+|
+|Phu Thach My JSC
+|
+|
+|-
+|Song Bung 5
+|
+|57
+|
+|Power Engineering Consulting JSC 1 (PECC1)
+|
+|
+|-
+|Song Con 2
+|
+|63
+|
+|Geruco - Song Con Hydropower JSC
+|
+|
+|-
+|Song Giang 2
+|
+|37
+|
+|Song Giang Hydropower JSC
+|
+|
+|-
+|Song Tranh 3
+|
+|62
+|
+|Song Tranh Hydropower JSC 3
+|
+|
+|-
+|Srepok 4
+|
+|80
+|
+|Dai Hai Electric Investment and Development JSC
+|
+|
+|-
+|Srepok 4A
+|
+|64
+|
+|Buon Don Hydropower JSC
+|
+|
+|-
+|Vinh Son
+|
+|66
+|
+|Vinh Son - Song Hinh Hydropower JSC
+|
+|
+|-
+|Song Hinh
+|
+|70
+|
+|Vinh Son - Song Hinh Hydropower JSC
+|
+|
+|-
+|Bac Binh
+|
+|33
+|
+|Vietnam Power Development JSC (VNPD)
+|
+|
+|-
+|Can Don
+|
+|77.6
+|
+|Can Don Hydroelectric JSC
+|
+|
+|-
+|Da Dang 2
+|
+|34
+|
+|Southern Hydropower JSC (SHP)
+|
+|
+|-
+|Dam Bri
+|
+|75
+|
+|Southern Hydropower JSC (SHP)
+|
+|
+|-
+|Dong Nai 2
+|
+|73
+|
+|Trung Nam Power JSC
+|
+|
+|-
+|Srokphumieng
+|
+|51
+|
+|Srok Phu Mieng IDICO Hydropower JSC
+|
+|
+|-
+|Small hydro North
+|
+|1931
+|
+|
+|
+|
+|-
+|Small hydro Center
+|
+|1137
+|
+|
+|
+|
+|-
+|Small hydro South
+|
+|254
+|
+|
+|
+|
+|-
+|Ka Nak
+|
+|13
+|
+|EVNGENCO 2
+|
+|
+|-
+|Sông Pha
+|
+|7.5
+|
+|Da Nhim-Ham Thuan-Da Mi Hydropower JSC/EVNGENCO 1
+|
+|
+|-
+|Hoa Binh expansion
+|
+|2x240
+|2023
+|EVN
+|Under construction or proposed
+|Report 58/BC-CBT annex row I.21
+|-
+|Ialy expansion
+|
+|2x180
+|2023
+|EVN
+|Under construction or proposed
+|Report 58/BC-CBT annex row I.22
+|-
+|Tri An expansion
+|
+|200
+|2025
+|EVN
+|Under construction or proposed
+|Report 58/BC-CBT annex row I.23
+|-
+|My Ly
+|
+|250
+|2024
+|IPP
+|Under construction or proposed
+|Report 58/BC-CBT annex row V.5
+|-
+|Nam Mo
+|
+|90
+|2026
+|IPP
+|Under construction or proposed
+|Report 58/BC-CBT annex row V.6
+|}
+
+== Notes ==
+
+=== For solar, wind power plants ===
+{| class="wikitable"
+|Rooftop solar
+|RS
+|-
+|Operational
+|OP
+|-
+|Under Construction
+|UC
+|-
+|Groundbreaking
+|GB
+|-
+|Approved
+|AP
+|}
+
+=== For gas, coal-fired power plants ===
+
+* '''Announced:''' Projects that are in the planning decision of the government or companies but have not yet obtained a permit or permission for land use rights, coal supply rights...<ref name=":15">{{Cite web|url=https://endcoal.org/global-coal-plant-tracker/about-the-tracker/|archive-url=https://web.archive.org/web/20150919205943/http://endcoal.org/global-coal-plant-tracker/about-the-tracker/|url-status=usurped|archive-date=September 19, 2015|title=End Coal {{!}} Frequently Asked Questions|website=End Coal|language=en-US|access-date=2019-07-25}}</ref>
+* '''Pre-permit development:''' Projects have started to implement one of the following items: environmental licenses, land and water use rights, financial security, transmission contract guarantees, etc.<ref name=":15" />
+* '''Permitted:''' Projects that have been licensed for environmental licenses but have not yet begun to break ground.<ref name=":15" />
+* '''Construction:''' Projects are being built after the groundbreaking ceremony.<ref name=":15" />
+* '''Shelved:''' Projects do not have specific information on the project's progress but do not have enough information to declare the project canceled.<ref name=":15" />
+* '''Cancelled:''' Projects are not progressing after a very long time with no information about the project; Projects converted to natural gas are considered to have not used coal anymore; projects have appeared in government documents but then disappeared.<ref name=":15" />
+* '''Operating:''' Projects with an official date of Commercial Operation Date (COD).<ref name=":15" />
+
+== See also ==
+* [[List of power stations in Asia]]
+* [[List of largest power stations in the world]]
+* [[Energy in Vietnam]]
+* [[Renewable energy in Vietnam]]
+
+== References ==
+{{reflist}}
+
+== External links ==
+{{Power stations}}
+{{Vietnam topics}}
+
+[[Category:Lists of power stations by country|Vietnam]]
+[[Category:Power stations in Vietnam| ]]
+[[Category:Lists of buildings and structures in Vietnam|Power stations]]

--- a/experiments/exploration/0486/README.md
+++ b/experiments/exploration/0486/README.md
@@ -1,0 +1,24 @@
+# 0486 source-concordance prototypes
+
+Throwaway exploration scripts that produced the **light-reviewed** numbers quoted
+in tickets 0486 and 0494. The raid is expected to *productionise* these into a
+Makefile-wired `src/aedist/` script; they live here so the numbers are
+reproducible in the meantime.
+
+Run from the **repo root** (they use repo-root-relative paths + `aedist.config`):
+
+```bash
+uv run python experiments/exploration/0486/explore_bars.py       # aggregate bars: Wikipedia 90, GEM 120 (raw)
+uv run python experiments/exploration/0486/explore_review.py     # ASCII-fold review: GEM 88%, Wikipedia 73%
+uv run python experiments/exploration/0486/explore_superset.py   # GEM 153 rows/119 distinct; 11 true GEM-only
+```
+
+Inputs (all tracked):
+- `data/reference/vietnam_thermal_plants_v2_classified.csv` — the reference
+- `data/reference/gem_thermal.csv` — GEM
+- `data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext` + `wikipedia_power_vietnam-2026-06-09.wikitext`
+  — Wikipedia (coal list + general page's `==Gas turbines==` section; raw wikitext, `?action=raw`)
+
+Caveats (carried into the tickets): the ASCII-fold recovery slightly over-counts via
+grain mismatch (one source row ↔ several reference phases), so 88%/73% are upper-ish.
+The full per-plant HITL concordance is post-arXiv (ticket 0498).

--- a/experiments/exploration/0486/explore_bars.py
+++ b/experiments/exploration/0486/explore_bars.py
@@ -1,0 +1,106 @@
+"""0486 prototype: source-coverage 'bars' — GEM and Wikipedia (coal+gas) coverage
+of the reference, aggregate and built-fleet. Answers: does the GEM count differ
+from the Wikipedia count (→ show/no-show the Exp2 GEM bar)?
+
+Run from the repo root:  uv run python experiments/exploration/0486/explore_bars.py
+Reproduces the 0486 ticket numbers (Wikipedia 90 raw, GEM 120 raw aggregate).
+"""
+
+import csv
+import re
+import tempfile
+from pathlib import Path
+
+from aedist.config import GEM_THERMAL_REFERENCE_CSV, VN_THERMAL_PLANTS_RELEASE_CSV
+from aedist.evaluate import load_plants_csv
+from aedist.reconcile import reconcile
+from aedist.schema import MatchType
+
+MATCHED = {MatchType.EXACT, MatchType.EXACT_CAPACITY_DIFF, MatchType.FUZZY, MatchType.FUZZY_CAPACITY_DIFF}
+RAW = Path("data/reference/raw")
+BUILT = {"operating", "construction", "permitted"}
+
+
+def status_label(raw):
+    return re.sub(r"^\d+\s+", "", (raw or "").strip()) or "?"
+
+
+def parse_wikitable(text):
+    """Yield the first-column (name) of each data row of the first wikitable."""
+    if "{|" not in text:
+        return []
+    table = text.split("{|", 1)[1].split("|}", 1)[0]
+    names = []
+    for row in table.split("\n|-"):
+        cells = [c.strip() for c in re.split(r"\n\|", row) if c.strip()]
+        cells = [c for c in cells if not c.startswith("!") and "class=" not in c and "width=" not in c]
+        if not cells:
+            continue
+        nm = re.sub(r"\[\[|\]\]|'''|<ref.*?</ref>|<ref.*?/>", "", cells[0]).split("|")[0].strip()
+        nm = re.sub(r"\s+(gas|coal)?\s*power (plant|station).*$", "", nm, flags=re.I).strip()
+        if nm and len(nm) > 2 and "Station" not in nm and "Power plant" not in nm:
+            names.append(nm)
+    return names
+
+
+def gas_section(text):
+    out, g = [], False
+    for line in text.splitlines():
+        if line.startswith("==Gas turbines=="):
+            g = True
+        elif re.match(r"^==[^=]", line) and "Gas turbines" not in line:
+            g = False
+        if g:
+            out.append(line)
+    return "\n".join(out)
+
+
+ref_plants = load_plants_csv(VN_THERMAL_PLANTS_RELEASE_CSV)
+ref_status = {}
+with open(VN_THERMAL_PLANTS_RELEASE_CSV, newline="", encoding="utf-8") as fh:
+    for r in csv.DictReader(fh):
+        ref_status[r["name"].strip()] = status_label(r.get("status", ""))
+print(f"reference: {len(ref_plants)} plants  ({sum(1 for s in ref_status.values() if s in BUILT)} built-fleet)")
+
+coal = parse_wikitable((RAW / "wikipedia_coal_vietnam-2026-06-09.wikitext").read_text(encoding="utf-8"))
+gas = parse_wikitable(gas_section((RAW / "wikipedia_power_vietnam-2026-06-09.wikitext").read_text(encoding="utf-8")))
+wiki_names = sorted(set(coal) | set(gas))
+print(f"Wikipedia thermal names: {len(coal)} coal + {len(gas)} gas = {len(wiki_names)} unique")
+
+
+def to_plants(names):
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False, newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["name", "capacity_mwe", "fuel", "status"])
+        for nm in names:
+            w.writerow([nm, "0", "", ""])
+        p = Path(f.name)
+    pl = load_plants_csv(p)
+    p.unlink(missing_ok=True)
+    return pl
+
+
+def coverage(source_plants, label):
+    entries = reconcile(ref_plants, source_plants)
+    agg = built = 0
+    for e in entries:
+        rn = getattr(e, "reference_name", None)
+        if not rn or e.match_type not in MATCHED:
+            continue
+        agg += 1
+        if ref_status.get(rn) in BUILT:
+            built += 1
+    n_ref = len(ref_plants)
+    n_built = sum(1 for s in ref_status.values() if s in BUILT)
+    print(f"\n{label} bar:")
+    print(f"  aggregate (all statuses): {agg}/{n_ref}  ({agg / n_ref:.0%})")
+    print(f"  built-fleet only:         {built}/{n_built}  ({built / n_built:.0%})")
+    return agg, built
+
+
+wiki_agg, wiki_built = coverage(to_plants(wiki_names), "WIKIPEDIA (coal+gas)")
+gem_agg, gem_built = coverage(load_plants_csv(GEM_THERMAL_REFERENCE_CSV), "GEM")
+
+print("\n=== DOES GEM DIFFER FROM WIKIPEDIA? ===")
+print(f"  aggregate:  Wikipedia {wiki_agg}  vs  GEM {gem_agg}   (Δ={abs(wiki_agg - gem_agg)})")
+print(f"  built-fleet: Wikipedia {wiki_built}  vs  GEM {gem_built}   (Δ={abs(wiki_built - gem_built)})")

--- a/experiments/exploration/0486/explore_review.py
+++ b/experiments/exploration/0486/explore_review.py
@@ -1,0 +1,130 @@
+"""0486 prototype: light matcher review. For the reference plants the project
+matcher marked absent from GEM / Wikipedia, ASCII-fold (Vietnamese diacritics →
+ASCII) and re-match loosely to separate naming-variant misses (recoverable → real
+coverage) from true absences. Corrects the raw matcher-floored bar counts.
+
+Run from repo root:  uv run python experiments/exploration/0486/explore_review.py
+Reproduces the 0486 ticket numbers: GEM 120→159 (88%), Wikipedia 90→131 (73%).
+"""
+
+import csv
+import re
+import tempfile
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+from rapidfuzz import fuzz
+
+from aedist.config import GEM_THERMAL_REFERENCE_CSV, VN_THERMAL_PLANTS_RELEASE_CSV
+from aedist.evaluate import load_plants_csv
+from aedist.reconcile import reconcile
+from aedist.schema import MatchType
+
+MATCHED = {MatchType.EXACT, MatchType.EXACT_CAPACITY_DIFF, MatchType.FUZZY, MatchType.FUZZY_CAPACITY_DIFF}
+RAW = Path("data/reference/raw")
+RECOVER = 88  # ascii-folded partial_ratio threshold to call a residual a variant
+
+
+def fold(s):
+    s = (s or "").replace("Đ", "D").replace("đ", "d")
+    s = "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+    s = re.sub(r"\b(nd|tbkhh|tbk|nhiet dien|ccgt|gt)\b", "", s.lower())
+    return re.sub(r"[^a-z0-9 ]", " ", s).strip()
+
+
+def parse_wikitable(text):
+    if "{|" not in text:
+        return []
+    table = text.split("{|", 1)[1].split("|}", 1)[0]
+    names = []
+    for row in table.split("\n|-"):
+        cells = [c.strip() for c in re.split(r"\n\|", row) if c.strip()]
+        cells = [c for c in cells if not c.startswith("!") and "class=" not in c and "width=" not in c]
+        if not cells:
+            continue
+        nm = re.sub(r"\[\[|\]\]|'''|<ref.*?</ref>|<ref.*?/>", "", cells[0]).split("|")[0].strip()
+        nm = re.sub(r"\s+(gas|coal)?\s*power (plant|station).*$", "", nm, flags=re.I).strip()
+        if nm and len(nm) > 2 and "Station" not in nm and "Power plant" not in nm:
+            names.append(nm)
+    return names
+
+
+def gas_section(text):
+    out, g = [], False
+    for line in text.splitlines():
+        if line.startswith("==Gas turbines=="):
+            g = True
+        elif re.match(r"^==[^=]", line) and "Gas turbines" not in line:
+            g = False
+        if g:
+            out.append(line)
+    return "\n".join(out)
+
+
+ref_plants = load_plants_csv(VN_THERMAL_PLANTS_RELEASE_CSV)
+ref_status = {}
+with open(VN_THERMAL_PLANTS_RELEASE_CSV, newline="", encoding="utf-8") as fh:
+    for r in csv.DictReader(fh):
+        ref_status[r["name"].strip()] = re.sub(r"^\d+\s+", "", (r.get("status") or "").strip())
+
+
+def names_to_plants(names):
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False, newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["name", "capacity_mwe", "fuel", "status"])
+        for nm in names:
+            w.writerow([nm, "0", "", ""])
+        p = Path(f.name)
+    pl = load_plants_csv(p)
+    p.unlink(missing_ok=True)
+    return pl
+
+
+def review(source_plants, source_raw_names, label):
+    entries = reconcile(ref_plants, source_plants)
+    matched = {getattr(e, "reference_name", None) for e in entries if e.match_type in MATCHED}
+    matched.discard(None)
+    residual = [p.name for p in ref_plants if p.name not in matched]
+    folded_src = [(fold(n), n) for n in source_raw_names]
+
+    recovered, absent = [], []
+    for rn in residual:
+        fr = fold(rn)
+        best, cand = 0, ""
+        for fs, orig in folded_src:
+            sc = fuzz.partial_ratio(fr, fs)
+            if sc > best:
+                best, cand = sc, orig
+        (recovered if best >= RECOVER else absent).append((rn, cand, best))
+
+    n = len(ref_plants)
+    raw = len(matched)
+    corr = raw + len(recovered)
+    print(f"\n===== {label} =====")
+    print(f"  raw matcher coverage:        {raw}/{n}  ({raw / n:.0%})")
+    print(f"  + ascii-fold recovered:      {len(recovered)}  (naming-variant misses)")
+    print(f"  = corrected coverage:        {corr}/{n}  ({corr / n:.0%})")
+    print(f"  true absences:               {len(absent)}")
+    print("  recovered examples (ref → source candidate @score):")
+    for rn, cand, sc in recovered[:10]:
+        print(f"     {rn:28} → {cand} @{sc}")
+    print("  true-absence by status:")
+    for st, c in Counter(ref_status.get(rn, "?") for rn, _, _ in absent).most_common():
+        print(f"     {st:16} {c}")
+    return raw, corr, len(absent)
+
+
+gem_plants = load_plants_csv(GEM_THERMAL_REFERENCE_CSV)
+gem_raw_names = [r["Name"] for r in csv.DictReader(open(GEM_THERMAL_REFERENCE_CSV, encoding="utf-8")) if r.get("Name")]
+g_raw, g_corr, _ = review(gem_plants, gem_raw_names, "GEM")
+
+coal = parse_wikitable((RAW / "wikipedia_coal_vietnam-2026-06-09.wikitext").read_text(encoding="utf-8"))
+gas = parse_wikitable(gas_section((RAW / "wikipedia_power_vietnam-2026-06-09.wikitext").read_text(encoding="utf-8")))
+wiki_names = sorted(set(coal) | set(gas))
+w_raw, w_corr, _ = review(names_to_plants(wiki_names), wiki_names, "WIKIPEDIA (coal+gas)")
+
+print("\n=== CORRECTED BARS (after light review) ===")
+print(f"  Wikipedia: {w_raw} raw → {w_corr} corrected")
+print(f"  GEM:       {g_raw} raw → {g_corr} corrected")
+print(f"  GEM − Wikipedia gap: {g_raw - w_raw} raw → {g_corr - w_corr} corrected")

--- a/experiments/exploration/0486/explore_superset.py
+++ b/experiments/exploration/0486/explore_superset.py
@@ -1,0 +1,62 @@
+"""0486 prototype: is the reference a strict superset of GEM? Count GEM plants
+NOT in the reference (GEM-only), with ASCII-fold review so naming variants don't
+inflate it.
+
+Run from repo root:  uv run python experiments/exploration/0486/explore_superset.py
+Reproduces the 0486 ticket numbers: GEM 153 rows / 119 distinct; 11 true GEM-only.
+"""
+
+import csv
+import re
+import unicodedata
+
+from rapidfuzz import fuzz
+
+from aedist.config import GEM_THERMAL_REFERENCE_CSV, VN_THERMAL_PLANTS_RELEASE_CSV
+from aedist.evaluate import load_plants_csv
+from aedist.reconcile import reconcile
+from aedist.schema import MatchType
+
+MATCHED = {MatchType.EXACT, MatchType.EXACT_CAPACITY_DIFF, MatchType.FUZZY, MatchType.FUZZY_CAPACITY_DIFF}
+RECOVER = 88
+
+
+def fold(s):
+    s = (s or "").replace("Đ", "D").replace("đ", "d")
+    s = "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+    s = re.sub(r"\b(nd|tbkhh|tbk|nhiet dien|ccgt|gt)\b", "", s.lower())
+    return re.sub(r"[^a-z0-9 ]", " ", s).strip()
+
+
+ref_plants = load_plants_csv(VN_THERMAL_PLANTS_RELEASE_CSV)
+gem_plants = load_plants_csv(GEM_THERMAL_REFERENCE_CSV)
+gem_rows = list(csv.DictReader(open(GEM_THERMAL_REFERENCE_CSV, encoding="utf-8")))
+folded_ref = [fold(p.name) for p in ref_plants]
+
+print(f"GEM rows: {len(gem_rows)}   |   reference rows: {len(ref_plants)}")
+print(f"GEM distinct names: {len({r['Name'].strip() for r in gem_rows})}")
+print(f"GEM status values: {sorted({r.get('Status', '').strip() for r in gem_rows})}\n")
+
+# reconcile(ref, gem): SYSTEM_ONLY = GEM-only (in GEM, not matched to reference)
+entries = reconcile(ref_plants, gem_plants)
+gem_only_raw = [getattr(e, "system_name", None) for e in entries if e.match_type == MatchType.SYSTEM_ONLY]
+gem_only_raw = [n for n in gem_only_raw if n]
+
+true_gem_only, recovered = [], []
+for gn in gem_only_raw:
+    fg = fold(gn)
+    best = max((fuzz.partial_ratio(fg, fr) for fr in folded_ref), default=0)
+    (recovered if best >= RECOVER else true_gem_only).append((gn, best))
+
+print(f"GEM-only (raw matcher):     {len(gem_only_raw)} GEM plants not matched to reference")
+print(f"  - ascii-fold recovered:   {len(recovered)} (were naming variants)")
+print(f"  = TRUE GEM-only:          {len(true_gem_only)}\n")
+
+if not true_gem_only:
+    print(">>> STRICT SUPERSET: every GEM plant is in the reference (reference superset of GEM).")
+else:
+    print(f">>> NOT a strict superset - {len(true_gem_only)} GEM plant(s) absent from the reference:")
+    gem_by_name = {r["Name"].strip(): r for r in gem_rows}
+    for gn, best in sorted(true_gem_only, key=lambda t: t[1]):
+        r = gem_by_name.get(gn, {})
+        print(f"    {gn:34} {r.get('Fuel', '?'):6} {r.get('Capacity', '?'):>7} MW  {r.get('Status', '?'):14} (fold {best:.0f})")

--- a/tickets/0486-comparison-table-reference-vs-gem-osm-wiki.erg
+++ b/tickets/0486-comparison-table-reference-vs-gem-osm-wiki.erg
@@ -6,7 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-06-09T00:00Z HDMX-coding-agent created
 2026-06-09T08:30Z HDMX-coding-agent note DEFERRED by raid Imagine/Plan verification — three exit-criteria decisions were author-only.
-2026-06-09T11:30Z HDMX-coding-agent note SCOPE LOCKED after the 0486 design dialogue + grounding computation. The three deferred decisions are resolved (see below). Numbers below are measured (light-reviewed); the executor consumes them, does not re-derive the design. Prototype scripts live in /tmp throwaway (explore_review.py, explore_superset.py) — productionise.
+2026-06-09T11:30Z HDMX-coding-agent note SCOPE LOCKED after the 0486 design dialogue + grounding computation. The three deferred decisions are resolved (see below). Numbers below are measured (light-reviewed); the executor consumes them, does not re-derive the design. Prototype scripts committed at `experiments/exploration/0486/` (reproduce the numbers from tracked inputs); productionise.
 
 --- body ---
 
@@ -67,9 +67,9 @@ upper-ish — label as light-reviewed, full per-plant HITL is post-arXiv (ticket
 
 - `data/reference/vietnam_thermal_plants_v2_classified.csv` — reference (177 post-0497)
 - `data/reference/gem_thermal.csv` — GEM (153 rows / 119 plants)
-- `data/reference/raw/wikipedia_coal_vietnam.wikitext`, `wikipedia_power_vietnam.wikitext` — cached Wikipedia (raw, reproducible); gas plants are in the general page "==Gas turbines==" section
+- `data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext`, `wikipedia_power_vietnam-2026-06-09.wikitext` — cached Wikipedia (raw, reproducible); gas plants are in the general page "==Gas turbines==" section
 - `src/aedist/reconcile.py`, `src/aedist/evaluate.py` — matcher + reference loader
-- prototypes: `/tmp/wt-0486/explore_review.py`, `explore_superset.py`, `explore_bars.py`
+- prototypes: `experiments/exploration/0486/{explore_review,explore_superset,explore_bars}.py` (committed; run from repo root)
 - `src/aedist/plot_*exp1*`, `plot_*exp2*` — figure scripts (add the bar lines)
 - `slides/manuscript/main.md` — annex (table) + §4/§5 (quoted numbers, bars referenced)
 

--- a/tickets/0494-wikipedia-recall-bar-early-framing.erg
+++ b/tickets/0494-wikipedia-recall-bar-early-framing.erg
@@ -27,7 +27,7 @@ training corpus. Scoring below it is not "missing obscure facts" — it is
 failing to retrieve knowledge the models demonstrably have.
 
 The bar has **two regimes** (measured 2026-06-09, coal subset, against the
-180-plant v2.3 reference; see `data/reference/raw/wikipedia_coal_vietnam.wikitext`):
+180-plant v2.3 reference; see `data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext`):
 
 - **Built fleet** (operating 92%, construction/permitted 100%): high bar.
   Models recalling fewer than ~92% of operating plants underperform an
@@ -53,10 +53,10 @@ lets the reader carry it through §4–§7.
 ## Relevant files
 
 - `slides/manuscript/main.md` — §2 quality bar / §4 setup (where the bar is introduced); §7 conclusion (where it is revisited)
-- `data/reference/raw/wikipedia_coal_vietnam.wikitext` — cached coal list (raw, reproducible)
-- `data/reference/raw/wikipedia_power_vietnam.wikitext` — cached general list (has the gas/CCGT plants needed to complete the thermal bar)
+- `data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext` — cached coal list (raw, reproducible)
+- `data/reference/raw/wikipedia_power_vietnam-2026-06-09.wikitext` — cached general list (has the gas/CCGT plants needed to complete the thermal bar)
 - `src/aedist/reconcile.py`, `src/aedist/evaluate.py` (`load_plants_csv`, `reference_plant_count`) — matcher + reference loader
-- prototype: `/tmp/wt-0486/explore_wiki.py` (throwaway — coal-only; productionise + add gas)
+- prototype: `experiments/exploration/0486/explore_bars.py` (committed; already coal+gas — parses the general page `==Gas turbines==` section)
 
 ## Actions
 

--- a/tickets/0500-audit-matcher-diacritic-folding-tp-undercount.erg
+++ b/tickets/0500-audit-matcher-diacritic-folding-tp-undercount.erg
@@ -1,0 +1,70 @@
+%erg 0.1
+Title: Audit: matcher's missing diacritic-folding may undercount Exp1/2/3 TP (confound risk)
+Created: 2026-06-09
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-06-09T13:00Z HDMX-coding-agent created — roar sweep from the 0486 GEM-coverage review.
+
+--- body ---
+
+## Context (observation, cause not yet established)
+
+The 0486 source-coverage review surfaced that the project's LP matcher
+(`reconcile()` / `name_clean`) does **not fold Vietnamese diacritics**. Empirics:
+GEM coverage of the reference scored **67%** with the matcher as-is, and
+**88%** after ASCII-folding both sides — **39 GEM matches recovered**, all
+clean diacritic/aggregation variants ("Cà Mau I" ↔ "Ca Mau", "Bà Rịa GT" ↔
+"Ba Ria", "Duyên Hải 2" ↔ "Duyen Hai"). Diacritic-folding utilities already
+exist in the codebase (`src/aedist/util.py`, `src/aedist/cleaner/cleaner.py`,
+`self_consistency.py`) — but the matching pipeline's `name_clean` does not use
+them.
+
+The same `reconcile()` matcher scores Exp1/2/3 (model output vs reference). So
+**if any model outputs ASCII-transliterated plant names** ("Ca Mau" rather than
+"Cà Mau"), its true positives would be **undercounted** the same way GEM's were —
+which would *inflate* the paper's headline "models fall short of research-grade
+recall" finding. This is a **confound to rule in or out**, not yet a confirmed
+defect.
+
+## Audit (do this before any fix)
+
+1. **Measure model-output naming.** Across Exp1/2/3 outputs, sample how models
+   render plant names — diacritic'd (matches the reference, no impact) vs ASCII
+   (at risk). Likely varies by model family (Vietnamese-aware vs not).
+2. **Re-score with ASCII-folding** as an A/B: run the existing scoring with the
+   matcher's `name_clean` ASCII-folded (wire in `util`/`cleaner` folding), compare
+   per-model TP / F1 against the current numbers. Quantify the delta.
+3. **Decide:** if the delta is immaterial (models output diacritics), document the
+   non-finding and close — no code change. If material, it is a real confound:
+   wire diacritic-folding into `name_clean` for ALL matching (Exp1/2/3 + coverage +
+   recognition matrix), re-score, and update the manuscript numbers + a caveat.
+
+## Relevant files
+
+- `src/aedist/reconcile.py`, `src/aedist/matching/lp.py` — the matcher (`name_clean`)
+- `src/aedist/util.py`, `src/aedist/cleaner/cleaner.py` — existing folding utilities to reuse
+- `src/aedist/score_exp1.py` / `score_mechanical.py` — Exp scoring consumers
+- `experiments/derived/exp1_cross_eval.csv` etc. — outputs that would change if material
+
+## Test
+
+If the audit confirms a material undercount and a fix lands: a regression test
+that a known diacritic-variant pair ("Cà Mau I" vs "Ca Mau 1") matches under the
+scoring matcher. (Do not write the test until the audit decides a fix is warranted.)
+
+## Why needs-human
+
+Touches the paper's central numbers; the re-score + manuscript update is an
+author-supervised change, not an autonomous one. The audit (steps 1–2) is safe to
+run; the decision (step 3) is the author's.
+
+## Exit criteria
+
+- [ ] Model-output naming characterised (diacritic vs ASCII, by model)
+- [ ] A/B re-score delta (folded vs current) quantified per model
+- [ ] Decision recorded: immaterial (close, non-finding) OR material (fix + re-score + caveat)
+- [ ] `make check` passes
+
+Related: 0486 (where this surfaced), 0498 (complex-grain reconciliation — same matcher-floor family), recognition matrix / FP audit (partial existing mitigation)


### PR DESCRIPTION
Integrates `chore/unblock-0486-inputs` (commit `d50dacb`), which was pushed but never merged and had fallen **19 commits behind main**. These are the wave-2 inputs 0486/0494 need — stranded when the `/tmp/wt-0486` exploration worktree was cleared before its cached inputs were committed.

## Brings onto main
- `data/reference/raw/wikipedia_coal_vietnam-2026-06-09.wikitext` (728 lines) + `wikipedia_power_vietnam-2026-06-09.wikitext` (6146 lines) — re-fetched **byte-identical** (coal 17630 B), datestamped per the raw-snapshot convention, tracked and reproducible.
- `experiments/exploration/0486/{explore_review,explore_superset,explore_bars}.py` + README — the prototypes that produced the documented numbers (GEM 88% / Wikipedia 73% reviewed; 119 distinct GEM; 11 GEM-only), now reproducible from tracked inputs.
- 0486/0494 ticket prototype references repointed off `/tmp` to the committed path.

## Integration notes
- **No conflicts** — current main's `0486`/`0494` ticket blobs exactly matched the branch's merge base, so the ticket edits applied cleanly.
- `testpaths = ["tests"]`, so `experiments/exploration/` is not collected; full collection green (2436 tests).
- This is the hard input prerequisite for executing 0486 (the Wikipedia recall bar + concordance Wikipedia column) — it satisfies the ticket's *"raw snapshots committed under `data/reference/raw/`"* exit criterion.

https://claude.ai/code/session_012nMMytSw4Z1BHwNyo3xWcQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012nMMytSw4Z1BHwNyo3xWcQ)_