### PR TITLE
Rewrote abstract

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -41,6 +41,9 @@
 \newunicodechar{↔}{\ensuremath{\leftrightarrow}}
 \newunicodechar{·}{\ensuremath{\cdot}}
 
+% Author affiliations
+\usepackage{authblk}
+
 % Tables and figures
 \usepackage{longtable,booktabs,array}
 \usepackage{graphicx}
@@ -70,14 +73,13 @@
 
 \title{Can Frontier AI Build a Statistical Register?\\
 A Benchmark and Research Programme on Vietnam's Thermal Power
-Fleet\thanks{Technical report accompanying a talk at Econom'IA 2026, Paris.
-Original talk title: Beyond RAG: Stateful-Agentic Architectures for Reliable
-Economic Statistics.}}
-\author{Minh Ha-Duong\\
-\href{https://orcid.org/0000-0001-9988-2100}{ORCID 0000-0001-9988-2100}
---- \href{mailto:minh.ha-duong@cnrs.fr}{\nolinkurl{minh.ha-duong@cnrs.fr}}\\
-CIRED --- Centre International de Recherche\\
-sur l'Environnement et le Développement, CNRS, France}
+Fleet\thanks{Technical report of the communication: ``Beyond RAG: Stateful-Agentic Architectures for Reliable Economic Statistics'', presented at the Econom'IA 2026 workshop in Cergy on May 27th, 2026. Slides eprint: \href{https://hal.science/hal-05644906v1}{https://hal.science/hal-05644906v1}}}
+\author[1]{Minh Ha-Duong\thanks{Corresponding author.
+  \href{mailto:minh.ha-duong@cnrs.fr}{\nolinkurl{minh.ha-duong@cnrs.fr}}.
+  ORCID: \href{https://orcid.org/0000-0001-9988-2100}{0000-0001-9988-2100}.
+  \url{https://minh.haduong.com/}}}
+\affil[1]{Centre International de Recherche sur l'Environnement
+  et le Développement (CIRED), CNRS, France}
 \date{\today}
 
 \begin{document}
@@ -92,25 +94,14 @@ We introduce a computable benchmark for this task: reconstruct the
 register of Vietnam's \NumRefPlants{} thermal power plants and score the result
 against a hand-compiled, fully sourced reference. The register spans the
 whole project lifecycle: proposed and planned projects as well as
-operating, cancelled, and retired plants. The task is hard for today's
-AI systems. Fourteen language models answering from memory recover at
-most about two thirds of the plants, and usually far fewer, even though
-group-seeded Wikipedia lists covering 92\% of the built fleet had sat in
-their training corpus for years. Four frontier agents with web access
-and extended reasoning improve coverage, but they still fall short on
-the quality dimensions measured here: row-level accuracy, coverage, and
-citation-based provenance. The experiments point toward a working
-hypothesis about why: the binding constraint is the quality of the
-source documents, not the capability of the model. In an exploratory,
-unregistered condition, handing the agents a curated document set in a
-single query equalised three of the four; the multi-turn protocol did
-not replicate the effect. Finally, reference-free coherence criteria
-suffice to screen out the weakest models: degenerate outputs betray
-themselves by template-like, near-constant tables, so the worst runs can
-be rejected without any ground truth. The results argue for investing in
-the corpus and the sourcing process rather than in a stronger model,
-building a sourced, auditable knowledge base from which statistical
-tables derive as dated snapshots.
+operating, cancelled, and retired plants. It is historical, current and prospective.
+We find that the task is hard for today's AI systems.
+First, fourteen language models answering from memory recovered much less than Wikipedia lists, even if these lists presumably sat in their training corpus for years.
+Second, enabling web access and extended reasoning improved coverage over the memory-only query in only one of the four frontier agents.
+Third, introducing a harness in which agents were given the opportunity to plan and execute multi-step search and reasoning degraded results.
+Finally, handing the agents a curated document set did improve coverage, especially for the initially weaker agents.
+Complementary experiments suggest ways forward. Since the goal is to discover the statistical register, it is necessary to be able to screen out weak models without the ground truth, and we found that scoring the internal coherence of replies allows it. Fusing the lists from multiple runs is effective.
+We conclude that an evergreen statistical-quality register requires more knowledge engineering. We propose that statistical datasets should be derived as dated snapshots from a sourced, auditable knowledge base, mechanically updated to assimilate the evidential corpus harvested periodically. Humans can stay in the loop to vet information sources and resolve the authentic hard statistical questions.
 \end{abstract}
 
 \section{Introduction}\label{sec:intro}

--- a/tests/test_manuscript_cohort_and_caveats.py
+++ b/tests/test_manuscript_cohort_and_caveats.py
@@ -150,10 +150,11 @@ def test_binding_constraint_framed_as_hypothesis():
     """Ticket 0532: abstract and conclusion frame the binding-constraint claim
     as a hypothesis, not a finding.
 
-    Round 2 (author brief) literals: the abstract's "working hypothesis"
-    framing and the exploratory/unregistered qualifier on the documents
-    condition; the conclusion's "conjecture about why" opener and the
-    conditional recommendation.
+    Round 2 (author brief) literals: the conclusion's "conjecture about why"
+    opener and the conditional recommendation. The 2026-06-12 abstract rewrite
+    dropped the binding-constraint claim from the abstract altogether —
+    absence satisfies the no-overclaim intent by construction; the abstract
+    guard now only forbids reintroducing it as a flat finding.
 
     Ticket 0541 (scoped divergence): the body speaks within-experiment with
     light epistemic markers — "suggests" in the equalisation paragraph,
@@ -163,11 +164,8 @@ def test_binding_constraint_framed_as_hypothesis():
     abstract = _abstract_paragraph()
     text = body()
     conclusion = text.split("\\section{Conclusion}\\label{sec:conclusion}")[1].split("\\appendix")[0]
-    assert "point toward a working hypothesis" in abstract, (
-        "abstract must frame the binding-constraint claim as a working hypothesis"
-    )
-    assert "exploratory, unregistered condition" in abstract, (
-        "abstract must name the equalisation evidence exploratory and unregistered"
+    assert "binding constraint is" not in abstract, (
+        "abstract must not state the binding-constraint claim as a flat finding"
     )
     assert "the evidence points toward a conjecture about why" in conclusion, (
         "conclusion must frame the binding-constraint claim as a conjecture"

--- a/tests/test_manuscript_structure.py
+++ b/tests/test_manuscript_structure.py
@@ -43,7 +43,9 @@ def test_no_synopsis_framing():
 
 
 def test_abstract_present_and_leads_with_frontier():
-    """Abstract must be present and lead with the frontier-falls-short result."""
+    """Abstract must be present and state the task-is-hard result for frontier
+    agents (2026-06-12 rewrite: "hard for today's AI systems" + the
+    one-of-four frontier improvement framing replaced "fall short")."""
     text = body()
     assert "\\begin{abstract}" in text, (
         "no abstract environment found in main.tex — add a structured abstract"
@@ -52,12 +54,13 @@ def test_abstract_present_and_leads_with_frontier():
     assert "frontier" in abstract_block.lower() or "sota" in abstract_block.lower(), (
         "abstract does not mention frontier agents"
     )
-    has_fall_short = (
+    has_hard_result = (
         "fall short" in abstract_block.lower()
         or "falls short" in abstract_block.lower()
         or "still fall" in abstract_block.lower()
+        or "hard for today's ai systems" in abstract_block.lower()
     )
-    assert has_fall_short, "abstract does not lead with the frontier-falls-short result"
+    assert has_hard_result, "abstract does not state the task-is-hard result"
 
 
 def test_abstract_numbers_in_body():


### PR DESCRIPTION
## Summary

Author's rewrite of the manuscript abstract and title-page block in `slides/manuscript/main.tex`:

- Abstract restructured as a findings sequence (memory-only recall, web access, harness, curated documents), ending with the knowledge-engineering conclusion and the dated-snapshot register proposal.
- Title footnote updated to cite the delivered Econom'IA 2026 talk (Cergy, 2026-05-27) with the HAL slides eprint.
- Author block migrated to `authblk` with affiliation and corresponding-author footnote.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)