### PR TITLE
intro: scope the title's Benchmark claim to its narrow sense (0546)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -138,7 +138,11 @@ benchmark suites that rank today's systems \citep{Hendrycks-Dan2021:mmlu,
 Ni-Shiwen2025:llm-benchmark-survey}; this paper extends the practice to
 national statistical registers. Three results stand out. First, we offer
 a new computable benchmark, scored against a hand-compiled, fully
-sourced reference. Second, the task is hard for today's agents: neither
+sourced reference. We use \emph{benchmark} in the narrow sense of a
+frozen task definition, a public gold reference, and a computable
+metric --- not a suite or a leaderboard --- and the design measures
+training-data contamination, as a parametric ceiling, rather than
+trying to prevent it. Second, the task is hard for today's agents: neither
 model memory nor web access yields a complete, well-sourced register.
 Third, reference-free coherence criteria suffice to screen out the
 weakest models.

--- a/tickets/0546-benchmark-sense-demining-sentence.erg
+++ b/tickets/0546-benchmark-sense-demining-sentence.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-11T21:30Z orchestrator created from author question "Is the word Benchmark in the title overpromising?"
+2026-06-12T00:10Z claude note Checked intro for duplication: no existing scoping sentence and no contamination mention near key results (parametric ceiling first appears in conclusion/methods). Added one sentence with the contamination clause after the key-results benchmark claim in main.tex. Adherence suite green (269 passed), tectonic build green.
 
 --- body ---
 ## Context
@@ -43,8 +44,8 @@ weakening the title to "testbed"/"evaluation".
   hand-typed cross-ref numbers introduced).
 
 ## Verification
-- [ ] Sentence present in intro, register-consistent, no duplication.
-- [ ] tectonic build green.
+- [x] Sentence present in intro, register-consistent, no duplication.
+- [x] tectonic build green.
 
 ## Invariants
 - Title unchanged.
@@ -52,6 +53,6 @@ weakening the title to "testbed"/"evaluation".
 - Conclusion and abstract untouched (0532-ratified).
 
 ## Exit criteria
-- [ ] Intro contains the benchmark-sense scoping sentence (or waiver logged
+- [x] Intro contains the benchmark-sense scoping sentence (or waiver logged
       with pointer to equivalent existing prose).
-- [ ] Build + adherence green.
+- [x] Build + adherence green.

--- a/tickets/closed/0546-benchmark-sense-demining-sentence.erg
+++ b/tickets/closed/0546-benchmark-sense-demining-sentence.erg
@@ -2,11 +2,13 @@
 Title: De-mine the title's "Benchmark" claim: one intro sentence defining the sense claimed
 Created: 2026-06-11
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1000
 
 --- log ---
 2026-06-11T21:30Z orchestrator created from author question "Is the word Benchmark in the title overpromising?"
 2026-06-12T00:10Z claude note Checked intro for duplication: no existing scoping sentence and no contamination mention near key results (parametric ceiling first appears in conclusion/methods). Added one sentence with the contamination clause after the key-results benchmark claim in main.tex. Adherence suite green (269 passed), tectonic build green.
 
+2026-06-12T05:21Z HDMX-coding-agent closed — autoclosed — PR #1000
 --- body ---
 ## Context
 The title claims "A Benchmark and Research Programme". The claim is earned —


### PR DESCRIPTION
**Ticket:** tickets/0546-benchmark-sense-demining-sentence.erg

One sentence added to the introduction, directly after the key-results benchmark claim, defining the narrow sense in which the title claims "Benchmark" (frozen task definition, public gold reference, computable metric; no suite or leaderboard claim) plus a clause noting the design measures contamination as the parametric ceiling rather than preventing it.

Duplication check: the 0537 key-results statement says "new computable benchmark" but contains no scoping/disclaimer prose, and the intro nowhere mentions contamination — both additions warranted.

Verification: tectonic build green (slides/manuscript/main.pdf), adherence suite green (269 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)