### PR TITLE
Retitle manuscript for arXiv + add front/back matter (0509)

### DIFF
--- a/slides/manuscript/main.md
+++ b/slides/manuscript/main.md
@@ -9,9 +9,11 @@ header-includes:
   - \newunicodechar{ρ}{\ensuremath{\rho}}
 ---
 
-# Beyond RAG: Stateful-Agentic Architectures for Reliable Economic Statistics
+# Can Frontier AI Build a Statistical Register? A Benchmark and Research Programme on Vietnam's Thermal Power Fleet[^econom]
 
-Minh Ha-Duong
+[^econom]: Technical report accompanying a talk at Econom'IA 2026, Paris. Original talk title: Beyond RAG: Stateful-Agentic Architectures for Reliable Economic Statistics.
+
+Minh Ha-Duong — [ORCID 0000-0001-9988-2100](https://orcid.org/0000-0001-9988-2100) — <minh.ha-duong@cnrs.fr>
 
 CIRED — Centre International de Recherche sur l'Environnement et le Développement, CNRS, France
 
@@ -108,11 +110,32 @@ Submitting a direct query to a large language model produces an inventory-shaped
 
 How well do the state of the art tools perform when it comes to producing research-quality statistical datasets? The parametric ceiling of §4 is a deliberately handicapped baseline — no web, no tools, no reasoning budget beyond what each model carries internally. The commercially available frontier, by contrast, ships agents that combine extended reasoning, web search, document ingestion, and tool use into a single "deep research" surface. The question is whether removing the §4 handicaps suffices to clear the §2 quality bar. Even the best independent public tracker, Global Energy Monitor, covers only 89% of the reference after light review (Annex B); the frontier agents are therefore measured against an inventory no single open database fully reproduces.
 
-**Experiment 2 — SOTA frontier (Annex C).** We conduct an experiment with four state-of-the-art cloud AI agents that have extended reasoning and web access, queried over direct vendor APIs (no browser automation): Anthropic Claude Opus 4.6 (US, web_search + adaptive thinking), OpenAI GPT-5.5 (US, Responses API + web_search + reasoning), Mistral Large 2512 (FR, Agents API + web_search connector), and Qwen3-Max via DashScope (CN, web_search inside thinking mode). The fourth slot is hypothesis-relevant rather than decorative: Chinese-language investor and trade documents on Vietnamese power assets are under-indexed by Western search. The experiment runs two arms over the same four agents (N=5 each). **Arm 1 (naive)** — a single-shot prompt (Doc-07) with no scaffolding, web on; the null comparator. **Arm 2 (optimised, simple-harness multi-turn)** — a multi-turn protocol in which each agent first designs its own prompt and settings (Phase A), runs once as a smoke gate (Phase B-0), then runs N=5 against a single provider under a per-session cap of 50K tokens / $3 (Phase B); this constitutes a simple harness — an LLM orchestrator (DeepSeek classifier) controlling a loop with the tested LLM as the tool. The naive-vs-optimised contrast isolates the protocol's contribution over raw model capability. Row-level F1 against the 177-plant reference is now scored for all four arms (see the 2×2 factorial table); cross-model judging on the four §2 dimensions remains reserved for post-conference analysis (Phase C, ticket 0171).
+**Experiment 2 — SOTA frontier (Annex C).** We conduct an experiment with four state-of-the-art cloud AI agents that have extended reasoning and web access, queried over direct vendor APIs (no browser automation): Anthropic Claude Opus 4.6 (US, web_search + adaptive thinking), OpenAI GPT-5.5 (US, Responses API + web_search + reasoning), Mistral Large 2512 (FR, Agents API + web_search connector), and Qwen3-Max via DashScope (CN, web_search inside thinking mode). The fourth slot is hypothesis-relevant rather than decorative: Chinese-language investor and trade documents on Vietnamese power assets are under-indexed by Western search. The experiment runs two arms over the same four agents (N=5 each). **Arm 1 (naive)** — a single-shot prompt (Doc-07) with no scaffolding, web on; the null comparator. **Arm 2 (optimised, simple-harness multi-turn)** — a multi-turn protocol in which each agent first designs its own prompt and settings (Phase A), runs once as a smoke gate (Phase B-0), then runs N=5 against a single provider under a per-session cap of 50K tokens / $3 (Phase B); this constitutes a simple harness — an LLM orchestrator (DeepSeek classifier) controlling a loop with the tested LLM as the tool. The naive-vs-optimised contrast isolates the protocol's contribution over raw model capability. Row-level F1 against the 177-plant reference is now scored for all four arms (Table 1); cross-model judging on the four §2 dimensions remains reserved for post-conference analysis (Phase C, ticket 0171).
+
+| Agent | Query mode | Documents | F1 (mean) | Cost (mean, USD) |
+|-------|-----------|-----------|-----------|------------------|
+| Anthropic | naive (single-shot) | no  | 0.60 | 2.02 |
+| Anthropic | optimised (multi-turn) | no  | 0.56 | 1.78 |
+| Anthropic | naive (single-shot) | yes | 0.61 | 2.74 |
+| Anthropic | optimised (multi-turn) | yes | 0.38 | 3.60 |
+| Mistral   | naive (single-shot) | no  | 0.49 | 0.25 |
+| Mistral   | optimised (multi-turn) | no  | 0.39 | 0.23 |
+| Mistral   | naive (single-shot) | yes | 0.59 | 0.06 |
+| Mistral   | optimised (multi-turn) | yes | 0.53 | 0.21 |
+| OpenAI    | naive (single-shot) | no  | 0.63 | 0.27 |
+| OpenAI    | optimised (multi-turn) | no  | 0.65 | 0.68 |
+| OpenAI    | naive (single-shot) | yes | 0.77 | 0.48 |
+| OpenAI    | optimised (multi-turn) | yes | 0.74 | 1.05 |
+| Qwen      | naive (single-shot) | no  | 0.37 | 0.06 |
+| Qwen      | optimised (multi-turn) | no  | 0.27 | 0.21 |
+| Qwen      | naive (single-shot) | yes | 0.62 | 0.30 |
+| Qwen      | optimised (multi-turn) | yes | 0.55 | 0.76 |
+
+**Table 1.** Experiment 2 — row-level F1 and per-run API cost (USD) by agent across the 2×2 factorial (query mode × documents), N=5 per cell. The §5 narrative concerns the two **registered** arms (naive vs optimised, documents = no). The two documents = yes rows per agent are the **unregistered, exploratory** conditions added during execution (Annex C); they are reported here for completeness, not as confirmatory tests. Values re-derived from `experiments/derived/tab_exp2_2x2.csv`.
 
 ![](../report/inputs/generated/fig_exp2_arms_comparison.pdf)\
 
-*Figure 5. Experiment 2 — naive (arm 1, single-shot) vs optimised (arm 2, multi-turn) comparison, N=5 per agent. Panel (a): Plants found — TP bars (blue, upward, matched against the 177-plant reference) and FP bars (red, downward, unrecognized plants), median over runs with scored outputs; left bar = arm 1, right bar = arm 2 per agent group. Grey bars indicate runs with no matched-row scores available. Panel (b): API cost per run (USD), individual runs as scatter points. Dashed green line marks the 177-plant reference count; the light-grey dotted line marks GEM's light-reviewed coverage (89%), the best independent external database (Annex B). Row-level F1 against the 177-plant reference is now scored for all 80 runs; the 2×2 factorial analysis of F1 and cost (query mode × documents) appears in the slides and Annex C. With N=4 agents as the blocking factor, effects are reported as directional consistency (k/n agents agreeing in sign) rather than significance tests, since the minimum attainable p at n=4 is 1/2⁴ = 0.0625.*
+*Figure 5. Experiment 2 — naive (arm 1, single-shot) vs optimised (arm 2, multi-turn) comparison, N=5 per agent. Panel (a): Plants found — TP bars (blue, upward, matched against the 177-plant reference) and FP bars (red, downward, unrecognized plants), median over runs with scored outputs; left bar = arm 1, right bar = arm 2 per agent group. Grey bars indicate runs with no matched-row scores available. Panel (b): API cost per run (USD), individual runs as scatter points. Dashed green line marks the 177-plant reference count; the light-grey dotted line marks GEM's light-reviewed coverage (89%), the best independent external database (Annex B). Row-level F1 against the 177-plant reference is now scored for all 80 runs; the 2×2 factorial analysis of F1 and cost (query mode × documents) is given in Table 1 and detailed in Annex C. With N=4 agents as the blocking factor, effects are reported as directional consistency (k/n agents agreeing in sign) rather than significance tests, since the minimum attainable p at n=4 is 1/2⁴ = 0.0625.*
 
 **Observed results (operational metrics).** For agents in the naive arm (arm 1): Anthropic median 77 rows (4/5 usable, one zero-row run); Mistral median 57 rows (range 48–74); OpenAI median 83 rows (range 76–90); Qwen median 42 rows (range 33–45). For the optimised arm (arm 2): OpenAI median 86 rows versus arm 1 median 83 rows (modest improvement; individual runs 79–96 vs 76–90); Qwen median 25 rows versus arm 1 median 42 rows (regression; Qwen's Phase A self-designed protocol imposed a strict dual-source admissibility filter that constrains coverage from Turn 1). The optimised protocol costs 2–4× more per run than naive across all agents; OpenAI's ratio is most extreme (median \$0.73 optimised vs \$0.27 naive). We did not find published comparisons of frontier deep-research agents on structured-output coverage at this granularity; the contrast is mixed — modest gain for OpenAI, regression for Qwen.
 
@@ -471,6 +494,12 @@ The §4 Discussion paragraph "Internal coherence as a zero-reference screen" rep
 ## Acknowledgements
 
 We thank Econom'IA 2026 participants for their comments, in particular those that led to the updated reference list, the per-plant recognition matrix, and the status-composition analysis of task difficulty in the annex.
+
+**Data & Code Availability.** Code and data are available at https://github.com/MinhHaDuong/aedist-technical-report (CC BY 4.0).
+
+**Funding.** This work was supported by CNRS/CIRED.
+
+**Author contributions and conflicts of interest.** The author compiled the 177-plant reference list and also authored the Wikipedia pages for several of the plants in the list. This dual role is disclosed; the reference list is provided as a supplementary artifact with per-plant source citations.
 
 ## Bibliography
 

--- a/tests/test_manuscript_frontmatter.py
+++ b/tests/test_manuscript_frontmatter.py
@@ -1,0 +1,68 @@
+"""Ticket 0509 — arXiv re-title and front/back matter for the standalone preprint.
+
+Asserts the manuscript carries its arXiv identity: the new (registered) title as
+the H1, the Econom'IA provenance footnote, author ORCID/email, the back-matter
+sections (Data & Code Availability, Funding, author contributions / conflict of
+interest), and that the two stale forward-references to a non-inline 2×2 table /
+to "the slides" are gone.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+MAIN_MD = (
+    Path(__file__).resolve().parent.parent / "slides" / "manuscript" / "main.md"
+)
+
+NEW_TITLE_SUBSTR = "Can Frontier AI Build a Statistical Register?"
+
+
+def _md() -> str:
+    return MAIN_MD.read_text(encoding="utf-8")
+
+
+def _h1_line() -> str:
+    for line in _md().splitlines():
+        if line.startswith("# "):
+            return line
+    raise AssertionError("no H1 line found in main.md")
+
+
+def test_new_title_is_h1():
+    """The H1 carries the new title; 'Beyond RAG' must not be the H1 title."""
+    h1 = _h1_line()
+    assert NEW_TITLE_SUBSTR in h1, f"new title missing from H1; got: {h1}"
+    assert "Beyond RAG" not in h1, (
+        "old 'Beyond RAG' title must not remain the H1 (it may survive only "
+        f"inside the Econom'IA provenance footnote); got: {h1}"
+    )
+
+
+def test_data_and_code_availability_present():
+    assert "Data & Code Availability" in _md()
+
+
+def test_funding_present():
+    assert re.search(r"\*\*Funding\.\*\*", _md()), "Funding back-matter section missing"
+
+
+def test_orcid_present():
+    assert "0000-0001-9988-2100" in _md(), "author ORCID missing"
+
+
+def test_conflict_of_interest_present():
+    assert "conflicts of interest" in _md(), "author conflict-of-interest disclosure missing"
+
+
+def test_no_dangling_forward_references():
+    md = _md()
+    assert "see the 2×2 factorial table" not in md, (
+        "stale forward-ref to a non-inline 2×2 table must be removed"
+    )
+    assert "appears in the slides" not in md, (
+        "standalone paper must not forward-reference 'the slides'"
+    )

--- a/tests/test_manuscript_frontmatter.py
+++ b/tests/test_manuscript_frontmatter.py
@@ -7,6 +7,7 @@ interest), and that the two stale forward-references to a non-inline 2×2 table 
 to "the slides" are gone.
 """
 
+import csv
 import re
 from pathlib import Path
 
@@ -14,11 +15,28 @@ import pytest
 
 pytestmark = pytest.mark.adherence
 
-MAIN_MD = (
-    Path(__file__).resolve().parent.parent / "slides" / "manuscript" / "main.md"
-)
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAIN_MD = REPO_ROOT / "slides" / "manuscript" / "main.md"
+EXP2_2X2_CSV = REPO_ROOT / "experiments" / "derived" / "tab_exp2_2x2.csv"
 
 NEW_TITLE_SUBSTR = "Can Frontier AI Build a Statistical Register?"
+
+# Maps the markdown agent label to the CSV `agent` value, and the markdown
+# query-mode/documents cell pair to the CSV (`arm`, `docs`) key. The CSV uses
+# arm names (naive/optimised/arm3/arm4); the table re-labels them by the 2×2
+# factors it presents (query mode × documents).
+_AGENT_LABEL_TO_CSV = {
+    "Anthropic": "anthropic",
+    "Mistral": "mistral",
+    "OpenAI": "openai",
+    "Qwen": "qwen",
+}
+_CELL_TO_CSV_ARM = {
+    ("naive (single-shot)", "no"): "naive",
+    ("optimised (multi-turn)", "no"): "optimised",
+    ("naive (single-shot)", "yes"): "arm3",
+    ("optimised (multi-turn)", "yes"): "arm4",
+}
 
 
 def _md() -> str:
@@ -66,3 +84,56 @@ def test_no_dangling_forward_references():
     assert "appears in the slides" not in md, (
         "standalone paper must not forward-reference 'the slides'"
     )
+
+
+def _csv_lookup() -> dict[tuple[str, str, str], tuple[float, float]]:
+    """(agent, arm, docs) -> (f1_mean, cost_mean) parsed from the source CSV."""
+    out: dict[tuple[str, str, str], tuple[float, float]] = {}
+    with EXP2_2X2_CSV.open(encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            key = (row["agent"], row["arm"], row["docs"])
+            out[key] = (float(row["f1_mean"]), float(row["cost_mean"]))
+    return out
+
+
+def _parse_table_rows() -> list[tuple[str, str, str, float, float]]:
+    """Parse Table 1 markdown rows: (agent_label, mode, docs, f1, cost)."""
+    rows: list[tuple[str, str, str, float, float]] = []
+    in_table = False
+    for line in _md().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Agent ") and "F1 (mean)" in stripped:
+            in_table = True
+            continue
+        if in_table:
+            if not stripped.startswith("|"):
+                break
+            cells = [c.strip() for c in stripped.strip("|").split("|")]
+            if set(cells[0]) <= {"-", " "}:  # the |---|---| separator row
+                continue
+            agent, mode, docs, f1, cost = cells[:5]
+            rows.append((agent, mode, docs, float(f1), float(cost)))
+    return rows
+
+
+def test_table1_values_match_source_csv():
+    """Every Table 1 cell re-derives from experiments/derived/tab_exp2_2x2.csv.
+
+    Guards the 0452 failure mode: hand-typed manuscript numbers silently drift
+    when the source CSV is regenerated. Each markdown cell is re-parsed and
+    compared (to the table's 2-decimal precision) against the CSV.
+    """
+    csv_data = _csv_lookup()
+    table_rows = _parse_table_rows()
+    assert len(table_rows) == 16, f"expected 16 Table 1 data rows, got {len(table_rows)}"
+    for agent_label, mode, docs, f1_md, cost_md in table_rows:
+        csv_agent = _AGENT_LABEL_TO_CSV[agent_label]
+        csv_arm = _CELL_TO_CSV_ARM[(mode, docs)]
+        f1_csv, cost_csv = csv_data[(csv_agent, csv_arm, docs)]
+        assert round(f1_csv, 2) == f1_md, (
+            f"{agent_label} {mode} docs={docs}: F1 {f1_md} != CSV {round(f1_csv, 2)}"
+        )
+        assert round(cost_csv, 2) == cost_md, (
+            f"{agent_label} {mode} docs={docs}: cost {cost_md} != CSV {round(cost_csv, 2)}"
+        )

--- a/tickets/0512-structural-revisions-s3.erg
+++ b/tickets/0512-structural-revisions-s3.erg
@@ -2,12 +2,12 @@
 Title: Structural revisions §3 review — RW split, §3 halved, annex scheme, §6 split, dangling refs, internal scaffolding
 Created: 2026-06-10
 Author: claude
-Blocked-by: 0509
 Blocked-by: 0511
 
 --- log ---
 2026-06-10T00:00Z claude created — sub-ticket of 0508
 
+2026-06-10T11:00Z HDMX-coding-agent note blocker 0509 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0509-retitle-and-front-matter-arxiv.erg
+++ b/tickets/closed/0509-retitle-and-front-matter-arxiv.erg
@@ -2,10 +2,12 @@
 Title: Re-title manuscript + add arXiV front/back matter (Data & Code, funding, ORCID, conflict note)
 Created: 2026-06-10
 Author: claude
+Closed: autoclosed — PR #920
 
 --- log ---
 2026-06-10T00:00Z claude created — sub-ticket of 0508; Phase 0 decisions
 
+2026-06-10T11:00Z HDMX-coding-agent closed — autoclosed — PR #920
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0509-retitle-and-front-matter-arxiv

## Summary
Gives the standalone preprint (`slides/manuscript/main.md`) its own arXiv identity, replacing the conference talk title and removing forward-references to artifacts that exist only in the slide deck.

### Changes
- **Title** replaced with `Can Frontier AI Build a Statistical Register? A Benchmark and Research Programme on Vietnam's Thermal Power Fleet`. The original Econom'IA talk title is preserved as a pandoc footnote on the H1 (the H1 is body text, so `\thanks{}` cannot attach; a pandoc footnote renders as a real `\footnote`).
- **Author block** gains linked ORCID (`0000-0001-9988-2100`) and institutional email (`minh.ha-duong@cnrs.fr`).
- **Inline Table 1** in §5, rendered from `experiments/derived/tab_exp2_2x2.csv` (4 agents × 2×2 query-mode × documents), replacing the dangling `(see the 2×2 factorial table)`. Caption marks the two `documents = yes` rows per agent as the unregistered/exploratory conditions (per Annex C), keeping the registered naive-vs-optimised contrast honest. Numbers re-derived from the CSV.
- **Figure 5 caption** `appears in the slides and Annex C` rewritten to point at Table 1 and Annex C (dropped "slides").
- **Back matter** before the Bibliography: Data & Code Availability (CC BY 4.0), Funding (CNRS/CIRED), author contributions / conflict-of-interest disclosure.

### Exit criteria met
- New title is the H1; "Beyond RAG" survives only inside the provenance footnote.
- ORCID, email, Data & Code, Funding, conflict-of-interest all present.
- No remaining `see the 2×2 factorial table` or `appears in the slides` dangling refs.
- New adherence test `tests/test_manuscript_frontmatter.py` (written red first, now green).
- Table labelled `Table 1` (not `Figure N`), so `test_manuscript_figure_numbering`'s gapless 1..7 invariant holds.
- Manuscript PDF rebuilds cleanly via pandoc+tectonic; full suite green (`PYTEST_ADDOPTS="" uv run pytest -m "not integration and not slow"` → 2405 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)