### PR TITLE
manuscript: artifact-backed fuzzy false-match claim (0534 item 6 follow-up)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -902,7 +902,13 @@ belongs to the measuring instrument rather than the model: plant-name
 matching is itself a named-entity recognition problem, and a true plant
 reported under a name variant the LP matcher does not recognise is
 scored as a false positive plus a false negative --- a matcher limit,
-not a metric limit (\ref{sec:annex-exp1}). The same instrument limit
+not a metric limit (\ref{sec:annex-exp1}). The converse failure ---
+fuzzily merging two distinct plants --- appears bounded: a
+phase-collision audit of the reference name space leaves
+\PhaseCollisionResidualNinety{} of \PhaseCollisionPairsNinety{}
+ambiguous distinct-plant name pairs matchable after the unit-number
+veto, and the scored runs realise \RealisedFuzzyBelowNinety{} such
+false fuzzy matches (Table~\ref{tbl:source-concordance}). The same instrument limit
 arises from reporting-level mismatches: the same asset can be reported
 at three grains --- the power center, the power plants it hosts, and
 their generating units --- and a model row at one grain matched against


### PR DESCRIPTION
Adds one sentence to the Discussion matcher-limit caveat in `slides/manuscript/main.tex`, upgrading the fuzzy-matcher false-match caveat to an artifact-backed bound.

**Provenance.** All numbers come from existing generated macros — no new emitter work was needed:
- `src/aedist/analyze_matcher_phase_collisions.py` (PR #1009, ticket 0551) emits `report/inputs/generated/macros_phase_collisions.tex` (\`\PhaseCollisionPairsNinety\`=174, \`\PhaseCollisionResidualNinety\`=45, \`\RealisedFuzzyBelowNinety\`=0), backed by `tab_phase_collisions.csv`.
- That fragment is already first in `MANUSCRIPT_MACRO_FRAGMENTS` in `experiments/render.mk`, and the macros are already present in the committed consolidated `report/inputs/generated/macros_manuscript.tex` — verified, no regeneration required.
- Cross-reference is symbolic: `Table~\ref{tbl:source-concordance}`, whose caption already cites the same macros.

**Context.** Reading-1 item 6 (ticket 0534) wanted a validated rapidfuzz false-match estimate; it was waived because no committed artifact supported one. PR #1009's digit-asymmetric veto analysis now provides the bound (residual ambiguous pairs 70→45 at threshold 90; zero realised false fuzzy matches across all scored runs).

**Checks.** `pytest -m adherence` (273 passed), `make check-fast` pass; `make -C slides manuscript` compiles (PDF not committed).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)