### PR TITLE
chore: track symbolic cross-ref migration (0518) + IDH writing rule (0519)

### DIFF
--- a/tickets/0518-migrate-manuscript-to-symbolic-cross-ref.erg
+++ b/tickets/0518-migrate-manuscript-to-symbolic-cross-ref.erg
@@ -1,0 +1,56 @@
+%erg 0.1
+Title: Migrate manuscript to symbolic cross-references (pandoc-crossref): replace hardcoded §N/Figure N with labels
+Created: 2026-06-10
+Author: HDMX-coding-agent
+Blocked-by: 0512
+
+--- log ---
+2026-06-10T12:28Z HDMX-coding-agent created
+
+--- body ---
+
+## Context
+
+`slides/manuscript/main.md` uses hand-typed cross-references (`§3.3`,
+`Figure 4`, `Annex C`, `Figure S1`). These silently rot under restructuring —
+ticket 0512's section renumbering forced manual §N bookkeeping and the stale-base
+incident (2026-06-10) showed how fragile hand-typed numbers are. The author
+wants symbolic labels + references so numbers are never typed by hand.
+
+## What to do
+
+1. Wire the build: `slides/Makefile` pandoc invocation gains `--number-sections`
+   and the `pandoc-crossref` filter (install it; it is NOT currently installed —
+   add to the toolchain/`uv`/system deps and document). Filter must run before
+   `--citeproc`.
+2. Label headings/figures: add `{#sec:id}` to section headings and `{#fig:id}`
+   to figure blocks throughout main.md and all annexes.
+3. Convert prose: every hand-typed `§N` / `Figure N` / `Annex X` / `Figure SN`
+   reference → `[@sec:id]` / `[@fig:id]` form.
+4. Rewrite the literal-matching adherence tests that pin `## N. Title` / `§N` /
+   `Figure N`: `tests/test_manuscript_figure_numbering.py`,
+   `tests/test_main_md_structure.py`, and any 0512 structure test — they must
+   assert on labels/ids, not literal numbers.
+5. Update `.claude/rules/writing.md` to MANDATE symbolic refs (the interim fix
+   in the 0512/migration PR only stops prescribing hardcoded §N; this ticket
+   makes symbolic the rule once the build supports it).
+
+## First test
+
+An adherence test asserting main.md contains NO hand-typed section/figure
+reference literal (regex for `§\d`, `Figure \d`, `Figure S\d` in prose, modulo
+labelled definitions), and that every `@sec:`/`@fig:` reference resolves to a
+defined `{#sec:}`/`{#fig:}` label.
+
+## Verification
+
+- [ ] `pandoc-crossref` installed + wired in `slides/Makefile`; manuscript PDF
+      builds with auto-numbered sections/figures and resolved refs.
+- [ ] No hand-typed `§N`/`Figure N` reference literals remain in main.md prose.
+- [ ] Adherence tests rewritten to label-based assertions; `make check` green.
+- [ ] `.claude/rules/writing.md` mandates symbolic refs.
+
+## Related
+
+Surfaced by 0512 (structural renumbering); harness-level sibling 0519
+(IDH global rule). Blocked-by: 0512 (run on the final restructured manuscript).

--- a/tickets/0519-harness-add-idh-level-writing-rule-manda.erg
+++ b/tickets/0519-harness-add-idh-level-writing-rule-manda.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: Harness: add IDH-level writing rule mandating symbolic cross-references (prevent hardcoded §N recurrence)
+Created: 2026-06-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-10T12:28Z HDMX-coding-agent created
+
+--- body ---
+
+## Context
+
+The hardcoded-`§N` cross-reference defect (2026-06-10) lived in this project's
+`.claude/rules/writing.md` ("point the reader there ('see §3.3')"), which
+*prescribed* hand-typed section numbers. Those rot under restructuring and
+caused manual bookkeeping + near-miss content loss during the 0509–0515 raid.
+The fix belongs at the **IDH (Imperial Dragon Harness) / user-global** level so
+EVERY project inherits it, not just this one.
+
+This is a cross-repo / harness change (the IDH is user-level, never vendored
+into a project — see harness-architecture memory), so it is tracked here but
+APPLIED in the harness repo / `~/.claude`, not in this project tree.
+
+## What to do (in the harness, not this repo)
+
+1. Add a user-global writing rule (e.g. `~/.claude/rules/writing.md`) with a
+   general, project-agnostic convention:
+   > **Cross-reference symbolically, never by hand-typed number.** In any
+   > document with an auto-numbering system (LaTeX, pandoc-crossref, Quarto,
+   > Sphinx), label targets and reference labels — never write `§3.3` or
+   > `Figure 4` literally. Hand-typed numbers silently rot under restructuring.
+2. Register it in `~/.claude/rules/README.md`'s index table with its scope
+   signal (condition: project builds a labelled document — `.tex`/`.qmd`/pandoc).
+3. Coordinate with the in-flight `dream-consolidate-2026-06-09` branch in
+   `~/.claude` (do not clobber its uncommitted `rules/README.md` edit).
+
+## Exit criteria
+
+- [ ] IDH-level writing rule present + indexed in `~/.claude/rules/README.md`.
+- [ ] Project-level `.claude/rules/writing.md` aligned (no longer prescribes
+      hardcoded `§N`) — done in this repo by ticket 0518's PR.
+
+## Related
+
+Project-level execution: 0518 (manuscript migration + project-rule fix).
+Surfaced during the 0509–0515 arXiv raid.


### PR DESCRIPTION
Two tracking tickets surfaced by the 0509–0515 arXiv raid.

- **0518** — migrate the manuscript to symbolic cross-references (pandoc-crossref); replaces hand-typed §N/Figure N with labels. Blocked-by 0512 (run on the final restructured manuscript). Will be executed, not deferred.
- **0519** — apply the symbolic-cross-ref convention at IDH/harness (user-global) level so every project inherits it; prevents the hardcoded-§N defect recurring.

Root cause: the project writing rule prescribed hardcoded `§N`, which rots under restructuring (caused manual bookkeeping + a near-miss content loss during the raid).

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)