### PR TITLE
Standing adherence test: Makefile prerequisites cover script imports (0535)

### DIFF
--- a/experiments/derived/score.mk
+++ b/experiments/derived/score.mk
@@ -237,7 +237,7 @@ $(ANALYSIS_DERIVED_DIR)/arm2_flat/.done: $(ANALYSIS_EXPERIMENTS_DIR)/outputs/sot
 # no dedicated holding directory. score_exp1 appends, hence the rm -f;
 # .DELETE_ON_ERROR (set via the included paths.mk) makes a crashed write
 # self-clean (tickets 0460, 0461).
-$(ANALYSIS_EXP1_CROSS_EVAL_CSV): $(ANALYSIS_EXP1_INPUT_CSVS) $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_exp1.py $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_mechanical.py
+$(ANALYSIS_EXP1_CROSS_EVAL_CSV): $(ANALYSIS_EXP1_INPUT_CSVS) $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_exp1.py $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/score_mechanical.py $(ANALYSIS_EXPERIMENTS_DIR)/../src/aedist/extract.py
 	rm -f $@
 	uv run python -m aedist.score_exp1 \
 	    --input-dir $(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2 \

--- a/experiments/render.mk
+++ b/experiments/render.mk
@@ -255,7 +255,8 @@ $(ANALYSIS_EXP1_SPIDER_CLAUDE_FR): $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
 # the internal-coherence veto renders as 1−veto inside the Coherence group.
 $(ANALYSIS_EXP1_QUALITY_HEATMAP): $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
 		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_quality_floor_heatmap_exp1.py \
-		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_quality_spider_exp1.py
+		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_quality_spider_exp1.py \
+		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_quality_floor_heatmap_exp1 \
 	    --input $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
@@ -318,6 +319,7 @@ $(ANALYSIS_FUSION_MVP_CSV) $(ANALYSIS_FUSION_MVP_MACROS) $(ANALYSIS_FUSION_MVP_F
 		$(wildcard $(ANALYSIS_DERIVED_DIR)/arm3_flat/*.md) \
 		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_fusion_mvp.py \
 		$(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py \
+		$(ANALYSIS_REPO_ROOT)/src/aedist/extract.py \
 		$(ANALYSIS_FUSION_MVP_REF)
 	@mkdir -p $(dir $(ANALYSIS_FUSION_MVP_CSV))
 	uv run python -m aedist.plot_fusion_mvp \
@@ -427,7 +429,8 @@ $(ANALYSIS_EXP2_COVERAGE_SPLIT) $(ANALYSIS_EXP2_COST_SPLIT) &: \
 $(ANALYSIS_GROUNDING_LADDER_FIG): \
 		$(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
 		$(ANALYSIS_EXP2_CROSS_EVAL_CSV) \
-		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_grounding_ladder.py
+		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_grounding_ladder.py \
+		$(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_arms_split.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_grounding_ladder \
 	    --exp1 $(ANALYSIS_EXP1_CROSS_EVAL_CSV) \
@@ -450,7 +453,8 @@ $(ANALYSIS_SLIDE_MACROS): $(ANALYSIS_MEASUREMENTS)
 $(ANALYSIS_EXP2_WIKI_CSV) $(ANALYSIS_EXP2_WIKI_MACROS) &: \
 		$(wildcard $(ANALYSIS_DERIVED_DIR)/arm1_flat/*.md) \
 		$(wildcard $(ANALYSIS_DERIVED_DIR)/arm2_flat/*.md) \
-		$(ANALYSIS_REPO_ROOT)/src/aedist/audit_exp2_wiki_citations.py
+		$(ANALYSIS_REPO_ROOT)/src/aedist/audit_exp2_wiki_citations.py \
+		$(ANALYSIS_REPO_ROOT)/src/aedist/extract_exp2_bib.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.audit_exp2_wiki_citations \
 	    --naive-dir $(ANALYSIS_DERIVED_DIR)/arm1_flat \
@@ -564,7 +568,8 @@ $(ANALYSIS_GEN)/tab_converter_benchmark.tex: $(ANALYSIS_CONVERTER_META) $(ANALYS
 $(ANALYSIS_GEN)/tab_source_grounding.tex: \
 		$(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/archive/outputs/rag_cited/claude-opus-4.6-run*.csv) \
 		$(wildcard $(ANALYSIS_EXPERIMENTS_DIR)/archive/outputs/rag_per_fuel/deepseek-v3.2-run*.json) \
-		$(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_source_grounding.py
+		$(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_source_grounding.py \
+		$(ANALYSIS_REPO_ROOT)/src/aedist/extract.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_source_grounding
 
@@ -620,7 +625,8 @@ ANALYSIS_EXP3_FN_TRIAGE_SUMMARY_CSV := $(ANALYSIS_DERIVED_DIR)/tab_exp3_fn_triag
 ANALYSIS_EXP3_FN_TRIAGE_TEX := $(ANALYSIS_GEN)/tab_exp3_fn_triage.tex
 
 $(ANALYSIS_EXP3_FN_TRIAGE_TEX): $(ANALYSIS_EXP3_FN_TRIAGE_WORKSHEET) \
-		$(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_exp3_fn_triage.py
+		$(ANALYSIS_REPO_ROOT)/src/aedist/tabulate_exp3_fn_triage.py \
+		$(ANALYSIS_REPO_ROOT)/src/aedist/extract.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.tabulate_exp3_fn_triage --mode summary \
 	    --input $(ANALYSIS_EXP3_FN_TRIAGE_WORKSHEET) \
@@ -750,7 +756,7 @@ $(ANALYSIS_GEN)/fig_direct_p1_base.pdf $(ANALYSIS_GEN)/macros_p1_base.tex &: $(A
 # recognition from the records + reference via aedist.exp1_recognition (shared
 # library; the status table 0434 derives the same data independently — no
 # side-output). Emits a macros file for the caption's plant/run/FP counts.
-$(ANALYSIS_GEN)/fig_exp1_recognition_matrix.pdf $(ANALYSIS_GEN)/macros_exp1_matrix.tex &: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/fig_exp1_recognition_matrix.pdf $(ANALYSIS_GEN)/macros_exp1_matrix.tex &: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \
@@ -763,7 +769,7 @@ $(ANALYSIS_GEN)/fig_exp1_recognition_matrix.pdf $(ANALYSIS_GEN)/macros_exp1_matr
 # No longer referenced by report.tex (the FR annex adopted the portrait
 # variant, ticket 0503); kept as a standalone exploration artifact like
 # the strong/top subsets below.
-$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_fr.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_fr.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \
@@ -776,7 +782,7 @@ $(ANALYSIS_GEN)/fig_exp1_recognition_matrix_fr.pdf: $(ANALYSIS_EXP1_BATCH2_RECOR
 # weakest models (haiku, both gpt-oss, the two small qwen3.6); `top` keeps only
 # the strongest model of each architectural family. Exploration artifacts — not
 # yet referenced by the manuscript or report.
-$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_strong.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_strong.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \
@@ -784,7 +790,7 @@ $(ANALYSIS_GEN)/fig_exp1_recognition_matrix_strong.pdf: $(ANALYSIS_EXP1_BATCH2_R
 	    --output $@ \
 	    --exclude-models claude-haiku-4.5 gpt-oss-120b gpt-oss-20b qwen3.6-flash qwen3.6-35b-a3b
 
-$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_top.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_top.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \
@@ -800,7 +806,7 @@ $(ANALYSIS_GEN)/fig_exp1_recognition_matrix_top.pdf: $(ANALYSIS_EXP1_BATCH2_RECO
 # Exploration artifact — not yet placed in the manuscript; author orientation
 # decision deferred (ticket 0451 exit criterion). The script imports
 # _order_runs/_order_plants from plot_exp1_matrix, so both are prerequisites.
-$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_portrait.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix_portrait.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_portrait.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix_portrait.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix_portrait \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \
@@ -810,7 +816,7 @@ $(ANALYSIS_GEN)/fig_exp1_recognition_matrix_portrait.pdf: $(ANALYSIS_EXP1_BATCH2
 # French-label portrait variant for the report annex (ticket 0503): status
 # band labels in FR, page titles stay EN (matches the landscape `_fr`
 # precedent — only band/margin labels are localised).
-$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_portrait_fr.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix_portrait.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/fig_exp1_recognition_matrix_portrait_fr.pdf: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix_portrait.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix_portrait \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \
@@ -826,7 +832,7 @@ $(ANALYSIS_GEN)/fig_exp1_recognition_matrix_portrait_fr.pdf: $(ANALYSIS_EXP1_BAT
 # the manuscript; author placement decision deferred.
 # The plot scripts (exp2_recognition.py + plot_exp2_matrix.py) are prerequisites
 # so a script edit re-triggers the build (mirrors the exp1 matrix rules).
-$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_naive.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_naive.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py
+$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_naive.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_naive.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/extract.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_matrix \
 	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
@@ -835,7 +841,7 @@ $(ANALYSIS_GEN)/fig_exp2_recognition_matrix_naive.pdf $(ANALYSIS_GEN)/macros_exp
 	    --output $(ANALYSIS_GEN)/fig_exp2_recognition_matrix_naive.pdf \
 	    --output-macros $(ANALYSIS_GEN)/macros_exp2_matrix_naive.tex
 
-$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_optimised.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_optimised.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py
+$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_optimised.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_optimised.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/extract.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_matrix \
 	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
@@ -844,7 +850,7 @@ $(ANALYSIS_GEN)/fig_exp2_recognition_matrix_optimised.pdf $(ANALYSIS_GEN)/macros
 	    --output $(ANALYSIS_GEN)/fig_exp2_recognition_matrix_optimised.pdf \
 	    --output-macros $(ANALYSIS_GEN)/macros_exp2_matrix_optimised.tex
 
-$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_arm3.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_arm3.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py
+$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_arm3.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_arm3.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/extract.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_matrix \
 	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
@@ -853,7 +859,7 @@ $(ANALYSIS_GEN)/fig_exp2_recognition_matrix_arm3.pdf $(ANALYSIS_GEN)/macros_exp2
 	    --output $(ANALYSIS_GEN)/fig_exp2_recognition_matrix_arm3.pdf \
 	    --output-macros $(ANALYSIS_GEN)/macros_exp2_matrix_arm3.tex
 
-$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_arm4.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_arm4.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py
+$(ANALYSIS_GEN)/fig_exp2_recognition_matrix_arm4.pdf $(ANALYSIS_GEN)/macros_exp2_matrix_arm4.tex &: $(ANALYSIS_EXP2_MART_JSONL) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp2_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp2_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/extract.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp2_matrix \
 	    --mart-jsonl $(ANALYSIS_EXP2_MART_JSONL) \
@@ -932,7 +938,7 @@ $(ANALYSIS_GEN)/fig_longtail_recognition.pdf $(ANALYSIS_GEN)/macros_longtail.tex
 # QA — hover any cell to see the reference-vs-reply comparison table.  Output
 # is gitignored (nothing downstream consumes it); not in RENDER_CHART_FIGURES.
 # One output per rule (single HTML), DAG-wired to records + reference + scripts.
-$(ANALYSIS_GEN)/exp1_recognition_matrix_interactive.html: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix_interactive.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py
+$(ANALYSIS_GEN)/exp1_recognition_matrix_interactive.html: $(ANALYSIS_EXP1_BATCH2_RECORDS) $(ANALYSIS_EXPERT_REF) $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix_interactive.py $(ANALYSIS_REPO_ROOT)/src/aedist/exp1_recognition.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_exp1_matrix.py $(ANALYSIS_REPO_ROOT)/src/aedist/plot_method_convergence.py
 	@mkdir -p $(dir $@)
 	uv run python -m aedist.plot_exp1_matrix_interactive \
 	    --records-glob "$(ANALYSIS_EXPERIMENTS_DIR)/outputs/exp1_batch2/*.record.json" \

--- a/tests/test_makefile_dag_adherence.py
+++ b/tests/test_makefile_dag_adherence.py
@@ -1,0 +1,278 @@
+"""Makefile prerequisites must cover what the recipes' scripts actually use.
+
+Standing guard for the defect class hit three times in the 2026-06-11 raid
+(tickets 0505-0507, fixed piecemeal in PRs #949/#960, recurrence in 0530):
+a Makefile rule whose prerequisite list lags behind the code it runs, so an
+edit to a behavior-carrying script (or a new manuscript include) does not
+re-trigger the build and the committed artifact silently goes stale.
+
+Two checks, both purely static (no make execution, no imports executed):
+
+1. Script-prerequisite import closure (score.mk + render.mk).
+   The repo convention is that a rule lists a ``src/aedist/*.py`` file as a
+   prerequisite when that script *carries behavior* for the artifact (label
+   sets, scoring logic, layout). Shared library modules (config, evaluate,
+   metrics, ...) are deliberately NOT per-rule prerequisites — a library
+   change is handled by a deliberate ``make world`` re-run, not by per-rule
+   edges. The invariant enforced here: when a rule lists script X, every
+   module in X's *transitive first-party import closure* that is itself a
+   script (i.e. executed via ``python -m aedist.<mod>`` by some rule in the
+   registered makefiles) must also be listed. This is exactly the PR #949
+   defect: exp1_cross_eval listed score_exp1.py but not score_mechanical.py,
+   which score_exp1 imports and which carries the scoring behavior.
+
+2. MANUSCRIPT_ASSETS parity (slides/Makefile vs slides/manuscript/main.tex).
+   The asset list must equal exactly the set of report/inputs/generated/
+   files main.tex pulls in via \\includegraphics / \\includepdf / \\input —
+   no missing prerequisite (stale PDF, the PR #960 defect) and no ghost
+   prerequisite (spurious rebuilds, the PR #969 review finding).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src" / "aedist"
+
+# The registered analysis makefiles (ticket 0535 scope: P2 score + P3 render).
+ANALYSIS_MAKEFILES = [
+    "experiments/derived/score.mk",
+    "experiments/render.mk",
+]
+
+# Rules exempt from the closure check, by (makefile, raw target text).
+# sota_cross_eval: ticket 0530 (sibling, in flight) adds score_mechanical.py
+# to this rule's prerequisites; once it lands, lift this exemption and add
+# the closure scripts (extract.py) the check will then demand.
+CLOSURE_EXEMPT = {
+    ("experiments/derived/score.mk", "$(ANALYSIS_EXP2_CROSS_EVAL_CSV)"),
+}
+
+ASSIGN_RE = re.compile(r"^\s*[A-Za-z_.][A-Za-z0-9_.]*\s*(:=|\?=|\+=|=)")
+LISTED_SCRIPT_RE = re.compile(r"src/aedist/(\w+)\.py")
+EXECUTED_MODULE_RE = re.compile(r"-m aedist\.(\w+)\b")
+FIRST_PARTY_IMPORT_RE = re.compile(
+    r"^(?:from (?:aedist\.|\.)(\w+)|import aedist\.(\w+))", re.M
+)
+
+
+def parse_rules(makefile_text: str) -> list[tuple[str, str, str]]:
+    """Return (target, prerequisites, recipe) per rule, statically parsed.
+
+    Backslash continuations are joined; comments stripped; variable
+    assignments and non-rule lines skipped. Grouped targets (``a b &:``)
+    yield one entry. No variable expansion is performed — the checks below
+    match path *suffixes* (src/aedist/<mod>.py), which survive any
+    $(VAR)-prefixed spelling used in the makefiles.
+    """
+    rules: list[list[str]] = []
+    current: list[str] | None = None
+    for line in makefile_text.replace("\\\n", " ").splitlines():
+        if line.startswith("\t"):
+            if current is not None:
+                current[2] += line + "\n"
+            continue
+        code = line.split("#", 1)[0]
+        if not code.strip():
+            continue
+        if ASSIGN_RE.match(code) or ":" not in code:
+            current = None
+            continue
+        target, _, prereqs = code.partition(":")
+        target = target.strip().removesuffix("&").strip()
+        current = [target, prereqs.lstrip(":").strip(), ""]
+        rules.append(current)
+    return [tuple(r) for r in rules]
+
+
+def listed_scripts(prereqs: str) -> set[str]:
+    """Module names of src/aedist/*.py files in a prerequisite list."""
+    return set(LISTED_SCRIPT_RE.findall(prereqs))
+
+
+def executed_scripts(rules: list[tuple[str, str, str]]) -> set[str]:
+    """Module names run via ``python -m aedist.<mod>`` in any recipe."""
+    found: set[str] = set()
+    for _, _, recipe in rules:
+        found |= set(EXECUTED_MODULE_RE.findall(recipe))
+    return found
+
+
+def first_party_imports(module_source: str) -> set[str]:
+    """Direct first-party imports (``from .x`` / ``from aedist.x`` forms)."""
+    return {a or b for a, b in FIRST_PARTY_IMPORT_RE.findall(module_source)}
+
+
+def import_closure(module: str, sources: dict[str, str]) -> set[str]:
+    """Transitive first-party import closure of `module` (excluded itself).
+
+    `sources` maps module name -> source text; names absent from it
+    (subpackages, third-party) are ignored.
+    """
+    seen: set[str] = set()
+    stack = [module]
+    while stack:
+        mod = stack.pop()
+        if mod not in sources:
+            continue
+        for dep in first_party_imports(sources[mod]):
+            if dep not in seen and dep in sources:
+                seen.add(dep)
+                stack.append(dep)
+    return seen - {module}
+
+
+def closure_violations(
+    makefiles: dict[str, str],
+    sources: dict[str, str],
+    exempt: set[tuple[str, str]] = frozenset(),
+) -> list[tuple[str, str, list[str]]]:
+    """(makefile, target, missing-modules) for every rule breaking the rule.
+
+    A violation: the rule lists script X as a prerequisite, but some script
+    (executed module) in X's transitive first-party import closure is not
+    listed alongside it.
+    """
+    parsed = {name: parse_rules(text) for name, text in makefiles.items()}
+    scripts = set().union(*(executed_scripts(r) for r in parsed.values()))
+    violations = []
+    for name, rules in parsed.items():
+        for target, prereqs, _ in rules:
+            if (name, target) in exempt:
+                continue
+            listed = listed_scripts(prereqs)
+            if not listed:
+                continue
+            needed: set[str] = set()
+            for mod in listed:
+                needed |= import_closure(mod, sources) & scripts
+            missing = sorted(needed - listed)
+            if missing:
+                violations.append((name, target, missing))
+    return violations
+
+
+def _repo_sources() -> dict[str, str]:
+    return {p.stem: p.read_text() for p in SRC_DIR.glob("*.py")}
+
+
+def test_script_prereqs_cover_import_closure():
+    makefiles = {rel: (REPO_ROOT / rel).read_text() for rel in ANALYSIS_MAKEFILES}
+    violations = closure_violations(makefiles, _repo_sources(), CLOSURE_EXEMPT)
+    msg = "\n".join(
+        f"{mk}: rule '{tgt}' lists a src/aedist script whose import closure "
+        f"includes script(s) not in its prerequisites: "
+        + ", ".join(f"src/aedist/{m}.py" for m in missing)
+        for mk, tgt, missing in violations
+    )
+    assert not violations, (
+        "Makefile prerequisite gaps (add the missing script .py files to the "
+        "rule's prerequisite list so edits re-trigger the build):\n" + msg
+    )
+
+
+# --- MANUSCRIPT_ASSETS parity ------------------------------------------------
+
+GENERATED_BASENAME_RE = re.compile(r"generated/([\w.-]+\.[A-Za-z0-9]+)")
+TEX_INCLUDE_RE = re.compile(
+    r"^[^%\n]*\\(?:includegraphics|includepdf|input)\s*(?:\[[^]]*\])?"
+    r"\{([^}]*/inputs/generated/[^}]+)\}",
+    re.M,
+)
+
+
+def manuscript_assets(slides_makefile_text: str) -> set[str]:
+    """Basenames listed in the MANUSCRIPT_ASSETS variable.
+
+    The entries are spelled ``$(LOCAL_ROOT_REPORT_GEN)/<basename>``, so the
+    comparison key is the basename (unique within the generated tree).
+    """
+    text = slides_makefile_text.replace("\\\n", " ")
+    for line in text.splitlines():
+        m = re.match(r"^MANUSCRIPT_ASSETS\s*:?=\s*(.*)$", line)
+        if m:
+            return {tok.rsplit("/", 1)[-1] for tok in m.group(1).split()}
+    raise AssertionError("MANUSCRIPT_ASSETS not found in slides/Makefile")
+
+
+def manuscript_includes(main_tex_text: str) -> set[str]:
+    """Basenames of generated files main.tex includes (non-comment lines)."""
+    return {
+        GENERATED_BASENAME_RE.search(path).group(1)
+        for path in TEX_INCLUDE_RE.findall(main_tex_text)
+    }
+
+
+def test_manuscript_assets_match_main_tex_includes():
+    assets = manuscript_assets((REPO_ROOT / "slides" / "Makefile").read_text())
+    includes = manuscript_includes(
+        (REPO_ROOT / "slides" / "manuscript" / "main.tex").read_text()
+    )
+    missing = sorted(includes - assets)
+    ghosts = sorted(assets - includes)
+    assert not missing, (
+        f"main.tex includes generated files absent from MANUSCRIPT_ASSETS "
+        f"(stale-PDF hazard, PR #960 class): {missing}"
+    )
+    assert not ghosts, (
+        f"MANUSCRIPT_ASSETS lists generated files main.tex does not include "
+        f"(ghost prerequisites, spurious rebuilds): {ghosts}"
+    )
+
+
+# --- Fang: the checks must go red on seeded violations ------------------------
+
+
+def test_closure_check_catches_seeded_violation():
+    sources = {
+        "score_a": "import csv\nfrom .score_b import scorer\n",
+        "score_b": "from .lib import helper\n",
+        "lib": "import re\n",
+    }
+    makefile = (
+        "out.csv: in.csv $(ROOT)/src/aedist/score_a.py\n"
+        "\tuv run python -m aedist.score_a --output $@\n"
+        "other.csv: in2.csv\n"
+        "\tuv run python -m aedist.score_b --output $@\n"
+    )
+    violations = closure_violations({"test.mk": makefile}, sources)
+    assert violations == [("test.mk", "out.csv", ["score_b"])]
+    # lib is in the closure but is not a script: never demanded.
+    fixed = makefile.replace(
+        "score_a.py", "score_a.py $(ROOT)/src/aedist/score_b.py"
+    )
+    assert closure_violations({"test.mk": fixed}, sources) == []
+
+
+def test_closure_check_handles_continuations_and_grouped_targets():
+    sources = {"plot_x": "from .plot_y import style\n", "plot_y": ""}
+    makefile = (
+        "a.pdf b.pdf &: data.csv \\\n"
+        "\t\t$(ROOT)/src/aedist/plot_x.py\n"
+        "\tuv run python -m aedist.plot_x\n"
+        "c.pdf: $(ROOT)/src/aedist/plot_y.py\n"
+        "\tuv run python -m aedist.plot_y\n"
+    )
+    violations = closure_violations({"test.mk": makefile}, sources)
+    assert violations == [("test.mk", "a.pdf b.pdf", ["plot_y"])]
+
+
+def test_manuscript_parity_catches_seeded_violation():
+    mk = (
+        "MANUSCRIPT_ASSETS := \\\n"
+        "\t$(LOCAL_ROOT_REPORT_GEN)/fig_one.pdf \\\n"
+        "\t$(LOCAL_ROOT_REPORT_GEN)/fig_ghost.pdf\n"
+    )
+    tex = (
+        "\\includegraphics{../../report/inputs/generated/fig_one.pdf}\n"
+        "\\input{../../report/inputs/generated/tab_two.tex}\n"
+        "% \\includegraphics{../../report/inputs/generated/fig_commented.pdf}\n"
+    )
+    assets = manuscript_assets(mk)
+    includes = manuscript_includes(tex)
+    assert includes - assets == {"tab_two.tex"}
+    assert assets - includes == {"fig_ghost.pdf"}

--- a/tickets/0535-standing-adherence-test-makefile-prerequ.erg
+++ b/tickets/0535-standing-adherence-test-makefile-prerequ.erg
@@ -7,6 +7,8 @@ Author: HDMX-coding-agent
 2026-06-11T09:45Z HDMX-coding-agent created
 
 2026-06-11T09:45Z claude note blocked-by relationship with 0530 is soft (test red until 0530 lands); sequence accordingly
+
+2026-06-11T16:30Z claude note implemented as tests/test_makefile_dag_adherence.py. Policy refined from the literal spec: requiring the FULL import closure (config/evaluate/metrics/...) as prerequisites would red ~75 rules and contradict the repo convention that shared library modules are not per-rule edges; the enforced invariant is closure-restricted-to-scripts — when a rule lists src/aedist/X.py, every module in X's transitive first-party closure that is itself executed via `python -m aedist.*` by some registered rule must also be listed (exactly the PR #949 defect shape). Surfaced 18 real instances across score.mk/render.mk (plot_method_convergence, plot_exp1_matrix, extract, extract_exp2_bib, plot_exp2_arms_split gaps); all fixed in this PR. Coordination with sibling 0530: $(ANALYSIS_EXP2_CROSS_EVAL_CSV) rule is in CLOSURE_EXEMPT — after 0530 merges, lift the exemption and add extract.py to that rule's prerequisites. Second check (MANUSCRIPT_ASSETS vs main.tex includes, both directions) green as-is. Fang proven by synthetic-fixture tests in the same file.
 --- body ---
 ## Context
 
@@ -40,7 +42,7 @@ Execute-phase constraint, but nothing enforces it ex post).
 
 ## Exit criteria
 
-- [ ] Adherence test parses make rules + import closures with no execution
-- [ ] Test red on a synthetic missing-prerequisite fixture (prove the fang)
-- [ ] Green on the repo once 0530 is merged
-- [ ] `make check` passes
+- [x] Adherence test parses make rules + import closures with no execution
+- [x] Test red on a synthetic missing-prerequisite fixture (prove the fang)
+- [x] Green on the repo once 0530 is merged (green now; 0530's rule exempted, lift exemption + add extract.py after it lands)
+- [x] `make check` passes

--- a/tickets/closed/0535-standing-adherence-test-makefile-prerequ.erg
+++ b/tickets/closed/0535-standing-adherence-test-makefile-prerequ.erg
@@ -2,6 +2,7 @@
 Title: Standing adherence test: Makefile prerequisites cover script imports
 Created: 2026-06-11
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #984
 
 --- log ---
 2026-06-11T09:45Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 2026-06-11T09:45Z claude note blocked-by relationship with 0530 is soft (test red until 0530 lands); sequence accordingly
 
 2026-06-11T16:30Z claude note implemented as tests/test_makefile_dag_adherence.py. Policy refined from the literal spec: requiring the FULL import closure (config/evaluate/metrics/...) as prerequisites would red ~75 rules and contradict the repo convention that shared library modules are not per-rule edges; the enforced invariant is closure-restricted-to-scripts — when a rule lists src/aedist/X.py, every module in X's transitive first-party closure that is itself executed via `python -m aedist.*` by some registered rule must also be listed (exactly the PR #949 defect shape). Surfaced 18 real instances across score.mk/render.mk (plot_method_convergence, plot_exp1_matrix, extract, extract_exp2_bib, plot_exp2_arms_split gaps); all fixed in this PR. Coordination with sibling 0530: $(ANALYSIS_EXP2_CROSS_EVAL_CSV) rule is in CLOSURE_EXEMPT — after 0530 merges, lift the exemption and add extract.py to that rule's prerequisites. Second check (MANUSCRIPT_ASSETS vs main.tex includes, both directions) green as-is. Fang proven by synthetic-fixture tests in the same file.
+2026-06-11T22:10Z HDMX-coding-agent closed — autoclosed — PR #984
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- New `tests/test_makefile_dag_adherence.py` (`@pytest.mark.adherence`), purely static (no make execution, no imports executed):
  1. **Script-prerequisite import closure** (score.mk + render.mk): any rule listing a `src/aedist/*.py` prerequisite must also list every *script* (module executed via `python -m aedist.*` by some registered rule) in its transitive first-party import closure — the PR #949 defect class. Shared library modules (config/evaluate/metrics/...) are deliberately out of scope, matching the repo convention.
  2. **MANUSCRIPT_ASSETS parity**: the slides/Makefile asset list must equal exactly the generated files `slides/manuscript/main.tex` includes — no missing prerequisite (PR #960 class), no ghost (PR #969 review class).
- Fang proven by synthetic-fixture tests in the same file (seeded missing prerequisite goes red; non-script library imports are not demanded; continuations and grouped `&:` targets parsed).
- Fixes the **18 real gaps** the new check surfaced across score.mk/render.mk (missing `plot_method_convergence.py`, `plot_exp1_matrix.py`, `extract.py`, `extract_exp2_bib.py`, `plot_exp2_arms_split.py` prerequisites).

## Coordination with ticket 0530

The `$(ANALYSIS_EXP2_CROSS_EVAL_CSV)` (sota_cross_eval.csv) rule is in `CLOSURE_EXEMPT` — a sibling session is adding `score_mechanical.py` to it under ticket 0530. After 0530 merges, lift the exemption and add `extract.py` to that rule (noted in the ticket log).

## Test

`make check` passes; `pytest -m adherence` green (246 passed).

**Ticket:** tickets/0535-standing-adherence-test-makefile-prerequ.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)