### PR TITLE
fix(0526): repair silently-dead erg validation hook in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file=$(cat | jq -r '.tool_input.file_path // empty'); case \"$file\" in *.erg) tickets/tools/go/erg validate tickets/ 2>&1 ;; esac",
+            "command": "file=$(cat | jq -r '.tool_input.file_path // empty'); case \"$file\" in *.erg) tickets/erg check tickets/ 2>&1 ;; esac",
             "timeout": 10
           }
         ]

--- a/tickets/0526-fix-stale-erg-validation-hook-path-in-settings.erg
+++ b/tickets/0526-fix-stale-erg-validation-hook-path-in-settings.erg
@@ -3,12 +3,14 @@ Title: Fix stale erg validation hook in .claude/settings.json (wrong path and ve
 Created: 2026-06-11
 Author: Claude
 Label: needs-human
+Closed: hook command fixed: tickets/erg check tickets/
 
 --- log ---
 2026-06-11T00:00Z Claude created
 2026-06-11T00:01Z Claude tag needs-human
 2026-06-11T00:01Z Claude note tagged needs-human — agent permission classifier blocks edits to .claude/settings.json (self-modification); a human or explicitly-authorized session must apply the one-line fix
 
+2026-06-11T08:37Z HDMX-coding-agent closed — hook command fixed: tickets/erg check tickets/
 --- body ---
 ## Context
 


### PR DESCRIPTION
One-line hook fix: `tickets/tools/go/erg validate tickets/` → `tickets/erg check tickets/`. The old path never existed in this repo and `validate` rejects directories, so .erg edits were never validated. Pipe-tested with synthetic hook stdin: `ERG CHECK: PASS (509 tickets)`, exit 0. Ticket closed in the same PR.

**Ticket:** tickets/0526-fix-stale-erg-validation-hook-path-in-settings.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)