### PR TITLE
0557: demote positive prose-literal adherence tests to negative guards + editorial brief

### DIFF
--- a/.claude/rules/writing.md
+++ b/.claude/rules/writing.md
@@ -114,10 +114,15 @@ is guarded by `tests/test_manuscript_macros.py` (`@pytest.mark.adherence`).
 Prose adherence tests pin only **negative guards** (forbidden phrasings —
 overclaim signatures, banned registers) and **mechanical checks** (values
 re-derived from committed artifacts, verbatim quotes of fixed external
-documents, structural presence). Tests must never assert that a specific
-*positive* authorial phrasing appears in the prose: positive pins break on
-every legitimate rewrite and force test-chasing edits (bit on PR #1014,
-the 2026-06-12 abstract rewrite).
+documents, structural presence). A third, narrow category is allowed:
+**loose structural anchors** — section-scoped presence of a marker class
+(e.g. ≥2 primacy-marker sentences in §fusion) or of fixed *external*
+terminology (e.g. the STANAG 2511 term pair) — where the anchor pins a
+vocabulary the author does not own, never a sentence the author wrote.
+Tests must never assert that a specific *positive* authorial phrasing
+appears in the prose: positive pins break on every legitimate rewrite and
+force test-chasing edits (bit on merge request #1014, the 2026-06-12
+abstract rewrite).
 
 The asymmetry that makes this work: defects are lexically stable (an
 overclaim reads "the binding constraint is …" in any draft), while good
@@ -127,7 +132,8 @@ must NOT be said works with literals.
 Positive editorial intent (claim X stays hedged, the abstract leads with
 the difficulty result, …) lives in `docs/editorial-brief.md` — one entry
 per standing decision with **Decision:** / **Rationale:** /
-**Originating ticket:** / **Status:** — and is checked at review time by
+**Ticket:** / **Status:** (the first three are the schema the
+review-panel brief auditor consumes) — and is checked at review time by
 the `/review-pr-prose` panel against each manuscript diff. Conditional
 negatives are the CI-side bridge: "IF ρ = 0.92 appears in the conclusion,
 the in-sample caveat must accompany it" guards the decision without

--- a/.claude/rules/writing.md
+++ b/.claude/rules/writing.md
@@ -108,3 +108,27 @@ the prose or into the macros file.
 The ≤3-values inline rule above still applies to slides/report one-offs;
 manuscript numbers always go through the consolidated file. The defect class
 is guarded by `tests/test_manuscript_macros.py` (`@pytest.mark.adherence`).
+
+## CI test polarity rule (ticket 0557)
+
+Prose adherence tests pin only **negative guards** (forbidden phrasings —
+overclaim signatures, banned registers) and **mechanical checks** (values
+re-derived from committed artifacts, verbatim quotes of fixed external
+documents, structural presence). Tests must never assert that a specific
+*positive* authorial phrasing appears in the prose: positive pins break on
+every legitimate rewrite and force test-chasing edits (bit on PR #1014,
+the 2026-06-12 abstract rewrite).
+
+The asymmetry that makes this work: defects are lexically stable (an
+overclaim reads "the binding constraint is …" in any draft), while good
+prose is not — pinning what must be said requires NLP; forbidding what
+must NOT be said works with literals.
+
+Positive editorial intent (claim X stays hedged, the abstract leads with
+the difficulty result, …) lives in `docs/editorial-brief.md` — one entry
+per standing decision with **Decision:** / **Rationale:** /
+**Originating ticket:** / **Status:** — and is checked at review time by
+the `/review-pr-prose` panel against each manuscript diff. Conditional
+negatives are the CI-side bridge: "IF ρ = 0.92 appears in the conclusion,
+the in-sample caveat must accompany it" guards the decision without
+pinning its wording.

--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -1,0 +1,228 @@
+# Editorial brief — standing editorial decisions
+
+Standing editorial decisions for `slides/manuscript/main.tex`. CI enforces
+only mechanical checks and *negative* guards (forbidden phrasings); the
+positive intent behind each decision lives here and is checked at review
+time by the `/review-pr-prose` panel against every manuscript diff (CI test
+polarity rule, `.claude/rules/writing.md`, ticket 0557).
+
+Entry format: one H2 per decision, slug-style heading, with
+**Decision:** / **Rationale:** / **Originating ticket:** / **Status:**.
+A decision is retired by flipping **Status:** to `retired (reason)`,
+never by deleting the entry.
+
+## lifecycle-scope
+
+**Decision:** The abstract disambiguates the 177-plant register as spanning
+the whole project lifecycle (proposed, planned, operating, cancelled,
+retired) — it must never read as an operating-only register.
+
+**Rationale:** "177 plants" without the lifecycle scope invites comparison
+with operating-fleet counts (~50–60 plants) and makes the benchmark look
+inflated. CI keeps the negative guard ("operating plants" /
+"operating-only" forbidden in the abstract); the positive wording is free.
+
+**Originating ticket:** 0532 (round 2, author reading-1 brief); demoted from
+CI by 0557.
+
+**Status:** active
+
+## rho-caveat-conclusion
+
+**Decision:** If the conclusion cites the ρ = 0.92 screen correlation, the
+sentence carries the pooled-across-models and in-sample qualifications and
+points to the within-model validation annex (`sec:annex-screen`). Current
+phrasing: "Spearman ρ = 0.92, pooled across models and in-sample;
+within-model signal positive but modest".
+
+**Rationale:** Pooled in-sample ρ overstates the screen; the within-model
+signal is positive but modest. CI keeps the conditional-negative guard
+(unqualified ρ = 0.92 in the conclusion fails); the exact caveat wording is
+free.
+
+**Originating ticket:** 0532 (round 2); demoted from CI by 0557.
+
+**Status:** active
+
+## rho-caveat-discussion
+
+**Decision:** If the Discussion cites ρ = 0.92, the existence-proof
+qualification accompanies it ("an existence proof rather than a validated
+detector, as the cutoffs were tuned on the same 70 runs").
+
+**Rationale:** The threshold rule was tuned on the same 70 runs it rejects
+from — presenting it as a validated detector would be an overclaim. CI keeps
+the conditional-negative guard ("existence proof" and an in-sample marker
+must accompany ρ = 0.92 in the Discussion); the phrasing is free.
+
+**Originating ticket:** 0532 (round 2); demoted from CI by 0557.
+
+**Status:** active
+
+## binding-constraint-conjecture
+
+**Decision:** The binding-constraint claim ("the binding constraint is the
+data, not the model") is framed as a conjecture everywhere, never as a
+finding. The conclusion opens it with "the evidence points toward a
+conjecture about why" and keeps the recommendation conditional ("If the
+constraint is indeed the documents, …"). The abstract does not carry the
+claim at all (2026-06-12 rewrite).
+
+**Rationale:** The claim rests on the exploratory, unregistered documents
+condition (one corpus, four agents, single-query only) — conjecture is the
+honest register. CI keeps the negatives: the claim is forbidden in the
+abstract, and any body sentence stating "binding constraint is" must carry
+conjecture/conditional framing.
+
+**Originating ticket:** 0532; demoted from CI by 0557.
+
+**Status:** active
+
+## equalisation-hedge
+
+**Decision:** The equalisation paragraph (§exp2, documents condition) hedges
+the constraint-relocation claim with an epistemic marker — current phrasing
+"it suggests the binding constraint lies in document quality rather than
+model capability, without resolving it".
+
+**Rationale:** Scoped divergence (ticket 0541): the body speaks
+within-experiment with light epistemic markers so a later edit cannot
+silently revert to a flat factual register. CI keeps the sentence-scoped
+negative: any sentence containing "binding constraint lies" must contain
+"suggest"/"appear".
+
+**Originating ticket:** 0541; demoted from CI by 0557.
+
+**Status:** active
+
+## fusion-hedge
+
+**Decision:** The constraint-shift claim (annex-fusion architecture
+paragraph) is hedged — current phrasing "the binding constraint appears to
+shift from model capability to document quality".
+
+**Rationale:** Same scoped-divergence policy as equalisation-hedge; the
+shift is observed in one exploratory condition. CI keeps the sentence-scoped
+negative: any sentence claiming a constraint shift must carry
+"appear"/"may"/"suggest".
+
+**Originating ticket:** 0541; demoted from CI by 0557.
+
+**Status:** active
+
+## novelty-benchmark-gap
+
+**Decision:** Surviving novelty claim (1): the benchmark gap, stated in
+§fusion — current phrasing "To our knowledge, no published benchmark or
+system targets open-world enumeration of a national asset class with
+per-cell provenance at this granularity."
+
+**Rationale:** One of exactly three primacy claims the author kept (ticket
+0532 demoted the MoE-non-determinism, day-scale-drift, and cost-F1 claims).
+Epistemic-humility register mandatory ("to our knowledge", never "nobody
+has done"). CI keeps a loose guard (≥2 primacy-marker sentences in §fusion);
+the wording is free.
+
+**Originating ticket:** 0532; demoted from CI by 0557.
+
+**Status:** active
+
+## novelty-provenance-temporality
+
+**Decision:** Surviving novelty claim (2): the conjunction of per-cell
+provenance with per-cell temporal validity, stated in §fusion — current
+phrasing "Nor did we find a published demonstration of the conjunction of
+per-cell provenance with per-cell temporal validity in LLM-augmented
+inventories".
+
+**Rationale:** Same kept-three policy and humility register as
+novelty-benchmark-gap; counted by the same §fusion loose guard.
+
+**Originating ticket:** 0532; demoted from CI by 0557.
+
+**Status:** active
+
+## novelty-two-grain
+
+**Decision:** Surviving novelty claim (3): the two-grain scoring design,
+stated in the Discussion — current phrasing "the run-level screen rates
+*information credibility* while the model-level grade rates *source
+reliability*" (STANAG 2511 Admiralty vocabulary).
+
+**Rationale:** Same kept-three policy. CI keeps the loose anchor that both
+STANAG terms ("information credibility", "source reliability") appear in
+the Discussion — fixed external terminology, not authorial prose; the
+surrounding sentence is free.
+
+**Originating ticket:** 0532; demoted from CI by 0557.
+
+**Status:** active
+
+## status-vocab-mismatch
+
+**Decision:** The status-vocabulary mismatch is explained where status
+accuracy is discussed (§exp1): models answering from memory do not use the
+GEM controlled vocabulary, and the grouped ~38% Proposed share mechanically
+depresses measured status accuracy. Current anchors: "controlled
+vocabulary", "status accuracy".
+
+**Rationale:** Without this sentence the low status-accuracy numbers read
+as model failure when part is vocabulary mismatch plus stratum composition.
+CI keeps only the mechanical check (the ~38% share re-derived from
+`tab_status_difficulty.tex` must appear in the body); the explanatory
+phrasing is free.
+
+**Originating ticket:** 0532 round 2 (table citation), 0511; phrase anchors
+demoted from CI by 0557.
+
+**Status:** active
+
+## frontier-result-abstract
+
+**Decision:** The abstract leads with the difficulty result and names the
+frontier-agent finding — the paper's lead claim is that frontier agents
+with web access fall short on the measured quality dimensions.
+
+**Rationale:** Author brief (reading 1): the frontier result is what a
+general reader takes away. CI keeps a loose topical check
+("frontier"/"sota" in the abstract, `test_manuscript_structure.py`) — kept
+in CI as a loose positive because the lead claim is structural, not
+phrasing.
+
+**Originating ticket:** 0532; recorded here by 0557 (CI check unchanged).
+
+**Status:** active
+
+## rho-value-static
+
+**Decision:** The ρ = 0.92 value itself is hand-typed in the manuscript
+(not macro-generated). If the screen analysis is re-run and ρ changes, every
+occurrence (Discussion, conclusion, annex-screen) must be updated manually.
+
+**Rationale:** `test_manuscript_structure.py` pins "0.92" as a fixed
+empirical value; the conditional caveat guards in
+`test_manuscript_cohort_and_caveats.py` key on the literal "ρ = 0.92".
+A silent re-derivation would leave stale prose — this entry is the reminder
+the value is static.
+
+**Originating ticket:** 0531/0532; recorded here by 0557 (CI checks
+unchanged).
+
+**Status:** active
+
+## built-fleet-pipeline-tail
+
+**Decision:** The Wikipedia-seeding paragraph keeps the built-fleet vs
+pipeline-tail coverage caveat: the group-seeded lists cover the *built*
+fleet (92%), not the pipeline tail — no overclaim that every plant was
+visible to every model.
+
+**Rationale:** Scientific-accuracy caveat (prevents "Wikipedia covers all
+177" misreading), not editorial framing — therefore KEPT in CI
+(`test_wikipedia_seeding_date_matches_provenance`) as a low-risk factual
+descriptor pair; recorded here so the review panel knows the phrase pair is
+load-bearing.
+
+**Originating ticket:** 0511; triaged keep-in-CI by 0557.
+
+**Status:** active

--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -7,9 +7,11 @@ time by the `/review-pr-prose` panel against every manuscript diff (CI test
 polarity rule, `.claude/rules/writing.md`, ticket 0557).
 
 Entry format: one H2 per decision, slug-style heading, with
-**Decision:** / **Rationale:** / **Originating ticket:** / **Status:**.
-A decision is retired by flipping **Status:** to `retired (reason)`,
-never by deleting the entry.
+**Decision:** / **Rationale:** / **Ticket:** / **Status:**. The first
+three fields are the schema the `/review-pr-prose` brief auditor
+consumes; **Status:** is bookkeeping local to this file. A decision is
+retired by flipping **Status:** to `retired (reason)`, never by
+deleting the entry.
 
 ## lifecycle-scope
 
@@ -22,7 +24,7 @@ with operating-fleet counts (~50–60 plants) and makes the benchmark look
 inflated. CI keeps the negative guard ("operating plants" /
 "operating-only" forbidden in the abstract); the positive wording is free.
 
-**Originating ticket:** 0532 (round 2, author reading-1 brief); demoted from
+**Ticket:** 0532 (round 2, author reading-1 brief); demoted from
 CI by 0557.
 
 **Status:** active
@@ -40,7 +42,7 @@ signal is positive but modest. CI keeps the conditional-negative guard
 (unqualified ρ = 0.92 in the conclusion fails); the exact caveat wording is
 free.
 
-**Originating ticket:** 0532 (round 2); demoted from CI by 0557.
+**Ticket:** 0532 (round 2); demoted from CI by 0557.
 
 **Status:** active
 
@@ -55,7 +57,7 @@ from — presenting it as a validated detector would be an overclaim. CI keeps
 the conditional-negative guard ("existence proof" and an in-sample marker
 must accompany ρ = 0.92 in the Discussion); the phrasing is free.
 
-**Originating ticket:** 0532 (round 2); demoted from CI by 0557.
+**Ticket:** 0532 (round 2); demoted from CI by 0557.
 
 **Status:** active
 
@@ -74,7 +76,7 @@ honest register. CI keeps the negatives: the claim is forbidden in the
 abstract, and any body sentence stating "binding constraint is" must carry
 conjecture/conditional framing.
 
-**Originating ticket:** 0532; demoted from CI by 0557.
+**Ticket:** 0532; demoted from CI by 0557.
 
 **Status:** active
 
@@ -91,7 +93,7 @@ silently revert to a flat factual register. CI keeps the sentence-scoped
 negative: any sentence containing "binding constraint lies" must contain
 "suggest"/"appear".
 
-**Originating ticket:** 0541; demoted from CI by 0557.
+**Ticket:** 0541; demoted from CI by 0557.
 
 **Status:** active
 
@@ -106,7 +108,7 @@ shift is observed in one exploratory condition. CI keeps the sentence-scoped
 negative: any sentence claiming a constraint shift must carry
 "appear"/"may"/"suggest".
 
-**Originating ticket:** 0541; demoted from CI by 0557.
+**Ticket:** 0541; demoted from CI by 0557.
 
 **Status:** active
 
@@ -123,7 +125,7 @@ Epistemic-humility register mandatory ("to our knowledge", never "nobody
 has done"). CI keeps a loose guard (≥2 primacy-marker sentences in §fusion);
 the wording is free.
 
-**Originating ticket:** 0532; demoted from CI by 0557.
+**Ticket:** 0532; demoted from CI by 0557.
 
 **Status:** active
 
@@ -138,7 +140,7 @@ inventories".
 **Rationale:** Same kept-three policy and humility register as
 novelty-benchmark-gap; counted by the same §fusion loose guard.
 
-**Originating ticket:** 0532; demoted from CI by 0557.
+**Ticket:** 0532; demoted from CI by 0557.
 
 **Status:** active
 
@@ -154,7 +156,7 @@ STANAG terms ("information credibility", "source reliability") appear in
 the Discussion — fixed external terminology, not authorial prose; the
 surrounding sentence is free.
 
-**Originating ticket:** 0532; demoted from CI by 0557.
+**Ticket:** 0532; demoted from CI by 0557.
 
 **Status:** active
 
@@ -172,7 +174,7 @@ CI keeps only the mechanical check (the ~38% share re-derived from
 `tab_status_difficulty.tex` must appear in the body); the explanatory
 phrasing is free.
 
-**Originating ticket:** 0532 round 2 (table citation), 0511; phrase anchors
+**Ticket:** 0532 round 2 (table citation), 0511; phrase anchors
 demoted from CI by 0557.
 
 **Status:** active
@@ -189,7 +191,7 @@ general reader takes away. CI keeps a loose topical check
 in CI as a loose positive because the lead claim is structural, not
 phrasing.
 
-**Originating ticket:** 0532; recorded here by 0557 (CI check unchanged).
+**Ticket:** 0532; recorded here by 0557 (CI check unchanged).
 
 **Status:** active
 
@@ -205,7 +207,7 @@ empirical value; the conditional caveat guards in
 A silent re-derivation would leave stale prose — this entry is the reminder
 the value is static.
 
-**Originating ticket:** 0531/0532; recorded here by 0557 (CI checks
+**Ticket:** 0531/0532; recorded here by 0557 (CI checks
 unchanged).
 
 **Status:** active
@@ -223,6 +225,24 @@ visible to every model.
 descriptor pair; recorded here so the review panel knows the phrase pair is
 load-bearing.
 
-**Originating ticket:** 0511; triaged keep-in-CI by 0557.
+**Ticket:** 0511; triaged keep-in-CI by 0557.
+
+**Status:** active
+
+## annex-quote-anchor
+
+**Decision:** The Annex baseline-prompt quote reproduces the as-sent
+Doc-07 prompt faithfully, including the sentences "primary-sourced
+reference inventory" and "Actual or expected commercial operation date".
+
+**Rationale:** Content fidelity of a fixed external document, not
+authorial prose — the annex quotes what was actually sent to the models,
+so the verbatim anchors are KEPT in CI
+(`test_annex_baseline_prompt_carries_as_sent_status_vocabulary`,
+`test_annex_carries_doc07_prompt_verbatim_anchors`). Recorded here so a
+reviewer rewording the annex framing knows the quoted block itself is
+immutable.
+
+**Ticket:** 0511; triaged keep-in-CI by 0557.
 
 **Status:** active

--- a/tests/test_manuscript_cohort_and_caveats.py
+++ b/tests/test_manuscript_cohort_and_caveats.py
@@ -203,10 +203,12 @@ def test_binding_constraint_framed_as_hypothesis():
         assert "suggest" in sentence or "appear" in sentence, (
             f"unhedged constraint-relocation claim: {sentence!r}"
         )
-    for sentence in _sentences_containing(text, "constraint"):
+    for sentence in _sentences_containing(text, "binding constraint"):
         if "shift" not in sentence:
             continue
-        assert any(h in sentence for h in ("appear", "may", "suggest")), (
+        # A hedged claim ("appears to shift") or an explicit negation
+        # ("did not shift") is fine; only the flat positive claim is banned.
+        assert any(h in sentence for h in ("appear", "may", "suggest", "not")), (
             f"unhedged constraint-shift claim: {sentence!r}"
         )
 

--- a/tests/test_manuscript_cohort_and_caveats.py
+++ b/tests/test_manuscript_cohort_and_caveats.py
@@ -18,6 +18,13 @@ wherever it still appears (conclusion, Discussion). The cost-savings claim and
 the cost-F1 non-monotonicity novelty claim must be gone. The status-vocabulary
 mismatch sentence must cite the grouped ~38% from the committed
 status-difficulty table.
+
+Ticket 0557 (CI test polarity rule, see .claude/rules/writing.md): assertions
+here are mechanical (re-derived from artifacts), content-fidelity (verbatim
+quotes of fixed external documents), or *negative/conditional* guards on
+forbidden phrasings. Positive authorial-wording pins are banned — the standing
+editorial decisions they encoded live in docs/editorial-brief.md, checked at
+review time by /review-pr-prose.
 """
 
 import csv
@@ -100,7 +107,9 @@ def test_abstract_register_follows_author_brief():
     """Ticket 0532 round 2 (author reading-1 brief): the abstract is written
     for the general reader — no statistics (no F1 scores, no ρ/τ), no
     em-dashes, no literature-review closing, no fusion sentence — and the
-    177-plant register is disambiguated as spanning the whole lifecycle."""
+    177-plant register must not be misstated as operating-only (ticket 0557:
+    the positive 'lifecycle' wording pin moved to docs/editorial-brief.md,
+    entry lifecycle-scope)."""
     abstract = _abstract_paragraph()
     assert "F1" not in abstract, "author brief: no F1 detail in the abstract"
     assert "ρ" not in abstract and "τ" not in abstract and "\\tau" not in abstract, (
@@ -113,9 +122,9 @@ def test_abstract_register_follows_author_brief():
     assert "Pooling" not in abstract and "pooling" not in abstract, (
         "author brief: the fusion/pooling sentence leaves the abstract"
     )
-    assert "lifecycle" in abstract, (
-        "author brief: 177 plants must read as the full-lifecycle register, "
-        "not 177 operating plants"
+    assert "operating plants" not in abstract and "operating-only" not in abstract, (
+        "author brief: the 177-plant register must not read as operating-only "
+        "— it spans the whole project lifecycle (see docs/editorial-brief.md)"
     )
     assert len(abstract.split()) < 300, (
         "author brief: the abstract must stay markedly shorter than the "
@@ -124,61 +133,82 @@ def test_abstract_register_follows_author_brief():
 
 
 def test_rho_caveat_wherever_rho_appears():
-    """Ticket 0532 round 2: ρ=0.92 left the abstract; wherever it still
-    appears in the narrative (conclusion, Discussion), the pooled /
-    across-model / in-sample qualification must accompany it."""
+    """Ticket 0532 round 2, demoted to conditional-negative form (ticket 0557):
+    IF ρ = 0.92 appears in the conclusion or Discussion, the pooled /
+    in-sample qualification must accompany it in that section. The exact
+    caveat phrasings are editorial decisions recorded in
+    docs/editorial-brief.md (rho-caveat-conclusion, rho-caveat-discussion);
+    CI only forbids an unqualified ρ. The annex occurrence (sec:annex-screen)
+    is out of scope: both extractions are bounded before \\appendix."""
     text = body()
     conclusion = text.split("\\section{Conclusion}\\label{sec:conclusion}")[1].split("\\appendix")[0]
-    assert "ρ = 0.92, pooled across models and in-sample" in conclusion, (
-        "conclusion ρ=0.92 must carry the pooled/in-sample caveat"
-    )
-    assert "within-model signal positive but modest, \\ref{sec:annex-screen}" in conclusion, (
-        "conclusion ρ=0.92 must point to the within-model validation annex"
-    )
+    if "ρ = 0.92" in conclusion:
+        assert "pooled" in conclusion and "in-sample" in conclusion, (
+            "conclusion cites ρ = 0.92 without the pooled/in-sample caveat"
+        )
+        assert "\\ref{sec:annex-screen}" in conclusion, (
+            "conclusion cites ρ = 0.92 without pointing to the within-model "
+            "validation annex"
+        )
     discussion = text.split("\\section{Discussion}\\label{sec:discussion}")[1].split(
         "\\section*{Related Work — Methods}"
     )[0]
-    assert "ρ = 0.92" in discussion and "existence proof rather than a validated detector" in discussion, (
-        "Discussion ρ=0.92 must keep the existence-proof qualification"
-    )
-    assert "tuned on the same 70 runs" in discussion, (
-        "Discussion must keep the in-sample (cutoffs tuned on the same runs) caveat"
-    )
+    if "ρ = 0.92" in discussion:
+        assert "existence proof" in discussion, (
+            "Discussion cites ρ = 0.92 without the existence-proof qualification"
+        )
+        assert "in-sample" in discussion or "tuned on the same" in discussion, (
+            "Discussion cites ρ = 0.92 without the in-sample (cutoffs tuned "
+            "on the same runs) caveat"
+        )
+
+
+def _sentences_containing(text: str, phrase: str) -> list[str]:
+    """Sentences of the normalized text that contain `phrase` (sentence =
+    split at .!? followed by whitespace; decimals like 0.92 survive intact)."""
+    return [s for s in re.split(r"(?<=[.!?])\s+", text) if phrase in s]
 
 
 def test_binding_constraint_framed_as_hypothesis():
-    """Ticket 0532: abstract and conclusion frame the binding-constraint claim
-    as a hypothesis, not a finding.
+    """Tickets 0532/0541, demoted to negative/sentence-scoped form (ticket
+    0557): the binding-constraint claim is never stated as a flat finding,
+    anywhere.
 
-    Round 2 (author brief) literals: the conclusion's "conjecture about why"
-    opener and the conditional recommendation. The 2026-06-12 abstract rewrite
-    dropped the binding-constraint claim from the abstract altogether —
-    absence satisfies the no-overclaim intent by construction; the abstract
-    guard now only forbids reintroducing it as a flat finding.
+    - Abstract: the claim must not appear at all (unchanged negative; the
+      2026-06-12 rewrite dropped it — absence satisfies the no-overclaim
+      intent by construction).
+    - Body-wide: every sentence asserting "binding constraint is ..." must
+      carry conjecture/conditional framing; every sentence relocating the
+      constraint ("binding constraint lies") or claiming the constraint
+      shifts must carry an epistemic hedge.
 
-    Ticket 0541 (scoped divergence): the body speaks within-experiment with
-    light epistemic markers — "suggests" in the equalisation paragraph,
-    "appears to" in the fusion section — so a later edit cannot silently
-    revert the body to a flat factual register.
+    The exact hedged phrasings ("the evidence points toward a conjecture
+    about why", "If the constraint is indeed the documents", "suggests the
+    binding constraint lies", "appears to shift from model capability") are
+    editorial decisions recorded in docs/editorial-brief.md
+    (binding-constraint-conjecture, equalisation-hedge, fusion-hedge).
     """
     abstract = _abstract_paragraph()
     text = body()
-    conclusion = text.split("\\section{Conclusion}\\label{sec:conclusion}")[1].split("\\appendix")[0]
     assert "binding constraint is" not in abstract, (
         "abstract must not state the binding-constraint claim as a flat finding"
     )
-    assert "the evidence points toward a conjecture about why" in conclusion, (
-        "conclusion must frame the binding-constraint claim as a conjecture"
-    )
-    assert "If the constraint is indeed the documents" in conclusion, (
-        "conclusion recommendation must stay conditional on the hypothesis"
-    )
-    assert "suggests the binding constraint lies" in text, (
-        "equalisation paragraph must hedge the relocation claim with 'suggests'"
-    )
-    assert "appears to shift from model capability" in text, (
-        "fusion section must hedge the constraint-shift claim with 'appears to'"
-    )
+    hedges = ("conjectur", "hypothes", "suggest", "appear", "If ", "if the constraint")
+    for sentence in _sentences_containing(text, "binding constraint is"):
+        assert any(h in sentence for h in hedges), (
+            f"flat binding-constraint finding (no conjecture/conditional "
+            f"framing in sentence): {sentence!r}"
+        )
+    for sentence in _sentences_containing(text, "binding constraint lies"):
+        assert "suggest" in sentence or "appear" in sentence, (
+            f"unhedged constraint-relocation claim: {sentence!r}"
+        )
+    for sentence in _sentences_containing(text, "constraint"):
+        if "shift" not in sentence:
+            continue
+        assert any(h in sentence for h in ("appear", "may", "suggest")), (
+            f"unhedged constraint-shift claim: {sentence!r}"
+        )
 
 
 def test_intro_does_not_claim_per_cell_provenance_checking():
@@ -208,17 +238,23 @@ def test_cost_f1_nonmonotonicity_novelty_dropped():
     )
 
 
-def test_exactly_three_novelty_claims_survive():
-    """Exactly three explicit primacy claims survive; demoted observations lose framing.
+def test_novelty_claim_demotions_hold():
+    """Demoted primacy claims stay demoted; surviving claims keep loose anchors.
 
-    Counts the manuscript-level primacy assertions of the form
-    'to our knowledge ... has not been / no published / no prior'. The three
-    kept are: (1) benchmark gap, (2) per-row provenance × temporality, and
-    (3) two-grain credibility/reliability scoring. The MoE-non-determinism and
-    day-scale-drift assertions are demoted to plain observations; the cost-F1
-    claim is dropped. 'we did not find' epistemic hedges are NOT primacy claims.
-    Round 2 (author brief): the abstract's copy of claim (1) is removed (no
-    literature review in the abstract); the claim survives in §fusion.
+    Negative half (unchanged ratchet): the MoE-non-determinism, day-scale-drift
+    and per-row-provenance primacy phrasings were demoted to plain observations
+    (ticket 0532) and must not return.
+
+    Positive half, demoted to loose anchors (ticket 0557): the three surviving
+    novelty claims — (1) benchmark gap and (2) per-row provenance × temporality,
+    both in §fusion; (3) two-grain credibility/reliability scoring, in the
+    Discussion — are guarded by section-scoped marker presence, not verbatim
+    sentences. §fusion must keep at least two primacy-marker sentences (one per
+    claim); the Discussion must keep the STANAG 2511 two-grain vocabulary
+    ("information credibility" / "source reliability" — fixed external
+    terminology, not authorial prose). The verbatim phrasings are recorded in
+    docs/editorial-brief.md (novelty-benchmark-gap, novelty-provenance-temporality,
+    novelty-two-grain).
     """
     text = body()
     demoted_phrasings = [
@@ -228,14 +264,27 @@ def test_exactly_three_novelty_claims_survive():
     ]
     for phrase in demoted_phrasings:
         assert phrase not in text, f"demoted observation still carries primacy framing: {phrase!r}"
-    # The three surviving novelty claims (verbatim anchors).
-    survivors = [
-        "no published benchmark or system targets open-world enumeration",  # (1) benchmark gap
-        "conjunction of per-cell provenance with per-cell temporal validity",  # (2)
-        "run-level screen rates \\emph{information credibility} while the model-level grade rates \\emph{source reliability}",  # (3) two-grain
+    fusion = text.split("\\section{Need and potential for fusion}\\label{sec:fusion}")[1].split(
+        "\\section{Discussion}\\label{sec:discussion}"
+    )[0]
+    markers = ("no published", "to our knowledge", "did we find", "has not been")
+    marker_sentences = [
+        s
+        for s in re.split(r"(?<=[.!?])\s+", fusion)
+        if any(m in s.lower() for m in markers)
     ]
-    for s in survivors:
-        assert s in text, f"surviving novelty claim missing: {s!r}"
+    assert len(marker_sentences) >= 2, (
+        "§fusion must keep both surviving primacy claims (benchmark gap; "
+        f"provenance × temporality) — found {len(marker_sentences)} "
+        "primacy-marker sentence(s)"
+    )
+    discussion = text.split("\\section{Discussion}\\label{sec:discussion}")[1].split(
+        "\\section*{Related Work — Methods}"
+    )[0]
+    assert "information credibility" in discussion and "source reliability" in discussion, (
+        "Discussion must keep the two-grain scoring claim (STANAG 2511 "
+        "information-credibility / source-reliability vocabulary)"
+    )
 
 
 def test_wikipedia_seeding_date_matches_provenance():
@@ -265,8 +314,11 @@ def test_wikipedia_seeding_date_matches_provenance():
     )
 
 
-def test_status_vocab_mismatch_sentence_present():
-    """The status-vocabulary mismatch sentence cites the grouped ~38% from the table."""
+def test_status_vocab_mismatch_share_matches_artifact():
+    """The manuscript cites the grouped ~38% Proposed share from the committed
+    status-difficulty table (mechanical artifact check). The "controlled
+    vocabulary" / "status accuracy" phrase anchors were demoted to
+    docs/editorial-brief.md (status-vocab-mismatch) by ticket 0557."""
     if not DIFF_TEX.exists():
         pytest.skip("status difficulty table not generated")
     tex = DIFF_TEX.read_text(encoding="utf-8")
@@ -277,11 +329,7 @@ def test_status_vocab_mismatch_sentence_present():
     assert int(share.split(".")[0]) == 38, (
         f"expected grouped Proposed share ~38%, table says {share}"
     )
-    text = body()
-    assert "controlled vocabulary" in text and "status accuracy" in text, (
-        "status-vocab mismatch sentence missing"
-    )
-    assert f"{share}%" in text, (
+    assert f"{share}%" in body(), (
         f"status-vocab sentence must state the {share}% Proposed share "
         "(via \\StatusProposedSharePct)"
     )

--- a/tickets/0557-demote-positive-prose-literal-adherence.erg
+++ b/tickets/0557-demote-positive-prose-literal-adherence.erg
@@ -8,6 +8,7 @@ Author: HDMX-coding-agent
 2026-06-12T14:10Z claude note raid-557 Imagine pass — drift verdict clean, inventory + triage table appended
 2026-06-12T14:25Z claude note raid-557 Plan pass — concrete rewrites, day-one guard safety verified, IDH companion is existing ticket 0253
 2026-06-12T14:40Z claude note raid-557 Feasibility PASS — all paths/headings/phrases verified, baseline 22 passed; WARN: PR #1017 also touches .claude/rules/writing.md (rebase before merge)
+2026-06-12T10:42Z claude note executed — demotions per triage, brief 13 entries, polarity rule appended; gates a/b + fang verified on scratch copies; IDH companion already merged upstream (IDH PR #393, ticket 0253 closed there)
 
 --- body ---
 ## Context
@@ -67,10 +68,10 @@ Policy decided with the author (2026-06-12 session):
 
 ## Verification
 
-- [ ] `make check` green
-- [ ] A trial rewording of a hedged sentence (same meaning, different
+- [x] `make check` green
+- [x] A trial rewording of a hedged sentence (same meaning, different
   words) no longer fails CI
-- [ ] Reintroducing "the binding constraint is the documents" flatly in
+- [x] Reintroducing "the binding constraint is the documents" flatly in
   the abstract DOES fail CI
 
 ## Invariants
@@ -82,9 +83,9 @@ Policy decided with the author (2026-06-12 session):
 
 ## Exit criteria
 
-- [ ] No positive prose-literal assertion remains in CI
-- [ ] `docs/editorial-brief.md` exists and carries every demoted decision
-- [ ] Prose review path references the brief
+- [x] No positive prose-literal assertion remains in CI
+- [x] `docs/editorial-brief.md` exists and carries every demoted decision
+- [x] Prose review path references the brief
 
 ## Reimagined (raid 2026-06-12)
 

--- a/tickets/0557-demote-positive-prose-literal-adherence.erg
+++ b/tickets/0557-demote-positive-prose-literal-adherence.erg
@@ -8,7 +8,8 @@ Author: HDMX-coding-agent
 2026-06-12T14:10Z claude note raid-557 Imagine pass — drift verdict clean, inventory + triage table appended
 2026-06-12T14:25Z claude note raid-557 Plan pass — concrete rewrites, day-one guard safety verified, IDH companion is existing ticket 0253
 2026-06-12T14:40Z claude note raid-557 Feasibility PASS — all paths/headings/phrases verified, baseline 22 passed; WARN: PR #1017 also touches .claude/rules/writing.md (rebase before merge)
-2026-06-12T10:42Z claude note executed — demotions per triage, brief 13 entries, polarity rule appended; gates a/b + fang verified on scratch copies; IDH companion already merged upstream (IDH PR #393, ticket 0253 closed there)
+2026-06-12T15:00Z claude note executed — demotions per triage, brief 13 entries, polarity rule appended; gates a/b + fang verified on scratch copies; IDH companion already merged upstream (IDH PR #393, ticket 0253 closed there)
+2026-06-12T15:55Z claude note raid-557 review round 1 — brief field renamed to Ticket: (skill schema), 14th entry annex-quote-anchor, polarity rule third category, constraint-shift guard rescoped to binding-constraint + negation-tolerant, executed-log timestamp corrected (was 10:42Z stale clock)
 
 --- body ---
 ## Context

--- a/tickets/0557-demote-positive-prose-literal-adherence.erg
+++ b/tickets/0557-demote-positive-prose-literal-adherence.erg
@@ -6,6 +6,7 @@ Author: HDMX-coding-agent
 --- log ---
 2026-06-12T09:29Z HDMX-coding-agent created
 2026-06-12T14:10Z claude note raid-557 Imagine pass — drift verdict clean, inventory + triage table appended
+2026-06-12T14:25Z claude note raid-557 Plan pass — concrete rewrites, day-one guard safety verified, IDH companion is existing ticket 0253
 
 --- body ---
 ## Context
@@ -153,3 +154,66 @@ Approach refinements (exit criteria unchanged):
    three claims can't be silently dropped — the brief is review-time only.
 3. 0557 is independent of the reading-1 wave (test infra, not prose) —
    safe in parallel.
+
+## Plan (raid 2026-06-12)
+
+Ordered actions; apply the triage table above as the lookup record.
+
+1. **`tests/test_manuscript_cohort_and_caveats.py`** — demote per triage:
+   - `test_abstract_register_follows_author_brief`: drop `"lifecycle" in
+     abstract`; add negative `"operating plants" not in abstract and
+     "operating-only" not in abstract` (verified: phrase "operating plants"
+     absent from current abstract — green day one; abstract says
+     "operating, cancelled, and retired plants").
+   - `test_rho_caveat_wherever_rho_appears`: rewrite as conditional
+     negatives — if "ρ = 0.92" in conclusion → "pooled" AND "in-sample"
+     AND `\ref{sec:annex-screen}` must accompany; if in discussion →
+     "existence proof" AND ("in-sample" OR "tuned on the same") must
+     accompany. Exact phrasings → brief.
+   - `test_binding_constraint_framed_as_hypothesis`: keep abstract
+     negative; add conclusion negatives on flat forms ("the binding
+     constraint is the data/model"); body hedge guards as
+     sentence-scoped checks: any sentence containing "binding constraint
+     lies" must contain "suggests"/"appear"; any sentence claiming the
+     constraint shift must be hedged ("appears to"). (Plan antipattern
+     fix A: sentence-scoped hedge check, not str.replace tricks.)
+   - `test_exactly_three_novelty_claims_survive`: keep demoted_phrasings
+     negatives; replace 3 verbatim survivors with per-section
+     primacy-marker presence (markers: "no published", "to our
+     knowledge", "we did not find", "has not been"); verbatim claims →
+     brief. CAUTION: confirm actual section heading strings in main.tex
+     before writing split keys.
+   - `test_status_vocab_mismatch_sentence_present`: keep `{share}%`
+     artifact check; delete "controlled vocabulary"/"status accuracy"
+     anchors → brief (no replacement negative needed).
+   - `test_wikipedia_seeding_date_matches_provenance`: KEEP entirely —
+     "built fleet"/"pipeline tail" resolved as scientific-accuracy
+     coverage caveats (prevent "Wikipedia covers all 177" overclaim),
+     not editorial framing.
+   - `test_annex_baseline_prompt_carries_as_sent_status_vocabulary`:
+     KEEP both `in prompt` and `in quote` — fixed-document verbatim
+     fidelity, same class as Doc-07 anchors.
+2. **`tests/test_manuscript_structure.py`** — no changes (all KEEP).
+3. **`docs/editorial-brief.md`** — new file; one H2 per decision with
+   fields `**Decision:** / **Rationale:** / **Originating ticket:** /
+   **Status:** active`. 13 entries: lifecycle-scope, rho-caveat-conclusion,
+   rho-caveat-discussion, binding-constraint-conjecture,
+   equalisation-hedge, fusion-hedge, 3× novelty claim phrasings,
+   status-vocab-mismatch, frontier-result-abstract, rho-value-static,
+   built-fleet-pipeline-tail (kept in CI but documented).
+4. **`.claude/rules/writing.md`** — append "CI test polarity rule":
+   prose adherence tests pin only negative guards + mechanical checks;
+   positive intent lives in the brief, checked by /review-pr-prose.
+5. **IDH companion** — ticket 0253 already exists in ~/.claude/tickets/
+   (filed 2026-06-12T09:30Z). Add step 2b "Editorial brief check" to
+   review-pr-prose SKILL.md via IDH worktree branch t0253 + PR with
+   `**Ticket:** tickets/0253-...`. Degrade silently when brief absent.
+
+First test (red step): rewrite `test_rho_caveat_wherever_rho_appears`
+to the conditional-negative form FIRST and run it — must be green on
+current text (before/after symmetry proves the demotion safe). Then
+verify ticket criterion (b): "binding constraint is" in abstract still
+fails (existing negative, unchanged).
+
+Scope estimate: 4 durable files, ~+170/−40 LOC. No dependencies; no
+Blocked-by.

--- a/tickets/0557-demote-positive-prose-literal-adherence.erg
+++ b/tickets/0557-demote-positive-prose-literal-adherence.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-12T09:29Z HDMX-coding-agent created
+2026-06-12T14:10Z claude note raid-557 Imagine pass — drift verdict clean, inventory + triage table appended
 
 --- body ---
 ## Context
@@ -82,3 +83,73 @@ Policy decided with the author (2026-06-12 session):
 - [ ] No positive prose-literal assertion remains in CI
 - [ ] `docs/editorial-brief.md` exists and carries every demoted decision
 - [ ] Prose review path references the brief
+
+## Reimagined (raid 2026-06-12)
+
+Approach refinements (exit criteria unchanged):
+
+- **Drop the meta-test allowlist** (YAGNI). A grep meta-test can't
+  distinguish polarity (`assert X in` vs `assert X not in`) without complex
+  regex, and the allowlist needs maintenance on every legitimate addition.
+  Instead: state the policy in a project rule and let the verify-adherence
+  grep ratchet flag `assert .* in (abstract|conclusion|discussion|...)`
+  positives for review.
+- **The triage table below is the lookup record** — Execute applies it
+  inline; do not build per-assertion triage machinery.
+- **Content-fidelity anchors are mechanical, not prose pins**: assertions
+  that quote a *fixed external document* (Doc-07 prompt verbatim in annex)
+  or a structurally derived value verify content faithfulness, not
+  authorial wording — they stay.
+
+### Triage table — test_manuscript_cohort_and_caveats.py
+
+| Assertion | Class | Disposition |
+|---|---|---|
+| cohort counts 16/14 from TOML+CSV | mechanical | KEEP |
+| zero-good-run set from artifact | mechanical | KEEP |
+| abstract: no F1/ρ/τ/em-dash/"To our knowledge"/pooling | negative | KEEP |
+| abstract: `"lifecycle" in` | positive | demote: negative guard or brief ("177 plants = full-lifecycle register, not operating-only") |
+| abstract word cap <300 | mechanical | KEEP |
+| conclusion: exact "ρ = 0.92, pooled across models and in-sample" | positive | demote: negative form — if "ρ = 0.92" present, "pooled" + "in-sample" must accompany; exact phrasing → brief |
+| conclusion: exact "within-model signal positive but modest, \ref" | positive | demote: if ρ cited, annex-screen ref must appear; phrasing → brief |
+| discussion: "existence proof rather than a validated detector" | positive | demote: caveat-accompanies-ρ negative; phrasing → brief |
+| discussion: "tuned on the same 70 runs" | positive | demote: in-sample qualification must accompany ρ; phrasing → brief |
+| abstract: "binding constraint is" not in | negative | KEEP |
+| conclusion: "the evidence points toward a conjecture about why" | positive | demote → brief |
+| conclusion: "If the constraint is indeed the documents" | positive | demote → brief |
+| body: "suggests the binding constraint lies" | positive | demote: negative guard — flat-claim register banned in equalisation paragraph |
+| body: "appears to shift from model capability" | positive | demote: same negative guard |
+| intro per-cell provenance, cost-savings cut, nonmonotonicity dropped, demoted_phrasings loop | negative | KEEP |
+| novelty `survivors` loop (3 verbatim claims) | positive | demote: loose primacy-marker presence check (e.g. "no published") per section; verbatim claims → brief |
+| wikipedia seeding dates/revisions from PROVENANCE.md | mechanical | KEEP |
+| "built fleet"/"pipeline tail" | positive (low-risk factual) | borderline — keep OR demote; Plan decides, bias to keep (data-structure descriptors, not editorial framing) |
+| status-vocab: `{share}%` artifact check | mechanical | KEEP |
+| status-vocab: "controlled vocabulary"/"status accuracy" anchors | positive | demote phrase anchors → brief; keep share-% check |
+| analysis-cohort prompt matches shipped record | mechanical | KEEP |
+| body no longer attributes modules prompt to cohort | negative | KEEP |
+| annex statuses loop (re-derived from record) | mechanical | KEEP |
+| annex GEM-only negatives | negative | KEEP |
+| annex quote anchor ("primary-sourced reference inventory", …) | mixed | keep record-derivation check; demote annex quote anchor → brief |
+| annex Doc-07 verbatim anchors | content-fidelity | KEEP (quotes a fixed document, not prose) |
+
+### Triage table — test_manuscript_structure.py
+
+| Assertion | Class | Disposition |
+|---|---|---|
+| no-synopsis framing | negative | KEEP |
+| `\begin{abstract}` present | mechanical | KEEP |
+| "frontier"/"sota" in abstract | positive (loose topical) | KEEP — the frontier result is the paper's lead claim; note in brief |
+| has_hard_result 4-way OR | positive (already loosened) | KEEP — OR-pattern acts structural |
+| F1 stats from macros | mechanical | KEEP |
+| "0.92" in text | positive (fixed empirical value) | KEEP — note in brief: update manually if ρ changes |
+| affiliation / intro / conclusion / related-work present | mechanical | KEEP |
+
+### Risks carried forward
+
+1. IDH companion: review-pr-prose SKILL.md lives in `~/.claude` (IDH repo).
+   Exit criterion (c) needs at minimum the brief-check step added there via
+   IDH PR; file the companion ticket AND add the section, don't just note it.
+2. Novelty survivors: keep a weakened primacy-marker check in CI so the
+   three claims can't be silently dropped — the brief is review-time only.
+3. 0557 is independent of the reading-1 wave (test infra, not prose) —
+   safe in parallel.

--- a/tickets/0557-demote-positive-prose-literal-adherence.erg
+++ b/tickets/0557-demote-positive-prose-literal-adherence.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-06-12T09:29Z HDMX-coding-agent created
 2026-06-12T14:10Z claude note raid-557 Imagine pass — drift verdict clean, inventory + triage table appended
 2026-06-12T14:25Z claude note raid-557 Plan pass — concrete rewrites, day-one guard safety verified, IDH companion is existing ticket 0253
+2026-06-12T14:40Z claude note raid-557 Feasibility PASS — all paths/headings/phrases verified, baseline 22 passed; WARN: PR #1017 also touches .claude/rules/writing.md (rebase before merge)
 
 --- body ---
 ## Context
@@ -217,3 +218,32 @@ fails (existing negative, unchanged).
 
 Scope estimate: 4 durable files, ~+170/−40 LOC. No dependencies; no
 Blocked-by.
+
+## Feasibility (raid 2026-06-12): PASS
+
+Verified against the tree (commit a442dc24 base):
+
+- All 15 test functions present in test_manuscript_cohort_and_caveats.py.
+- Section headings exact: `\section{Need and potential for fusion}
+  \label{sec:fusion}` (827), `\section{Discussion}\label{sec:discussion}`
+  (860), `\section{Conclusion}\label{sec:conclusion}` (1091). NOTE:
+  Discussion PRECEDES Conclusion in this manuscript.
+- ρ = 0.92 at lines 977 (Discussion), 1114 (Conclusion, already carries
+  "pooled across models and"), 2377 (annex — out of guard scope; scope
+  the conditional guards to Discussion/Conclusion extraction only).
+- "operating plants" absent from abstract block — new negative guard
+  green day one. Hedge phrases present (820, 2493).
+- "no published benchmark or" present in fusion section.
+- docs/editorial-brief.md absent; .claude/rules/writing.md present.
+- IDH ticket 0253 exists, open, title matches; review-pr-prose
+  SKILL.md ## Setup step 2 = "Read the diff of the merge request." —
+  insert the brief check as step 2b after it.
+- Baseline: both prose test files → 22 passed.
+
+WARN (cross-PR): open PR #1017 (t0558 em-dash sweep) touches
+.claude/rules/writing.md, slides/manuscript/main.tex, and adds
+tests/test_manuscript_em_dash.py. Only 2 PRs share writing.md → no
+coordination PR; rebase onto origin/main before opening and again
+before merging. Note 1017 converts prose "---" to Unicode "—"; the
+abstract em-dash negative guard in this ticket's file is KEEP-unchanged
+and the abstract currently has no em-dash, so no interaction expected.

--- a/tickets/closed/0557-demote-positive-prose-literal-adherence.erg
+++ b/tickets/closed/0557-demote-positive-prose-literal-adherence.erg
@@ -2,6 +2,7 @@
 Title: Demote positive prose-literal adherence tests to negative guards + editorial brief
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1020
 
 --- log ---
 2026-06-12T09:29Z HDMX-coding-agent created
@@ -11,6 +12,7 @@ Author: HDMX-coding-agent
 2026-06-12T15:00Z claude note executed — demotions per triage, brief 13 entries, polarity rule appended; gates a/b + fang verified on scratch copies; IDH companion already merged upstream (IDH PR #393, ticket 0253 closed there)
 2026-06-12T15:55Z claude note raid-557 review round 1 — brief field renamed to Ticket: (skill schema), 14th entry annex-quote-anchor, polarity rule third category, constraint-shift guard rescoped to binding-constraint + negation-tolerant, executed-log timestamp corrected (was 10:42Z stale clock)
 
+2026-06-12T11:08Z HDMX-coding-agent closed — autoclosed — PR #1020
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0557-demote-positive-prose-literal-adherence.erg

## Summary

Implements the CI test polarity policy (author decision, 2026-06-12): prose adherence tests keep only mechanical checks and *negative/conditional* guards; positive editorial intent moves to a review-time editorial brief.

### Demotions in `tests/test_manuscript_cohort_and_caveats.py` (per the ticket's triage table)

| Disposition | Count | Detail |
|---|---|---|
| Positive pin → negative guard | 2 | abstract `"lifecycle" in` → `"operating plants"`/`"operating-only"` forbidden; status-vocab phrase anchors dropped (artifact-derived ~38% share kept) |
| Positive pin → conditional negative | 2 | ρ = 0.92 caveats: IF cited in conclusion/Discussion THEN pooled/in-sample/existence-proof markers must accompany (extractions bounded before `\appendix`, annex ρ out of scope) |
| Positive pin → sentence-scoped hedge check | 3 | any "binding constraint is/lies/shift" sentence must carry conjecture/epistemic framing (replaces 4 verbatim sentence pins) |
| Positive pin → loose structural anchor | 1 | 3 verbatim novelty-claim sentences → ≥2 primacy-marker sentences in §fusion + STANAG two-grain vocabulary in Discussion |
| KEEP (mechanical / negative / content-fidelity) | rest | cohort counts, zero-good-run set, abstract negatives, demoted-phrasings ratchet, Wikipedia provenance, Doc-07/baseline prompt verbatim anchors |

`tests/test_manuscript_structure.py` unchanged (all triaged KEEP). Mechanical files (crossref, macros, abstract_numbers, no_inline_plots) untouched. `slides/manuscript/main.tex` untouched.

### New artifacts

- `docs/editorial-brief.md` — 13 standing editorial decisions (H2 + **Decision/Rationale/Originating ticket/Status**), including 3 entries documenting checks deliberately KEPT in CI (frontier-result-abstract, rho-value-static, built-fleet-pipeline-tail).
- `.claude/rules/writing.md` — new "CI test polarity rule (ticket 0557)" section.

## Verification evidence

- **Gate (a)** — scratch copy of main.tex with three hedged sentences reworded (same meaning, different words: conclusion ρ caveat, equalisation hedge, conclusion conjecture): all new guards stay GREEN (the old verbatim pins would have failed all three).
- **Gate (b)** — scratch copy with "the binding constraint is the documents" injected flatly into the abstract: goes RED via the kept negative guard (`AssertionError: abstract must not state the binding-constraint claim as a flat finding`). No manuscript changes committed.
- **Fang check** — scratch copy with the in-sample caveat stripped from the conclusion ρ sentence: goes RED (`conclusion cites ρ = 0.92 without the pooled/in-sample caveat`) — the demoted guards keep teeth.
- Before/after symmetry: 22 prose tests passed before and after the rewrite on unmodified text.
- `make check` green post-rebase: 2553 passed, 5 skipped, 1 xfailed (coverage run) + 39 passed (slow run).

## Cross-PR notes

- **writing.md overlap with #1017 (t0558)**: resolved — #1017 merged while this branch was in flight; this branch is rebased on top of it and the polarity section appends after the em-dash rule. No conflict remains.
- **IDH companion (exit criterion c)**: already shipped upstream — IDH PR #393 (MERGED, https://github.com/MinhHaDuong/ImperialDragonHarness/pull/393) added the editorial-brief auditor to `review-pr-prose/SKILL.md` (per-entry upheld/violated/not-touched verdict table, silent skip when the brief is absent), and IDH ticket 0253 was closed and archived there by a parallel session. No new IDH PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)