### PR TITLE
docs: editorial review of manuscript main.md + ticket 0503 to revise

### DIFF
--- a/docs/2026-06-09-review.md
+++ b/docs/2026-06-09-review.md
@@ -1,0 +1,298 @@
+# Editorial review — `slides/manuscript/main.md` (2026-06-09)
+
+Reviewer: Claude (Fable 5), session `claude/sleepy-feynman-t91907`.
+Scope: editorial review of the Econom'IA 2026 technical-report manuscript for
+arXiv/HAL archiving, plus peer-review publication strategy. Audience assumed:
+CIRED colleagues not specialized in LLMs.
+
+Author disposition (2026-06-09): concurs with all points. Revision tracked in
+ticket 0503; a short Imagine session precedes execution. Already ratified:
+re-title (original talk title preserved in the Econom'IA 2026 footnote);
+consider reorganizing the annexes or parking contents in the project-scale
+multi-chapter `report.md`.
+
+---
+
+## 1. Publication strategy
+
+### Who is the audience that will actually cite this?
+
+Three communities could care, and they pull in different directions:
+
+1. **Energy-systems data people** (PyPSA, GEM, powerplantmatching users) —
+   they have the *need* (inventories for under-documented countries) and will
+   cite the paper for years, because their problem doesn't stale.
+2. **LLM-evaluation people** — crowded field, 6-month half-life. The benchmark
+   numbers (Opus 4.6, GPT-5.5) will be obsolete by the time a journal review
+   cycle ends. Don't make them the primary audience.
+3. **Official-statistics / data-quality people** — the four-dimension quality
+   bar, the DQAF/Wang–Strong lineage, and the "statistical business register
+   from unstructured sources" framing speak their language exactly, and "LLMs
+   for official statistics" is an active topic in that community with very
+   little supply of careful empirical work.
+
+Recommendation: **audience 1 or 3, not 2.** The durable contributions are
+(a) the task formalisation + quality bar, (b) the 177-plant sourced reference,
+(c) the reference-free coherence screen, (d) the fusion direction. The specific
+model scores are perishable framing, not the asset.
+
+### Outlets, in order of fit for an exploratory "mark the land" report
+
+- **Energy and AI** (Elsevier, open access). Best single fit: readers span
+  energy modelling and AI methods, exploratory/benchmark papers are in scope,
+  review is reasonably fast, and not so prestigious that reviewers demand the
+  stateful architecture be built before publishing. First choice for the
+  condensed version.
+- **Statistical Journal of the IAOS** — strong second choice to mark the land
+  in the *statistics* community instead. The framing "can AI agents produce
+  data meeting official-statistics quality standards?" is almost tailor-made
+  for it, and it is explicitly hospitable to exploratory work. A power-plant
+  inventory is essentially a statistical register; that hook will resonate.
+- **Environmental Data Science** (Cambridge, OA) — good third option,
+  data-centric environmental scope, methods welcome.
+- **Workshop route** (ClimateNLP at ACL, Tackling Climate Change with ML at
+  NeurIPS/ICLR): fast, gets ML-community eyeballs, often non-archival so it
+  doesn't burn journal rights. Worth doing *in addition*, not instead.
+
+**Strategic complement:** publish the 177-plant reference itself as a short
+data paper (*Scientific Data* data descriptor, or *Data in Brief*). This gives
+the reference a DOI and a citable identity independent of this report — which
+matters for Paper B, where the reference becomes the held-out validation
+object. It also pre-empts the reviewer objection that the whole edifice rests
+on a single-author unaudited compilation.
+
+**For Paper B** (fusion without the reference): the natural target is the
+journal *Information Fusion* — truth discovery, multi-source conflict
+resolution, and capture–recapture-style estimation are squarely in scope. That
+one *is* prestigious, but the fusion paper will have the methodological novelty
+to justify it. Anchor it in the Dawid–Skene / latent-truth-discovery
+literature; the per-plant recognition matrix (Annex E) is exactly the input
+object that literature studies.
+
+**For the arXiv/HAL deposit now:** primary category cs.AI (or cs.CL),
+cross-list econ.GN — the cross-list is what makes it findable by the Econom'IA
+audience. Use a CC BY license so the HAL deposit is clean. Add a footnote on
+page 1: "Technical report accompanying a talk at Econom'IA 2026, Paris." That
+positions it honestly as a conference text and lowers the bar reviewers apply
+when they later see the journal version.
+
+---
+
+## 2. Scientific issues (fix before arXiv)
+
+**2.1 The 16 / 14 / 12 model-count contradiction.** The most damaging internal
+inconsistency. The abstract and §4 say *fourteen* models, 70 runs. Annex B's
+Models section says "*Sixteen* models from `modelset_exp1_journal`" and lists
+16 rows, then the Run-parameters table says 70 = 14 × 5. §6 says "pooling the
+**16** parametric-baseline outputs" in one paragraph and "the **14-model**
+exp1_batch2 cohort (a subset of the 16-model Experiment 1 sweep)" in the next.
+Figure 4 uses **12** models. A reader cannot reconstruct which cohort backs
+which figure. Fix: one "cohorts" paragraph (or small table) early in §4
+stating: 16 models run → 2 excluded for X → 14-model analysis cohort → 12 in
+Figure 4 because DeepSeek lacks a quality-taxonomy panel. Then make every
+figure caption name its cohort consistently. (Per the project's
+derive-prose-from-artifacts rule: re-derive these counts from
+`measurements.jsonl`, not from memory.)
+
+**2.2 Parameter contradictions in Annex B.** The Run-parameters table says
+max_tokens = 32768 and budget = $15; the Sweep-configuration section says
+`max_tokens = 8192, budget_usd = 10`. One of these is wrong, and it's the kind
+of discrepancy that destroys trust in everything else. Regenerate from
+`experiments.toml`.
+
+**2.3 The seeded-recall-bar argument has a timing hole.** The claim "the
+answer key was placed directly in the training corpus" requires that the
+Wikipedia publication date *precedes the training cutoff of each of the 14
+models*. If the list was published in, say, 2025 and some models have earlier
+cutoffs, the bar is not valid for them. State the Wikipedia publication date
+explicitly and compare it against the models' cutoffs (or say which models the
+bar validly applies to). Also clarify *intent*: was the seeding a deliberate
+experimental manipulation or pre-existing outreach work? Reviewers will ask,
+and the answer changes how the design reads (clever instrument vs. fortunate
+accident — either is fine, ambiguity is not).
+
+**2.4 The abstract oversells the ρ = 0.92 screen.** Annex F — which is
+excellent and honest — shows that roughly half the pooled signal is
+across-model confound, with a within-model stratified Kendall τ of only
++0.215. The abstract and conclusion headline ρ = 0.92 with no caveat. A reader
+who reaches Annex F will feel the abstract misled them. Add one clause:
+"…(ρ = 0.92 pooled; the within-model signal is positive but modest,
+Annex F)". This costs nothing — the screen is still useful as triage — and
+buys credibility.
+
+**2.5 §5's title claims more than §5 measures.** "The commercially available
+frontier still falls short" — falls short of the *four-dimensional quality
+bar*, but Phase C (the four-dimension cross-evaluation) is explicitly
+deferred. What's actually measured: row-level F1, coverage, and provenance
+counts. Those *do* support "falls short" (coverage < 60% of reference,
+Mistral's zero corroboration), but say precisely which dimensions were
+measured and which are deferred, in the section body, not only in Annex C.
+
+**2.6 Status-vocabulary mismatch may mechanically depress status accuracy.**
+The prompt's controlled vocabulary (Approved / Planned / Operational / Under
+construction / Suspended / Cancelled / Retired) doesn't match the reference's
+statuses (operational, under construction, **proposed**, planned, cancelled,
+retired). "Proposed" — 38% of the reference — has no prompt equivalent. The
+reported status accuracy of 0.57 may partly be an artifact of this mapping.
+One sentence acknowledging (or refuting, if there's a mapping layer) this is
+needed.
+
+**2.7 Unsupported claim in the Conclusion.** "Cost savings relative to manual
+compilation are substantial: from weeks of expert monitoring to a few euros
+per query" — nothing in the body quantifies manual-compilation effort, and the
+paper's own thesis is that the few-euro queries *don't deliver the product*,
+so the comparison is also conceptually slippery. Either substantiate (the
+author compiled the reference himself — the hours are a legitimate data point)
+or cut.
+
+**2.8 Too many novelty claims.** Seven "to our knowledge, X has not been
+published/documented" claims (non-monotone cost–F1, per-row provenance
+analysis, day-scale drift, MoE non-determinism on structured outputs, per-cell
+provenance × temporality, the benchmark itself, articulation). Each is
+individually hedged correctly, but the cumulative effect reads as planting
+seven flags, and reviewers will pick the weakest one to attack (the cost–F1
+non-monotonicity is folklore in the eval community even if unpublished — drop
+that claim entirely). Keep two: the benchmark gap (already well-placed at the
+end of Related Work) and the per-cell provenance analysis. Demote the others
+to plain observations.
+
+---
+
+## 3. Structural issues
+
+**3.1 Section numbering.** "Related work" is unnumbered between §1 and §2; the
+intro roadmap skips §3 entirely. Number Related Work as §2 and renumber, or
+move it before the Conclusion (common in this genre and arguably better here,
+since the Related Work reads partly as a contributions-vs-literature
+comparison). Also: the intro promises "§6 … show that targeted pipeline design
+is needed" — §6 *motivates* a design, it doesn't show one is needed; the
+experiments do. Reword the roadmap.
+
+**3.2 §3 is written for LLM insiders, but the declared audience is CIRED
+economists.** "RLHF", "test-time compute", "MCP-like surface", "co-deployment
+of framework × trained-model × product packaging" — the densest section and
+the least essential to the argument. Cut §3 to roughly half, keep Figure 1 and
+the envelope/integration framing, move the lab-by-lab shipping-order analysis
+(features 3-and-4 parallelism, DeepSeek negative case, the constraint-axis
+paragraph) to an annex. Add a short glossary box (parametric memory, RAG,
+agent, token, temperature, F1). The "articulation as Type-III error" idea is
+genuinely original and accessible — promote it, don't bury it mid-§3.
+
+**3.3 Internal scaffolding leaks everywhere.** Ticket numbers (0167–0173,
+0198, 0214, 0453), PR #379, commit `85a0e6c`, `palette.toml`,
+`experiments/outputs/...` paths, "Doc-07", "protocol_05", "the slides". For an
+archived technical report this is *partially* defensible — but only if the
+repository is public and cited. Decide: if the repo will be public, add a Data
+& Code Availability section with the URL and keep paths (but still strip
+ticket/PR numbers, which are meaningless to outsiders); if not, all of it must
+go. Figure 5's caption pointing to "the slides" for the 2×2 factorial is a
+broken reference in an archived document — the factorial table must be *in
+this report*.
+
+**3.4 Figure numbering is inconsistent.** Main text Figures 1–6, then Annex D
+has S1–S3, then Annex E has "Figure 7". Pick one scheme (S-numbers for all
+annex figures).
+
+**3.5 §6 conflates two analyses.** The run-aggregation paragraph describes a
+4 × 3 × 4 factorial sweep over the 14-model cohort (recall 0.644, $0.94,
+etc.), then Figure 6 shows a *different* analysis (≥2-models rule on 4 SOTA
+models, E1 vs E2). A reader can't tell which numbers belong to which. Split
+into two labelled paragraphs, each pointing at its own artifact.
+
+**3.6 Missing front/back matter for arXiv/HAL.** No data & code availability,
+no funding statement, no conflict-of-interest note (relevant: the author wrote
+the Wikipedia lists *and* the reference — that dual role should be disclosed
+explicitly; it's a strength when disclosed and a liability when discovered),
+no ORCID/email. The Wikipedia-seeding disclosure belongs in a short "Author's
+role and conflicts" note, not only scattered through §4 and Annex C.
+
+**3.7 Dangling references.** "Experiments 1–3" (Annex B — there is no
+Experiment 3 in this paper); "Paper B" (cite as "in preparation" with a
+working title); "Protocol §3.4" cited in §4 before any reader knows what the
+Protocol is (point to Annex C instead); Annex F's first line says "the §4
+Discussion paragraph" but that paragraph is in §7; Annex C says "the
+cross-provider variance reported … in Annex C" — it means Annex B.
+
+**3.8 Title.** "Beyond RAG: Stateful-Agentic Architectures for Reliable
+Economic Statistics" promises an architecture paper; the manuscript delivers a
+benchmark + motivation paper. Flip the weight, e.g. *"Frontier AI agents do
+not yet produce research-grade statistics: a sourced benchmark on Vietnam's
+thermal power fleet"*, with the architecture as subtitle material. Also
+"Economic Statistics" is a stretch — this is infrastructure/industrial
+statistics (a register, not national accounts); "official statistics" or
+"statistical inventories" is more defensible and the better hook for the IAOS
+audience anyway. *[Ratified 2026-06-09: re-title; keep the original talk title
+in the Econom'IA 2026 footnote.]*
+
+---
+
+## 4. Intellectual / framing suggestions
+
+- **The strongest original ideas are under-sold:** (a) the seeded-Wikipedia
+  recall bar — a genuinely clever identification trick for separating
+  retrieval failure from coverage absence; (b) the run-level credibility vs
+  model-level reliability two-grain scoring, with the STANAG 2511 Admiralty
+  analogy — a memorable framing the eval literature lacks; (c) articulation as
+  Type-III error. Each currently sits mid-paragraph. Consider a short
+  "Contributions" list at the end of §1 naming them.
+- **GPT-5.5's principled refusals deserve a paragraph, not a buried bold
+  sentence in Annex B.** A frontier model declining to fabricate
+  primary-sourced citations *is itself evidence about the epistemic standard*
+  being tested — arguably the most quotable single finding for a general
+  audience. Surface it in §4 results and the Discussion.
+- **Annex A (Parmenides/Heraclitus → IFRS → IAM vintaging) is charming for a
+  talk and fine for the technical report, but cut it from any journal
+  version** — reviewers in all three target communities will read it as
+  padding. Keep T1/T2 (two crisp paragraphs) and drop the philosophy
+  genealogy.
+- For CIRED economists specifically: the most persuasive frame is the
+  **make-or-buy economics of data**: data as a costly intermediate good, AI
+  agents as an unreliable low-cost supplier, fusion as quality control over
+  multiple unreliable suppliers. One paragraph in the intro casting it this
+  way would land better with that room than any amount of agent taxonomy.
+
+---
+
+## 5. Language (representative, not exhaustive)
+
+- "a random words generator somewhere in the cloud" (§1) — grammatically off
+  and tonally snide for an archived report; "a plausible-text generator"
+  carries the point.
+- "How well do the state of the art tools perform when it comes to producing
+  research-quality statistical datasets?" (§5) — hyphenate and tighten: "How
+  well do state-of-the-art tools perform at producing research-grade
+  statistical datasets?"
+- "FP … unrecognized plants" (Figures 2, 5, 7): "unrecognized" reads as a
+  *miss* (FN), not a false positive. Adopt "**unmatched** plants (extracted
+  but not in the reference)" everywhere.
+- Em-dash density is very high (often 3–4 per sentence); in long sentences it
+  forces rereading. A pass converting half of them to commas, colons, or
+  sentence breaks would do more for readability than any other single edit.
+- Figure 3's caption is ~200 words of methods including ticket numbers and
+  `palette.toml` — move methods to Annex B, keep captions to what the eye
+  needs.
+- Spelling is consistently British (optimised, colour) — fine; keep it through
+  revisions. "Annex" vs "Appendix": Annex is fine for a European technical
+  report; switch to Appendix for a journal version.
+- Mitroff and Featheringham 1974 (§3) is the only citation not in `[@...]`
+  form — it will silently fail to appear in the pandoc bibliography.
+
+---
+
+## TL;DR priority list for the arXiv version
+
+1. Reconcile the 16/14/12 cohort counts and the Annex B parameter
+   contradictions (regenerate from artifacts).
+2. Temper ρ = 0.92 in abstract/conclusion with the Annex F within-model
+   caveat.
+3. Pin the Wikipedia-seeding timeline against model cutoffs; add an
+   author-role disclosure note.
+4. Strip ticket/PR numbers; add Data & Code Availability; pull the 2×2 table
+   into the report (no "see the slides").
+5. Halve §3 and add a glossary for the non-LLM reader.
+6. Fix dangling cross-references (§4→Protocol, Annex F→§7, Annex C→Annex B,
+   "Experiments 1–3", "Paper B").
+7. Then: arXiv cs.AI cross-listed econ.GN, CC BY, deposit on HAL with the
+   conference footnote; condensed version to **Energy and AI** (or SJIAOS to
+   plant the flag in official statistics); spin the 177-plant reference into a
+   separate data paper; aim Paper B at *Information Fusion*.

--- a/tickets/0503-revise-manuscript-after-author-consultat.erg
+++ b/tickets/0503-revise-manuscript-after-author-consultat.erg
@@ -1,0 +1,98 @@
+%erg 0.1
+Title: Revise manuscript after author consultation on 2026-06-09 editorial review
+Created: 2026-06-09
+Author: minhhaduong
+
+--- log ---
+2026-06-09T20:25Z minhhaduong created
+2026-06-09T20:30Z claude note Review committed at docs/2026-06-09-review.md; author concurs with all points; Imagine session to precede execution
+
+--- body ---
+## Context
+
+A full editorial review of `slides/manuscript/main.md` (the Econom'IA 2026
+technical report, destined for arXiv + HAL) is at
+`docs/2026-06-09-review.md`. The author concurs with all points.
+
+This is a tracking ticket. **Do not start execution directly from this
+ticket**: the workflow begins with one short Imagine session with the author
+to settle the open editorial choices, then this ticket is split into scoped
+sub-tickets (`Blocked-by:` sequenced) per the divide-and-conquer rule.
+
+## Phase 0 — Short Imagine session (with author, required first)
+
+Open choices to settle before any edit:
+
+- [ ] New title (re-title is ratified; pick the wording — review §3.8 offers
+      a candidate; original talk title goes in the Econom'IA 2026 footnote)
+- [ ] Annex strategy: reorganize annexes in place vs. park contents (Annex A
+      philosophy genealogy, §3 lab-by-lab shipping-order analysis, Figure 3
+      caption methods) in the project-scale multi-chapter `report.md`
+- [ ] Repo visibility decision (drives review §3.3: keep file paths + add
+      Data & Code Availability, or strip all internal references)
+- [ ] Which two novelty claims survive (review §2.8 recommends: benchmark gap
+      + per-row provenance analysis)
+- [ ] Related-work placement: number as §2 vs. move before Conclusion
+- [ ] Peer-review target to optimize the condensed version for: Energy and AI
+      vs. Statistical Journal of the IAOS (review §1)
+
+## Ratified by the author (2026-06-09, no further discussion needed)
+
+- Re-title; footnote states this is the Econom'IA 2026 report and gives the
+  original talk title.
+- Consider annex reorganization / parking content in the general
+  project-scale multi-chapter `report.md` (exact split decided in Phase 0).
+- All review points accepted on the merits.
+
+## Work plan after Imagine (split into sub-tickets)
+
+Scientific integrity (review §2 — before arXiv):
+
+- [ ] 2.1 Reconcile 16/14/12 cohort counts: one cohort paragraph in §4,
+      re-derived from `measurements.jsonl`, captions name their cohort
+- [ ] 2.2 Fix Annex B parameter contradictions (max_tokens 32768 vs 8192,
+      budget $15 vs $10) — regenerate from `experiments.toml`
+- [ ] 2.3 Pin Wikipedia-seeding date vs model training cutoffs; state
+      seeding intent
+- [ ] 2.4 Temper ρ = 0.92 in abstract + conclusion with Annex F
+      within-model caveat (τ = +0.215)
+- [ ] 2.5 §5: state which quality dimensions were measured vs deferred
+      (Phase C) in the section body
+- [ ] 2.6 Add sentence on prompt-vs-reference status-vocabulary mismatch
+      ("Proposed" absent from prompt vocabulary; cf.
+      docs/status-vocabulary-map.md)
+- [ ] 2.7 Substantiate or cut the manual-compilation cost-savings claim in
+      the Conclusion
+- [ ] 2.8 Reduce seven novelty claims to the two keepers
+
+Structure (review §3):
+
+- [ ] 3.1 Number Related Work, fix intro roadmap (§3 missing; §6 wording)
+- [ ] 3.2 Halve §3, add glossary box, promote articulation/Type-III idea
+- [ ] 3.3 Strip ticket/PR numbers; resolve internal-path policy per repo
+      visibility; move 2x2 factorial table into the report (no "see the
+      slides")
+- [ ] 3.4 Unify annex figure numbering (S-scheme)
+- [ ] 3.5 Split §6 run-aggregation paragraph from Figure 6 analysis
+- [ ] 3.6 Add Data & Code Availability, funding, author-role/conflict note
+      (Wikipedia dual role), ORCID/email
+- [ ] 3.7 Fix dangling refs: "Experiments 1-3", "Paper B", "Protocol §3.4",
+      Annex F "§4"→§7, Annex C self-reference→Annex B
+- [ ] 3.8 Apply new title + talk-title footnote (ratified)
+
+Framing and language (review §4-5):
+
+- [ ] Contributions list at end of §1 (seeded bar, two-grain
+      credibility/reliability scoring, articulation)
+- [ ] Surface GPT-5.5 principled refusals in §4 results + Discussion
+- [ ] Language pass: "unmatched" FP terminology, em-dash reduction,
+      §1/§5 fixes, Mitroff citation to [@...] form, caption diets
+
+## Exit criteria
+
+- [ ] Phase 0 Imagine session held; decisions logged in this ticket
+- [ ] Sub-tickets created and sequenced with Blocked-by:
+- [ ] All review §2 scientific items resolved in `slides/manuscript/main.md`
+- [ ] Adherence tests still pass; numbers in prose re-derived from committed
+      artifacts (not from the review text)
+- [ ] `make check` passes


### PR DESCRIPTION
Editorial review of `slides/manuscript/main.md` (Econom'IA 2026 technical report) ahead of the arXiv/HAL deposit, archived at `docs/2026-06-09-review.md`:

- **Publication strategy**: target audience (energy-data or official-statistics community, not LLM-eval), outlets (Energy and AI / SJIAOS / Environmental Data Science / workshop route), data-paper spin-off for the 177-plant reference, *Information Fusion* for Paper B, arXiv cs.AI × econ.GN + CC BY.
- **Scientific issues** (pre-arXiv): 16/14/12 cohort-count contradictions, Annex B parameter contradictions, Wikipedia-seeding timing vs model cutoffs, ρ = 0.92 vs Annex F within-model τ = +0.215, §5 measured-vs-deferred dimensions, status-vocabulary mismatch, unsupported cost-savings claim, novelty-claim dilution.
- **Structural, framing, language** findings.

Ticket **0503** tracks the revision: one short Imagine session with the author first (open choices listed in the ticket), then sub-tickets. Already ratified: re-title with the original talk title preserved in the Econom'IA 2026 footnote; consider parking annex content in the project-scale multi-chapter `report.md`.

Author concurs with all review points (2026-06-09).

Chore scope only (docs/ + tickets/) — `quickpr.sh` flow unavailable in this remote session (no `gh`), hence this manual PR.

https://claude.ai/code/session_01E6n5agGs8yrWcx92ShUhji

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6n5agGs8yrWcx92ShUhji)_