### PR TITLE
ticket 0515: CUT — cheaper-models RAG cohort does not support the claim

### DIFF
--- a/tickets/closed/0515-exp2-arm1d-rerun-cheap-models-rag.erg
+++ b/tickets/closed/0515-exp2-arm1d-rerun-cheap-models-rag.erg
@@ -2,10 +2,12 @@
 Title: Exp2 arm 1D rerun — Sonnet, Mistral Medium, Mistral Small, DeepSeek: RAG rescues cheaper models (cost/perf refresh)
 Created: 2026-06-10
 Author: claude
+Closed: CUT: non-finding documented; 2/4 models unusable, thesis contradicted (Mistral Medium RAG F1=0.318)
 
 --- log ---
 2026-06-10T00:00Z claude created — author idea 2026-06-10; IN arXiV but DETACHABLE: timebox 1 day, cut without touching the rest if it slips
 
+2026-06-10T10:52Z HDMX-coding-agent closed — CUT: non-finding documented; 2/4 models unusable, thesis contradicted (Mistral Medium RAG F1=0.318)
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0515-exp2-arm1d-rerun-cheap-models-rag

## Verdict: CUT (documented non-finding)

Ticket 0515 wanted to demonstrate "RAG rescues cheaper models" by running
Exp2 arm-1D (RAG / evidence pack) on four cheaper/mid models and refreshing
the cost/performance figure. The ticket is explicitly **detachable** — a clean
cut with a documented non-finding is a success outcome.

Phase A "test one before blasting" (repeat=1 probe per model, RAG with
evidence pack `all18tables.yaml`, web search off) was run; the result triggers
CUT.

### Phase A results

| Model (OpenRouter) | Result | F1 (arm3, local score) | Notes |
|---|---|---|---|
| `anthropic/claude-sonnet-4.6` | report | **0.712** | 98 rows but truncated at 16K (`finish_reason=length`); frontier-priced (~$0.51/run), not cheap |
| `mistralai/mistral-medium-3-5` | report | **0.318** | 37 rows; below frontier sibling `mistral-large` no-RAG F1=0.487 |
| `mistralai/mistral-small-2603` | report | **parse_failed** | canonicalizer can't find the plant-name column → would need NEW scoring code |
| `deepseek/deepseek-v3.2` | **404** | — | retired from OpenRouter; `v4-pro`/`v4-flash` route but return null/`length` even at 32K + `no_think` |

### CUT triggers (two independent)
- **≥2 of 4 unusable**: DeepSeek (unservable) + Mistral Small (unscoreable).
- **Scoring would need new code**: Mistral Small's bilingual / link-formatted
  source columns aren't recognized by the canonicalizer.

The thesis is contradicted, not just unmeasured: the genuinely-cheap models
are dead / unscoreable / weak, and the only strong RAG point (Sonnet 0.712) is
frontier-priced and token-truncated. Frontier arm3 reference: gpt-5.5 0.775,
qwen3.7-max 0.623, opus 0.615, mistral-large 0.591.

### Footprint
Clean cut: **runner changes reverted** (identical to `origin/main`), **no
figure and no `main.md` prose touched**, probe scratch outputs removed. The
only change in this PR is the ticket file (closed + non-finding documented,
moved to `tickets/closed/`).

### Cost
Total API spend ≈ **\$0.57** (3 successful probes + dialogue classifier;
DeepSeek failures cost \$0).

`PYTEST_ADDOPTS="" make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)