### PR TITLE
prose(0538): methods & figure-prose rework — reading-1 annotations

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -297,8 +297,8 @@ philosophy-of-science empirical adequacy
   aggregate totals match subtotals, capacities are non-negative,
   duplicate units are counted once. Externally, the dataset must remain
   compatible with other available knowledge --- units, orders of
-  magnitude, locations, technology types, and commissioning dates all
-  plausible. A coherent dataset identifies conflicts between sources
+  magnitude, locations, technology types, and commissioning dates should
+  all be plausible. A coherent dataset identifies conflicts between sources
   rather than silently overwriting them. A weak working test is whether
   repeated runs of the same system agree with one another
   \citep{Wang2022:self-consistency}; the stronger requirement is
@@ -388,8 +388,8 @@ Figure~\ref{fig:capability-timeline} is the date the framework ×
 trained-model × product triple first appears in a publicly available
 commercial product.
 
-The integrations are by now familiar; each maps to a row of
-Figure~\ref{fig:capability-timeline}:
+Each row of Figure~\ref{fig:capability-timeline} corresponds to one
+integration:
 
 \begin{itemize}
 \item
@@ -429,7 +429,7 @@ casting the problem into a query the system can answer. The
 articulation is double: the problem must be cast as the analyst's
 question, and the question as the LLM prompt. The LLM must answer the
 question asked and follow the prompt; but the question must also match
-the problem, and the two links fail independently. A failure of the
+the problem, and either link can fail on its own. A failure of the
 first link is the \emph{Type-III error} \citep{Mitroff1974}: solving
 the wrong problem --- in LLM work, a well-executed answer to a
 mis-posed question. Prompt engineering is the craft that addresses the
@@ -440,7 +440,7 @@ extractor does not recognise produces a missing value indistinguishable
 from a genuine coverage gap (developed in §\ref{sec:discussion}). The
 experiments exercise articulation through structured prompts
 (§\ref{sec:exp1} and §\ref{sec:exp2}); the verbatim prompts are
-reproduced in the protocol annexes \ref{sec:annex-exp1} and
+reproduced verbatim in \ref{sec:annex-exp1} and
 \ref{sec:annex-exp2}.
 
 \begin{figure}
@@ -451,9 +451,9 @@ capability is a feature of the lab's public commercial product, not a
 property of the underlying model. Each row is a capability feature (1
 chat LLM → 8 multi-agent recursion); each marker places when the named
 lab first shipped that feature in a consumer-facing product. The figure
-reads as a capability checklist for the experiments: a lab's position
-on each row is the capability set its system brings to §\ref{sec:exp1}
-and §\ref{sec:exp2}. Source: author's compilation; per-lab primary
+sets the experimental conditions: a lab's position on each row is the
+capability set its system brings to §\ref{sec:exp1} and
+§\ref{sec:exp2}. Source: author's compilation; per-lab primary
 announcements documented in
 \ref{sec:annex-rollout}.}\label{fig:capability-timeline}
 \end{figure}

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -293,47 +293,33 @@ philosophy-of-science empirical adequacy
   \citep{Lin-Stephanie2022:truthfulqa}.
 \item
   \emph{Coherence} asks whether the dataset is internally and externally
-  consistent. Internally, statistical tables have control constraints:
-  aggregate totals should match regional or technology subtotals when
-  those totals are known; capacities should not be negative; duplicate
-  units should not be counted twice; and cross-row values should not
-  contradict one another. Externally, the dataset should remain
-  compatible with other available knowledge: units, orders of magnitude,
-  geographic location, technology type, and commissioning dates should
-  all be plausible. A coherent dataset identifies conflicts between
-  sources rather than silently overwriting them. A minimal coherence
-  requirement is non-contradiction; a weak working test is whether
+  consistent. Internally, statistical tables carry control constraints:
+  aggregate totals match subtotals, capacities are non-negative,
+  duplicate units are counted once. Externally, the dataset must remain
+  compatible with other available knowledge --- units, orders of
+  magnitude, locations, technology types, and commissioning dates all
+  plausible. A coherent dataset identifies conflicts between sources
+  rather than silently overwriting them. A weak working test is whether
   repeated runs of the same system agree with one another
-  \citep{Wang2022:self-consistency}. A stronger requirement is
-  inferential closure: the system should derive and expose all
-  consequences that follow from the available documents and accounting
-  rules, rather than merely storing isolated claims. Coherence thus has
-  two axes --- \emph{scope} (internal to the dataset vs.~external
-  against world knowledge) and \emph{strength} (weak: no contradiction,
-  vs.~strong: inferential closure). This paper measures weak-internal
-  coherence; the external axis is discussed in the Discussion section.
+  \citep{Wang2022:self-consistency}; the stronger requirement is
+  inferential closure --- the system derives and exposes all
+  consequences of the available documents and accounting rules. This
+  paper measures weak-internal coherence; the external axis is deferred
+  to the Discussion.
 \item
-  \emph{Provenance} requires a pedigree for each data item. Every row,
-  and ideally every cell, should trace back to specific passages,
-  tables, images, or records in specific sources. Strong provenance
-  means more than attaching a plausible citation: the cited source must
-  actually support the value claimed
+  \emph{Provenance} requires a pedigree for each data item: every row,
+  and ideally every cell, traces back to specific passages, tables, or
+  records in specific sources. Strong provenance means more than
+  attaching a plausible citation --- the cited source must actually
+  support the value claimed
   \citep{Gao-Tianyu2023:alce, Asai-Akari2024:self-rag, Es-Shahul2023:ragas}.
   We distinguish \emph{verifiable} provenance --- a citation is present
   and could in principle be checked --- from \emph{verified} provenance
   --- the citation was retrieved and confirmed to support the stated
   value. Verified provenance is the stronger standard; verifiable is the
   minimum floor. When sources contradict one another, the resolution ---
-  which source was preferred and why --- should itself be documented as
-  part of the provenance record. Ideally, each important item should be
-  backed by two independent primary sources. Weaker forms of
-  justification --- for example, one primary source, a regulator
-  database, or a clearly marked secondary compilation --- are still
-  preferable to unsupported values, provided their evidential status is
-  explicit. Satellite imagery and visual inspection can also provide
-  evidence for industrial assets, but they are costly, hard to scale,
-  and mainly confirm the presence of existing installations rather than
-  full project histories.
+  which source was preferred and why --- is itself part of the
+  provenance record.
 \item
   \emph{Temporality} is not metadata added after the fact; it is part of
   the statistical fact itself. Energy infrastructure changes over time:
@@ -356,6 +342,15 @@ philosophy-of-science empirical adequacy
   §\ref{sec:fusion} and discussed in \ref{sec:annex-temporality}.
 \end{enumerate}
 
+Of the four dimensions, accuracy is the only one whose measurement
+requires a held-out gold reference. Coherence, provenance, and
+temporality are reference-free: they can be assessed from the dataset
+and its sources alone. The screening logic of this paper follows from
+that asymmetry: where reference-free indicators correlate with accuracy,
+they can estimate it --- screening out weak outputs without the
+reference. The experiments exercise this logic directly
+(§\ref{sec:exp1}).
+
 The task is not simply to generate a plausible inventory-shaped answer.
 The statistical object is a dated, sourced, internally reconciled set of
 claims about energy-system assets and events. Accuracy determines
@@ -365,90 +360,111 @@ temporality determines what period of the world they describe.
 
 \section{AI capability landscape: from chatbots to agentic systems}\label{sec:capability}
 
-General-purpose AI systems vary along four axes: \emph{training
-objective} (from raw text completion through instruction-following to
-extended reasoning), \emph{input and output media} (text, vision, audio,
-video), \emph{tool access} (none, web browser, code execution, computer
+Between 2022 and 2025, AI capability advanced as an industry-wide
+\emph{envelope} --- the outer surface of commercially attainable
+capability --- not as a staircase any single lab climbs. The systems
+that push this envelope vary along four axes: \emph{training objective}
+(from raw text completion through instruction-following to extended
+reasoning), \emph{input and output media} (text, vision, audio, video),
+\emph{tool access} (none, web browser, code execution, computer
 control), and \emph{product workflow} (simple chat, single-task agent,
 deep research, coding agent, autonomous task runner). The first two are
 properties of the model; the last two are properties of the software
-that wraps it. The cross-product is large, and any single comparison
-axis is a projection. Figure~\ref{fig:capability-timeline} uses one such
-projection: a timeline of when each of eight capability surfaces first
-shipped as a consumer-facing product --- the threshold at which a
+that wraps it. Figure~\ref{fig:capability-timeline} shows one projection
+of this coordinate system: when each of eight capability surfaces first
+shipped in a consumer-facing product --- the threshold at which a
 working analyst can rely on it, months after API or privileged-partner
 availability.
 
-Agent capabilities improve statistical-dataset quality, and the
-2022--2025 industry trajectory bears this out --- not as a single
-staircase any one lab climbs, but as an \emph{envelope}, the outer
-surface of commercially attainable capability, pushed outward through a
-sequence of integrations rather than inventions. None of these
-integrations are model properties: retrieval, web access, reasoning
-surfaces, code execution, tool use, and recursion all live in the
-runtime that wraps the model. What the model contributes is
-\emph{conditioning} --- a lab's investment in training the model to
-exploit retrieved documents, tool calls, long reasoning chains, and
-delegated sub-tasks is what lets it use each surface when the
-framework exposes it. Each marker in
+The envelope is pushed outward through a sequence of integrations
+rather than inventions. None of these integrations are model
+properties: retrieval, web access, reasoning surfaces, code execution,
+tool use, and recursion all live in the runtime that wraps the model.
+What the model contributes is \emph{conditioning} --- a lab's
+investment in training the model to exploit retrieved documents, tool
+calls, long reasoning chains, and delegated sub-tasks is what lets it
+use each surface when the framework exposes it. Each marker in
 Figure~\ref{fig:capability-timeline} is the date the framework ×
 trained-model × product triple first appears in a publicly available
 commercial product.
 
-Below these integrations sits \emph{articulation} --- the craft of
-writing the query so that it asks what the analyst actually means. It is
-the LLM-specific form of the \emph{Type-III error}, solving the wrong
-problem \citep{Mitroff1974}; to our knowledge it has had no explicit
-treatment in the LLM literature. Articulation is a confound for every
-downstream quality metric: a model that retrieves the correct fact but
-expresses it in a form the extractor does not recognise produces a
-missing value indistinguishable from a genuine coverage gap (developed
-in §\ref{sec:discussion}). The §\ref{sec:exp1} baseline already
-exercises articulation through a structured four-section prompt.
+The integrations are by now familiar; each maps to a row of
+Figure~\ref{fig:capability-timeline}:
 
-The integrations are by now familiar. \emph{Retrieval-augmented
-generation} \citep{Lewis-Patrick2020:rag, Gao-Yunfan2024:rag-survey}
-answers the coverage limit; \emph{reasoning} --- step-by-step
-deliberation first elicited by prompting \citep{Wei-Jason2022:cot},
-later built in as computation the model spends before answering ---
-narrows the coherence limit on long, multi-source synthesis; their
-combination is the deep-research surface
-\citep{Wei-Jason2025:browsecomp}. \emph{Code execution} lets the model
-verify arithmetic and produce executable artefacts; \emph{external tool
-use} --- a standardised tool-connection protocol
-\citep{Yao-Shunyu2023:react} --- generalises code execution to an
-extensible registry of external services, with benchmarks on coding
-\citep{Jimenez-Carlos2024:swe-bench}, OS control
-\citep{Xie-Tianbao2024:osworld}, and general-assistant tasks
-\citep{Mialon-Gregoire2024:gaia}; \emph{agency} is the closure of that
-surface, when the tool-use set includes the model itself. Each
-integration lifts one or more of the §\ref{sec:quality} quality limits
-at the margin; none lifts all four. The detailed per-lab shipping order
---- feature parallelism, the deep-research dependency, and the DeepSeek
-negative case --- is given in \ref{sec:annex-rollout}.
+\begin{itemize}
+\item
+  \emph{Retrieval-augmented generation}
+  \citep{Lewis-Patrick2020:rag, Gao-Yunfan2024:rag-survey} answers the
+  coverage limit.
+\item
+  \emph{Reasoning} --- step-by-step deliberation first elicited by
+  prompting \citep{Wei-Jason2022:cot}, later built in as computation
+  the model spends before answering --- narrows the coherence limit on
+  long, multi-source synthesis.
+\item
+  Their combination is the deep-research surface
+  \citep{Wei-Jason2025:browsecomp}.
+\item
+  \emph{Code execution} lets the model verify arithmetic and produce
+  executable artefacts.
+\item
+  \emph{External tool use} --- a standardised tool-connection protocol
+  \citep{Yao-Shunyu2023:react} --- generalises code execution to an
+  extensible registry of external services, with benchmarks on coding
+  \citep{Jimenez-Carlos2024:swe-bench}, OS control
+  \citep{Xie-Tianbao2024:osworld}, and general-assistant tasks
+  \citep{Mialon-Gregoire2024:gaia}.
+\item
+  \emph{Agency} is the closure of that surface, when the tool-use set
+  includes the model itself.
+\end{itemize}
+
+Each integration lifts one or more of the §\ref{sec:quality} quality
+limits at the margin; none lifts all four. The detailed per-lab shipping
+order --- feature parallelism, the deep-research dependency, and the
+DeepSeek negative case --- is given in \ref{sec:annex-rollout}.
+
+Below these integrations sits \emph{articulation} --- the craft of
+casting the problem into a query the system can answer. The
+articulation is double: the problem must be cast as the analyst's
+question, and the question as the LLM prompt. The LLM must answer the
+question asked and follow the prompt; but the question must also match
+the problem, and the two links fail independently. A failure of the
+first link is the \emph{Type-III error} \citep{Mitroff1974}: solving
+the wrong problem --- in LLM work, a well-executed answer to a
+mis-posed question. Prompt engineering is the craft that addresses the
+second link, from the analyst's question to the prompt the model
+receives. Articulation also confounds every downstream quality metric:
+a model that retrieves the correct fact but words it in a form the
+extractor does not recognise produces a missing value indistinguishable
+from a genuine coverage gap (developed in §\ref{sec:discussion}). The
+experiments exercise articulation through structured prompts
+(§\ref{sec:exp1} and §\ref{sec:exp2}); the verbatim prompts are
+reproduced in the protocol annexes \ref{sec:annex-exp1} and
+\ref{sec:annex-exp2}.
 
 \begin{figure}
 \centering
 \includegraphics[width=\linewidth]{../../report/inputs/generated/fig_capability_timeline.pdf}
-\caption{Empirical capability rollout across the five labs in Experiment
-1. Each row is a capability feature (1 chat LLM → 8 multi-agent
-recursion); each marker places when the named lab first shipped that
-feature in a consumer-facing product. Markers are coloured by
-architectural model family (claude / gpt / mistral / qwen / deepseek)
-and shaped by lab. The horizontal spread within each row is the
-cross-lab emergence window; vertical neighbours that overlap in time
-(notably features 3 and 4) indicate parallel-not-sequential capability
-development. The figure is descriptive --- no claim is made that any lab
-is ``ahead'' or that the order is forced. Source:
-\texttt{data/capability\_timeline.csv}; per-lab primary announcements
-documented in
-\texttt{docs/capability-timeline.md}.}\label{fig:capability-timeline}
+\caption{Empirical capability rollout across five leading AI labs. Each
+capability is a feature of the lab's public commercial product, not a
+property of the underlying model. Each row is a capability feature (1
+chat LLM → 8 multi-agent recursion); each marker places when the named
+lab first shipped that feature in a consumer-facing product. The figure
+reads as a capability checklist for the experiments: a lab's position
+on each row is the capability set its system brings to §\ref{sec:exp1}
+and §\ref{sec:exp2}. Source: author's compilation; per-lab primary
+announcements documented in
+\ref{sec:annex-rollout}.}\label{fig:capability-timeline}
 \end{figure}
 
-The empirical envelope nonetheless leaves the §\ref{sec:quality} quality
-bar uncleared, which is what §\ref{sec:exp2} (Experiment 2) tests
-directly.
+This capability envelope defines the conditions under which the
+experiments run; whether any of it clears the §\ref{sec:quality} quality
+bar is an empirical question. §\ref{sec:exp1} measures the parametric
+floor --- what a bare model produces from memory --- and
+§\ref{sec:exp2} tests the full agentic frontier.
 
+\clearpage
 \section{Experiment 1: parametric baseline}\label{sec:exp1}
 
 Submitting a direct query to a large language model produces an

--- a/tickets/0538-methods-figures-prose-rework.erg
+++ b/tickets/0538-methods-figures-prose-rework.erg
@@ -8,6 +8,12 @@ Author: HDMX-coding-agent
 
 2026-06-11T11:05Z blocked on 0524 — structural rewrites run LaTeX-native post-conversion (author decision)
 2026-06-11T14:00Z HDMX-coding-agent note blocker 0524 closed — Blocked-by removed.
+2026-06-11T16:05Z HDMX-coding-agent imagine scope = main.tex §quality (266-365) + §capability (366-450) + fig:capability-timeline caption; items 3-7 all target fig:capability-timeline by content match (ticket's "Figure 3" is a build-numbering artifact)
+2026-06-11T16:05Z HDMX-coding-agent imagine item 2 disposition: readability surgery on the §quality enumerate only; glossary consolidation waived — glossary block is 0537 territory (its item 2 relocates the concepts paragraph); revisit post-0537 if still wanted
+2026-06-11T16:05Z HDMX-coding-agent imagine item 7 float fix = \clearpage before \section{Experiment 1}; no placeins package (YAGNI); take-home reframed as capabilities-as-experimental-variables with forward-refs to sec:exp1/sec:exp2
+2026-06-11T16:25Z HDMX-coding-agent plan 9 edits on slides/manuscript/main.tex: (1-2) trim coherence+provenance enumerate items, keep Wang2022:self-consistency; (3) screening-logic paragraph after the enumerate; (4) assertive envelope-led §capability opening; (5) integrations paragraph moved before the figure, bullet-list option; (6) articulation rewrite — drop anteriority claim, double articulation, type-III, prompt engineering, forward-refs exp1/exp2 + annex-exp1/annex-exp2; (7) caption surgery — five leading AI labs, capability=product feature, drop legend + no-claim, capabilities-as-variables take-home, source=author+annex-rollout; (8) \clearpage before sec:exp1; (9) transition rewrite. Verify: tectonic build + test_manuscript_crossref + sharpened greps.
+2026-06-11T16:40Z HDMX-coding-agent verify-feasibility PASS — all 16 mechanical checks green; corrections: "no claim is made" exists only in the caption (not in annex-rollout — drop without compensation per author directive); Wang2022:self-consistency cited only at the coherence item (must survive the trim); \clearpage baseline 0
+2026-06-11T15:53Z HDMX-coding-agent execute started — raid worktree
 --- body ---
 ## Context
 Author reading-1 directives on the quality-bar section and Figures 2-3 prose.

--- a/tickets/0538-methods-figures-prose-rework.erg
+++ b/tickets/0538-methods-figures-prose-rework.erg
@@ -14,6 +14,14 @@ Author: HDMX-coding-agent
 2026-06-11T16:25Z HDMX-coding-agent plan 9 edits on slides/manuscript/main.tex: (1-2) trim coherence+provenance enumerate items, keep Wang2022:self-consistency; (3) screening-logic paragraph after the enumerate; (4) assertive envelope-led §capability opening; (5) integrations paragraph moved before the figure, bullet-list option; (6) articulation rewrite — drop anteriority claim, double articulation, type-III, prompt engineering, forward-refs exp1/exp2 + annex-exp1/annex-exp2; (7) caption surgery — five leading AI labs, capability=product feature, drop legend + no-claim, capabilities-as-variables take-home, source=author+annex-rollout; (8) \clearpage before sec:exp1; (9) transition rewrite. Verify: tectonic build + test_manuscript_crossref + sharpened greps.
 2026-06-11T16:40Z HDMX-coding-agent verify-feasibility PASS — all 16 mechanical checks green; corrections: "no claim is made" exists only in the caption (not in annex-rollout — drop without compensation per author directive); Wang2022:self-consistency cited only at the coherence item (must survive the trim); \clearpage baseline 0
 2026-06-11T15:53Z HDMX-coding-agent execute started — raid worktree
+2026-06-11T16:55Z HDMX-coding-agent item 1 implemented — screening-logic paragraph added after the §quality enumerate: accuracy alone needs the gold reference, the three reference-free dimensions estimate it where correlated, forward-ref sec:exp1
+2026-06-11T16:55Z HDMX-coding-agent item 2 implemented (partial) — coherence item trimmed to ~6 sentences (two-axis taxonomy cut), provenance to ~5 (graduated-evidence enumeration + satellite tangent cut); glossary consolidation waived per imagine disposition (0537 territory)
+2026-06-11T16:55Z HDMX-coding-agent item 3 implemented — §capability opens with the envelope idea then the four axes, assertive "Figure~\ref shows one projection"; envelope/conditioning paragraph deduplicated
+2026-06-11T16:55Z HDMX-coding-agent item 4 implemented — articulation paragraph rewritten in author tone: anteriority claim dropped (no replacement), double articulation problem→question→prompt, Type-III expanded (Mitroff1974 kept), prompt engineering named, confound sentence condensed, forward-refs sec:exp1/sec:exp2 + annexes; verbatim-prompt inclusion itself is 0539
+2026-06-11T16:55Z HDMX-coding-agent item 5 implemented — integrations paragraph moved before articulation and the figure, recast as itemize mapping to figure rows; all 8 citation keys preserved; bare annex-rollout ref kept
+2026-06-11T16:55Z HDMX-coding-agent item 6 implemented — post-figure sentence rewritten as 2-sentence transition: envelope = experimental conditions, quality bar = empirical question, exp1 floor / exp2 frontier
+2026-06-11T16:55Z HDMX-coding-agent item 7 implemented — caption: "five leading AI labs" (no Experiment-1 cross-ref), capability = public-commercial-product feature, markers legend + no-claim sentence deleted, take-home = capabilities-as-experimental-variables checklist, source = author's compilation + annex-rollout; \clearpage inserted before sec:exp1
+2026-06-11T16:55Z HDMX-coding-agent verified — tectonic build 0 undefined refs/citations, test_manuscript_crossref 3/3, adherence 241 passed, all 16 sharpened greps green
 --- body ---
 ## Context
 Author reading-1 directives on the quality-bar section and Figures 2-3 prose.
@@ -49,5 +57,5 @@ Sequenced after the 0524 LaTeX conversion.
    Sources = author, see annex.
 
 ## Exit criteria
-- [ ] Each annotation implemented or waived with reason in log.
-- [ ] Floats placed correctly in the converted LaTeX build.
+- [x] Each annotation implemented or waived with reason in log.
+- [x] Floats placed correctly in the converted LaTeX build.

--- a/tickets/0543-manuscript-editorial-author-annotations-14-22.erg
+++ b/tickets/0543-manuscript-editorial-author-annotations-14-22.erg
@@ -3,13 +3,13 @@ Title: Manuscript editorial: author annotation items 14-22 (reading 1)
 Created: 2026-06-11
 Author: HDMX-coding-agent
 Blocked-by: 0537
-Blocked-by: 0538
 Blocked-by: 0540
 
 --- log ---
 2026-06-11T15:35Z HDMX-coding-agent created split from 0534
 2026-06-11T15:45Z HDMX-coding-agent note renumbered from 0542 (ID collision with 0542-semantic-latex-cleanup, PR #970) — items 14-22 postdate PR #968 (executed 11:37Z, annotations triaged 12:30Z) and were not implemented by the t0532/t0534 port PR, which closes 0534
 
+2026-06-11T16:18Z HDMX-coding-agent note blocker 0538 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0538-methods-figures-prose-rework.erg
+++ b/tickets/closed/0538-methods-figures-prose-rework.erg
@@ -2,6 +2,7 @@
 Title: Manuscript methods & figure-prose rework (reading-1 annotations)
 Created: 2026-06-11
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #977
 
 --- log ---
 2026-06-11T12:30Z HDMX-coding-agent created from author reading-1 annotations (main+hdm.pdf p6-9)
@@ -22,6 +23,7 @@ Author: HDMX-coding-agent
 2026-06-11T16:55Z HDMX-coding-agent item 6 implemented — post-figure sentence rewritten as 2-sentence transition: envelope = experimental conditions, quality bar = empirical question, exp1 floor / exp2 frontier
 2026-06-11T16:55Z HDMX-coding-agent item 7 implemented — caption: "five leading AI labs" (no Experiment-1 cross-ref), capability = public-commercial-product feature, markers legend + no-claim sentence deleted, take-home = capabilities-as-experimental-variables checklist, source = author's compilation + annex-rollout; \clearpage inserted before sec:exp1
 2026-06-11T16:55Z HDMX-coding-agent verified — tectonic build 0 undefined refs/citations, test_manuscript_crossref 3/3, adherence 241 passed, all 16 sharpened greps green
+2026-06-11T16:18Z HDMX-coding-agent closed — autoclosed — PR #977
 --- body ---
 ## Context
 Author reading-1 directives on the quality-bar section and Figures 2-3 prose.


### PR DESCRIPTION
**Ticket:** tickets/0538-methods-figures-prose-rework.erg

Implements the seven author reading-1 annotations on §quality, §capability, and the capability-timeline figure of `slides/manuscript/main.tex`.

## Per-item summary

| # | Annotation | Disposition |
|---|-----------|-------------|
| 1 | Surface the screening logic | **Implemented** — new paragraph after the §quality enumerate: accuracy alone needs the held-out gold reference; coherence/provenance/temporality are reference-free and, where correlated, estimate it — forward-ref to Experiment 1. |
| 2 | Quality-bar prose readability | **Implemented (partial)** — coherence item trimmed to ~6 sentences (two-axis taxonomy cut), provenance to ~5 (graduated-evidence enumeration + satellite-imagery tangent cut). Glossary consolidation **waived**: the glossary block is 0537 territory; revisit post-0537 if still wanted. |
| 3 | Assertive figure stance | **Implemented** — §capability now leads with the envelope idea (was buried in paragraph 2), then the four axes as coordinate system, then "Figure~\ref shows one projection…"; envelope/conditioning paragraph deduplicated. |
| 4 | Articulation paragraph | **Implemented** — rewritten in author tone: anteriority claim dropped without replacement; articulation made double (problem→question→prompt, links fail independently); Type-III error expanded (Mitroff1974 kept); prompt engineering named; confound sentence condensed; forward-refs to both experiments and both protocol annexes. Verbatim-prompt inclusion itself is 0539. |
| 5 | Integrations paragraph earlier + clearer | **Implemented** — moved before articulation and the figure (final order: lead → envelope/conditioning → integrations → articulation → figure → transition); recast as an itemize mapping to the figure rows; all 8 citation keys preserved; bare annex-rollout ref kept. |
| 6 | Transition | **Implemented** — post-figure sentence rewritten as an explicit transition: the envelope defines the experimental conditions; clearing the quality bar is an empirical question; Experiment 1 measures the parametric floor, Experiment 2 the agentic frontier. Does not open with "nonetheless". |
| 7 | Figure caption + float | **Implemented** — "five leading AI labs" (no Experiment-1 cross-ref); capability = feature of the lab's public commercial product; markers-legend and "no claim is made" sentences deleted; take-home reframed as capabilities-as-experimental-variables checklist; source = author's compilation + annex-rollout (texttt paths dropped); `\clearpage` before Experiment 1 so the float clears. |

## Verification

- **Build**: `make -C slides manuscript/main.pdf` — tectonic clean, **0** undefined references/citations (PDF built for verification, not committed).
- **Adherence**: `tests/test_manuscript_crossref.py` 3/3 passed; full `pytest -m adherence` battery **241 passed, 1 skipped**.
- **Sharpened greps** (all green): anteriority claim 0; markers-legend 0; "no claim is made" 0; "five leading AI labs" 1 / "labs in Experiment" 0; csv/md texttt paths 0; `\clearpage` immediately before `sec:exp1` PASS (awk adjacency); Wang2022:self-consistency 1; Mitroff1974 1; "prompt engineering" ≥1; "bar uncleared" 0; new `sec:annex-exp2` occurrence in §capability (line 444); all 8 integration citation keys ≥1.
- **Read-through**: §quality and §capability read top-to-bottom — no dangling "these integrations" referent (integrations now precede articulation), no duplicate envelope definition, paragraph flow intact.

## Waived

- Item 2 glossary consolidation — glossary block belongs to ticket 0537 (its item 2 relocates the concepts paragraph); revisit after 0537 if still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)