### PR TITLE
ticket(0564): label deferred — next-paper material, revisit at follow-on planning

### DIFF
--- a/tickets/0564-enumeration-budget-vs-knowledge-ceiling.erg
+++ b/tickets/0564-enumeration-budget-vs-knowledge-ceiling.erg
@@ -2,9 +2,11 @@
 Title: Enumeration budget vs knowledge ceiling — retrospective audit of Exp 1 runs (no API calls)
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Label: deferred
 
 --- log ---
 2026-06-12T13:11Z HDMX-coding-agent created
+2026-06-12T13:22Z HDMX-coding-agent note deferred per author — next-paper material, nothing depends on it; revisit at follow-on paper planning
 
 --- body ---
 ## Context


### PR DESCRIPTION
Defers ticket 0564 per author decision: the enumeration-budget audit is follow-on-paper material with no dependents; the deferred label keeps autonomous pickers off it.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)