### PR TITLE
t0565: Future research — insert the three KB design items

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -325,3 +325,25 @@ rewrite (PR #1023) rephrased it. CI keeps the negative guard:
 **Ticket:** 0513; demoted during PR #1023 gate.
 
 **Status:** active
+
+## kb-programme-items
+
+**Decision:** The Future-research programme names the three
+knowledge-base design items at no-spoiler altitude: the
+representation-authority tension (narrative asset page vs knowledge
+graph vs append-only claim log of which both are projections, with
+this benchmark as the arbiter), the extract-once/render-many asymmetry
+principle (text→structure is the measured lossy direction;
+structure→text is cheap), and the bitemporal/modal claim log covering
+plans, forecasts, and scenario projections. The topology analysis and
+the modal model stay in `docs/kb-design-note.md` — the manuscript only
+names the questions.
+
+**Rationale:** 0560 restructure discussion + `docs/kb-design-note.md`
+(2026-06-12 Imagine session, §7). Per the CI polarity rule, no positive
+CI assertion pins the wording — this entry is the guard, checked by the
+review panel against manuscript diffs.
+
+**Ticket:** tickets/0565-future-research-kb-design-items-insert.erg
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1155,9 +1155,10 @@ second axis.
 currency; scenario-projection use cases need historical
 reconstructability — the event-log representation discussed in
 \ref{sec:annex-temporality}. Concretely, that is a bitemporal claim
-log whose modality layer covers plans, forecasts, and scenario
-projections: occurrents fold into the actual state, while scenario
-claims stay qualified by issuing institution, scenario, and vintage.
+log (recording both when a fact held and when it was asserted) whose
+modality layer covers plans, forecasts, and scenario projections:
+completed events fold into the actual state, while scenario claims
+stay qualified by issuing institution, scenario, and vintage.
 Upgrading the temporality dimension from states to events is the
 third axis.
 
@@ -1181,9 +1182,9 @@ benchmark can arbitrate: build both representations from the same
 corpus, derive a table from each, score both with the same matcher
 against the same reference. The articulation findings
 (§\ref{sec:discussion}) already support one design principle:
-text→structure is the measured lossy direction while structure→text
-is cheap, so do the hard direction once at ingest and the easy one at
-every render — the sixth axis.
+extracting structure from text is the measured lossy direction while
+rendering text from structure is cheap, so the extraction happens once
+at ingest and the rendering at every output — the sixth axis.
 
 \section{Conclusion}\label{sec:conclusion}
 

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1154,8 +1154,12 @@ second axis.
 \textbf{Event-grain temporality.} The paper scopes to snapshot
 currency; scenario-projection use cases need historical
 reconstructability — the event-log representation discussed in
-\ref{sec:annex-temporality}. Upgrading the temporality dimension from
-states to events is the third axis.
+\ref{sec:annex-temporality}. Concretely, that is a bitemporal claim
+log whose modality layer covers plans, forecasts, and scenario
+projections: occurrents fold into the actual state, while scenario
+claims stay qualified by issuing institution, scenario, and vintage.
+Upgrading the temporality dimension from states to events is the
+third axis.
 
 \textbf{Industrialising the screen.} The two-grain scoring design
 (§\ref{sec:ext-screen}) is an existence proof tuned in-sample; making
@@ -1168,6 +1172,18 @@ parameters, and the quality bar were all developed against one
 reference (§\ref{sec:discussion}); transferring them to another
 country or asset class is a replication study in its own right — the
 fifth axis.
+
+\textbf{Knowledge-base architecture.} The auditable knowledge base
+sketched in §\ref{sec:ext-system} leaves open which representation is
+canonical (the narrative asset page, the knowledge graph, or an
+append-only claim log of which both are projections), a question this
+benchmark can arbitrate: build both representations from the same
+corpus, derive a table from each, score both with the same matcher
+against the same reference. The articulation findings
+(§\ref{sec:discussion}) already support one design principle:
+text→structure is the measured lossy direction while structure→text
+is cheap, so do the hard direction once at ingest and the easy one at
+every render — the sixth axis.
 
 \section{Conclusion}\label{sec:conclusion}
 

--- a/tickets/0565-future-research-kb-design-items-insert.erg
+++ b/tickets/0565-future-research-kb-design-items-insert.erg
@@ -7,6 +7,8 @@ Author: HDMX-coding-agent
 2026-06-12T13:15Z HDMX-coding-agent created
 
 2026-06-12T13:46Z HDMX-coding-agent note blocker 0562 closed — Blocked-by removed.
+
+2026-06-12T14:34Z HDMX-coding-agent note executed — items inserted, brief entry added
 --- body ---
 ## Context
 
@@ -69,10 +71,10 @@ ticket-as-contract. This follow-up inserts them once 0562 has merged.
 
 ## Verification
 
-- [ ] `make check` green; manuscript builds
-- [ ] The three items present in the Future research programme, no
+- [x] `make check` green; manuscript builds
+- [x] The three items present in the Future research programme, no
   duplication with 0562's T2 sentence
-- [ ] Brief entry added; no new CI positive pin
+- [x] Brief entry added; no new CI positive pin
 
 ## Invariants
 
@@ -81,5 +83,5 @@ ticket-as-contract. This follow-up inserts them once 0562 has merged.
 
 ## Exit criteria
 
-- [ ] Programme contains the three KB design items at no-spoiler altitude
-- [ ] `make check` passes
+- [x] Programme contains the three KB design items at no-spoiler altitude
+- [x] `make check` passes

--- a/tickets/closed/0565-future-research-kb-design-items-insert.erg
+++ b/tickets/closed/0565-future-research-kb-design-items-insert.erg
@@ -2,6 +2,7 @@
 Title: Future research §: insert the three knowledge-base design items (docs/kb-design-note.md §7)
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1033
 
 --- log ---
 2026-06-12T13:15Z HDMX-coding-agent created
@@ -9,6 +10,7 @@ Author: HDMX-coding-agent
 2026-06-12T13:46Z HDMX-coding-agent note blocker 0562 closed — Blocked-by removed.
 
 2026-06-12T14:34Z HDMX-coding-agent note executed — items inserted, brief entry added
+2026-06-12T15:01Z HDMX-coding-agent closed — autoclosed — PR #1033
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0565-future-research-kb-design-items-insert.erg

Inserts the three knowledge-base design items from `docs/kb-design-note.md` §7 into the Future research programme (`sec:future`) at no-spoiler altitude — the topology analysis and the modal model stay in the note.

## What changed

- **Item (iii), bitemporal claim log** — merged into the existing **Event-grain temporality** axis paragraph: one added sentence recasts the annex's event-log representation as a bitemporal claim log whose modality layer covers plans, forecasts, and scenario projections (occurrents fold into actual state; scenario claims stay qualified by issuing institution, scenario, and vintage). The `\ref{sec:annex-temporality}` anchor and the original framing sentences are kept — merge, not duplication.
- **Items (i) authority question + (ii) extract-once/render-many asymmetry** — a compact sixth axis paragraph (**Knowledge-base architecture**) after Replication, anchored on `§\ref{sec:ext-system}` (the auditable-KB sketch) and `§\ref{sec:discussion}` (the articulation-conflation analysis). Two sentences: the page/graph/claim-log authority question with the benchmark-as-arbiter recipe, and the asymmetry principle (text→structure is the measured lossy direction; structure→text is cheap; hard direction once at ingest, easy direction at every render).
- **`docs/editorial-brief.md`** — new `## kb-programme-items` entry recording the intent for the `/review-pr-prose` panel. No positive CI assertion (polarity rule; the ticket specifies no CI test by design).
- Ticket checkboxes ticked, log line appended.

## Notes

- This PR was specified as stacked on PR #1032 (t0563); #1032 merged while this was in flight (merge commit 8bbf65b8) and the branch was deleted, so the branch was rebased onto current `origin/main` and the PR targets `main` directly.
- House rules respected: no new citations, no new `\section`/`\label`, no figure, literal U+2014 em dashes (per-paragraph cap 2, global ratchet 145 — we land exactly at the ceiling), no banned promise phrasings, symbolic `\ref` only.
- `make check` / full pytest: 2611 passed, 10 skipped, 1 xfailed. Manuscript builds (tectonic, 3 passes, stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)