### PR TITLE
tickets(0560-0563): manuscript back-half restructure — tracker + de-anchor/main-text/annex children

### DIFF
--- a/tickets/0560-restructure-manuscript-back-half-tracker.erg
+++ b/tickets/0560-restructure-manuscript-back-half-tracker.erg
@@ -1,0 +1,68 @@
+%erg 0.1
+Title: Restructure manuscript back half — tracking ticket (Extensions / Discussion / Future research / Conclusion + annex reorder)
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T13:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The narrative arc of `slides/manuscript/main.tex` breaks at §7: "Need and
+potential for fusion" is a two-paragraph trailer for Annex H; the Discussion
+mixes instrument critique, a smuggled result (the reference-free screen,
+contribution #3 of the intro), and the research programme; "Related Work —
+Methods" sits unnumbered between Discussion and Conclusion ending on a
+backward-looking gap statement; the conference questions (why is it hard,
+fusion, role of the knowledge graph) are scattered or annex-only.
+
+Author approved (2026-06-12 session) the following target structure:
+
+Main text, §1–§6 unchanged, then:
+- §7 **Extensions** — framing paragraph marking these as post-hoc analyses
+  prompted by the conference, then four subsections:
+  1. Why is the task hard? (recognition matrix + status composition)
+  2. Screening without a reference (screen promoted out of Discussion)
+  3. Can runs be fused? (union recall gain, two-model vote gate)
+  4. What system do the findings imply? (cell = KG triple, fusion =
+     triple-set merging, narrative KB → dated-snapshot projection;
+     promoted from Annex H prose)
+- §8 **Discussion** — instrument critique only (F1 limits, matcher limits,
+  interday drift, refusal-as-evidence, external coherence, N=1)
+- §9 **Future research** — numbered; absorbs "Related Work — Methods" as its
+  opening ("lessons from the field"), then the programme ("how we will use
+  them"): capture–recapture + LP bounds, external-coherence metric, T2 event
+  log, screen industrialisation, replication. No unnumbered section remains.
+- §10 **Conclusion** — slimmed to verdict + investment claim
+- No companion-paper promises anywhere (4 occurrences stripped)
+
+Annexes, each behind a `\clearpage`, grouped method / investigation / support:
+- A. Experiment 1: technical specification
+- B. Experiment 2: technical specification (absorbs fig coverage-certainty)
+- C. Recognition matrix and status composition
+- D. Aggregation sweep and vote gate
+- E. Run-grain screen validation
+- F. Capability rollout (absorbs fig capability-dag + referencing sentence)
+- G. Temporality: state vs. event representations
+- "Supplementary figures" annex dissolved.
+
+Label-stability contract: all existing `\label{}` names (sec:fusion,
+sec:discussion, sec:annex-*) stay attached to their content as it moves;
+tests and the editorial brief anchor on labels, never on letters, numbers,
+titles, or adjacency.
+
+## Children
+
+- 0561 — de-anchor adherence tests + editorial brief from section structure
+  (lands FIRST; makes the restructure CI-safe)
+- 0562 — main-text restructure (Blocked-by: 0561)
+- 0563 — annex reorder, page breaks, suppfigs dissolution (Blocked-by: 0562)
+
+## Exit criteria
+
+- [ ] All three children closed
+- [ ] Integration review (/roar step 8): re-read child diffs together, full
+  `make check`, manuscript builds, arc reads results → extensions →
+  discussion → future research → conclusion
+- [ ] No companion-paper promise and no unnumbered mid-paper section remains

--- a/tickets/0561-de-anchor-adherence-tests-and-brief-from.erg
+++ b/tickets/0561-de-anchor-adherence-tests-and-brief-from.erg
@@ -1,0 +1,100 @@
+%erg 0.1
+Title: De-anchor adherence tests and editorial brief from manuscript section structure (label-keyed extraction)
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T13:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Tracking ticket 0560 restructures the manuscript back half. Several
+adherence tests slice manuscript sections with full
+`\section{Title}\label{label}` string matches AND terminate the slice at
+the heading of whichever section happens to follow (e.g.
+`test_manuscript_annex_c_as_run.py::_annex_c` ends at the "Supplementary
+figures" heading — a section 0563 deletes). Any retitle, reorder, or
+deletion breaks them, so the restructure PRs would be CI-blocked or forced
+to bundle test rewrites with prose moves.
+
+This ticket makes extraction label-keyed BEFORE the restructure: a section
+is found by its `\label{}` (stable identifier contract, recorded in 0560)
+and sliced to the next `\section` command, whatever it is. Titles, annex
+letters, and adjacency become free to change. This is mechanical re-keying
+only — no assertion is weakened, no manuscript change, no new structure
+pre-implemented. Distinct from ticket 0559 (polarity triage of two
+vocabulary pins in the same file family — no overlap).
+
+Known exception: `test_manuscript_0512_structure.py` asserts the OLD
+decision ("Related Work — Methods" unnumbered, before Conclusion). That is
+a decision pin, not an anchor; it cannot be de-anchored without changing
+the decision. It is updated in 0562's PR together with the prose change.
+Here, only re-key its *extraction* mechanics if any; leave its decision
+assertions intact.
+
+## Relevant files
+
+- `tests/manuscript_source.py` — add `section(label: str) -> str` helper:
+  locate `\label{<label>}` on a `\section`/`\section*` line, slice to the
+  next sectioning command (or `\appendix`/`\end{document}`)
+- `tests/test_manuscript_annex_c_as_run.py` — re-key `_annex_c()` to
+  `section("sec:annex-exp2")`; rename file to
+  `test_manuscript_exp2_annex_as_run.py` (its name encodes the letter C;
+  docstring records two previous letter-churn renames — this ends that)
+- `tests/test_manuscript_cohort_and_caveats.py` — lines ~149–290: replace
+  title+adjacency splits (`sec:fusion`, `sec:discussion`, Conclusion) with
+  the helper
+- `tests/test_manuscript_exp2_equalization.py` — same re-keying
+- `tests/test_manuscript_0512_structure.py` — extraction mechanics only
+- `docs/editorial-brief.md` — entries fusion-hedge, novelty-benchmark-gap,
+  novelty-conjunction-claim: reword section references to label form
+  ("the section labelled `sec:fusion`") so they survive the move; add a
+  brief entry recording the label-stability contract from 0560
+
+## Actions
+
+1. Implement `section(label)` in `tests/manuscript_source.py` with a clear
+   error message when the label is absent.
+2. Re-key each listed test to the helper; delete local slicing code.
+3. `git mv tests/test_manuscript_annex_c_as_run.py
+   tests/test_manuscript_exp2_annex_as_run.py`; update docstring (letters
+   out, labels in).
+4. Update `docs/editorial-brief.md` section references to label form; add
+   the label-stability-contract entry (**Decision:** / **Rationale:** /
+   **Ticket:** 0560 / **Status:** active).
+5. Sweep remaining `tests/test_manuscript_*.py` for other
+   title/adjacency/letter anchors; re-key any found (mechanical checks on
+   headings that ARE the assertion target, e.g. frontmatter/backmatter
+   presence, stay as-is).
+
+## Test
+
+- Red step first: in a scratch copy of `main.tex`, swap the order of two
+  annexes and retitle one section (labels unchanged) — current
+  `_annex_c()`-style extraction fails; after re-keying, the same
+  perturbation applied via monkeypatched `body()` passes extraction. Write
+  this as `tests/test_manuscript_source_section.py` unit tests of the
+  helper (label found, label absent, last-section slice, robustness to
+  retitle/reorder of a synthetic document).
+
+## Verification
+
+- [ ] `make check` green before and after (no manuscript change in this PR)
+- [ ] Grep proof: no `\section{` full-title split remains in the re-keyed
+  tests except where the heading itself is the assertion target
+- [ ] Brief entries reference labels, not section numbers/letters
+
+## Invariants
+
+- No assertion weakened or deleted; negative guards untouched
+- `slides/manuscript/main.tex` untouched
+- Decision pins in `test_manuscript_0512_structure.py` intact
+
+## Exit criteria
+
+- [ ] All manuscript section/annex extraction in tests goes through the
+  label-keyed helper
+- [ ] Reordering or retitling sections (labels kept) cannot break any
+  adherence test except intentional decision pins
+- [ ] `make check` passes

--- a/tickets/0562-manuscript-main-text-restructure-extensi.erg
+++ b/tickets/0562-manuscript-main-text-restructure-extensi.erg
@@ -1,0 +1,138 @@
+%erg 0.1
+Title: Manuscript main-text restructure — Extensions section, slimmed Discussion, Future research absorbs Related Work — Methods
+Created: 2026-06-12
+Author: HDMX-coding-agent
+Blocked-by: 0561
+
+--- log ---
+2026-06-12T13:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Child of tracker 0560 (target structure recorded there; author-approved).
+This ticket reshapes the main text after §6. Core moves: §7 "Need and
+potential for fusion" (a two-paragraph trailer) is replaced by an
+**Extensions** section gathering the post-hoc analyses prompted by the
+conference; the reference-free screen — contribution #3 in the intro, yet
+currently a Discussion paragraph — is promoted into it; "Related Work —
+Methods" (unnumbered, a sore thumb) merges into a numbered **Future
+research** section as its "lessons from the field" opening; the Conclusion
+slims; all companion-paper promises go.
+
+Label-stability contract (0560): moved content KEEPS its existing labels
+(`sec:fusion` stays on the fusion subsection, `sec:discussion`,
+`sec:conclusion` stay). New subsections get new labels. Tests are
+label-keyed after 0561, so prose moves do not break extraction; only the
+decision pins listed below change, in this same PR.
+
+## Relevant files
+
+- `slides/manuscript/main.tex` — all prose moves (single file)
+- `tests/test_manuscript_0512_structure.py` — decision pins on the OLD
+  structure (unnumbered RW—Methods before Conclusion): update to pin the
+  NEW decision (numbered Future research section exists; no unnumbered
+  `\section*{Related Work` remains in the body)
+- `docs/editorial-brief.md` — update fusion-hedge / novelty entries if
+  their conditional-negative guards reference the fusion *section* role;
+  add entry for the no-companion-paper-promise decision
+- `.claude/rules/writing.md` § CI polarity — no change, but the §fusion
+  loose guard (≥2 primacy-marker sentences) must keep counting inside the
+  moved `sec:fusion` subsection
+
+## Actions
+
+1. **§7 Extensions** (`\section{Extensions}\label{sec:extensions}`), one
+   framing paragraph: these analyses were performed after the conference
+   presentation, responding to audience questions; exploratory, not
+   registered. Conference named once here (and in Acknowledgements), not
+   in any heading. Four subsections:
+   a. *Why is the task hard?* `\label{sec:ext-difficulty}` — 2–3 ¶ from
+      the Discussion paragraph "From noisy runs to fused estimates"'s
+      recognition-matrix half + Annex recognition summary: status
+      composition makes low recognition structural (proposed plants
+      dominate the list; parametric memory cannot know them). Pointer to
+      the recognition annex.
+   b. *Screening without a reference* — keep/move `\label` usage
+      consistent: reuse existing screen prose from Discussion ("Internal
+      coherence rejects the weakest runs...", ρ = 0.92, in-sample caveat
+      REQUIRED next to ρ per brief entry, Admiralty two-grain framing).
+      Pointer to screen-validation annex.
+   c. *Can runs be fused?* `\label{sec:fusion}` (label preserved) —
+      current §7 content minus promises: union gain, vote gate, numbers
+      via existing macros. Pointer to fusion annex.
+   d. *What system do the findings imply?* `\label{sec:ext-system}` —
+      promote Annex H architecture prose (stateful pipeline, managed
+      auditable KB, narrative inventory → dated-snapshot projection; cell
+      = KG triple, table fusion = triple-set fusion with conflict
+      resolution/source authority/temporal versioning; LLM value at the
+      hard cases). Demonstrating per-cell provenance × temporal validity
+      stays *future work*, no paper promised.
+2. **§8 Discussion** — remove the promoted screen paragraphs and the
+   research-programme tail ("From noisy runs to fused estimates" moves:
+   difficulty half to 1a, estimation half to Future research). Keep:
+   opening reading (rewire its §-refs), F1 aggregate/conflation, matcher
+   + grain limits, interday drift, refusal-as-evidence, external
+   coherence, N=1. Rewrite the N=1 paragraph's last sentence ("the next
+   paragraph") to point at the Future research section.
+3. **§9 Future research** (`\section{Future research}\label{sec:future}`)
+   — absorb the four "Related Work — Methods" review paragraphs as the
+   opening ("lessons from the field"; keep all citations, strict budget
+   per writing rules); REWRITE the closing gap paragraph from
+   backward-looking ("the gap this paper addresses") into the bridge
+   ("how we will use these lessons"); then the programme: estimation
+   (capture–recapture, LP bounds vs control totals \citep{HaDuong2005}),
+   principled external-coherence metric, T2 event-log temporality,
+   screen industrialisation (two-grain scoring in the standard pipeline),
+   replication beyond Vietnam. Delete `\section*{Related Work — Methods}`
+   and its `\addcontentsline`.
+4. **§10 Conclusion** — slim: verdict (task hard, twice established),
+   conjecture (constraint is the data), the two levers in one or two
+   sentences each (keep the ρ = 0.92 in-sample caveat if ρ is kept —
+   conditional guard), investment claim. Strip "deferred to a planned
+   cross-evaluation" promise (rephrase as not-measured-here scoping).
+5. **Roadmap paragraph** (§1, last ¶) — rewrite to narrate the new arc:
+   ... measure (§exp1), test frontier (§exp2), extend with post-hoc
+   analyses (§extensions), discuss instrument limits (§discussion),
+   programme (§future), conclude. Symbolic \ref only.
+6. **Promise strip (body)**: delete/rephrase the §fusion "companion paper
+   in preparation (working title ...)" sentence and the "follow-on paper"
+   contribution sentence; Conclusion per action 4. (Annex A's "subsequent
+   paper" sentence belongs to 0563.)
+7. Update `test_manuscript_0512_structure.py` decision pins (same PR);
+   sweep `\ref{sec:fusion}` call sites — §quality line ~348 and
+   Conclusion — still read correctly now that sec:fusion is a subsection.
+
+## Test
+
+- Red step: extend `test_manuscript_0512_structure.py` — assert a numbered
+  `\section{Future research}` exists containing both a methods-review
+  citation (e.g. `Petroni-Fabio2019:lm-as-kb`) and a programme keyword,
+  and assert no `\section*{Related Work` remains in the body. Red on
+  current main.tex, green after the restructure.
+
+## Verification
+
+- [ ] `make check` green (incl. crossref test: every \ref resolves)
+- [ ] Manuscript builds (tectonic via the manuscript Makefile rule)
+- [ ] No `companion paper`, `follow-on paper`, `planned cross-evaluation`
+  match in the body (grep)
+- [ ] §fusion loose guard still counts ≥2 primacy markers inside the moved
+  subsection
+- [ ] Roadmap paragraph mentions no dead section
+
+## Invariants
+
+- All empirical numbers stay macro-sourced (no hand-typed values)
+- Existing labels preserved on moved content; no orphaned \label
+- Negative guards and the in-sample-caveat conditional guard untouched
+- §1–§6 prose unchanged except the roadmap paragraph
+
+## Exit criteria
+
+- [ ] New arc in place: Extensions (4 subsections incl. promoted screen) →
+  Discussion (instrument critique only) → Future research (numbered,
+  lessons + programme, RW—Methods gone) → slim Conclusion
+- [ ] No unnumbered section between §6 and the backmatter
+- [ ] No companion-paper promise in the main text
+- [ ] `make check` passes

--- a/tickets/0563-annex-reorder-clearpage-dissolve-suppfig.erg
+++ b/tickets/0563-annex-reorder-clearpage-dissolve-suppfig.erg
@@ -1,0 +1,95 @@
+%erg 0.1
+Title: Annex reorder (method / investigation / support), \clearpage per annex, dissolve Supplementary-figures annex
+Created: 2026-06-12
+Author: HDMX-coding-agent
+Blocked-by: 0562
+
+--- log ---
+2026-06-12T13:30Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Child of tracker 0560. Current annex order leads with a conceptual scoping
+note (Temporality), buries the investigation annexes, and carries a
+"Supplementary figures" annex that is two unanchored floats with no prose —
+as typeset, the heading can sit orphaned on an empty section. Target order
+(approved, grouping method → investigation → support):
+
+- A. Experiment 1: technical specification        (sec:annex-exp1)
+- B. Experiment 2: technical specification        (sec:annex-exp2)
+- C. Recognition matrix and status composition    (sec:annex-recognition)
+- D. Aggregation sweep and vote gate              (sec:annex-fusion)
+- E. Run-grain screen validation                  (sec:annex-screen)
+- F. Capability rollout: per-lab shipping order   (sec:annex-rollout)
+- G. Temporality: state vs. event representations (sec:annex-temporality)
+
+Labels stay; only block order changes (0561 made tests order-agnostic).
+Every annex starts on a new page.
+
+## Relevant files
+
+- `slides/manuscript/main.tex` — annex block reorder after `\appendix`;
+  `\clearpage` insertions; suppfigs dissolution; body \ref retargeting
+- `tests/test_manuscript_figure_style.py` (and crossref test) — should
+  pass unchanged; check for suppfigs references
+
+## Actions
+
+1. Reorder the annex `\section` blocks to the target order (move whole
+   blocks; content untouched except as below).
+2. Insert `\clearpage` immediately before each annex `\section` (the
+   recognition annex's `\includepdf` already page-breaks internally;
+   still give the section heading its own `\clearpage`).
+3. Dissolve `\section{Supplementary figures}` (sec:annex-suppfigs):
+   - `fig:coverage-certainty` figure block → Experiment 2 annex
+     (Evaluation or Arms subsection, nearest to its discussion); retarget
+     the two §exp2 body refs (`\ref{sec:annex-suppfigs}` at ~684, ~793)
+     to `\ref{sec:annex-exp2}` or directly to
+     `Figure~\ref{fig:coverage-certainty}` where the sentence reads
+     better.
+   - `fig:capability-dag` figure block → Capability rollout annex; it is
+     referenced NOWHERE in the body — add one referencing sentence in the
+     rollout annex ("Figure~\ref{fig:capability-dag} aggregates these
+     transitions...") tying it to the existing transition-matrix prose.
+   - Delete the empty section and the `sec:annex-suppfigs` label; grep to
+     confirm zero remaining references.
+4. Strip the Annex Temporality companion-paper promise ("that design
+   choice is deferred to a subsequent paper" → "that design choice is out
+   of scope here" or equivalent); also re-check its §-refs (it cites
+   sec:fusion and sec:exp2) still read correctly post-0562.
+5. Rebuild and eyeball the PDF: each annex opens on a fresh page; S-series
+   figure numbering re-flows consistently; recognition-matrix
+   `\refstepcounter`+`\includepdf` block intact.
+
+## Test
+
+- Red step: adherence test (extend an existing manuscript-structure test
+  file) asserting (a) `sec:annex-suppfigs` absent, (b) every annex
+  `\section` after `\appendix` is immediately preceded by `\clearpage`,
+  (c) `fig:capability-dag` is `\ref`'d at least once. Red on current file,
+  green after.
+
+## Verification
+
+- [ ] `make check` green (crossref: all \ref resolve; figure-style test)
+- [ ] Manuscript builds; visual check of annex page starts and the
+  three-page recognition matrix
+- [ ] No reference to sec:annex-suppfigs anywhere
+- [ ] Annex letters in the PDF match the target table above
+
+## Invariants
+
+- All `sec:annex-*` labels preserved (suppfigs deleted by design)
+- Annex CONTENT unchanged except the two figure relocations, the one new
+  referencing sentence, and the promise strip
+- The `\theHfigure`/S-counter preamble block after `\appendix` intact
+
+## Exit criteria
+
+- [ ] Annex order = method / investigation / support as listed
+- [ ] Each annex starts on a new page
+- [ ] Supplementary-figures annex gone, both figures live in their
+  natural annexes, DAG figure referenced
+- [ ] No companion-paper promise remains anywhere in the manuscript
+- [ ] `make check` passes


### PR DESCRIPTION
Files four tickets for the manuscript back-half restructure approved in today's session: tracker 0560 (target structure + label-stability contract), 0561 de-anchor adherence tests/brief (lands first, makes the restructure CI-safe), 0562 main-text restructure (Extensions w/ promoted screen, Future research absorbs Related Work — Methods), 0563 annex reorder + clearpage + suppfigs dissolution.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)