### PR TITLE
build(slides): cap manuscript tectonic at 3 passes

### DIFF
--- a/slides/Makefile
+++ b/slides/Makefile
@@ -77,8 +77,12 @@ manuscript: manuscript/main.pdf
 # dropped the pandoc/pandoc-crossref toolchain). Asset paths inside main.tex
 # are relative to manuscript/ (tectonic resolves against the input file's
 # directory), hence ../../report/... there vs ../report/... here.
+# -r 2 caps the engine at 3 passes: tectonic's change detection trips on a
+# byte-identical bibtex .bbl rewrite ("internal consistency problem"), looping
+# to its 6-pass ceiling. Convergence at 3 passes is verified (stable .aux/.bbl
+# hashes, zero undefined references in the log).
 manuscript/main.pdf: manuscript/main.tex $(MANUSCRIPT_ASSETS) ../report/refs.bib
-	tectonic $<
+	tectonic -r 2 $<
 
 clean:
 	rm -f slides.pdf slides-en.pdf manuscript/main.pdf *.aux *.log *.nav *.out *.snm *.toc


### PR DESCRIPTION
Ticket: none

Workaround for the upstream tectonic change-detection quirk: bibtex rewrites a byte-identical `.bbl`, tectonic's hash bookkeeping reports an *internal consistency problem*, and the build loops to the 6-pass ceiling ending with a spurious "TeX rerun seems needed" warning.

`tectonic -r 2` forces exactly 1+2 passes. Safe because convergence is verified: `.aux`/`.bbl` are byte-identical across runs and the 3-pass log contains zero `undefined` references. Also roughly halves manuscript build time. Slides rules left as-is (no loop there).

Verification: `make -C slides -B manuscript` — no consistency warnings, no rerun-needed warning, 0 overfull, PDF written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)