### PR TITLE
manuscript: reporting-level mismatch as a second instrument limit (0553)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -907,7 +907,16 @@ belongs to the measuring instrument rather than the model: plant-name
 matching is itself a named-entity recognition problem, and a true plant
 reported under a name variant the LP matcher does not recognise is
 scored as a false positive plus a false negative --- a matcher limit,
-not a metric limit (\ref{sec:annex-exp1}).
+not a metric limit (\ref{sec:annex-exp1}). The same instrument limit
+arises from reporting-level mismatches: the same asset can be reported
+at three grains --- the power center, the power plants it hosts, and
+their generating units --- and a model row at one grain matched against
+a reference row at another scores as a false positive plus a false
+negative even when the asset itself is right. The prompt's asset-row
+rule (\ref{sec:annex-exp1}) fixes the intended grain at the plant /
+unit-group level, but models do not always comply, and a share of the
+false-positive and false-negative counts likely reflects such grain
+disagreements rather than genuine errors.
 
 \textbf{Interday drift is an unquantified variance source.} Beyond the
 5-rep within-session spread, provider-side silent movement --- routing

--- a/tickets/0553-manuscript-reporting-level-mismatch-scoring-limit.erg
+++ b/tickets/0553-manuscript-reporting-level-mismatch-scoring-limit.erg
@@ -1,0 +1,36 @@
+%erg 0.1
+Title: Manuscript: state the reporting-level mismatch scoring limit
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T00:00Z HDMX-coding-agent created
+2026-06-12T00:30Z HDMX-coding-agent note Implemented in same PR: hedged passage added after the matcher-limit sentence in Discussion; no 16/40 macro exists so prose kept qualitative
+
+--- body ---
+## Context
+Author directive (2026-06-12): the Discussion's scoring-limits paragraph
+covers the name-variant matcher limit but not the granularity one. The
+report's sec:fn-triage (PR #993) quantifies 16/40 Exp3 FNs as
+comparateur (aggregate-vs-sub-unit) failures: a model row at one
+reporting grain (power center / plant / generating unit) matched against
+a reference row at another grain scores as a false positive plus a false
+negative even when the asset is right. The manuscript should say so
+explicitly, in the author's hedged register.
+
+## Actions
+1. In `slides/manuscript/main.tex`, after the existing matcher-limit
+   sentence ("...a matcher limit, not a metric limit
+   (\ref{sec:annex-exp1})"), add one or two hedged sentences stating the
+   reporting-level mismatch limit, referencing the Annex asset-row rule
+   via `\ref` (no hand-typed numbers).
+2. Do not hand-type the 16/40 figure unless a generated macro exists
+   (checked: `report/inputs/generated/macros_manuscript.tex` has none;
+   `tab_exp3_fn_triage.tex` is report-side only) — keep prose
+   qualitative.
+
+## Exit criteria
+- [x] Passage added in Discussion, hedged register, symbolic `\ref` only
+- [x] No hand-typed empirical number without a generated macro
+- [x] Tectonic build green
+- [x] `pytest -m adherence` green

--- a/tickets/closed/0553-manuscript-reporting-level-mismatch-scoring-limit.erg
+++ b/tickets/closed/0553-manuscript-reporting-level-mismatch-scoring-limit.erg
@@ -2,11 +2,13 @@
 Title: Manuscript: state the reporting-level mismatch scoring limit
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1003
 
 --- log ---
 2026-06-12T00:00Z HDMX-coding-agent created
 2026-06-12T00:30Z HDMX-coding-agent note Implemented in same PR: hedged passage added after the matcher-limit sentence in Discussion; no 16/40 macro exists so prose kept qualitative
 
+2026-06-12T06:19Z HDMX-coding-agent closed — autoclosed — PR #1003
 --- body ---
 ## Context
 Author directive (2026-06-12): the Discussion's scoring-limits paragraph


### PR DESCRIPTION
Adds hedged prose to the Discussion's scoring-limits paragraph: the same FP+FN instrument limit arises from reporting-level (grain) mismatches — center vs plant vs generating unit — not only name variants. References the Annex asset-row rule via \ref{sec:annex-exp1}; kept qualitative since no generated macro exists for the report's 16/40 fn-triage figure.

Verification: tectonic build green; adherence suite 272 passed.

**Ticket:** tickets/0553-manuscript-reporting-level-mismatch-scoring-limit.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)