### PR TITLE
tickets(0537-0540): block structural rewrite wave on 0524 conversion

### DIFF
--- a/tickets/0537-intro-motivation-reorg.erg
+++ b/tickets/0537-intro-motivation-reorg.erg
@@ -3,10 +3,12 @@ Title: Manuscript intro & motivation reorg (reading-1 annotations, structural)
 Created: 2026-06-11
 Author: HDMX-coding-agent
 Blocked-by: 0524
+Blocked-by: 0524
 
 --- log ---
 2026-06-11T12:30Z HDMX-coding-agent created from author reading-1 annotations (main+hdm.pdf p2-4)
 
+2026-06-11T11:05Z blocked on 0524 — structural rewrites run LaTeX-native post-conversion (author decision)
 --- body ---
 ## Context
 Author's first full read (2026-06-11) of the text body produced structural

--- a/tickets/0538-methods-figures-prose-rework.erg
+++ b/tickets/0538-methods-figures-prose-rework.erg
@@ -3,10 +3,12 @@ Title: Manuscript methods & figure-prose rework (reading-1 annotations)
 Created: 2026-06-11
 Author: HDMX-coding-agent
 Blocked-by: 0524
+Blocked-by: 0524
 
 --- log ---
 2026-06-11T12:30Z HDMX-coding-agent created from author reading-1 annotations (main+hdm.pdf p6-9)
 
+2026-06-11T11:05Z blocked on 0524 — structural rewrites run LaTeX-native post-conversion (author decision)
 --- body ---
 ## Context
 Author reading-1 directives on the quality-bar section and Figures 2-3 prose.

--- a/tickets/0539-prompt-transparency-demine.erg
+++ b/tickets/0539-prompt-transparency-demine.erg
@@ -3,10 +3,12 @@ Title: Prompt transparency (Annex B verbatim) + de-mine the "merge Wikipedia and
 Created: 2026-06-11
 Author: HDMX-coding-agent
 Blocked-by: 0524
+Blocked-by: 0524
 
 --- log ---
 2026-06-11T12:30Z HDMX-coding-agent created from author reading-1 annotations (main+hdm.pdf p9)
 
+2026-06-11T11:05Z blocked on 0524 — structural rewrites run LaTeX-native post-conversion (author decision)
 --- body ---
 ## Context
 Two author directives from reading 1, both about anticipating referee attacks

--- a/tickets/0540-endgame-reorg-research-programme.erg
+++ b/tickets/0540-endgame-reorg-research-programme.erg
@@ -3,10 +3,12 @@ Title: Manuscript endgame reorg: sections 7-8 + limitations around the research 
 Created: 2026-06-11
 Author: HDMX-coding-agent
 Blocked-by: 0524
+Blocked-by: 0524
 
 --- log ---
 2026-06-11T12:30Z HDMX-coding-agent created from author reading-1 annotations (main+hdm.pdf p17-23)
 
+2026-06-11T11:05Z blocked on 0524 — structural rewrites run LaTeX-native post-conversion (author decision)
 --- body ---
 ## Context
 Author reading-1 verdict on the paper's ending: sections 7, 8 and the


### PR DESCRIPTION
Adds `Blocked-by: 0524` + log entry to 0537/0538/0539/0540 per author decision: the current raid finishes 0532-0534 on main.md, then 0524 converts, then the rewrite wave runs LaTeX-native. erg check PASS.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)