### PR TITLE
tickets: file 0542 LaTeX cleanup; salvage 0541 from superseded branch

### DIFF
--- a/tickets/0541-harmonise-body-register-with-hedged-abst.erg
+++ b/tickets/0541-harmonise-body-register-with-hedged-abst.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: Harmonise body register with hedged abstract/conclusion (binding-constraint claim, Exp2 heading)
+Created: 2026-06-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-11T11:20Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Ticket 0532 (PR #967) rewrote the abstract and conclusion to frame the
+binding-constraint proposition ("the constraint is the documents, not the
+model") as a working hypothesis / conjecture. The strict review of #967 found
+three pre-existing body sites that still state the same proposition (or an
+adjacent unscoped claim) in factual register, a contrast that 0532 made more
+visible:
+
+1. `slides/manuscript/main.md` §Exp2 heading (~l.113):
+   "Experiment 2: the commercially available frontier still falls short" —
+   unscoped bar; abstract/conclusion now scope "falls short" to the measured
+   dimensions.
+2. `slides/manuscript/main.md` ~l.148 (equalisation paragraph):
+   "it relocates the binding constraint from model capability to document
+   quality" — stated as fact (the paragraph opener does hedge "the pattern is
+   read tentatively", but the relocation clause itself is declarative).
+3. `slides/manuscript/main.md` ~l.156 (fusion section):
+   "the binding constraint shifts from model capability to document quality" —
+   stated as fact.
+
+The abstract and conclusion now hedge ("working hypothesis", "conjecture about
+why", "If the constraint is indeed the documents"); the body asserts. One
+register should win — or the divergence should be a conscious authorial choice
+(e.g. body sections licensed to speak within-experiment, front matter hedging
+the generalisation).
+
+## Relevant files
+
+- `slides/manuscript/main.md` — the three sites above; abstract l.31 and
+  conclusion l.202 as the hedged reference register
+- `tests/test_manuscript_cohort_and_caveats.py` —
+  `test_binding_constraint_framed_as_hypothesis` pins the hedged framing; if
+  the body is re-registered with pinned phrasing, extend there
+
+## Actions
+
+1. Author decides which register wins (hedge the body, or scope the hedge to
+   the cross-experiment generalisation and waive the in-section assertions).
+2. Harmonise the three sites accordingly — or record the waiver in this
+   ticket's log and close.
+
+## Exit criteria
+
+- [ ] Author decision on register recorded
+- [ ] The three sites harmonised, or the divergence consciously waived in the
+      ticket log
+- [ ] `make check` passes

--- a/tickets/0542-semantic-latex-cleanup-main-tex.erg
+++ b/tickets/0542-semantic-latex-cleanup-main-tex.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: Semantic LaTeX cleanup of main.tex (author reading feedback on the 0524 conversion)
+Created: 2026-06-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-11T13:55Z HDMX-coding-agent created from author feedback on the merged #969 tex source
+
+--- body ---
+## Context
+
+The author read `slides/manuscript/main.tex` after the 0524 conversion (PR
+#969) and asked for a cleanup pass: "Clean semantic LaTeX is the idea" —
+pandoc conversion artifacts out, idiomatic article-class LaTeX in.
+
+Sequencing: runs AFTER the 0532/0534 port PR merges (it rewrites the abstract
+and conclusion; editing those regions in parallel guarantees conflicts).
+
+## Actions (author-specified)
+
+1. Drop every `\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}`
+   decoration (pandoc's rendering of markdown `---` rules).
+2. Unfold `\section{...}` (and `\subsection{...}`) heading lines — one heading
+   per source line, no mid-title line wrapping.
+3. Backmatter order: Acknowledgements, Availability, Funding, Author
+   contributions/COI, Bibliography — in that order, right after the
+   Conclusion, BEFORE `\appendix`. Move, do not reword.
+4. Abstract becomes the article-class `\begin{abstract}...\end{abstract}`
+   environment (it is currently a styled paragraph).
+5. τ glyph: replace the math-mode `$\tau$` workaround (ticket 0523 era) with
+   the project's `\newunicodechar` mechanism so the source carries the literal
+   τ; mirror how report.tex declares its other glyphs. Verify the glyph
+   renders (pdftotext / visual).
+6. General sweep for remaining pandoc/idiosyncratic cruft: `\tightlist`,
+   unused `\def`/`\providecommand` from the pandoc preamble, `\pandocbounded`,
+   gratuitous groups `{[}...{]}`, escaped entities that have clean LaTeX
+   forms, etc. Keep semantic intent; do not touch prose wording.
+
+## Invariants
+
+- Zero prose changes (pdftotext word-stream identical modulo whitespace and
+  the moved backmatter blocks).
+- `make -C slides manuscript/main.pdf` clean; no "??" refs; `make check` green.
+- House conventions in `.claude/rules/writing.md` stay accurate — update them
+  if the cleanup changes a documented idiom (e.g. abstract environment).
+
+## Exit criteria
+
+- [ ] All six actions applied.
+- [ ] pdftotext equivalence evidence in the PR (before/after).
+- [ ] `make check` passes; CI green.


### PR DESCRIPTION
Files 0542 (author feedback on the #969 tex: semantic LaTeX cleanup, runs after the 0532/0534 port) and salvages 0541 (filed on t0532, which gets superseded unmerged).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)