### PR TITLE
0504: shared census_model_order ends heatmap/Figure 2 ordering drift

### DIFF
--- a/src/aedist/plot_method_convergence.py
+++ b/src/aedist/plot_method_convergence.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 
 from .evaluate import reference_plant_count
@@ -57,6 +58,17 @@ _KNOWN_SIZE_B: dict[str, float] = {
     "nemotron-3-nano": 30,  # 30B MoE, 3B active
     "qwen3.5-plus-02-15": 397,  # 397B MoE, 17B active
     "step-3.5-flash": 196,  # 196B MoE, 11B active
+    # Exp1 census models with undisclosed parameter counts (ticket 0504):
+    # pinned to their _SIZE_CLASS_B value so name-only resolution reproduces
+    # the size_class-derived Figure 2 order exactly.
+    "claude-opus-4.6": 300,  # size_class=frontier in exp1_batch2 records
+    "claude-sonnet-4.6": 300,  # size_class=frontier in exp1_batch2 records
+    "claude-haiku-4.5": 30,  # size_class=medium in exp1_batch2 records
+    "gpt-5.5": 300,  # size_class=frontier in exp1_batch2 records
+    "deepseek-v4-pro": 300,  # size_class=frontier in exp1_batch2 records
+    "deepseek-v4-flash": 30,  # size_class=medium in exp1_batch2 records
+    "qwen3.7-max": 300,  # size_class=frontier in exp1_batch2 records
+    "qwen3.6-flash": 30,  # size_class=medium in exp1_batch2 records
 }
 
 
@@ -71,6 +83,19 @@ def _model_size_b(model: str, size_class: str | None = None) -> float:
     if matches:
         return max(float(m) for m in matches)
     return float(_SIZE_CLASS_B.get(size_class or "", 500))
+
+
+def census_model_order(models: Iterable[str]) -> list[str]:
+    """Canonical ordering of the census models, shared by Figure 2 and the
+    quality-floor heatmap (ticket 0504).
+
+    Sort key: architectural family alphabetical, then effective parameter
+    count descending (``_model_size_b``, name-only resolution: confirmed
+    registry → regex on the name), then name. Every census model must
+    resolve a size from its name alone — undisclosed sizes are pinned in
+    ``_KNOWN_SIZE_B`` — so callers need no per-record ``size_class``.
+    """
+    return sorted(models, key=lambda m: (model_family(m), -_model_size_b(m), m))
 
 
 log = logging.getLogger(__name__)
@@ -292,25 +317,13 @@ def write_pdf(
         # Pick representative reps per model: min / median / max TP.
         method_rows = _select_min_median_max(method_rows)
 
-        # Resolve size per model (not per record). Different reps of the same
-        # model can carry different size_class values in the data — take the
-        # minimum so that any real registry match (or named size_class) wins
-        # over the 500 default fallback when size_class is "unknown".
-        model_size: dict[str, float] = {}
-        for r in method_rows:
-            sz = _model_size_b(r["model"], r.get("size_class"))
-            model_size[r["model"]] = min(sz, model_size.get(r["model"], sz))
-
-        # Group by architectural family (alphabetical); within family, larger
-        # models go first so they land higher on the inverted Y axis.
-        method_rows.sort(
-            key=lambda r: (
-                model_family(r["model"]),
-                -model_size[r["model"]],
-                r["model"],
-                -r["tp"],
-            )
-        )
+        # Canonical census order (family alphabetical, size descending, name)
+        # via the shared name-only resolver — larger models land higher on
+        # the inverted Y axis. Within a model, runs sort by TP descending.
+        order_index = {
+            m: i for i, m in enumerate(census_model_order({r["model"] for r in method_rows}))
+        }
+        method_rows.sort(key=lambda r: (order_index[r["model"]], -r["tp"]))
 
         band_start = y_offset
         model_ys: dict[str, list[float]] = {}

--- a/src/aedist/plot_quality_floor_heatmap_exp1.py
+++ b/src/aedist/plot_quality_floor_heatmap_exp1.py
@@ -248,7 +248,7 @@ def heatmap_models(rows: list[dict[str, str]]) -> list[str]:
     by tests/test_census_model_order.py, verified against the committed
     figure). Unlike the four-panel spider, this includes DeepSeek.
     """
-    models = sorted({str(r.get("model", "")).strip() for r in rows if str(r.get("model", "")).strip()})
+    models = {str(r.get("model", "")).strip() for r in rows if str(r.get("model", "")).strip()}
     return census_model_order(models)
 
 

--- a/src/aedist/plot_quality_floor_heatmap_exp1.py
+++ b/src/aedist/plot_quality_floor_heatmap_exp1.py
@@ -46,9 +46,9 @@ import logging
 from collections import defaultdict
 from pathlib import Path
 
+from .plot_method_convergence import census_model_order
 from .plot_quality_spider_exp1 import (
     _load_rows,
-    _model_size_rank,
     _parse_optional_float,
 )
 from .util import model_family, model_family_color
@@ -240,20 +240,16 @@ def discriminating_columns(
 
 
 def heatmap_models(rows: list[dict[str, str]]) -> list[str]:
-    """Return the model column order, laid out to match the Figure 2 census.
+    """Return the model column order: the canonical Figure 2 census order.
 
-    Sort key: architectural family alphabetical, then a coarse name-based size
-    tier (``_model_size_rank``) descending, then name.  This approximates
-    plot_method_convergence's parameter-count ordering using only the model
-    name, so the heatmap reads against the same self-contained CSV without the
-    per-record size_class the census consumes; for the fourteen-model cohort the
-    two orders agree (guarded by test_model_order_literal_matches_figure2_render,
-    verified against the committed figure).  Unlike the four-panel spider, this
-    includes DeepSeek.
+    Delegates to ``census_model_order`` (ticket 0504) — the single shared
+    ordering, resolved from the model name alone, so the heatmap reads
+    against its self-contained CSV without a per-record size_class (guarded
+    by tests/test_census_model_order.py, verified against the committed
+    figure). Unlike the four-panel spider, this includes DeepSeek.
     """
     models = sorted({str(r.get("model", "")).strip() for r in rows if str(r.get("model", "")).strip()})
-    models.sort(key=lambda m: (model_family(m), -_model_size_rank(m), m))
-    return models
+    return census_model_order(models)
 
 
 def _collect_runs(

--- a/src/aedist/plot_quality_spider_exp1.py
+++ b/src/aedist/plot_quality_spider_exp1.py
@@ -182,6 +182,13 @@ def _model_label(model: str) -> str:
 
 
 def _model_size_rank(model: str) -> int:
+    """Coarse name-based size tier for the spider's 2x2 panels ONLY.
+
+    The spider sorts ascending-by-tier — intentionally different from the
+    census order (Figure 2 / heatmap), which uses the shared
+    ``plot_method_convergence.census_model_order`` (descending by size).
+    Do not reuse this for census ordering.
+    """
     slug = model.lower()
     if any(t in slug for t in ("haiku", "small", "20b", "flash")):
         return 1

--- a/tests/test_census_model_order.py
+++ b/tests/test_census_model_order.py
@@ -1,0 +1,65 @@
+"""Tests for the shared census model-ordering function (ticket 0504).
+
+`census_model_order` is the single source of truth for the 14-model census
+order used by Figure 2 (plot_method_convergence) and the quality-floor
+heatmap. Three guards:
+
+1. A literal-order tripwire: the order, verified visually against the
+   committed fig_direct_p1_base.pdf (PR #914, 2026-06-09). If the model set
+   changes, update it by re-reading Figure 2 — never by copying the
+   function's own output (that would make the test tautological).
+2. A delegation check: heatmap_models must produce exactly the shared order.
+3. A name-only resolution check: every census model resolves a size from its
+   name alone (registry or regex), never the 500 "unknown" fallback that
+   would collapse distinct models into one tie broken alphabetically.
+"""
+
+from pathlib import Path
+
+from aedist.plot_method_convergence import _model_size_b, census_model_order
+from aedist.plot_quality_floor_heatmap_exp1 import heatmap_models
+from aedist.plot_quality_spider_exp1 import _load_rows
+
+_CSV_PATH = Path("experiments/derived/exp1_cross_eval.csv")
+
+# Verified visually against the committed fig_direct_p1_base.pdf (PR #914).
+_FIGURE2_RENDER_ORDER = [
+    "claude-opus-4.6",
+    "claude-sonnet-4.6",
+    "claude-haiku-4.5",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "gpt-5.5",
+    "gpt-oss-120b",
+    "gpt-oss-20b",
+    "mistral-large-2512",
+    "mistral-medium-3-5",
+    "mistral-small-2603",
+    "qwen3.7-max",
+    "qwen3.6-35b-a3b",
+    "qwen3.6-flash",
+]
+
+
+def _census_models() -> list[str]:
+    rows = _load_rows(_CSV_PATH)
+    return sorted({str(r.get("model", "")).strip() for r in rows if str(r.get("model", "")).strip()})
+
+
+def test_census_order_matches_figure2_render():
+    """The real guard: shared order equals the visually-verified literal."""
+    assert census_model_order(_census_models()) == _FIGURE2_RENDER_ORDER
+
+
+def test_heatmap_delegates_to_census_order():
+    """Delegation, not coincidence: heatmap columns ARE the shared order."""
+    rows = _load_rows(_CSV_PATH)
+    assert heatmap_models(rows) == census_model_order(_census_models())
+
+
+def test_census_sizes_resolve_from_name_alone():
+    """Every census model resolves a size from its name (registry or regex),
+    never the 500 size_class-unknown fallback — so the order needs no
+    per-record size_class column (the heatmap CSV has none)."""
+    for model in _FIGURE2_RENDER_ORDER:
+        assert _model_size_b(model) != 500.0, f"{model} falls back to the 500 default"

--- a/tests/test_plot_quality_floor_heatmap_exp1.py
+++ b/tests/test_plot_quality_floor_heatmap_exp1.py
@@ -15,7 +15,7 @@ from aedist.plot_quality_floor_heatmap_exp1 import (
     make_figure,
     mean_score,
 )
-from aedist.plot_quality_spider_exp1 import _load_rows, _model_size_rank
+from aedist.plot_quality_spider_exp1 import _load_rows
 from aedist.util import model_family
 
 _CSV_PATH = Path("experiments/derived/exp1_cross_eval.csv")
@@ -124,49 +124,8 @@ def test_scored_columns_excludes_bookkeeping():
         assert col not in {"arm", "model", "run", "prompt_version", "reference", "n_rows"}
 
 
-# ── Model column order: identical to Figure 2, DeepSeek included ──────────────
-
-
-def _figure2_order_ref(rows):
-    """Reference: family alphabetical, size-rank descending, name (mirrors Fig 2)."""
-    models = sorted({str(r.get("model", "")).strip() for r in rows if str(r.get("model", "")).strip()})
-    models.sort(key=lambda m: (model_family(m), -_model_size_rank(m), m))
-    return models
-
-
-def test_model_order_matches_figure2_ordering():
-    """Heatmap columns follow the same ordering rule as Figure 2's census."""
-    rows = _load_rows(_CSV_PATH)
-    assert heatmap_models(rows) == _figure2_order_ref(rows)
-
-
-def test_model_order_literal_matches_figure2_render():
-    """Independent literal guard: the exact column order, verified visually
-    against the committed fig_direct_p1_base.pdf (PR #914, 2026-06-09).
-
-    _figure2_order_ref shares its sort key with heatmap_models, so it cannot
-    catch the name-rank heuristic diverging from Figure 2's size-registry sort
-    (e.g. '20b' substring-matching inside 'gpt-oss-120b'). This literal can:
-    if the model set changes, update it by re-reading Figure 2 — not by
-    copying heatmap_models output.
-    """
-    rows = _load_rows(_CSV_PATH)
-    assert heatmap_models(rows) == [
-        "claude-opus-4.6",
-        "claude-sonnet-4.6",
-        "claude-haiku-4.5",
-        "deepseek-v4-pro",
-        "deepseek-v4-flash",
-        "gpt-5.5",
-        "gpt-oss-120b",
-        "gpt-oss-20b",
-        "mistral-large-2512",
-        "mistral-medium-3-5",
-        "mistral-small-2603",
-        "qwen3.7-max",
-        "qwen3.6-35b-a3b",
-        "qwen3.6-flash",
-    ]
+# ── Model column order: delegation + literal guards live in
+#    tests/test_census_model_order.py (ticket 0504) ─────────────────────────────
 
 
 def test_deepseek_included_in_columns():

--- a/tickets/0504-shared-census-model-ordering-function-he.erg
+++ b/tickets/0504-shared-census-model-ordering-function-he.erg
@@ -54,7 +54,7 @@ truth.
   pulls in no heavy deps. Key: `(model_family(m), -size_b(m), m)`.
 - Make size resolution work from the **name alone** so the heatmap can use it:
   `_model_size_b(model, size_class=None)` already falls back to the regex and
-  then the `size_class` default (500). Add the 6 exp1 models missing confirmed
+  then the `size_class` default (500). Add the 8 exp1 models (count corrected from 6 by the raid plan below) missing confirmed
   sizes to `_KNOWN_SIZE_B` (claude-haiku-4.5 / -sonnet-4.6 / -opus-4.6,
   gpt-5.5, deepseek-v4-pro / -flash, qwen3.7-max, qwen3.6-flash) so the
   name-only path orders them correctly instead of colliding at 500.
@@ -97,7 +97,7 @@ def test_heatmap_and_figure2_share_one_order():
       `plot_method_convergence` both call it (no second size heuristic for
       census ordering).
 - [ ] Size resolution works from the model name alone (heatmap path needs no
-      `size_class`); the 6 missing exp1 models are in `_KNOWN_SIZE_B` with
+      `size_class`); the 8 missing exp1 models are in `_KNOWN_SIZE_B` with
       values pinned to preserve today's Figure 2 order.
 - [ ] `test_census_model_order.py` (the first test above) passes; the PR #914
       literal-order test is folded into / superseded by it (no orphaned

--- a/tickets/0504-shared-census-model-ordering-function-he.erg
+++ b/tickets/0504-shared-census-model-ordering-function-he.erg
@@ -5,6 +5,8 @@ Author: claude
 
 --- log ---
 2026-06-09T20:29Z claude created
+2026-06-11T08:30Z claude note raid imagine+plan — count fix: 8 missing models not 6; plan appended
+2026-06-11T09:08Z claude note feasibility PASS — registry gap, size_class values, regex miss, acyclic imports all verified
 
 --- body ---
 ## Context
@@ -113,6 +115,35 @@ def test_heatmap_and_figure2_share_one_order():
 - `src/aedist/plot_quality_floor_heatmap_exp1.py` — `heatmap_models`
 - `src/aedist/plot_quality_spider_exp1.py` — `_model_size_rank` (other consumer)
 - `tests/test_plot_quality_floor_heatmap_exp1.py` — `test_model_order_literal_matches_figure2_render` (to fold in)
+
+## Plan (raid 2026-06-11)
+
+Corrections from the raid Imagine + feasibility passes (binding):
+
+- **Count fix: 8 models, not 6**, are missing from `_KNOWN_SIZE_B` and miss the
+  name regex: claude-opus-4.6, claude-sonnet-4.6, claude-haiku-4.5, gpt-5.5,
+  deepseek-v4-pro, deepseek-v4-flash, qwen3.7-max, qwen3.6-flash. Verified
+  `size_class` from exp1_batch2 records: frontier (→300) for claude-opus-4.6,
+  claude-sonnet-4.6, deepseek-v4-pro, gpt-5.5, qwen3.7-max; medium (→30) for
+  claude-haiku-4.5, deepseek-v4-flash, qwen3.6-flash. Pin exactly 300/30 so
+  Figure 2's order is provably unchanged; comment each entry with its
+  size_class provenance.
+- `census_model_order` lives in `plot_method_convergence.py` next to
+  `_model_size_b` (util.py is presentation-only; matplotlib import is inside
+  write_pdf, so the import is cheap and acyclic).
+- Sort key: `(model_family(m), -size_b(m), m)`. Repoint both the inline census
+  sort in plot_method_convergence and `heatmap_models` at it.
+- `_model_size_rank` STAYS in plot_quality_spider_exp1.py (spider panels sort
+  ascending-by-tier, intentionally different); add a spider-panel-only
+  docstring note; delete its now-unused import from the heatmap module.
+- Tests: new tests/test_census_model_order.py with (a) literal-order guard,
+  (b) delegation test `heatmap_models(rows) == census_model_order(...)`,
+  (c) name-only resolution test. DELETE the tautological
+  `test_model_order_matches_figure2_ordering`; FOLD
+  `test_model_order_literal_matches_figure2_render` into the new file.
+- DoD "byte-for-deterministic rebuild" = order unchanged (literal test) + both
+  figures rebuild via make; no byte-hash test (matplotlib timestamps flaky);
+  do not commit noise-only pdf changes.
 
 ## Priority
 

--- a/tickets/closed/0504-shared-census-model-ordering-function-he.erg
+++ b/tickets/closed/0504-shared-census-model-ordering-function-he.erg
@@ -2,12 +2,14 @@
 Title: Shared census model-ordering function (heatmap vs Figure 2 drift)
 Created: 2026-06-09
 Author: claude
+Closed: autoclosed — PR #958
 
 --- log ---
 2026-06-09T20:29Z claude created
 2026-06-11T08:30Z claude note raid imagine+plan — count fix: 8 missing models not 6; plan appended
 2026-06-11T09:08Z claude note feasibility PASS — registry gap, size_class values, regex miss, acyclic imports all verified
 
+2026-06-11T10:10Z HDMX-coding-agent closed — autoclosed — PR #958
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0504-shared-census-model-ordering-function-he.erg

## Summary

Ends the heatmap/Figure 2 census-ordering drift risk: one canonical
`census_model_order(models) -> list[str]` (in `plot_method_convergence.py`,
next to `_model_size_b`) now computes the 14-model order for both Figure 2
(`fig_direct_p1_base`) and the quality-floor heatmap. Size resolution works
from the model name alone (registry → name regex), so the heatmap needs no
per-record `size_class`. The coarse `_model_size_rank` tier heuristic is no
longer used for census ordering; it stays in the spider module (its panels
sort ascending-by-tier, intentionally different) with a spider-only
docstring warning.

## Pinned sizes (8 models, not the ticket's 6 — raid count fix)

| Model | Pinned size (B) | Provenance |
|---|---|---|
| claude-opus-4.6 | 300 | size_class=frontier in exp1_batch2 records |
| claude-sonnet-4.6 | 300 | size_class=frontier |
| gpt-5.5 | 300 | size_class=frontier |
| deepseek-v4-pro | 300 | size_class=frontier |
| qwen3.7-max | 300 | size_class=frontier |
| claude-haiku-4.5 | 30 | size_class=medium |
| deepseek-v4-flash | 30 | size_class=medium |
| qwen3.6-flash | 30 | size_class=medium |

Values pinned to exactly `_SIZE_CLASS_B[size_class]` (frontier→300,
medium→30) so the name-only path provably reproduces today's
size_class-derived Figure 2 order.

## Test restructuring

- New `tests/test_census_model_order.py`: (a) literal-order guard — the
  visually-verified PR #914 list, moved verbatim; (b) delegation test
  `heatmap_models(rows) == census_model_order(models)`; (c) name-only
  resolution test (no census model hits the 500 size_class-unknown
  fallback).
- Deleted `test_model_order_matches_figure2_ordering`: it compared
  `heatmap_models` against a local copy of the same sort key —
  tautological by construction.
- `test_model_order_literal_matches_figure2_render` folded into the new
  file (no orphaned duplicate).

## Verification

- `make check` passes (exit 0), including the new tests.
- Both figures rebuilt via `make -f experiments/render.mk -B`:
  `pdftotext` extraction of old vs rebuilt PDFs is byte-identical for both
  → model order unchanged; only PDF metadata/timestamps differed, so the
  noise-only rebuilt PDFs were not committed (repo precedent).
- Ruff clean; the heatmap's dead `_model_size_rank` import removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
