### PR TITLE
manuscript: rewrite abstract, restructure introduction

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -246,3 +246,33 @@ immutable.
 **Ticket:** 0511; triaged keep-in-CI by 0557.
 
 **Status:** active
+
+## intro-contributions-runin
+
+**Decision:** §1 closes with the contributions woven into prose (author
+intro restructure, 2026-06-12, PR #1023); the earlier bold
+"Contributions." run-in label with a three-item list (0513) is no longer
+pinned. CI keeps only the negative guard: contributions never get their
+own section heading.
+
+**Rationale:** Authorial phrasing/structure choice — positive pin
+demoted per the CI polarity rule (0557). The framing history lives here,
+not in a test.
+
+**Ticket:** 0513; demoted during PR #1023 gate (residual missed by 0559
+sweep, which covered test_manuscript_0512_structure.py only).
+
+**Status:** active
+
+## plausible-text-generator
+
+**Decision:** The "plausible-text generator" phrase (0513 reframing of
+"random words generator") is no longer pinned positively; the abstract
+rewrite (PR #1023) rephrased it. CI keeps the negative guard:
+"random words generator" never returns.
+
+**Rationale:** Same polarity-rule demotion as above.
+
+**Ticket:** 0513; demoted during PR #1023 gate.
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -87,26 +87,20 @@ Fleet\thanks{Technical report of the communication: ``Beyond RAG: Stateful-Agent
 \maketitle
 
 \begin{abstract}
-Open energy-system models need plant-level data that
-are complete, dated, and traceable to sources, yet across much of the
+Energy policy models need asset-level data that are complete, current, historical and prospective,
+and traceable to authoritative primary sources. Yet across much of the
 world these data arrive late or incomplete.
 We introduce a computable benchmark for this task: reconstruct the
 register of Vietnam's \NumRefPlants{} thermal power plants and score the result
-against a hand-compiled, fully sourced reference. The register spans the
-whole project lifecycle: proposed and planned projects as well as
-operating, cancelled, and retired plants. It is historical, current and prospective.
+against a hand-compiled, comprehensive reference.
 We find that the task is hard for today's AI systems.
-First, fourteen language models answering from memory recovered much less than Wikipedia lists, even if these lists presumably sat in their training corpus for years.
-Second, enabling web access and extended reasoning improved coverage over the memory-only query in only one of the four frontier agents.
-Third, introducing a harness in which agents were given the opportunity to plan and execute multi-step search and reasoning degraded results.
-Finally, handing the agents a curated document set did improve coverage, especially for the initially weaker agents.
-Complementary experiments suggest ways forward. Since the goal is to discover the statistical register, it is necessary to be able to screen out weak models without the ground truth, and we found that scoring the internal coherence of replies allows it. Fusing the lists from multiple runs is effective.
-We conclude that an evergreen statistical-quality register requires more knowledge engineering. We propose that statistical datasets should be derived as dated snapshots from a sourced, auditable knowledge base, mechanically updated to assimilate the evidential corpus harvested periodically. Humans can stay in the loop to vet information sources and resolve the authentic hard statistical questions.
+Fourteen language models answering from memory recovered much less than the Wikipedia lists contain, even though these lists had presumably been in their training corpora for years. We observed that internal coherence metrics correlate with accuracy, allowing us to screen out weak runs without the reference. We then tested the commercial frontier of mid-2026: four agentic systems with web access and extended reasoning. Only one of them improved coverage over the memory-only query, and a harness giving them the opportunity to plan and execute a multi-step reply degraded the results. Handing the agents a curated document set did improve coverage, especially for the initially weaker agents. Fusing the lists from multiple runs more than doubles recall.
+We conclude that an evergreen statistical-quality register requires deliberate knowledge engineering. We propose that datasets should be derived as dated snapshots from a sourced, auditable knowledge base, mechanically updated to assimilate a periodically harvested evidential corpus. Humans can stay in the loop to vet information sources and resolve the tail of hard statistical questions.
 \end{abstract}
 
 \section{Introduction}\label{sec:intro}
 
-Open energy-system models such as PyPSA-ASEAN
+Energy policy models such as PyPSA-ASEAN
 \citep{PyPSAmeetsEarth2025:pypsa-asean} need power-plant
 inventories that are complete, accurately dated, and traceable to
 primary sources — the data infrastructure for quasi-real-time policy
@@ -116,51 +110,51 @@ arrive late, incomplete, or under licences that forbid redistribution,
 even though the underlying information is already public — scattered
 across project documents, master plans, environmental assessments,
 operator reports, and press releases. The general problem behind the
-specific one is older than AI: science needs knowledge, not opinions.
-Statistical work requires facts that are sourced, reproducible, and
-auditable, not fluent output from a plausible-text generator somewhere
-in the cloud.
+specific one is older than AI: statistical work requires facts that
+are sourced, reproducible, and auditable, and fluent but unsourced
+text does not qualify.
 
-This paper addresses a concrete task, building a complete, sourced
-inventory of Vietnam's thermal power plants, as a lens for evaluating
-whether AI systems can yet produce research-grade statistical data.
+This paper uses a concrete task — building a complete, sourced
+inventory of Vietnam's thermal power plants — as a lens for
+evaluating whether AI systems can yet produce research-grade
+statistical data.
 Computable benchmarks, tasks whose success criteria a machine can check,
 are how knowledge engineering and AI research have long measured
 progress, from knowledge-base construction with language models
 \citep{Petroni-Fabio2019:lm-as-kb, Singhania-Sneha2022:lm-kbc} to the
 benchmark suites that rank today's systems \citep{Hendrycks-Dan2021:mmlu,
 Ni-Shiwen2025:llm-benchmark-survey}; this paper extends the practice to
-national statistical registers. Three results stand out. First, we offer
-a new computable benchmark, scored against a hand-compiled, fully
-sourced reference. We use \emph{benchmark} in the narrow sense of a
-frozen task definition, a public gold reference, and a computable
-metric — not a suite or a leaderboard — and the design measures
-training-data contamination, as a parametric ceiling, rather than
-trying to prevent it. Second, the task is hard for today's agents: neither
-model memory nor web access yields a complete, well-sourced register.
-Third, reference-free coherence criteria suffice to screen out the
-weakest models.
+national statistical registers.
 
-\textbf{Contributions.} This paper makes three contributions.
+This paper makes three contributions, each reusable beyond the
+Vietnamese case. The first is the benchmark itself: to our knowledge,
+the first sourced evaluation of AI agents on national power-plant
+inventory construction, scored against a hand-compiled, fully sourced
+reference, with per-row citation coverage and corroboration measured
+(the paper counts and checks the presence of citations; it does not
+verify each cited source against each cell). We use \emph{benchmark}
+in the narrow sense: a frozen task definition, a public gold
+reference, and a computable metric — not a suite or a leaderboard —
+and the design measures training-data contamination as a
+parametric ceiling rather than trying to prevent it. The second is a
+four-dimension quality bar: per-row scoring of LLM-generated
+statistical tables on accuracy, coherence, provenance, and
+temporality. The third is two-grain credibility/reliability scoring:
+a run-level credibility screen and a model-level reliability grade,
+by analogy with the NATO Admiralty grading of STANAG 2511, which
+rates the credibility of each report separately from the reliability
+of its source.
 
-\begin{itemize}
-\tightlist
-\item
-  \emph{Benchmark gap.} To our knowledge, the first sourced evaluation
-  of AI agents on national power-plant inventory construction, scored
-  against a held-out reference, with per-row citation coverage and
-  corroboration measured (the paper counts and checks the presence of
-  citations; it does not verify each cited source against each cell).
-\item
-  \emph{Per-row provenance × temporality scoring.} A four-dimension
-  quality bar (accuracy, coherence, provenance, temporality) applied to
-  LLM-generated statistical tables.
-\item
-  \emph{Two-grain credibility/reliability scoring.} A run-level
-  credibility screen and a model-level reliability grade, by analogy
-  with the NATO Admiralty grading of STANAG 2511 (run-level information
-  credibility versus model-level source reliability).
-\end{itemize}
+Three empirical results stand out. First, the task is hard for
+today's AI systems: neither model memory nor web access yields a
+complete, well-sourced register, and a harness that lets the agents
+plan and execute a multi-step reply degrades rather than improves the
+result. Second, reference-free coherence criteria suffice to screen
+out the weakest runs. Third, targeted pipeline design narrows the
+gap: provisioning the agents with a curated document set improves
+coverage, and fusion reuses existing runs to good effect — pooling
+runs across models more than doubles recall, while requiring
+cross-model agreement nearly eliminates false positives.
 
 We situate the work against the existing open
 power-plant databases (§\ref{sec:related-empirical}), define a

--- a/tests/test_manuscript_framing_0513.py
+++ b/tests/test_manuscript_framing_0513.py
@@ -14,7 +14,6 @@ Guards the prose-quality changes that ticket 0513 lands on
    Parmenides/Heraclitus philosophy genealogy.
 """
 
-import re
 
 import pytest
 from manuscript_source import body
@@ -34,27 +33,23 @@ def _section_1_body() -> str:
     return md[start:end]
 
 
-def test_contributions_list_at_end_of_section_1() -> None:
-    """A Contributions run-in label plus three list items live inside §1."""
+def test_no_contributions_heading() -> None:
+    """Negative guard only: contributions must not get their own heading.
+
+    The positive pin on the bold run-in label was demoted to
+    docs/editorial-brief.md (CI polarity rule, 0557; author intro
+    rewrite 2026-06-12 restructured §1).
+    """
     sec1 = _section_1_body()
-    assert "\\textbf{Contributions.}" in sec1, (
-        "§1 must end with a bold 'Contributions.' run-in label, not a heading"
-    )
-    # Three list items: count \item bullets after the label.
-    tail = sec1[sec1.index("\\textbf{Contributions.}") :]
-    items = re.findall(r"\\item\b", tail)
-    assert len(items) >= 3, (
-        f"Contributions list should name three contributions; found {len(items)} items"
+    assert "\\section{Contributions}" not in sec1 and "\\subsection{Contributions}" not in sec1, (
+        "contributions stay inside §1 prose, never a separate heading"
     )
 
 
 def test_plausible_text_generator_reframing() -> None:
     md = _md()
-    assert "plausible-text generator" in md, (
-        "the 'plausible-text generator' reframing must be present"
-    )
     assert "random words generator" not in md, (
-        "'random words generator' must be replaced by 'plausible-text generator'"
+        "'random words generator' was reframed away (0513); never reintroduce it"
     )
 
 


### PR DESCRIPTION
Ticket: none

## Summary

- Abstract rewritten (author): leads with the data-need framing, enumerates the empirical findings, plus line edits (explicit Wikipedia comparison, "even though … corpora", fusion claim grounded as "more than doubles recall", "deliberate knowledge engineering").
- Introduction middle restructured: the former "Three results" paragraph and the Contributions itemize overlapped and contradicted each other ("held-out" vs "public gold reference"). Now two prose paragraphs — contributions (benchmark with its narrow-sense definition and contamination-ceiling disclaimer, four-dimension quality bar, two-grain Admiralty-style scoring) then empirical results (hard task incl. harness degradation, run-level coherence screen, curated documents + fusion levers). Itemization and \textbf tag dropped per author preference.
- Coherence screen now consistently operates on "runs" (was "models"), matching the run-level/model-level distinction of the two-grain scoring.
- Polemical close of the opening paragraph flattened; stacked appositives in the task sentence resolved with em-dashes.
- Em dashes in the new text use the Unicode glyph per ticket 0558; rebased onto current main (post-0557/0558/0559).

## Verification

- 34 manuscript adherence tests pass (em-dash, crossref, macros, cohort/caveats).
- Model counts (Fourteen / 14 / four) deliberately left hand-typed for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)