### PR TITLE
ci(0527): invert CI.yml chore filter so mixed diffs run lint+tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,16 +5,19 @@ on:
   pull_request:
 jobs:
   # Decide whether the diff touches anything that lint/tests care about.
-  # `chore` is true ONLY when *every* changed file matches the chore filter
-  # (predicate-quantifier: every) — ticket-only, STATE, in-repo notes, top-
-  # level READMEs, .claude/** harness files. Anything else — including a
-  # mixed diff or an empty/errored output — leaves it != 'true', so the
-  # heavy steps below run. Fail-safe: ambiguity always runs full CI.
-  # Kept in sync with docs-build.yml.
+  # paths-filter's output is true when ANY changed file matches the filter;
+  # predicate-quantifier: every quantifies over PATTERNS per file, not over
+  # files (ticket 0527 — the old `chore` filter fired on mixed diffs and
+  # skipped lint + tests). So the filter is inverted: `non-chore` is true
+  # when at least one changed file matches `**` AND is not in the chore set
+  # (tickets, STATE, in-repo notes, top-level READMEs, .claude/** harness
+  # files). Steps gate on != 'false', so a mixed diff runs full CI and an
+  # empty/errored output runs too. Fail-safe: ambiguity always runs;
+  # only a purely-chore diff skips. Kept in sync with docs-build.yml.
   changes:
     runs-on: ubuntu-latest
     outputs:
-      chore: ${{ steps.filter.outputs.chore }}
+      non-chore: ${{ steps.filter.outputs.non-chore }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -22,8 +25,9 @@ jobs:
         with:
           predicate-quantifier: 'every'
           filters: |
-            chore:
-              - '{tickets/**,.claude/**,docs/**,STATE.md,README.md,AGENTS.md,CLAUDE.md,ADR.md,MASTERPLAN.md,PLAN.md}'
+            non-chore:
+              - '**'
+              - '!{tickets/**,.claude/**,docs/**,STATE.md,README.md,AGENTS.md,CLAUDE.md,ADR.md,MASTERPLAN.md,PLAN.md}'
       - name: Check ticket corpus integrity
         run: tickets/erg check tickets/
   lint:
@@ -31,22 +35,22 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         uses: actions/checkout@v4
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         uses: astral-sh/setup-uv@v4
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         run: uv run ruff check src/ tests/
   tests:
     needs: changes
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         uses: actions/checkout@v4
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         uses: astral-sh/setup-uv@v4
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         run: uv sync --group dev
-      - if: needs.changes.outputs.chore != 'true'
+      - if: needs.changes.outputs.non-chore != 'false'
         run: uv run pytest -q

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -4,11 +4,14 @@ The actual end-to-end test is the workflow itself running on a PR. This
 adherence test guards the load-bearing pieces of the YAML — anything a
 casual edit could break without notice.
 
-Key invariant: the chore filter must use a SINGLE brace-expansion pattern
-under predicate-quantifier: every.  If the filter is split into N separate
-patterns, then every changed file must match ALL N patterns (picomatch
-semantics of 'every'), which is impossible when the patterns cover disjoint
-paths — making chore=false unconditionally.  See ticket 0377.
+Key invariant (tickets 0525/0527): under dorny/paths-filter, a filter's
+output is true when ANY changed file matches it, and predicate-quantifier:
+every quantifies over PATTERNS per file, not over files.  A positive
+`chore` filter therefore fired on mixed diffs and skipped lint + tests.
+The filter is inverted (`non-chore: ['**', '!{...}']`) and steps gate on
+`!= 'false'`, so only a purely-chore diff skips.  The emulation tests below
+replay chore-only, mixed, source-only, and empty-output diffs against the
+actual patterns in the workflow file.
 """
 
 from pathlib import Path
@@ -16,10 +19,14 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.workflow_filter_helpers import filter_patterns, job_runs, paths_filter_output
+
 pytestmark = pytest.mark.adherence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "CI.yml"
+
+GATED_JOBS = ("lint", "tests")
 
 
 def _load() -> dict:
@@ -36,7 +43,7 @@ def test_ci_runs_on_all_pull_requests():
 
     A `pull_request.paths` filter would skip chore-only PRs and leave the
     required check pending forever.  Heavy work is gated inside jobs via the
-    `changes` job's `chore` output instead.
+    `changes` job's `non-chore` output instead.
     """
     wf = _load()
     triggers = wf.get("on") or wf.get(True)
@@ -63,47 +70,15 @@ def test_changes_job_uses_paths_filter():
     steps = changes.get("steps") or []
     uses = [s.get("uses", "") for s in steps]
     assert any("dorny/paths-filter" in u for u in uses), (
-        "changes job must use dorny/paths-filter to compute chore output"
+        "changes job must use dorny/paths-filter to compute the non-chore output"
     )
     outputs = changes.get("outputs") or {}
-    assert "chore" in outputs, "changes job must expose `chore` output"
-
-
-def test_chore_filter_is_single_brace_pattern():
-    """Guard against the predicate-quantifier: every + multi-pattern trap.
-
-    Under predicate-quantifier: every, each changed file must match ALL
-    patterns listed.  With mutually-exclusive positive patterns (tickets/**,
-    STATE.md, etc.) no file can satisfy all patterns, so chore is always
-    false.  The fix is exactly one brace-expansion pattern so the single
-    picomatch call returns true whenever the file is in any branch of the
-    brace set.
-    """
-    wf = _load()
-    steps = wf["jobs"]["changes"].get("steps") or []
-    filter_step = next(
-        (s for s in steps if "dorny/paths-filter" in (s.get("uses") or "")),
-        None,
-    )
-    assert filter_step is not None, "dorny/paths-filter step not found"
-    raw_filters = (filter_step.get("with") or {}).get("filters", "")
-    parsed = yaml.safe_load(raw_filters)
-    chore_patterns = parsed.get("chore") or []
-    assert len(chore_patterns) == 1, (
-        f"chore filter must have exactly one brace-expansion pattern "
-        f"(predicate-quantifier: every requires this); found {len(chore_patterns)} patterns: "
-        f"{chore_patterns}"
-    )
-    pattern = chore_patterns[0]
-    assert pattern.startswith("{") and pattern.endswith("}"), (
-        f"chore filter pattern must be a brace expression like "
-        f"'{{tickets/**,...}}'; got: {pattern!r}"
-    )
+    assert "non-chore" in outputs, "changes job must expose `non-chore` output"
 
 
 def test_lint_and_tests_depend_on_changes():
     wf = _load()
-    for job_name in ("lint", "tests"):
+    for job_name in GATED_JOBS:
         job = wf["jobs"][job_name]
         needs = job.get("needs")
         assert needs == "changes" or (
@@ -115,17 +90,64 @@ def test_lint_and_tests_depend_on_changes():
         )
 
 
-def test_lint_and_tests_steps_gated_on_chore_flag():
+def test_lint_and_tests_steps_gated_on_non_chore_flag():
     """Every concrete step in lint and tests must skip when the diff is chore-only."""
     wf = _load()
-    for job_name in ("lint", "tests"):
+    for job_name in GATED_JOBS:
         steps = wf["jobs"][job_name].get("steps") or []
         assert steps, f"{job_name} job has no steps"
         ungated = [
             s.get("name") or s.get("uses") or "<unnamed>"
             for s in steps
-            if "needs.changes.outputs.chore" not in str(s.get("if", ""))
+            if "needs.changes.outputs.non-chore != 'false'" not in str(s.get("if", ""))
         ]
         assert not ungated, (
-            f"every {job_name} step must gate on the chore flag; ungated: {ungated}"
+            f"every {job_name} step must gate on the non-chore flag; ungated: {ungated}"
+        )
+
+
+def test_chore_only_diff_skips_lint_and_tests():
+    """A purely-chore diff (tickets/** alone) must skip lint + tests."""
+    wf = _load()
+    _, patterns = filter_patterns(wf)
+    output = paths_filter_output(["tickets/closed/0523-fix-tau.erg"], patterns)
+    for job_name in GATED_JOBS:
+        assert not job_runs(wf, job_name, output), (
+            f"chore-only diff must skip {job_name} steps"
+        )
+
+
+def test_mixed_diff_runs_lint_and_tests():
+    """A mixed diff (tickets/** + src/**) must run full CI.
+
+    This is the ticket 0527 regression (sibling of 0525 in docs-build):
+    a ticket file changed alongside source code and lint + tests were
+    skipped entirely.
+    """
+    wf = _load()
+    _, patterns = filter_patterns(wf)
+    output = paths_filter_output(
+        ["tickets/closed/0523-fix-tau.erg", "src/aedist/util.py"],
+        patterns,
+    )
+    for job_name in GATED_JOBS:
+        assert job_runs(wf, job_name, output), f"mixed diff must run {job_name} steps"
+
+
+def test_source_only_diff_runs_lint_and_tests():
+    wf = _load()
+    _, patterns = filter_patterns(wf)
+    output = paths_filter_output(["src/aedist/util.py"], patterns)
+    for job_name in GATED_JOBS:
+        assert job_runs(wf, job_name, output), (
+            f"non-chore diff must run {job_name} steps"
+        )
+
+
+def test_empty_filter_output_runs_lint_and_tests():
+    """Fail-safe: an empty/errored filter output must still run full CI."""
+    wf = _load()
+    for job_name in GATED_JOBS:
+        assert job_runs(wf, job_name, None), (
+            f"ambiguous filter output must default to running {job_name}"
         )

--- a/tests/test_docs_build_workflow.py
+++ b/tests/test_docs_build_workflow.py
@@ -5,11 +5,12 @@ adherence test guards the load-bearing pieces of the YAML — anything a
 casual edit could break without notice.
 """
 
-import re
 from pathlib import Path
 
 import pytest
 import yaml
+
+from tests.workflow_filter_helpers import filter_patterns, job_runs, paths_filter_output
 
 pytestmark = pytest.mark.adherence
 
@@ -148,89 +149,16 @@ def test_build_runner_pinned():
     )
 
 
-def _filter_patterns() -> tuple[str, list[str]]:
-    """Return (filter_name, patterns) from the paths-filter step."""
-    wf = _load()
-    steps = wf["jobs"]["changes"].get("steps") or []
-    filter_step = next(
-        (s for s in steps if "dorny/paths-filter" in (s.get("uses") or "")),
-        None,
-    )
-    assert filter_step is not None, "dorny/paths-filter step not found"
-    raw_filters = (filter_step.get("with") or {}).get("filters", "")
-    parsed = yaml.safe_load(raw_filters)
-    assert len(parsed) == 1, f"expected exactly one filter, got {list(parsed)}"
-    name, patterns = next(iter(parsed.items()))
-    return name, patterns
-
-
-def _glob_match(path: str, pattern: str) -> bool:
-    """Minimal picomatch subset covering the workflow's patterns.
-
-    Supports brace expansion `{a,b}`, the catch-all `**`, `dir/**`
-    prefixes, and literal filenames — nothing more.
-    """
-    if pattern.startswith("{") and pattern.endswith("}"):
-        return any(_glob_match(path, p) for p in pattern[1:-1].split(","))
-    if pattern == "**":
-        return True
-    if pattern.endswith("/**"):
-        return path.startswith(pattern[:-2])
-    return path == pattern
-
-
-def _paths_filter_output(changed_files: list[str], patterns: list[str]) -> bool:
-    """Emulate dorny/paths-filter with predicate-quantifier: every.
-
-    The filter output is true iff ANY changed file matches ALL patterns;
-    a leading `!` negates the individual pattern (per upstream README).
-    """
-
-    def file_matches(path: str) -> bool:
-        for pat in patterns:
-            if pat.startswith("!"):
-                if _glob_match(path, pat[1:]):
-                    return False
-            elif not _glob_match(path, pat):
-                return False
-        return True
-
-    return any(file_matches(f) for f in changed_files)
-
-
-def _gate_allows(cond: str, output: str, name: str) -> bool:
-    """Evaluate the non-chore comparison clause inside one `if:` condition."""
-    expr = cond.replace("${{", "").replace("}}", "").strip()
-    match = re.search(
-        rf"needs\.changes\.outputs\.{re.escape(name)}\s*(==|!=)\s*'([^']*)'", expr
-    )
-    assert match, f"no {name} comparison found in gate {cond!r}"
-    op, rhs = match.groups()
-    equal = output == rhs
-    return equal if op == "==" else not equal
-
-
-def _build_runs(filter_output: bool | None) -> bool:
-    """Evaluate every build-step gate as GitHub Actions would.
-
-    `filter_output is None` models an empty/errored filter output (the
-    expression then compares against the empty string). All steps must
-    agree — a step whose gate diverges from the others is an error.
-    """
-    wf = _load()
-    steps = wf["jobs"]["build"].get("steps") or []
-    output = "" if filter_output is None else str(filter_output).lower()
-    name, _ = _filter_patterns()
-    verdicts = {_gate_allows(str(s.get("if", "")), output, name) for s in steps}
-    assert len(verdicts) == 1, f"build steps disagree on the {name} gate"
-    return verdicts.pop()
+# Filter-emulation helpers are shared with test_ci_workflow.py (ticket 0527)
+# via tests/workflow_filter_helpers.py.
 
 
 def test_chore_only_diff_skips_build():
     """A purely-chore diff (tickets/** alone) must skip the heavy build."""
-    _, patterns = _filter_patterns()
-    output = _paths_filter_output(["tickets/closed/0523-fix-tau.erg"], patterns)
-    assert not _build_runs(output), "chore-only diff must skip the build steps"
+    wf = _load()
+    _, patterns = filter_patterns(wf)
+    output = paths_filter_output(["tickets/closed/0523-fix-tau.erg"], patterns)
+    assert not job_runs(wf, "build", output), "chore-only diff must skip the build steps"
 
 
 def test_mixed_diff_runs_build():
@@ -240,20 +168,24 @@ def test_mixed_diff_runs_build():
     slides/manuscript/main.tex alongside a ticket file and the entire
     docs-build was skipped.
     """
-    _, patterns = _filter_patterns()
-    output = _paths_filter_output(
+    wf = _load()
+    _, patterns = filter_patterns(wf)
+    output = paths_filter_output(
         ["tickets/closed/0523-fix-tau.erg", "slides/manuscript/main.tex"],
         patterns,
     )
-    assert _build_runs(output), "mixed diff must run the build steps"
+    assert job_runs(wf, "build", output), "mixed diff must run the build steps"
 
 
 def test_source_only_diff_runs_build():
-    _, patterns = _filter_patterns()
-    output = _paths_filter_output(["slides/Makefile"], patterns)
-    assert _build_runs(output), "non-chore diff must run the build steps"
+    wf = _load()
+    _, patterns = filter_patterns(wf)
+    output = paths_filter_output(["slides/Makefile"], patterns)
+    assert job_runs(wf, "build", output), "non-chore diff must run the build steps"
 
 
 def test_empty_filter_output_runs_build():
     """Fail-safe: an empty/errored filter output must still build."""
-    assert _build_runs(None), "ambiguous filter output must default to building"
+    assert job_runs(_load(), "build", None), (
+        "ambiguous filter output must default to building"
+    )

--- a/tests/workflow_filter_helpers.py
+++ b/tests/workflow_filter_helpers.py
@@ -1,0 +1,86 @@
+"""Shared helpers for emulating dorny/paths-filter gating in GHA workflows.
+
+Used by test_ci_workflow.py and test_docs_build_workflow.py (tickets 0525,
+0527): both workflows carry an inverted `non-chore` filter under
+predicate-quantifier: every, and steps gate on `!= 'false'`.
+"""
+
+import re
+
+import yaml
+
+
+def filter_patterns(wf: dict, changes_job: str = "changes") -> tuple[str, list[str]]:
+    """Return (filter_name, patterns) from the paths-filter step."""
+    steps = wf["jobs"][changes_job].get("steps") or []
+    filter_step = next(
+        (s for s in steps if "dorny/paths-filter" in (s.get("uses") or "")),
+        None,
+    )
+    assert filter_step is not None, "dorny/paths-filter step not found"
+    raw_filters = (filter_step.get("with") or {}).get("filters", "")
+    parsed = yaml.safe_load(raw_filters)
+    assert len(parsed) == 1, f"expected exactly one filter, got {list(parsed)}"
+    name, patterns = next(iter(parsed.items()))
+    return name, patterns
+
+
+def glob_match(path: str, pattern: str) -> bool:
+    """Minimal picomatch subset covering the workflows' patterns.
+
+    Supports brace expansion `{a,b}`, the catch-all `**`, `dir/**`
+    prefixes, and literal filenames — nothing more.
+    """
+    if pattern.startswith("{") and pattern.endswith("}"):
+        return any(glob_match(path, p) for p in pattern[1:-1].split(","))
+    if pattern == "**":
+        return True
+    if pattern.endswith("/**"):
+        return path.startswith(pattern[:-2])
+    return path == pattern
+
+
+def paths_filter_output(changed_files: list[str], patterns: list[str]) -> bool:
+    """Emulate dorny/paths-filter with predicate-quantifier: every.
+
+    The filter output is true iff ANY changed file matches ALL patterns;
+    a leading `!` negates the individual pattern (per upstream README).
+    """
+
+    def file_matches(path: str) -> bool:
+        for pat in patterns:
+            if pat.startswith("!"):
+                if glob_match(path, pat[1:]):
+                    return False
+            elif not glob_match(path, pat):
+                return False
+        return True
+
+    return any(file_matches(f) for f in changed_files)
+
+
+def gate_allows(cond: str, output: str, name: str) -> bool:
+    """Evaluate the filter-output comparison clause inside one `if:` condition."""
+    expr = cond.replace("${{", "").replace("}}", "").strip()
+    match = re.search(
+        rf"needs\.changes\.outputs\.{re.escape(name)}\s*(==|!=)\s*'([^']*)'", expr
+    )
+    assert match, f"no {name} comparison found in gate {cond!r}"
+    op, rhs = match.groups()
+    equal = output == rhs
+    return equal if op == "==" else not equal
+
+
+def job_runs(wf: dict, job_name: str, filter_output: bool | None) -> bool:
+    """Evaluate every step gate in a job as GitHub Actions would.
+
+    `filter_output is None` models an empty/errored filter output (the
+    expression then compares against the empty string). All steps must
+    agree — a step whose gate diverges from the others is an error.
+    """
+    steps = wf["jobs"][job_name].get("steps") or []
+    output = "" if filter_output is None else str(filter_output).lower()
+    name, _ = filter_patterns(wf)
+    verdicts = {gate_allows(str(s.get("if", "")), output, name) for s in steps}
+    assert len(verdicts) == 1, f"{job_name} steps disagree on the {name} gate"
+    return verdicts.pop()

--- a/tickets/0527-ci-yml-chore-filter-same-mixed-diff-bug.erg
+++ b/tickets/0527-ci-yml-chore-filter-same-mixed-diff-bug.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-11T09:00Z HDMX-coding-agent created during /review-pr 950
+2026-06-11T13:30Z claude note executed: (1) ported non-chore inversion to CI.yml, gates now != 'false'; (2) comment rewritten, "Kept in sync with docs-build.yml" restored truthfully; (3) test_ci_workflow.py rewritten with emulation tests; helpers extracted to tests/workflow_filter_helpers.py and shared with test_docs_build_workflow.py. Adherence 244 passed, fast suite 2480 passed.
 
 --- body ---
 ## Context
@@ -41,6 +42,6 @@ CI.yml exactly as #938 skipped docs-build.
   filter output true (lint/tests run) — fails against current CI.yml patterns.
 
 ## Exit criteria
-- [ ] Mixed diffs run lint + tests in CI.yml
-- [ ] Purely-chore diffs still skip
-- [ ] Comment matches behaviour; tests updated
+- [x] Mixed diffs run lint + tests in CI.yml
+- [x] Purely-chore diffs still skip
+- [x] Comment matches behaviour; tests updated


### PR DESCRIPTION
**Ticket:** tickets/0527-ci-yml-chore-filter-same-mixed-diff-bug.erg

## Summary
CI.yml carried the same mixed-diff skip bug fixed in docs-build by ticket 0525 (PR #950): under dorny/paths-filter, a filter's output is true when ANY changed file matches, and `predicate-quantifier: every` quantifies over patterns per file — so the positive `chore` brace-glob fired on mixed diffs (e.g. ticket file + src change) and skipped lint and tests entirely.

## Changes
- `.github/workflows/CI.yml`: port the non-chore inversion from docs-build.yml — filter is now `non-chore: ['**', '!{...}']`, all lint/tests step gates become `non-chore != 'false'`; comment rewritten and "Kept in sync with docs-build.yml" restored truthfully. Fail-safe: empty/errored filter output runs full CI; only purely-chore diffs skip.
- `tests/test_ci_workflow.py`: dropped the obsolete 0377 single-brace-pattern guard; added emulation tests replaying chore-only, mixed, source-only, and empty-output diffs against the actual workflow patterns (the mixed-diff test is red against the old filter).
- `tests/workflow_filter_helpers.py` (new): the paths-filter emulation helpers, extracted from test_docs_build_workflow.py and shared by both workflow test files.
- Ticket 0527: disposition log + exit criteria ticked.

## Tests
- adherence: 244 passed
- fast suite (`-m "not integration and not slow"`): 2480 passed, 5 skipped, 1 xfailed
- lint + erg check: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)