### PR TITLE
ticket(0369): cache audit confirms 0% Anthropic hits; sliding mid-conv breakpoint

### DIFF
--- a/experiments/sota/exp2_interactive_smoke.py
+++ b/experiments/sota/exp2_interactive_smoke.py
@@ -474,6 +474,59 @@ def run_openai_call(
     return record
 
 
+def _slide_followup_cache_breakpoint(messages: list[dict]) -> list[dict]:
+    """Breakpoint 3 (ticket 0369): cache the replayed conversation prefix.
+
+    Wraps the LAST assistant message in the replayed history with
+    ``cache_control: ephemeral`` so the whole prefix up to and including
+    that reply is the cache key for this turn. Any cache_control left on
+    *earlier* assistant messages by previous turns is stripped first — the
+    breakpoint slides forward each turn (Anthropic matches the longest
+    cached prefix, so sliding does not invalidate earlier cache segments,
+    and stripping keeps us within the 4-breakpoints-per-request limit:
+    system [1] + turn-1 user [2] + this slide [3]).
+
+    No token-minimum guard is needed on this workload: the prefix always
+    contains the ~200K-token turn-1 user message (evidence pack), far
+    above the 4096-token Opus cache minimum; an under-minimum breakpoint
+    would in any case be silently ignored by the API at zero cost.
+    """
+    out: list[dict] = []
+    last_assistant_idx = None
+    for i, msg in enumerate(messages):
+        if msg.get("role") == "assistant":
+            last_assistant_idx = i
+        out.append(msg)
+    for i, msg in enumerate(out):
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if i == last_assistant_idx:
+            if isinstance(content, str):
+                out[i] = {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": content,
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+        elif isinstance(content, list):
+            # Strip the wrap a previous turn's slide left behind.
+            out[i] = {
+                "role": "assistant",
+                "content": [
+                    {k: v for k, v in block.items() if k != "cache_control"}
+                    if isinstance(block, dict)
+                    else block
+                    for block in content
+                ],
+            }
+    return out
+
+
 def run_anthropic_call(
     prompt: str,
     *,
@@ -545,7 +598,9 @@ def run_anthropic_call(
             }
     if is_followup:
         new_user_msg = payload["messages"][-1]
-        payload["messages"] = list(continuation["messages"]) + [new_user_msg]
+        payload["messages"] = _slide_followup_cache_breakpoint(
+            list(continuation["messages"])
+        ) + [new_user_msg]
     if extra_metadata is not None:
         # Anthropic metadata only accepts ``user_id``; all other keys are
         # rejected with a 400.  Drop silently — budget info is already in

--- a/scripts/audit_arm34_cache.py
+++ b/scripts/audit_arm34_cache.py
@@ -1,0 +1,155 @@
+"""Audit prompt-cache utilisation in Exp 2 SOTA arms 3 & 4 (ticket 0369).
+
+Aggregates token usage from the raw per-call JSON files recorded under the
+arm 3 / arm 4 run directories and reports, per agent per arm:
+
+- total input tokens billed at full rate
+- cache_read / cache_creation tokens (Anthropic), cached_tokens (OpenAI/Qwen)
+- cache_hit_rate = cache_read / (cache_read + cache_write + input)
+
+Read-only: makes no API calls, mutates nothing.
+"""
+
+import argparse
+import glob
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ARM3 = "experiments/outputs/sota_exp3_arm3_batch1"
+DEFAULT_ARM4 = "experiments/outputs/sota_exp3_arm4_batch1"
+
+AGENTS = ("anthropic", "openai", "mistral", "qwen")
+
+
+def usage_from_raw(raw: dict) -> dict | None:
+    """Normalise one raw response JSON into a flat usage row, or None."""
+    u = raw.get("usage")
+    if not isinstance(u, dict):
+        return None
+    if "input_tokens" in u:  # Anthropic / OpenAI Responses / Qwen
+        cached = u.get("cache_read_input_tokens")
+        if cached is None:
+            cached = (u.get("input_tokens_details") or {}).get("cached_tokens")
+        if cached is None:
+            cached = (u.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
+        return {
+            "input": int(u["input_tokens"]),
+            "cache_read": int(cached or 0),
+            "cache_write": int(u.get("cache_creation_input_tokens") or 0),
+            "output": int(u.get("output_tokens") or 0),
+        }
+    if "prompt_tokens" in u:  # Mistral chat-completions shape
+        return {
+            "input": int(u["prompt_tokens"]),
+            "cache_read": 0,
+            "cache_write": 0,
+            "output": int(u.get("completion_tokens") or 0),
+        }
+    return None
+
+
+def collect_rows(arm3_dir: Path, arm4_dir: Path) -> list[dict]:
+    """Walk both arm directories and return one row per recorded API call."""
+    patterns = [
+        # arm 4: per-turn raw replies, one subdir per agent rep
+        (4, str(arm4_dir / "run*" / "{agent}_run*" / "{agent}_turn_*.raw.json")),
+        # arm 3: single-call direct records and probe raw replies
+        (3, str(arm3_dir / "run*" / "{agent}-direct-*.json")),
+        (3, str(arm3_dir / "run*" / "{agent}_probe.raw.json")),
+    ]
+    rows: list[dict] = []
+    for agent in AGENTS:
+        for arm, pat in patterns:
+            for f in sorted(glob.glob(pat.format(agent=agent))):
+                try:
+                    raw = json.loads(Path(f).read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    logger.warning("unreadable raw file skipped: %s", f)
+                    continue
+                # arm-3 direct records nest the reply under "response" in
+                # some variants; fall back to a recursive usage search.
+                u = usage_from_raw(raw) if isinstance(raw, dict) else None
+                if u is None and isinstance(raw, dict):
+                    u = _find_usage(raw)
+                if u is None:
+                    continue
+                rows.append({"arm": arm, "agent": agent, "file": f, **u})
+    return rows
+
+
+def _find_usage(obj) -> dict | None:
+    """Depth-first search for a usage-shaped dict inside a nested record."""
+    if isinstance(obj, dict):
+        u = usage_from_raw({"usage": obj}) if "input_tokens" in obj else None
+        if u:
+            return u
+        for v in obj.values():
+            u = _find_usage(v)
+            if u:
+                return u
+    elif isinstance(obj, list):
+        for v in obj:
+            u = _find_usage(v)
+            if u:
+                return u
+    return None
+
+
+def aggregate(rows: list[dict]) -> list[dict]:
+    """Per (arm, agent) aggregate with cache_hit_rate."""
+    out = []
+    for arm in (3, 4):
+        for agent in AGENTS:
+            sub = [r for r in rows if r["arm"] == arm and r["agent"] == agent]
+            if not sub:
+                continue
+            inp = sum(r["input"] for r in sub)
+            cr = sum(r["cache_read"] for r in sub)
+            cw = sum(r["cache_write"] for r in sub)
+            denom = cr + cw + inp
+            out.append(
+                {
+                    "arm": arm,
+                    "agent": agent,
+                    "n_calls": len(sub),
+                    "input_tokens": inp,
+                    "cache_read_tokens": cr,
+                    "cache_write_tokens": cw,
+                    "cache_hit_rate": round(cr / denom, 4) if denom else 0.0,
+                }
+            )
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arm3-dir", type=Path, default=Path(DEFAULT_ARM3))
+    parser.add_argument("--arm4-dir", type=Path, default=Path(DEFAULT_ARM4))
+    parser.add_argument(
+        "--per-call", action="store_true", help="also print one row per call"
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    rows = collect_rows(args.arm3_dir, args.arm4_dir)
+    if args.per_call:
+        for r in rows:
+            print(
+                f"arm{r['arm']} {r['agent']:<10} in={r['input']:>8,} "
+                f"cr={r['cache_read']:>8,} cw={r['cache_write']:>8,}  {r['file']}"
+            )
+    print(f"{'arm':<4}{'agent':<11}{'calls':>6}{'input':>13}{'cache_read':>12}"
+          f"{'cache_write':>12}{'hit_rate':>10}")
+    for a in aggregate(rows):
+        print(
+            f"{a['arm']:<4}{a['agent']:<11}{a['n_calls']:>6}"
+            f"{a['input_tokens']:>13,}{a['cache_read_tokens']:>12,}"
+            f"{a['cache_write_tokens']:>12,}{a['cache_hit_rate']:>10.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_audit_arm34_cache.py
+++ b/tests/test_audit_arm34_cache.py
@@ -1,0 +1,53 @@
+"""Tests for scripts/audit_arm34_cache.py (ticket 0369)."""
+
+import json
+from pathlib import Path
+
+from scripts.audit_arm34_cache import aggregate, collect_rows, usage_from_raw
+
+
+def test_usage_anthropic_shape():
+    u = usage_from_raw({"usage": {"input_tokens": 100, "cache_read_input_tokens": 30,
+                                  "cache_creation_input_tokens": 20, "output_tokens": 5}})
+    assert u == {"input": 100, "cache_read": 30, "cache_write": 20, "output": 5}
+
+
+def test_usage_openai_shape():
+    u = usage_from_raw({"usage": {"input_tokens": 100,
+                                  "input_tokens_details": {"cached_tokens": 40},
+                                  "output_tokens": 5}})
+    assert u["cache_read"] == 40
+
+
+def test_usage_mistral_shape():
+    u = usage_from_raw({"usage": {"prompt_tokens": 70, "completion_tokens": 7}})
+    assert u == {"input": 70, "cache_read": 0, "cache_write": 0, "output": 7}
+
+
+def test_usage_missing_returns_none():
+    assert usage_from_raw({}) is None
+    assert usage_from_raw({"usage": {"weird": 1}}) is None
+
+
+def test_collect_and_aggregate(tmp_path: Path):
+    arm4 = tmp_path / "arm4" / "run01" / "anthropic_run01"
+    arm4.mkdir(parents=True)
+    (arm4 / "anthropic_turn_01.raw.json").write_text(json.dumps(
+        {"usage": {"input_tokens": 1000, "cache_read_input_tokens": 0,
+                   "cache_creation_input_tokens": 0, "output_tokens": 10}}) + "\n")
+    (arm4 / "anthropic_turn_02.raw.json").write_text(json.dumps(
+        {"usage": {"input_tokens": 100, "cache_read_input_tokens": 900,
+                   "cache_creation_input_tokens": 0, "output_tokens": 10}}) + "\n")
+    arm3 = tmp_path / "arm3" / "run01"
+    arm3.mkdir(parents=True)
+    (arm3 / "anthropic-direct-m-run1.json").write_text(json.dumps(
+        {"response": {"usage": {"input_tokens": 500, "cache_read_input_tokens": 0,
+                                "cache_creation_input_tokens": 0,
+                                "output_tokens": 1}}}) + "\n")
+
+    rows = collect_rows(tmp_path / "arm3", tmp_path / "arm4")
+    assert len(rows) == 3
+    agg = {(a["arm"], a["agent"]): a for a in aggregate(rows)}
+    assert agg[(4, "anthropic")]["n_calls"] == 2
+    assert agg[(4, "anthropic")]["cache_hit_rate"] == round(900 / 2000, 4)
+    assert agg[(3, "anthropic")]["input_tokens"] == 500

--- a/tests/test_exp2_interactive_smoke.py
+++ b/tests/test_exp2_interactive_smoke.py
@@ -1116,10 +1116,20 @@ def test_run_anthropic_call_turn2_replays_full_history(monkeypatch, tmp_path):
         system_prompt="you are an analyst",
     )
 
-    # Full history replayed: prior 2 + new user = 3 messages.
+    # Full history replayed: prior 2 + new user = 3 messages. The last
+    # assistant reply carries the sliding cache breakpoint (ticket 0369).
     assert captured["messages"] == [
         {"role": "user", "content": "first user message"},
-        {"role": "assistant", "content": "first assistant reply"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "first assistant reply",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
         {"role": "user", "content": "second user message"},
     ]
     # System bytes identical to turn 1 (required by Anthropic), represented as
@@ -1689,3 +1699,67 @@ def test_min_phase_b_max_tokens_floor_applied():
     assert "args.min_phase_b_max_tokens" in src
     # Must use max(), not a conditional assignment
     assert "max(\n        int(design.get" in src or "= max(" in src
+
+
+# ---------------------------------------------------------------------------
+# Ticket 0369: sliding mid-conversation cache breakpoint (Anthropic)
+# ---------------------------------------------------------------------------
+
+
+class TestSlideFollowupCacheBreakpoint:
+    @staticmethod
+    def _mod():
+        import experiments.sota.exp2_interactive_smoke as mod
+
+        return mod
+
+    def test_wraps_last_assistant_with_cache_control(self):
+        mod = self._mod()
+        history = [
+            {"role": "user", "content": [{"type": "text", "text": "ep",
+                                          "cache_control": {"type": "ephemeral"}}]},
+            {"role": "assistant", "content": "reply 1"},
+        ]
+        out = mod._slide_followup_cache_breakpoint(history)
+        last = out[-1]
+        assert last["role"] == "assistant"
+        assert last["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert last["content"][0]["text"] == "reply 1"
+
+    def test_strips_stale_breakpoint_from_earlier_assistant(self):
+        mod = self._mod()
+        history = [
+            {"role": "user", "content": "ep"},
+            {"role": "assistant", "content": [{"type": "text", "text": "reply 1",
+                                               "cache_control": {"type": "ephemeral"}}]},
+            {"role": "user", "content": "nudge"},
+            {"role": "assistant", "content": "reply 2"},
+        ]
+        out = mod._slide_followup_cache_breakpoint(history)
+        assert "cache_control" not in out[1]["content"][0]
+        assert out[3]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_turn1_user_breakpoint_preserved(self):
+        mod = self._mod()
+        history = [
+            {"role": "user", "content": [{"type": "text", "text": "ep",
+                                          "cache_control": {"type": "ephemeral"}}]},
+            {"role": "assistant", "content": "reply 1"},
+        ]
+        out = mod._slide_followup_cache_breakpoint(history)
+        assert out[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_no_assistant_messages_is_noop(self):
+        mod = self._mod()
+        history = [{"role": "user", "content": "ep"}]
+        assert mod._slide_followup_cache_breakpoint(history) == history
+
+    def test_input_list_not_mutated(self):
+        mod = self._mod()
+        history = [
+            {"role": "user", "content": "ep"},
+            {"role": "assistant", "content": "reply 1"},
+        ]
+        snapshot = json.dumps(history)
+        mod._slide_followup_cache_breakpoint(history)
+        assert json.dumps(history) == snapshot

--- a/tickets/0369-rag-cell-cost-audit-claude-cache-breakpoints.erg
+++ b/tickets/0369-rag-cell-cost-audit-claude-cache-breakpoints.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-05-28T00:00Z claude created — Claude costs on arm4 (5D) and possibly arm3 (1D) look high; hypothesis is mid-conversation tail not cached
 2026-05-28T00:00Z claude note — TTL vulnerability surfaced: arm4 Claude wall_s median 253s / max 449s / 31% of turns > 5min ephemeral TTL; cache misses are likely the norm, not the exception (see §TTL vulnerability)
+2026-06-12T00:50Z claude note AUDIT CONFIRMED on existing data (scripts/audit_arm34_cache.py, zero API calls). Anthropic cache_hit_rate = 0.000 on BOTH arms: arm3 5 calls / 1.85M input tok, arm4 16 turns / 3.08M input tok — all billed full rate (~$24.6 at $5/MTok), cache_read=cache_write=0 everywhere. Cross-check: OpenAI auto-cache 21.1% (arm4) / 5.3% (arm3); Mistral 0%, Qwen 7.4% — uniformly-expensive vs tail-heavy split as predicted. CAUSE: batch1 anthropic runs predate the cache_control wiring — commit 96448fb7 (0295) landed 2026-05-25T10:33+02:00; last anthropic rerun is 20260525T0437Z. Not a wiring bug on those records. FIX SHIPPED: breakpoint 3 — sliding mid-conversation cache_control on the last replayed assistant message (_slide_followup_cache_breakpoint, exp2_interactive_smoke.py), stale wraps stripped to respect the 4-breakpoint limit; payload-shape unit tests added. REMAINING (needs API spend, deferred): live smoke verification that the wiring fires (incl. under-4096-token system concern) and the 1h-TTL decision.
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

Audit-before-instrumenting pass on ticket 0369, executed with **zero API spend** — all on existing recorded data.

### Audit findings (scripts/audit_arm34_cache.py, new)
- Anthropic `cache_hit_rate = 0.000` on **both** arms: arm 3 (5 calls, 1.85M input tok) and arm 4 (16 turns, 3.08M input tok). All 4.93M input tokens were billed at full rate (~$24.6 at $5/MTok); `cache_read = cache_write = 0` on every record.
- Cross-provider check matches the ticket's prediction: OpenAI auto-cache 21.1% (arm 4) / 5.3% (arm 3); Mistral 0%; Qwen 7.4% — uniformly-expensive vs tail-heavy split.
- **Cause isolated**: all batch1 Anthropic runs predate the cache_control wiring. Commit 96448fb7 (ticket 0295) landed 2026-05-25T10:33+02:00; the last Anthropic rerun summary is 20260525T0437Z. The zeros are pre-wiring records, not a wiring bug.

### Fix shipped (instrumentation phase, code-only)
- Breakpoint 3: `_slide_followup_cache_breakpoint()` in `experiments/sota/exp2_interactive_smoke.py` slides `cache_control: ephemeral` onto the last replayed assistant message on follow-up turns, stripping stale wraps from earlier assistants to stay within the 4-breakpoint limit. Anthropic matches the longest cached prefix, so sliding reuses earlier segments.
- Payload-shape unit tests (5 new in test_exp2_interactive_smoke.py, 5 in test_audit_arm34_cache.py); the existing turn-2 replay test updated for the new shape.

### Deferred (ticket stays open — needs API spend)
- Live smoke verification that the wiring actually fires (incl. the under-4096-token system-prompt concern).
- The 1h-TTL economics decision.

## Test status
- `make check-fast`: 2496 passed, 5 skipped
- adherence suite: 250 passed, 1 skipped
- ruff clean

Ticket-ref: tickets/0369-rag-cell-cost-audit-claude-cache-breakpoints.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)