### PR TITLE
tickets: wire 0374 triage findings into 0312/0402

### DIFF
--- a/tickets/0312-lp-matcher-tdd-fixtures.erg
+++ b/tickets/0312-lp-matcher-tdd-fixtures.erg
@@ -8,6 +8,7 @@ Label: deferred
 2026-05-25T00:00Z HDMX-coding-agent created
 2026-05-25T00:00Z HDMX-coding-agent note Spawned from ticket 0302 after surgical Mismatched fix landed (PR #t302)
 
+2026-06-12T09:30Z orchestrator note fixture source ready: experiments/derived/exp3_fn_triage.csv (PR #993, ticket 0374) — its 16 bucket=comparateur rows are real matcher failures with per-row rationales naming the unlinked model row; use them as the fixture collection
 --- body ---
 ## Context
 

--- a/tickets/0402-model-emits-level-and-capacity-coherence.erg
+++ b/tickets/0402-model-emits-level-and-capacity-coherence.erg
@@ -8,6 +8,7 @@ Author: claude
 
 2026-06-08T20:57Z HDMX-coding-agent note blocker 0401 closed — Blocked-by removed.
 2026-06-08T00:00Z claude note split — Part B (scorers) landed in PR ticket/0402-model-emits-level; Part A (prompt+audit+backfill) split into child ticket 0480. This is now a tracking ticket; stays open until 0480 closes.
+2026-06-12T09:30Z orchestrator note empirical motivation strengthened: 0374 triage (PR #993, exp3_fn_triage.csv) shows ~all 16 comparateur FNs are aggregate-vs-sub-unit grain mismatches (site row vs unit/phase reference rows) — exactly the level-conditioned matching this ticket adds; 40% of the Exp3 recall gap is recoverable here
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket-ref: tickets/0312-lp-matcher-tdd-fixtures.erg
Ticket-ref: tickets/0402-model-emits-level-and-capacity-coherence.erg

Annotates both open tickets with the comparateur-bucket findings of exp3_fn_triage.csv (PR #993): 16 real matcher failures, ~all aggregate-vs-sub-unit grain mismatches, ready as TDD fixtures.