### PR TITLE
roar(build-finetune): file overfull sweep tickets 0555/0556, document fpath convention

### DIFF
--- a/.claude/rules/writing.md
+++ b/.claude/rules/writing.md
@@ -53,6 +53,17 @@ macro).
   workaround.
 - Asset paths are relative to `slides/manuscript/` (tectonic resolves against
   the input file's directory): `../../report/inputs/generated/…`.
+- File paths, config keys, and other long monospaced identifiers in prose use
+  `\fpath{experiments/…}` (breakable, no underscore escaping; defined in the
+  preamble via xurl), never `\texttt{}` — long `\texttt` tokens cannot wrap
+  and are the dominant source of overfull \hbox warnings (PR #1010 removed
+  14 of them, worst 453pt). Keep `\texttt` for short literals (flag names,
+  single filenames) only. Brace-expansion shorthands like
+  `\{a.json,b.json\}` are unbreakable too — enumerate the files instead.
+- Tectonic's rerun detector trips on the byte-identical bibtex `.bbl` rewrite
+  ("internal consistency problem"); the manuscript Makefile rule caps passes
+  with `tectonic -r 2` (convergence verified). Don't chase the warning in
+  the document.
 
 ## Related Work sections
 

--- a/tickets/0555-report-build-139-overfull-hboxes-and-tec.erg
+++ b/tickets/0555-report-build-139-overfull-hboxes-and-tec.erg
@@ -1,0 +1,47 @@
+%erg 0.1
+Title: Report build: 139 overfull hboxes and tectonic 6-pass bbl loop
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T09:20Z HDMX-coding-agent created
+
+--- body ---
+## Context
+PR #1010/#1011 cleaned `slides/manuscript/main.tex` to zero overfull
+\hboxes and capped tectonic at 3 passes. The /roar sweep found the same
+defect class in the French report: `tectonic report.tex` emits 139
+Overfull \hbox warnings and the same spurious "internal consistency
+problem when checking if report.bbl changed" 6-pass loop.
+
+## Relevant files
+- `report/report.tex` — the prose; expect long unbreakable `\texttt{}` paths
+- `report/Makefile` (line ~19) — plain `tectonic $<` invocation
+- `slides/manuscript/main.tex` — reference implementation: `\fpath`
+  (`\DeclareUrlCommand\fpath{\urlstyle{tt}}` via xurl), brace-list rewrite,
+  `{\small\setlength{\tabcolsep}{4pt} …}` around over-wide generated tables
+
+## Actions
+1. Add the `\fpath` preamble command to `report.tex` (load `xurl` if absent).
+2. Convert the offending long `\texttt{}` paths; shrink over-wide tables
+   locally; rewrite any unbreakable brace-expansion token.
+3. Verify convergence (stable .aux/.bbl hashes across runs, zero
+   `undefined` in the log), then cap the Makefile rule with `tectonic -r 2`
+   mirroring the slides/Makefile comment.
+
+## Test
+- Build log grep: `tectonic report.tex 2>&1 | grep -c Overfull` → 0
+  (red first: currently 139).
+
+## Verification
+- [ ] 0 Overfull warnings on a clean rebuild
+- [ ] No "internal consistency"/"rerun seems needed" warnings
+- [ ] PDF page count and references unchanged (spot-check)
+
+## Invariants
+- No prose meaning changes; layout-only edits
+- Generated artifacts untouched (wrap at the `\input` site, not the emitters)
+
+## Exit criteria
+- `make -C report` (or the root target) builds report.pdf with zero
+  Overfull and zero tectonic consistency warnings.

--- a/tickets/0556-ci-ratchet-manuscript-and-report-builds.erg
+++ b/tickets/0556-ci-ratchet-manuscript-and-report-builds.erg
@@ -1,0 +1,39 @@
+%erg 0.1
+Title: CI ratchet: manuscript and report builds must emit zero Overfull warnings
+Created: 2026-06-12
+Author: HDMX-coding-agent
+Blocked-by: 0555
+
+--- log ---
+2026-06-12T09:20Z HDMX-coding-agent created
+
+--- body ---
+## Context
+The overfull-\hbox defect class regenerates: any prose edit can
+reintroduce a long unbreakable `\texttt{}` path. PR #1010 zeroed the
+manuscript; ticket 0555 will zero the report. Without a standing guard,
+the count silently creeps back — /gaze is per-PR and won't grep build
+logs for an unrelated future PR.
+
+## Relevant files
+- `slides/Makefile`, `report/Makefile` — build entry points
+- `tests/` — adherence-test home (`@pytest.mark.adherence`, but this one
+  needs tectonic + network bundle, so mark `slow` too)
+
+## Actions
+1. Add a test (or Make target wired into CI) that builds the document(s)
+   and asserts the log contains zero `Overfull \\hbox` lines.
+2. Start with `slides/manuscript/main.tex` (already at zero); extend to
+   `report.tex` once 0555 lands (hence Blocked-by).
+
+## Test
+- The ratchet itself: inject a deliberately overlong \texttt path in a
+  temp copy → test goes red.
+
+## Invariants
+- `make check-fast` stays <30s — the build ratchet runs in the slow/CI
+  tier only.
+
+## Exit criteria
+- CI fails when a PR reintroduces an Overfull \hbox in manuscript or
+  report builds.


### PR DESCRIPTION
Opened via scripts/quickpr.sh.