### PR TITLE
tickets(0564,0565)+docs: KB design note, enumeration-budget audit, post-0562 programme insert

### DIFF
--- a/docs/kb-design-note.md
+++ b/docs/kb-design-note.md
@@ -1,0 +1,221 @@
+# KB design note — information flow between corpus, claims, asset pages, and the statistical table
+
+**Status:** working design note, output of the 2026-06-12 Imagine session
+(post-conference discussion). Feeds the Future-research programme of the
+manuscript (ticket 0562, two–three sentences at no-spoiler altitude) and the
+follow-on system paper. Not citable from the manuscript bibliography
+(writing rule: no in-repo documents in the references).
+
+## 1. Product constraints
+
+- **One narrative page per asset** (power plant / power center), GEM-style,
+  in all cases. The page is the human audit interface and the only container
+  for what no schema holds: contested status discussions, plan-cycle
+  history, multilingual naming, developer changes.
+- Precision that pins the design: pages are required for **auditability and
+  contribution** (method quality), not for deriving the statistical table.
+  The table must not depend on re-extracting facts from prose.
+- The statistical table is a **dated projection**: T1 snapshot currency now,
+  T2 historical reconstructability ("the fleet as of 2018") eventually.
+
+## 2. Design space: four topologies
+
+Four artifact kinds: source corpus documents, structured claims (KG), asset
+pages, statistical table. The realistic flows:
+
+```
+A. Page-centric (GEM's process)      B. KG-centric (claim-first)
+   corpus → pages → KG → table          corpus → KG → pages
+                                                 KG → table
+
+C. Dual-authority (Wikipedia+Wikidata)  D. Log-centric (accounting)
+   corpus → pages ⇄ KG → table             corpus → claim log → KG → table
+            (reconciliation forever)                claim log → pages
+                                           (edits/verifications append to log)
+```
+
+Elimination arguments:
+
+- **A is eliminated by our own measurements.** Its load-bearing edge is
+  pages → KG: facts live in prose first and are extracted into structure.
+  That step is exactly the articulation failure mode and the matcher-as-NER
+  instrument limit the paper quantifies — and a page-authoritative store
+  pays the tax on every derivation, forever.
+- **GEM is not a counterexample.** GEM's pages work because the same human
+  researcher writes the page and curates the tracker row in the same act —
+  topology C with reconciliation done in the author's head at write time.
+  That labor model does not scale to the under-documented long tail, which
+  is our motivating setting. "Like GEM" is right as *product* spec (one
+  page per asset), wrong as *process* spec.
+- **C institutionalises reconciliation.** Wikipedia⇄Wikidata divergence is
+  the documented steady state; the bot ecosystem managing it is the
+  permanent maintenance bill. Not with a staff of zero.
+- **B vs D is the state-vs-event choice** (see §5): B keeps current values
+  and treats history as revisions; D makes an append-only claim log
+  authoritative and derives everything. D buys T2 reconstructability,
+  audit, and a clean edit discipline at a higher engineering cost. §6 gives
+  a staging that defers most of that cost.
+
+## 3. The asymmetry principle
+
+The one design lesson the experiments license directly:
+
+> **Text→structure is the lossy, hard direction (measured); structure→text
+> is cheap and reliable. Do the hard direction once, at ingest, against
+> source documents; do the easy direction many times, at render.**
+
+Corollaries: claims are extracted from corpus documents (not from pages);
+pages are rendered from claims; the table never re-extracts from prose.
+
+## 4. Information flow (topology D)
+
+```
+        harvest (per country × subsector)
+corpus docs ──LLM claim extraction──▶ claim log (append-only: s,p,o + citation
+   ▲                                      span + times + modality + author)
+   │                                          │ fold/consolidate (conflict
+   │                                          ▼  resolution HERE, with full
+   │                                   KG (current state)      provenance)
+   │                                    │            │ render
+   │                              project(date,     ▼
+   │                               world)        asset pages (audit UI;
+   └── gap-driven harvest tasks ◀── table         corrections append to log)
+       (LP bounds vs control totals;
+        sparse recognition-matrix rows)
+```
+
+- Conflict resolution does not disappear; it is **located** — at fold time,
+  with every competing claim and its source in hand. That is where LLM
+  reasoning adds value (the annex's hard cases) and where the
+  human-in-the-loop vets the authentic hard statistical questions.
+- Humans and LLM verifiers never patch a projection; they append a
+  correction or verification event and the projections regenerate — the
+  repo's own "fix the master, regenerate, never patch downstream"
+  discipline applied to the knowledge base.
+- The **feedback edge** closes the loop: the estimation layer (LP bounds
+  against control totals, capture–recapture residuals, sparse
+  recognition-matrix rows) generates the harvest queue. Harvesting is
+  per-subsector by construction (genericity rule), so divide-and-conquer
+  querying is the system's native mode.
+
+## 5. Claims vs events: the temporal-modal model
+
+Unifying rule: **every log entry is an assertion event** — transaction
+time, source document, citation span — whose payload is a claim. Claims
+carry a **modality**, and the fold rules differ by modality:
+
+| Modality | Example | Folds into |
+|---|---|---|
+| Attribute claim | "capacity = 1200 MW" (valid interval) | current state (KG, table) |
+| Occurrent (world event) | groundbreaking on 2029-06-01 | lifecycle state transitions |
+| Institutional act | PDP8 authorizes X | institutional status (proposed / planned / cancelled rungs) |
+| Forecast | PDP8 expects commissioning 2028–2029 | "current expectation" view per author; superseded chain; **resolved by occurrents** |
+| Scenario projection | in scenario A by institution I, X built 2031 | scenario-conditional views only; **never** actual state |
+
+Three time axes, plus a context axis:
+
+- **transaction time** — when we assimilated the claim (audit,
+  reproducibility);
+- **assertion/issue time** — when the source asserted it (orders
+  supersession among forecasts and plan revisions);
+- **valid/target time** — when the claimed thing holds (attribute
+  intervals, occurrent dates) or is projected to occur (forecast and
+  scenario targets);
+- **world context** — `actual`, or a named scenario world
+  `(institution, scenario-id, vintage)`. Scenario claims are conditional
+  on their assumption set — scenarios are explorations, not predictions
+  (standard IAM discipline) — so they never resolve against reality and
+  never fold into the actual register.
+
+### Worked examples (from the 2026-06-12 discussion)
+
+**"PDP8, published 2024, authorizes X and forecasts commissioning
+2028–2029."** One source span, three log entries of three modalities:
+
+1. occurrent: `publication(PDP8)`, valid 2024 — the administrative act
+   itself happened;
+2. institutional act: `authorization-granted(X, by=PDP8)`, effective 2024 →
+   folds: `status(X) = planned/authorized` as of 2024;
+3. forecast: `commissioning(X)`, target 2028–2029, author = PDP8, issued
+   2024 → folds into the official-expectation view; superseded by any later
+   plan revision.
+
+The decomposition of one sentence into modality-tagged claims is a language
+task — another place the LLM earns its keep at ingest.
+
+**"In scenario A by institution I, project X is built in 2031."**
+
+4. scenario projection: `commissioning(X)`, target 2031, world =
+   `(I, scenario-A, vintage)` → visible only in scenario-A projections,
+   e.g. `table(2031, world=scenario-A)`; absent from the register.
+
+**"Groundbreaking occurred on 2029-06-01"** (reported by source S,
+assimilated 2029-07):
+
+5. occurrent: `construction-start(X)`, valid 2029-06-01, source S,
+   transaction 2029-07 → folds: `status(X) = under-construction` from
+   2029-06-01 — **and resolves forecast (3)**: realised late against the
+   2028–2029 window. The resolution edge is itself data: a
+   forecast-realisation ledger (plan-cycle realisation rates) falls out of
+   the model as a research by-product.
+
+### Projections
+
+- `table(date, world=actual)` — the statistical register (T1 now, T2 by
+  log replay);
+- `table(date, world=scenario)` — scenario pipeline tables from the same
+  machinery;
+- `page(asset)` — renders all modalities as prose sections: current
+  status, lifecycle history, plans & projections, contested points.
+
+### Tie-back to the benchmark
+
+The status-composition finding says benchmark difficulty concentrates in
+proposed plants — precisely the institutional and prospective modalities.
+The hard tail of the task is the part that needs this machinery; models
+answering from memory fail worst exactly where representation is hardest.
+The benchmark also arbitrates the b/-tension empirically: build both a
+page-authoritative and a claim-authoritative state from the same harvested
+corpus, derive the table from each, score both with the same LP matcher
+against the same reference.
+
+## 6. Staging (CIRED-sized MVP)
+
+Defer the event store, keep the discipline:
+
+- one structured **claims file per asset** (citation spans, modality,
+  times) + one **rendered page**, in a git repository;
+- **git history is the transaction-time log for free** — append-only by
+  convention, diffable, blameable;
+- the table is a Makefile artifact projected from the claims files;
+- migration to a real event store / graph store is monotone (files →
+  store) if and when the claim files prove out; never a rewrite.
+
+## 7. What enters the manuscript now
+
+Two–three sentences in the Future-research programme (ticket 0562):
+
+1. the authority question — asset page, knowledge graph, or an append-only
+   claim log of which both are projections — with the page⇄graph edge
+   direction open and this benchmark as the arbiter;
+2. the extract-once/render-many asymmetry principle, as the design lesson
+   the articulation findings support;
+3. the T2 item recast as a bitemporal claim log whose modality layer covers
+   plans, forecasts, and scenario projections (occurrents fold into state;
+   scenario claims stay context-qualified).
+
+Nothing further — the topology analysis and the modal model are follow-on
+paper material.
+
+## 8. Open questions
+
+- Claim granularity (one claim per cell? per sentence? negation and
+  retraction semantics?).
+- Authority ordering among sources (adopted plan > draft > press) and its
+  interaction with the supersession chain.
+- Cross-source entity resolution: the matcher-as-NER problem recurs at
+  ingest (which X is this claim about?) — the LP matcher work is reusable.
+- Page-edit round-trip UX: how a human correction on the rendered page
+  becomes a log event with minimal friction.
+- When the consolidated state needs a real graph store rather than files.
+- Schema evolution of the claim model without log rewrites.

--- a/tickets/0564-enumeration-budget-vs-knowledge-ceiling.erg
+++ b/tickets/0564-enumeration-budget-vs-knowledge-ceiling.erg
@@ -1,0 +1,105 @@
+%erg 0.1
+Title: Enumeration budget vs knowledge ceiling — retrospective audit of Exp 1 runs (no API calls)
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T13:11Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Author hypothesis (2026-06-12 session): single-query inventory recall may be
+capped by a model-size property, and partitioned queries (coal and gas
+asked separately) might beat one full-inventory query — possibly explaining
+the Mistral vs GPT/Claude gap. Session discussion reframed it testably:
+"layer size" is unidentifiable (frontier architectures undisclosed; width /
+depth / params collinear on the open ladder), so the question becomes
+**retrieval ceiling vs generation budget** — does the model not KNOW the
+plants, or not EMIT them in one response?
+
+Per the audit-before-instrumenting rule, this ticket is the retrospective
+stage on existing data only — no new API calls, no schema changes, no
+manuscript changes. Its verdict gates a possible Stage-2 partitioned-query
+sweep, which is follow-on work (it would probe the paper's central
+data-not-model conjecture and belongs to the next paper, not this one).
+
+Prior evidence in hand (hypotheses to verify, per the
+derive-from-artifacts rule):
+
+- Mean extracted rows per run (awk over committed
+  `experiments/derived/exp1_cross_eval.csv`, arm=parametric, column
+  n_rows, reference = 177 plants): claude-sonnet-4.6 ≈ 112, opus ≈ 95,
+  gpt-5.5 ≈ 85, the three Mistrals ≈ 47–63, with tight within-model rep
+  counts (e.g. haiku 51/72/51). Tight per-model row budgets while WHICH
+  plants vary across reps is the budget signature.
+- Intra-model 5-rep union beats single runs (aggregation sweep,
+  `experiments/derived/aggregation_sweep.csv`) — single runs already
+  undershoot the model's own recoverable set.
+- Per-fuel decomposition exists ONLY in the RAG regime
+  (`outputs/rag_per_fuel/`, DeepSeek V3.2 decomposed, F1 = 98.8%) — it
+  conflates documents with decomposition; the memory-only decomposed cell
+  is untested.
+- Known confound at the agent grain: Exp 2 Mistral arm-2 runs produced
+  zero PARSED rows (format/parse failure, not capacity) — frontier-agent
+  gap explanations must exclude this class first.
+
+## Relevant files
+
+- `experiments/outputs/exp1_batch2/` — raw run records (finish_reason,
+  completion tokens, raw output tables in emission order)
+- `experiments/derived/exp1_cross_eval.csv` — per-run n_rows, F1
+- `experiments/derived/aggregation_sweep.csv` — union-vs-single baselines
+- `experiments/measurements.jsonl` — run-level token accounting
+- `src/aedist/exp1_recognition.py` — per run × plant recognition data
+  (reuse for the position analysis)
+
+## Actions
+
+1. **Truncation check (kills or saves the question).** For all 70
+   parametric runs: finish_reason and completion-token counts vs the
+   sweep's max_tokens. Any run stopped by the token cap reclassifies the
+   "budget" as harness configuration, not model behavior.
+2. **Row-budget profile.** Per model: distribution of n_rows across the 5
+   reps (mean, spread); spread of WHICH plants (Jaccard between reps'
+   TP sets, from recognition data). Tight n_rows + variable membership =
+   budget signature; loose n_rows tracking F1 = knowledge signature.
+3. **Serial-position analysis.** Within each raw output table (emission
+   order): TP density by list position (first vs last decile), and
+   per-fuel coverage vs the position at which that fuel first appears.
+   A generation budget predicts late-position thinning and
+   later-mentioned-category under-coverage.
+4. **Verdict.** One paragraph in the ticket close log: budget-cap
+   signature present / absent / mixed per model family, with the three
+   artifacts above as evidence. State explicitly whether Stage 2 (memory-
+   only partitioned-query sweep, matched call AND token budget against
+   repetition-union) is warranted.
+
+Implementation: one script `src/aedist/audit_enumeration_budget.py`
+(argparse, logging, tests per coding rules) emitting
+`experiments/derived/enumeration_budget_audit.csv`; wire a Makefile target
+only if a downstream artifact consumes it.
+
+## Test
+
+- Red step: unit test on synthetic run records — a truncated run
+  (finish_reason=length) must be flagged; a tight-rows/variable-membership
+  synthetic model must score as budget-signature; a loose-rows synthetic
+  as knowledge-signature.
+
+## Verification
+
+- [ ] `make check-fast` green; new script has tests
+- [ ] Audit CSV committed; numbers in the verdict re-derivable from it
+- [ ] Zero API calls (no new entries in measurements.jsonl)
+
+## Invariants
+
+- No manuscript change, no experiments.toml change, no new sweep config
+- Existing derived artifacts untouched
+
+## Exit criteria
+
+- [ ] All three checks run over the 70 exp1_batch2 parametric runs
+- [ ] Verdict logged with Stage-2 go/no-go recommendation
+- [ ] `make check` passes

--- a/tickets/0565-future-research-kb-design-items-insert.erg
+++ b/tickets/0565-future-research-kb-design-items-insert.erg
@@ -1,0 +1,85 @@
+%erg 0.1
+Title: Future research §: insert the three knowledge-base design items (docs/kb-design-note.md §7)
+Created: 2026-06-12
+Author: HDMX-coding-agent
+Blocked-by: 0562
+
+--- log ---
+2026-06-12T13:15Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The 2026-06-12 Imagine session (author + agent) produced
+`docs/kb-design-note.md`: information-flow topologies between corpus,
+claims/KG, asset pages, and the statistical table, plus a temporal-modal
+claim model covering plans, forecasts, and scenario projections. Its §7
+lists the two–three sentences that belong in the manuscript's Future
+research programme.
+
+Ticket 0562 (which builds the numbered Future research section) was
+already in execution when this discussion concluded, so the items were
+NOT added to its scope — mid-flight scope changes break the
+ticket-as-contract. This follow-up inserts them once 0562 has merged.
+
+## Relevant files
+
+- `docs/kb-design-note.md` §7 — the three items, with the full argument
+  in §§2–5 of the note
+- `slides/manuscript/main.tex` — Future research section
+  (`\label{sec:future}` per 0562)
+- `docs/editorial-brief.md` — positive editorial intent lives here, not
+  in CI (polarity rule)
+
+## Actions
+
+1. In the programme part of the Future research section (after the
+   estimation / external-coherence / screen / replication items 0562
+   lands), insert two–three sentences covering:
+   (i) the authority question — asset page, knowledge graph, or an
+   append-only claim log of which both are projections; page⇄graph edge
+   direction open; this benchmark arbitrates (same corpus → both
+   representations → same matcher and reference);
+   (ii) the extract-once/render-many asymmetry principle —
+   text→structure is the measured lossy direction (articulation
+   conflation), structure→text is cheap; structure at ingest, render at
+   output;
+   (iii) the T2 temporality item recast as a bitemporal claim log whose
+   modality layer covers plans, forecasts, and scenario projections
+   (occurrents fold into actual state; scenario claims stay
+   context-qualified by institution, scenario, vintage).
+   Wording is the executor's: derive from the note's §7, respect the
+   epistemic-humility and no-promise rules; if the T2 sentence 0562
+   wrote already covers part of (iii), merge rather than duplicate.
+2. No new citations required (citation budget); no new \section or
+   \label; no figure.
+3. Add an editorial-brief entry `kb-programme-items` (**Decision:** the
+   programme names the representation-authority tension, the asymmetry
+   principle, and the bitemporal/modal claim log; **Rationale:** 0560
+   restructure discussion + kb-design-note; **Ticket:**
+   tickets/0565-...; **Status:** active). Per the CI polarity rule this
+   is review-panel-checked intent — do NOT add a positive CI assertion
+   pinning the wording.
+
+## Test
+
+- None in CI by design (polarity rule: positive authorial phrasing is
+  never pinned). The brief entry is the guard; `/review-pr-prose`
+  validates it against the diff.
+
+## Verification
+
+- [ ] `make check` green; manuscript builds
+- [ ] The three items present in the Future research programme, no
+  duplication with 0562's T2 sentence
+- [ ] Brief entry added; no new CI positive pin
+
+## Invariants
+
+- No change outside the Future research section + editorial brief
+- No companion-paper promise reintroduced; no hand-typed numbers
+
+## Exit criteria
+
+- [ ] Programme contains the three KB design items at no-spoiler altitude
+- [ ] `make check` passes


### PR DESCRIPTION
Artifacts from the 2026-06-12 Imagine session on knowledge-base design and the divide-and-conquer hypothesis:

- **docs/kb-design-note.md** — information-flow topologies (page-centric / KG-centric / dual / log-centric) between corpus, claims, asset pages, and the statistical table; the extract-once/render-many asymmetry principle; and the temporal-modal claim model for plans, forecasts, and scenario projections (worked examples: PDP8 authorization+forecast, scenario projection, groundbreaking occurrent).
- **ticket 0564** — retrospective audit: enumeration budget vs knowledge ceiling on existing Exp 1 runs (zero API calls; gates a possible memory-only partitioned-query sweep, follow-on work).
- **ticket 0565** (Blocked-by: 0562) — inserts the note's §7 programme sentences into Future research after 0562 merges; filed separately because 0562 was already in execution (no mid-flight scope change).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)