### PR TITLE
t0561: label-keyed section extraction for manuscript adherence tests

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -99,9 +99,10 @@ negative: any sentence containing "binding constraint lies" must contain
 
 ## fusion-hedge
 
-**Decision:** The constraint-shift claim (annex-fusion architecture
-paragraph) is hedged — current phrasing "the binding constraint appears to
-shift from model capability to document quality".
+**Decision:** The constraint-shift claim (architecture paragraph in the
+section labelled `sec:annex-fusion`) is hedged — current phrasing "the
+binding constraint appears to shift from model capability to document
+quality".
 
 **Rationale:** Same scoped-divergence policy as equalisation-hedge; the
 shift is observed in one exploratory condition. CI keeps the sentence-scoped
@@ -115,15 +116,15 @@ negative: any sentence claiming a constraint shift must carry
 ## novelty-benchmark-gap
 
 **Decision:** Surviving novelty claim (1): the benchmark gap, stated in
-§fusion — current phrasing "To our knowledge, no published benchmark or
-system targets open-world enumeration of a national asset class with
-per-cell provenance at this granularity."
+the section labelled `sec:fusion` — current phrasing "To our knowledge, no
+published benchmark or system targets open-world enumeration of a national
+asset class with per-cell provenance at this granularity."
 
 **Rationale:** One of exactly three primacy claims the author kept (ticket
 0532 demoted the MoE-non-determinism, day-scale-drift, and cost-F1 claims).
 Epistemic-humility register mandatory ("to our knowledge", never "nobody
-has done"). CI keeps a loose guard (≥2 primacy-marker sentences in §fusion);
-the wording is free.
+has done"). CI keeps a loose guard (≥2 primacy-marker sentences in the
+section labelled `sec:fusion`); the wording is free.
 
 **Ticket:** 0532; demoted from CI by 0557.
 
@@ -132,13 +133,14 @@ the wording is free.
 ## novelty-provenance-temporality
 
 **Decision:** Surviving novelty claim (2): the conjunction of per-cell
-provenance with per-cell temporal validity, stated in §fusion — current
-phrasing "Nor did we find a published demonstration of the conjunction of
-per-cell provenance with per-cell temporal validity in LLM-augmented
-inventories".
+provenance with per-cell temporal validity, stated in the section labelled
+`sec:fusion` — current phrasing "Nor did we find a published demonstration
+of the conjunction of per-cell provenance with per-cell temporal validity
+in LLM-augmented inventories".
 
 **Rationale:** Same kept-three policy and humility register as
-novelty-benchmark-gap; counted by the same §fusion loose guard.
+novelty-benchmark-gap; counted by the same loose guard on the section
+labelled `sec:fusion`.
 
 **Ticket:** 0532; demoted from CI by 0557.
 
@@ -261,6 +263,25 @@ not in a test.
 
 **Ticket:** 0513; demoted during PR #1023 gate (residual missed by 0559
 sweep, which covered test_manuscript_0512_structure.py only).
+
+**Status:** active
+
+## label-stability-contract
+
+**Decision:** Every `\label{}` name in `slides/manuscript/main.tex`
+(`sec:intro`, `sec:fusion`, `sec:discussion`, `sec:annex-*`, …) stays
+attached to its content as that content moves through restructures. Tests
+and this brief anchor on labels — never on section numbers, annex letters,
+titles, or adjacency. Renaming or dropping a label is a contract change
+that must update every anchored test and brief entry in the same PR.
+
+**Rationale:** The back-half restructure (tracking ticket 0560) retitles,
+renumbers, and reorders sections; labels are the only structural
+identifiers that survive such moves. Label-keyed extraction
+(`manuscript_source.section()`, ticket 0561) makes the restructure PRs
+CI-safe without weakening any guard.
+
+**Ticket:** 0560 (contract recorded); anchors re-keyed by 0561.
 
 **Status:** active
 

--- a/tests/manuscript_source.py
+++ b/tests/manuscript_source.py
@@ -126,6 +126,12 @@ def section(label: str) -> str:
     end of the body. Retitles, reorders, annex-letter changes, and unlabelled
     neighbours therefore cannot break the extraction — only removing the
     label can, and that is the contract violation this error reports.
+
+    Only ``\\section``/``\\section*`` headings are searched: a label that
+    moves to a ``\\subsection`` heading (level demotion) is NOT found. A
+    restructure that demotes a labelled section (e.g. 0562 making
+    ``sec:fusion`` a subsection) must extend this helper or re-key the
+    consuming tests in the same PR.
     """
     text = body()
     heading_re = re.compile(_SECTION_TITLE + r"\s*" + re.escape(f"\\label{{{label}}}"))

--- a/tests/manuscript_source.py
+++ b/tests/manuscript_source.py
@@ -108,6 +108,37 @@ def body() -> str:
     return normalized(body_raw())
 
 
+# A sectioning heading: \section or \section*, title with at most one level
+# of brace nesting. Used both to anchor a label to its heading and to find
+# the terminator of a slice (any sectioning command, or \appendix).
+_SECTION_TITLE = r"\\section\*?\{(?:[^{}]|\{[^{}]*\})*\}"
+_SECTIONING_RE = re.compile(r"\\section\*?\{|\\appendix(?![A-Za-z])")
+_SECTION_LABELS_RE = re.compile(_SECTION_TITLE + r"\s*\\label\{([^}]*)\}")
+
+
+def section(label: str) -> str:
+    """Normalized text of the section labelled `label`, heading included.
+
+    Label-keyed extraction (ticket 0561; stability contract in ticket 0560):
+    the section is located by the ``\\label{...}`` attached to its
+    ``\\section``/``\\section*`` heading and sliced to the NEXT sectioning
+    command of ANY kind (``\\section``, ``\\section*``, ``\\appendix``) or the
+    end of the body. Retitles, reorders, annex-letter changes, and unlabelled
+    neighbours therefore cannot break the extraction — only removing the
+    label can, and that is the contract violation this error reports.
+    """
+    text = body()
+    heading_re = re.compile(_SECTION_TITLE + r"\s*" + re.escape(f"\\label{{{label}}}"))
+    m = heading_re.search(text)
+    assert m is not None, (
+        f"no \\section/\\section* heading labelled {label!r} in the manuscript "
+        f"body (label-stability contract, ticket 0560) — section labels "
+        f"present: {sorted(set(_SECTION_LABELS_RE.findall(text)))}"
+    )
+    nxt = _SECTIONING_RE.search(text, m.end())
+    return text[m.start() : nxt.start() if nxt else len(text)]
+
+
 def figure_caption(label: str) -> str:
     """Normalized \\caption text of the figure environment labelled `label`."""
     text = body_raw()

--- a/tests/test_abstract_numbers.py
+++ b/tests/test_abstract_numbers.py
@@ -18,7 +18,7 @@ import re
 from pathlib import Path
 
 import pytest
-from manuscript_source import body, body_raw, normalized
+from manuscript_source import body_raw, normalized, section
 
 pytestmark = pytest.mark.adherence
 
@@ -36,11 +36,8 @@ def _exp1_results_paragraph() -> str:
 
 
 def _conclusion() -> str:
-    text = body()
-    heading = "\\section{Conclusion}\\label{sec:conclusion}"
-    if heading not in text:
-        pytest.skip("conclusion section not found in main.tex")
-    return text.split(heading)[1].split("\\appendix")[0]
+    """The Conclusion section, label-keyed (ticket 0561)."""
+    return section("sec:conclusion")
 
 
 def _parse_macro(tex: str, name: str) -> str:

--- a/tests/test_manuscript_cohort_and_caveats.py
+++ b/tests/test_manuscript_cohort_and_caveats.py
@@ -34,7 +34,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
-from manuscript_source import body, body_raw, figure_caption, normalized
+from manuscript_source import body, body_raw, figure_caption, normalized, section
 
 pytestmark = pytest.mark.adherence
 
@@ -139,9 +139,9 @@ def test_rho_caveat_wherever_rho_appears():
     caveat phrasings are editorial decisions recorded in
     docs/editorial-brief.md (rho-caveat-conclusion, rho-caveat-discussion);
     CI only forbids an unqualified ρ. The annex occurrence (sec:annex-screen)
-    is out of scope: both extractions are bounded before \\appendix."""
-    text = body()
-    conclusion = text.split("\\section{Conclusion}\\label{sec:conclusion}")[1].split("\\appendix")[0]
+    is out of scope: both label-keyed extractions end at the next sectioning
+    command, well before the annexes (ticket 0561)."""
+    conclusion = section("sec:conclusion")
     if "ρ = 0.92" in conclusion:
         assert "pooled" in conclusion and "in-sample" in conclusion, (
             "conclusion cites ρ = 0.92 without the pooled/in-sample caveat"
@@ -150,9 +150,7 @@ def test_rho_caveat_wherever_rho_appears():
             "conclusion cites ρ = 0.92 without pointing to the within-model "
             "validation annex"
         )
-    discussion = text.split("\\section{Discussion}\\label{sec:discussion}")[1].split(
-        "\\section*{Related Work — Methods}"
-    )[0]
+    discussion = section("sec:discussion")
     if "ρ = 0.92" in discussion:
         assert "existence proof" in discussion, (
             "Discussion cites ρ = 0.92 without the existence-proof qualification"
@@ -217,9 +215,7 @@ def test_intro_does_not_claim_per_cell_provenance_checking():
     """Author brief (reading 1): the paper measures citation presence and
     counts; it does not check/trace per-cell provenance. The Introduction
     (through Contributions) must not claim that it does."""
-    intro = body().split("\\section{Introduction}\\label{sec:intro}")[1].split(
-        "\\section{Related Work — Empirical landscape}"
-    )[0]
+    intro = section("sec:intro")
     assert "per-cell provenance" not in intro, (
         "intro must not claim per-cell provenance checking; scope to per-row "
         "citation coverage and corroboration"
@@ -266,9 +262,7 @@ def test_novelty_claim_demotions_hold():
     ]
     for phrase in demoted_phrasings:
         assert phrase not in text, f"demoted observation still carries primacy framing: {phrase!r}"
-    fusion = text.split("\\section{Need and potential for fusion}\\label{sec:fusion}")[1].split(
-        "\\section{Discussion}\\label{sec:discussion}"
-    )[0]
+    fusion = section("sec:fusion")
     markers = ("no published", "to our knowledge", "did we find", "has not been")
     marker_sentences = [
         s
@@ -280,9 +274,7 @@ def test_novelty_claim_demotions_hold():
         f"provenance × temporality) — found {len(marker_sentences)} "
         "primacy-marker sentence(s)"
     )
-    discussion = text.split("\\section{Discussion}\\label{sec:discussion}")[1].split(
-        "\\section*{Related Work — Methods}"
-    )[0]
+    discussion = section("sec:discussion")
     assert "information credibility" in discussion and "source reliability" in discussion, (
         "Discussion must keep the two-grain scoring claim (STANAG 2511 "
         "information-credibility / source-reliability vocabulary)"

--- a/tests/test_manuscript_exp2_annex_as_run.py
+++ b/tests/test_manuscript_exp2_annex_as_run.py
@@ -1,11 +1,12 @@
-"""Ticket 0433 — manuscript Annex C (Exp2 tech spec) rewritten to the as-run story.
+"""Ticket 0433 — the manuscript's Exp2 tech-spec annex rewritten to the as-run story.
 
-Annex C of the preprint (slides/manuscript/main.tex since ticket 0524) holds
-the Experiment 2 technical specification. Naming history:
-- Originally Annex C (Exp2 tech spec).
-- Renamed to Annex B in ticket 0469 restructure (Annex A moved to Related Work).
-- Renamed back to Annex C in ticket 0482 section reorder (Temporality became
-  Annex A, Exp1-tech became Annex B, Exp2-tech became Annex C).
+The annex labelled ``sec:annex-exp2`` of the preprint
+(slides/manuscript/main.tex since ticket 0524) holds the Experiment 2
+technical specification. Its annex letter churned with every restructure
+(C originally, B after the 0469 restructure, C again after the 0482
+reorder), so this file, its tests, and its extraction are keyed on the
+stable label — never the letter, the title, or the neighbouring section
+(ticket 0561; label-stability contract recorded in ticket 0560).
 
 The annex was a PRE-RUN spec snapshot: it claimed Phase B at N=3, a $10/call
 dollar cap, and carried a "not yet executed" bracketed status note. That
@@ -15,8 +16,8 @@ two arms, N=5, a 2×2 factorial) and the committed artifacts
 
 This adherence test pins the rewrite's load-bearing invariants:
 
-1. No stale pre-run marker survives in Annex C: "N=3", the "not yet executed"
-   note, the "$10.00" status cap, "≤$10" / "≤$31" budget figures.
+1. No stale pre-run marker survives in the annex: "N=3", the "not yet
+   executed" note, the "$10.00" status cap, "≤$10" / "≤$31" budget figures.
 2. The as-run facts are present: two named arms (naive/optimised), N=5, the
    dual-axis cap (50K tokens + $3 guard), and the 2×2 / four-arm framing the
    body's Figure 3 caption forward-references.
@@ -30,27 +31,23 @@ stays fast and offline. It runs on the normalized body (line-wraps joined,
 """
 
 import pytest
-from manuscript_source import body
+from manuscript_source import section
 
 pytestmark = pytest.mark.adherence
 
 
-def _annex_c() -> str:
-    """The normalized text of Annex C (Experiment 2) — heading to next \\section."""
-    text = body()
-    start = text.index("\\section{Experiment 2: Technical specification}\\label{sec:annex-exp2}")
-    rest = text[start:]
-    nxt = rest.index("\\section{Supplementary figures}\\label{sec:annex-suppfigs}", 1)
-    return rest[:nxt]
+def _exp2_annex() -> str:
+    """The normalized text of the Exp2 tech-spec annex (label-keyed, 0561)."""
+    return section("sec:annex-exp2")
 
 
-def test_annex_c_exists_and_nonempty():
-    annex = _annex_c()
-    assert len(annex.strip()) > 1000, "Annex C is missing or truncated"
+def test_exp2_annex_exists_and_nonempty():
+    annex = _exp2_annex()
+    assert len(annex.strip()) > 1000, "the Exp2 annex is missing or truncated"
 
 
 def test_no_stale_pre_run_markers():
-    annex = _annex_c()
+    annex = _exp2_annex()
     stale = [
         "N=3",
         "not yet executed",
@@ -61,18 +58,18 @@ def test_no_stale_pre_run_markers():
         "Δ to N=3",
     ]
     found = [marker for marker in stale if marker in annex]
-    assert not found, f"stale pre-run markers still in Annex C: {found}"
+    assert not found, f"stale pre-run markers still in the Exp2 annex: {found}"
 
 
 def test_as_run_two_arms_and_n5():
-    annex = _annex_c().lower()
+    annex = _exp2_annex().lower()
     assert "naive" in annex, "naive arm not named"
     assert "optimised" in annex or "optimized" in annex, "optimised arm not named"
     assert "n=5" in annex, "as-run N=5 not stated"
 
 
 def test_dual_axis_cap_present():
-    annex = _annex_c()
+    annex = _exp2_annex()
     assert "dual-axis" in annex.lower(), "dual-axis cap framing absent"
     # The two axes, traced to protocol_05: 50K tokens + $3 guard.
     assert "50 000 tokens" in annex or "50000 tokens" in annex or "50K tokens" in annex, (
@@ -82,23 +79,23 @@ def test_dual_axis_cap_present():
 
 
 def test_factorial_framing_present():
-    annex = _annex_c().lower()
-    # The body's Figure 3 caption forward-references Annex C for the 2x2.
+    annex = _exp2_annex().lower()
+    # The body's Figure 3 caption forward-references this annex for the 2x2.
     assert "2×2" in annex or "2x2" in annex, "2×2 factorial framing absent"
     assert "exploratory" in annex, "the unregistered with-docs arms not labelled exploratory"
 
 
 def test_preregistration_named():
-    annex = _annex_c().lower()
+    annex = _exp2_annex().lower()
     assert "pre-registered" in annex or "registration" in annex or "registered" in annex, (
-        "Annex C does not disclose the preregistration"
+        "the Exp2 annex does not disclose the preregistration"
     )
 
 
 def test_claude_0_of_5_names_the_parse_dimension():
-    annex = _annex_c()
+    annex = _exp2_annex()
     if "0 of 5" not in annex and "0/5" not in annex:
-        pytest.skip("Claude 0/5 exclusion not mentioned in Annex C")
+        pytest.skip("Claude 0/5 exclusion not mentioned in the Exp2 annex")
     lowered = annex.lower()
     # Must name the dimension (bibliography parsability), not a flat exclusion.
     assert "parseable" in lowered or "parsab" in lowered or "bibliography-parsab" in lowered, (
@@ -118,23 +115,23 @@ def test_classifier_named_as_run_not_pilot():
     Guard: the as-run classifier is named, and mistral-small no longer stands
     as the classifier.
     """
-    annex = _annex_c()
+    annex = _exp2_annex()
     lowered = annex.lower()
     assert "deepseek-v4-pro" in lowered, (
-        "Annex C must name the as-run dialogue classifier (deepseek-v4-pro)"
+        "the Exp2 annex must name the as-run dialogue classifier (deepseek-v4-pro)"
     )
     # mistral-small may appear only as the pilot footnote, never as THE classifier.
     # The false same-vendor-Mistral disclosure must be gone.
     assert "both mistral models" not in lowered, (
-        "stale same-vendor-Mistral classifier disclosure still in Annex C"
+        "stale same-vendor-Mistral classifier disclosure still in the Exp2 annex"
     )
     assert "same-vendor pair" not in lowered, (
-        "stale same-vendor classifier framing still in Annex C"
+        "stale same-vendor classifier framing still in the Exp2 annex"
     )
 
 
 def test_references_report_chapter():
-    annex = _annex_c().lower()
+    annex = _exp2_annex().lower()
     assert "technical report" in annex and "chapter" in annex, (
-        "Annex C must reference the technical report's Exp2 chapter for the registered analysis"
+        "the Exp2 annex must reference the technical report's Exp2 chapter for the registered analysis"
     )

--- a/tests/test_manuscript_exp2_equalization.py
+++ b/tests/test_manuscript_exp2_equalization.py
@@ -18,7 +18,7 @@ import csv
 from pathlib import Path
 
 import pytest
-from manuscript_source import body
+from manuscript_source import section
 
 pytestmark = pytest.mark.adherence
 
@@ -26,15 +26,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CSV_2X2 = REPO_ROOT / "experiments" / "derived" / "tab_exp2_2x2.csv"
 
 
-def _md() -> str:
-    return body()
-
-
-def _section6(md: str) -> str:
-    # Tickets 0518/0524: section numbers are symbolic \label anchors.
-    start = md.index("\\label{sec:exp2}")
-    end = md.index("\\section{Need and potential for fusion}\\label{sec:fusion}", start)
-    return md[start:end]
+def _section6() -> str:
+    # Label-keyed, terminator-free extraction (tickets 0518/0524/0561).
+    return section("sec:exp2")
 
 
 def _f1_by_arm() -> tuple[dict[str, float], dict[str, float]]:
@@ -47,8 +41,7 @@ def _f1_by_arm() -> tuple[dict[str, float], dict[str, float]]:
 
 
 def test_section6_equalization_numbers_match_artifact():
-    md = _md()
-    sec = _section6(md)
+    sec = _section6()
     naive, arm3 = _f1_by_arm()
 
     # The two weakest naive agents (qwen, mistral) and their arm-1D recovery.
@@ -73,7 +66,7 @@ def test_section6_equalization_numbers_match_artifact():
 def test_section6_equalization_is_scoped_to_single_shot_docs():
     """Multi-turn+docs (arm4) hurts (e.g. Anthropic 0.61->0.38), so the claim
     must name the single-shot/documents (1D) condition, not 'docs' in general."""
-    sec = _section6(_md())
+    sec = _section6()
     lowered = sec.lower()
     assert "equalis" in lowered or "converg" in lowered, "no equalization framing in §6"
     assert "1d" in lowered or "single-shot" in lowered, "equalization not scoped to 1D"

--- a/tests/test_manuscript_framing_0513.py
+++ b/tests/test_manuscript_framing_0513.py
@@ -16,7 +16,7 @@ Guards the prose-quality changes that ticket 0513 lands on
 
 
 import pytest
-from manuscript_source import body
+from manuscript_source import body, section
 
 pytestmark = pytest.mark.adherence
 
@@ -25,12 +25,8 @@ def _md() -> str:
 
 
 def _section_1_body() -> str:
-    """Text of §1, the Introduction (labels are symbolic since 0518/0524)."""
-    md = _md()
-    start = md.find("\\section{Introduction}\\label{sec:intro}")
-    end = md.find("\\section{Related Work — Empirical landscape}\\label{sec:related-empirical}")
-    assert start != -1 and end != -1, "could not locate Introduction / Related Work headings"
-    return md[start:end]
+    """Text of §1, the Introduction (label-keyed since ticket 0561)."""
+    return section("sec:intro")
 
 
 def test_no_contributions_heading() -> None:

--- a/tests/test_manuscript_source_section.py
+++ b/tests/test_manuscript_source_section.py
@@ -113,7 +113,8 @@ def test_robust_to_retitle_and_reorder(monkeypatch):
     assert spec.endswith("annex spec prose.")
 
 
-def test_real_manuscript_sections_extract(tmp_path):
+@pytest.mark.adherence
+def test_real_manuscript_sections_extract():
     """Smoke test on the real main.tex: every body/annex label the adherence
     tests key on is extractable and non-empty."""
     for label in (

--- a/tests/test_manuscript_source_section.py
+++ b/tests/test_manuscript_source_section.py
@@ -1,0 +1,129 @@
+"""Ticket 0561 — unit tests for the label-keyed section extractor.
+
+``manuscript_source.section(label)`` locates a section by the ``\\label{}``
+on its ``\\section``/``\\section*`` heading and slices to the NEXT sectioning
+command of any kind (``\\section``, ``\\section*``, ``\\appendix``) or the end
+of the body. The label-stability contract (ticket 0560) makes the label the
+only structural identifier tests may key on: retitles, reorders, annex-letter
+changes, and unlabelled neighbours must not break extraction.
+
+These are pure unit tests on a synthetic document: ``body()`` is
+monkeypatched, so they exercise the slicing logic without reading main.tex.
+"""
+
+import manuscript_source
+import pytest
+from manuscript_source import section
+
+# A synthetic normalized body: labelled sections, an unlabelled starred
+# section (like the real "Related Work — Methods"), and an \appendix
+# boundary followed by annex sections.
+SYNTHETIC = (
+    "\\section{Introduction}\\label{sec:intro} intro prose. "
+    "\\section{Results}\\label{sec:results} results prose with 0.92. "
+    "\\section*{Related Work — Methods} methods prose. "
+    "\\section{Conclusion}\\label{sec:conclusion} concluding prose. "
+    "\\appendix "
+    "\\section{Spec}\\label{sec:annex-spec} annex spec prose. "
+    "\\section{Extras}\\label{sec:annex-extras} final annex prose."
+)
+
+
+@pytest.fixture
+def synthetic_body(monkeypatch):
+    monkeypatch.setattr(manuscript_source, "body", lambda: SYNTHETIC)
+
+
+def test_label_found_returns_heading_to_next_section(synthetic_body):
+    text = section("sec:intro")
+    assert text.startswith("\\section{Introduction}\\label{sec:intro}")
+    assert "intro prose." in text
+    assert "results prose" not in text
+
+
+def test_slice_ends_at_unlabelled_starred_section(synthetic_body):
+    """An unlabelled \\section* terminator works for free: the slice ends at
+    the next sectioning command of ANY kind, labelled or not."""
+    text = section("sec:results")
+    assert "results prose with 0.92." in text
+    assert "Related Work" not in text
+    assert "methods prose" not in text
+
+
+def test_slice_ends_at_appendix(synthetic_body):
+    text = section("sec:conclusion")
+    assert "concluding prose." in text
+    assert "\\appendix" not in text
+    assert "annex spec" not in text
+
+
+def test_last_section_slices_to_end_of_body(synthetic_body):
+    text = section("sec:annex-extras")
+    assert text.startswith("\\section{Extras}\\label{sec:annex-extras}")
+    assert text.endswith("final annex prose.")
+
+
+def test_label_absent_raises_clear_error(synthetic_body):
+    with pytest.raises(AssertionError, match="sec:nonexistent"):
+        section("sec:nonexistent")
+
+
+def test_label_absent_error_lists_available_labels(synthetic_body):
+    with pytest.raises(AssertionError, match="sec:results"):
+        section("sec:nonexistent")
+
+
+def test_figure_label_is_not_a_section(monkeypatch):
+    """A \\label that is not attached to a sectioning heading must not match."""
+    monkeypatch.setattr(
+        manuscript_source,
+        "body",
+        lambda: (
+            "\\section{Only}\\label{sec:only} prose "
+            "\\caption{A figure}\\label{fig:thing} more prose."
+        ),
+    )
+    with pytest.raises(AssertionError, match="fig:thing"):
+        section("fig:thing")
+
+
+def test_robust_to_retitle_and_reorder(monkeypatch):
+    """The red-step scenario from ticket 0561: retitle a section and swap the
+    order of two annexes — labels kept — and extraction still lands on the
+    same content. Title- or adjacency-anchored slicing would break here."""
+    perturbed = (
+        "\\section{Introduction}\\label{sec:intro} intro prose. "
+        # Retitled (was "Results"), label kept.
+        "\\section{Findings, renamed}\\label{sec:results} results prose with 0.92. "
+        "\\section*{Related Work — Methods} methods prose. "
+        "\\section{Conclusion}\\label{sec:conclusion} concluding prose. "
+        "\\appendix "
+        # Annexes swapped: extras now comes first, spec is last.
+        "\\section{Extras}\\label{sec:annex-extras} final annex prose. "
+        "\\section{Spec}\\label{sec:annex-spec} annex spec prose."
+    )
+    monkeypatch.setattr(manuscript_source, "body", lambda: perturbed)
+    assert "results prose with 0.92." in section("sec:results")
+    assert "methods prose" not in section("sec:results")
+    extras = section("sec:annex-extras")
+    assert "final annex prose." in extras
+    assert "annex spec" not in extras
+    spec = section("sec:annex-spec")
+    assert "annex spec prose." in spec
+    assert spec.endswith("annex spec prose.")
+
+
+def test_real_manuscript_sections_extract(tmp_path):
+    """Smoke test on the real main.tex: every body/annex label the adherence
+    tests key on is extractable and non-empty."""
+    for label in (
+        "sec:intro",
+        "sec:exp2",
+        "sec:fusion",
+        "sec:discussion",
+        "sec:conclusion",
+        "sec:annex-exp2",
+    ):
+        text = section(label)
+        assert f"\\label{{{label}}}" in text
+        assert len(text) > 200, f"section {label} suspiciously short"

--- a/tickets/0562-manuscript-main-text-restructure-extensi.erg
+++ b/tickets/0562-manuscript-main-text-restructure-extensi.erg
@@ -2,12 +2,12 @@
 Title: Manuscript main-text restructure — Extensions section, slimmed Discussion, Future research absorbs Related Work — Methods
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0561
 
 --- log ---
 2026-06-12T13:30Z HDMX-coding-agent created
 2026-06-12T12:17Z claude note raid feasibility PASS — see Feasibility notes section
 
+2026-06-12T12:56Z HDMX-coding-agent note blocker 0561 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0561-de-anchor-adherence-tests-and-brief-from.erg
+++ b/tickets/closed/0561-de-anchor-adherence-tests-and-brief-from.erg
@@ -2,11 +2,13 @@
 Title: De-anchor adherence tests and editorial brief from manuscript section structure (label-keyed extraction)
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1028
 
 --- log ---
 2026-06-12T13:30Z HDMX-coding-agent created
 2026-06-12T12:17Z claude note raid feasibility PASS — see Feasibility notes section
 
+2026-06-12T12:56Z HDMX-coding-agent closed — autoclosed — PR #1028
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Lands child 1 of the 0560 back-half restructure: manuscript section extraction in the adherence tests becomes **label-keyed** so the upcoming retitles, reorders, and annex-letter changes (labels kept) cannot break CI. Mechanical re-keying only — no assertion weakened, no manuscript change.

- **`tests/manuscript_source.py`**: new `section(label)` helper — locates the `\section`/`\section*` heading carrying `\label{<label>}` and slices to the NEXT sectioning command of ANY kind (`\section`, `\section*`, `\appendix`, end of body), so unlabelled terminators like `\section*{Related Work — Methods}` work for free. Clear error (listing available section labels) when the label is absent.
- **`tests/test_manuscript_source_section.py`** (new, TDD red step first): unit tests on a synthetic monkeypatched body — label found / absent, unlabelled-starred and `\appendix` terminators, last-section slice, figure-label rejection, and the ticket's retitle+annex-reorder perturbation; plus a smoke test over the real labels.
- **Re-keyed** (full-title + adjacency splits → `section(label)`):
  - `test_manuscript_annex_c_as_run.py` → `test_manuscript_exp2_annex_as_run.py` (git mv; letter-churn filename ends, docstring letters out / labels in)
  - `test_manuscript_cohort_and_caveats.py` (conclusion, discussion ×2, intro, fusion slices)
  - `test_manuscript_exp2_equalization.py` (start was already label-keyed; the full-title terminator is gone)
  - `test_manuscript_framing_0513.py` (Introduction slice — feasibility-notes catch)
  - `test_abstract_numbers.py` (sweep catch outside the `test_manuscript_*` glob; heading-missing skip becomes the helper's assert — strictly stronger)
- **Untouched per the exception rule**: decision pins and heading-presence checks in `test_manuscript_structure.py`, all of `test_manuscript_0512_structure.py`, and the Contributions negative guard where the heading is the assertion target.
- **`docs/editorial-brief.md`**: `fusion-hedge`, `novelty-benchmark-gap`, `novelty-provenance-temporality` reference "the section labelled `sec:…`"; new `label-stability-contract` entry records the 0560 contract (Decision/Rationale/Ticket/Status).

## Verification

- `make check` green (2604 passed, 10 skipped, 1 xfailed); `slides/manuscript/main.tex` untouched.
- Grep proof: no `\section{Title}` extraction split remains in the re-keyed tests.
- Conclusion slice now ends at backmatter `\section*{Acknowledgements}` instead of `\appendix`; the ρ = 0.92 caveat and `\ref{sec:annex-screen}` both live inside the Conclusion prose, so the conditional guard still fires.

**Ticket:** tickets/0561-de-anchor-adherence-tests-and-brief-from.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)