### PR TITLE
tickets: route the two #971 waivers — 0531 note + new 0544 (rapidfuzz threshold)

### DIFF
--- a/tickets/0531-macros-everywhere-manuscript-numbers.erg
+++ b/tickets/0531-macros-everywhere-manuscript-numbers.erg
@@ -9,6 +9,7 @@ Author: HDMX-coding-agent
 2026-06-11T09:10Z HDMX-coding-agent note folded 0501 (v2.4/177 prose sync) into this ticket — the macro pass re-derives every number anyway; hand-fixing 18 literals first would be double work (author-approved)
 
 2026-06-11T14:00Z HDMX-coding-agent note blocker 0524 closed — Blocked-by removed.
+2026-06-11T15:04Z absorb 0534 item-1 waiver: emit the status-accuracy-excluding-proposed-stratum value as a generated artifact/macro so the caveat prose can cite it (waived in #971 for lack of committed artifact)
 --- body ---
 ## Context
 The 2026-06-11 prose review panel (pre-arXiv) found the manuscript's hand-typed

--- a/tickets/0544-validate-rapidfuzz-match-threshold.erg
+++ b/tickets/0544-validate-rapidfuzz-match-threshold.erg
@@ -1,0 +1,43 @@
+%erg 0.1
+Title: Validate the rapidfuzz partial_ratio>=90 matcher threshold: false-match estimate on phase-named plants
+Created: 2026-06-11
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-11T14:55Z HDMX-coding-agent created — 0534 item 6, waived twice (#968, #971) for lack of artifact; ticketed so the question stops recurring
+
+--- body ---
+## Context
+
+The source-concordance matcher uses `rapidfuzz partial_ratio >= 90` to match
+model-emitted plant names against the reference. The threshold is unvalidated;
+review item 0534#6 asked for a false-match estimate, particularly on
+Vietnamese phase-named plants (Vũng Áng 1 vs Vũng Áng 2, Vĩnh Tân 1/2/3/4),
+where partial_ratio is structurally prone to cross-phase hits. The item was
+waived in both #968 and #971 because no committed artifact supports a number;
+the concordance table carries an upper-bound caveat instead.
+
+## Actions
+
+1. Script (src/aedist/, argparse, Makefile-wired): for every reference plant
+   pair (a, b), compute partial_ratio(a, b); report pairs >= 90 that are
+   distinct plants (the structural false-match set), grouped by phase-family.
+2. From the actual matcher inputs (model run outputs), estimate the realised
+   false-match rate at threshold 90, and the sensitivity at 85/95.
+3. Emit a small CSV artifact + macro (false-match count / rate) the
+   concordance caveat can cite; wire into the DAG.
+4. If the rate is material, propose the fix in the ticket log (e.g.
+   token_sort_ratio, phase-suffix guard) — do not change the matcher in this
+   ticket (scoring change = new ticket, cf. 0502 precedent).
+
+## Test
+
+- Unit test with the known phase families: Vũng Áng 1/2 must appear in the
+  structural false-match set at threshold 90 (red first if the set is empty).
+
+## Exit criteria
+
+- [ ] Artifact + macro committed, Makefile-wired
+- [ ] Concordance caveat cites the measured number (prose via macro)
+- [ ] Sensitivity at 85/90/95 documented in the ticket log
+- [ ] `make check` green


### PR DESCRIPTION
0534 item 1's waived number (status accuracy excluding the proposed stratum) is now in 0531's brief; 0534 item 6 (rapidfuzz partial_ratio>=90 false-match estimate) becomes ticket 0544 with a concrete artifact plan.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)