### PR TITLE
chore: re-close ticket 0500 (audit done, non-finding)

### DIFF
--- a/tickets/closed/0500-audit-matcher-diacritic-folding-tp-undercount.erg
+++ b/tickets/closed/0500-audit-matcher-diacritic-folding-tp-undercount.erg
@@ -3,11 +3,14 @@ Title: Audit: matcher's missing diacritic-folding may undercount Exp1/2/3 TP (co
 Created: 2026-06-09
 Author: HDMX-coding-agent
 Label: needs-human
+Closed: non-finding — audit refuted the premise: production reconcile() already folds diacritics both sides; immaterial to reported numbers (matcher_fold_audit.md)
 
 --- log ---
 2026-06-09T13:00Z HDMX-coding-agent created — roar sweep from the 0486 GEM-coverage review.
 
 2026-06-09T12:26Z haduong note AUDIT steps 1-2 done (branch audit/0500-matcher-fold): premise REFUTED — production reconcile() folds diacritics on BOTH sides via cleaner.clean_text (NFD+Mn+d-bar). GEM 67/88 was the throwaway 0486 prototype bypassing the cleaner. A/B fold-vs-folding-disabled on Exp1 (70 runs): folding load-bearing ~+0.12 F1/model AND already applied -> IMMATERIAL to reported numbers, no re-score. Zero folding-induced FP collisions; combined-grain cases are 0498. Recommend close as non-finding + regression guard for the existing fold. Artifacts in experiments/derived/matcher_fold_audit.md. NOT setting Closed — author decision.
+
+2026-06-10T14:15Z haduong closed — author decision: audit done, premise refuted, close as non-finding.
 --- body ---
 
 ## Context (observation, cause not yet established)


### PR DESCRIPTION
Re-close 0500 — the #927 stale-base dedup left it open without a `Closed:` header. Author confirmed the audit was done (premise refuted: production reconcile() already folds diacritics both sides; immaterial to reported numbers; audit in `experiments/derived/matcher_fold_audit.md`).

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)