### PR TITLE
0568: claims/findings alignment — coverage story, degraded-vs-mixed, scaffolding strip

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -94,7 +94,7 @@ We introduce a computable benchmark for this task: reconstruct the
 register of Vietnam's \NumRefPlants{} thermal power plants and score the result
 against a hand-compiled, comprehensive reference.
 We find that the task is hard for today's AI systems.
-Fourteen language models answering from memory recovered much less than the Wikipedia lists contain, even though these lists had presumably been in their training corpora for years. We observed that internal coherence metrics correlate with accuracy, allowing us to screen out weak runs without the reference. We then tested the commercial frontier of mid-2026: four agentic systems with web access and extended reasoning. Only one of them improved coverage over the memory-only query, and a harness giving them the opportunity to plan and execute a multi-step reply degraded the results. Handing the agents a curated document set did improve coverage, especially for the initially weaker agents. Fusing the lists from multiple runs more than doubles recall.
+Fourteen language models answering from memory recovered much less than the Wikipedia lists contain, even though these lists had presumably been in their training corpora for years. We observed that internal coherence metrics correlate with accuracy, allowing us to screen out weak runs without the reference. We then tested the commercial frontier of mid-2026: four agentic systems with web access and extended reasoning. Only one of them improved coverage over the memory-only query, and a harness giving them the opportunity to plan and execute a multi-step reply degraded the results for three of the four. Handing the agents a curated document set did improve coverage, especially for the initially weaker agents. Fusing the lists from multiple runs more than doubles recall.
 We conclude that an evergreen statistical-quality register requires deliberate knowledge engineering. We propose that datasets should be derived as dated snapshots from a sourced, auditable knowledge base, mechanically updated to assimilate a periodically harvested evidential corpus. Humans can stay in the loop to vet information sources and resolve the tail of hard statistical questions.
 \end{abstract}
 
@@ -149,7 +149,7 @@ Three empirical results stand out. First, the task is hard for
 today's AI systems: neither model memory nor web access yields a
 complete, well-sourced register, and a harness that lets the agents
 plan and execute a multi-step reply degrades rather than improves the
-result. Second, reference-free coherence criteria suffice to screen
+result for three of the four agents. Second, reference-free coherence criteria suffice to screen
 out the weakest runs. Third, targeted pipeline design narrows the
 gap: provisioning the agents with a curated document set improves
 coverage, and fusion reuses existing runs to good effect — pooling
@@ -674,14 +674,15 @@ Monitor, covers only \GemReviewedPct\% of the reference after light review
 (\ref{sec:annex-exp1}); the frontier agents are therefore measured
 against an inventory no single open database fully reproduces.
 
-The quality dimensions §\ref{sec:exp2} measures are the
+The quality dimensions this section measures are the
 \emph{operational and accuracy} ones: row-level F1 against the
 reference, coverage (plants enumerated), and per-row provenance counts
-(Source 1 / Source 2 citation presence, Figure~\ref{fig:coverage-certainty}). The
+(Source 1 / Source 2 citation presence,
+Figure~\ref{fig:coverage-certainty} in \ref{sec:annex-exp2}). The
 §\ref{sec:quality} dimensions that require \emph{peer cross-evaluation}
 — coherence, provenance support, and temporality scored on a rubric by
 judging agents — are deferred to Phase C (cross-model judging),
-reserved for post-conference analysis; §\ref{sec:exp2}'s claims rest on
+reserved for post-conference analysis; this section's claims rest on
 the F1, coverage, and citation-count metrics, not on the deferred
 cross-eval scores.
 
@@ -709,7 +710,13 @@ raw model capability. The naive arm is an independent sweep, not a
 re-run of the §\ref{sec:exp1} parametric protocol, so its scores are not
 directly comparable to §\ref{sec:exp1}'s per-model numbers;
 within-Experiment-2 comparisons all use this common arm-1 sweep as their
-baseline. Row-level F1 against the \NumRefPlants-plant reference is
+baseline. Read with that caveat, setting each agent's naive-arm mean F1
+(Table~\ref{tbl:exp2-2x2}) against the same lab's flagship in the
+§\ref{sec:exp1} parametric sweep, only Mistral improved (0.41 to 0.49):
+Anthropic declined (0.67 to 0.60), Qwen declined (0.41 to 0.37), and
+OpenAI stayed flat (0.63 to 0.63), so web access and extended reasoning
+improved on the memory-only baseline for only one of the four agents.
+Row-level F1 against the \NumRefPlants-plant reference is
 now scored for all four arms (Table~\ref{tbl:exp2-2x2}); cross-model
 judging on the four §\ref{sec:quality} dimensions remains reserved for
 post-conference analysis (Phase C).
@@ -776,15 +783,18 @@ rows versus arm 1 median 42 rows (regression; Qwen's self-designed
 protocol imposed a strict dual-source admissibility filter that
 constrains coverage from Turn 1). The optimised protocol costs 2--4×
 more per run than naive across all agents; OpenAI's ratio is most
-extreme (median \$0.73 optimised vs \$0.27 naive). We did not find
-published comparisons of frontier deep-research agents on
-structured-output coverage at this granularity; the contrast is mixed
-— modest gain for OpenAI, regression for Qwen.
+extreme (median \$0.73 optimised vs \$0.27 naive). On row-level F1
+(Table~\ref{tbl:exp2-2x2}, no-documents rows), the multi-turn protocol
+degraded three of the four agents (Anthropic 0.60 to 0.56, Mistral 0.49
+to 0.39, Qwen 0.37 to 0.27) and gave OpenAI a marginal gain (0.63 to
+0.65). We did not find published comparisons of frontier deep-research
+agents on structured-output coverage at this granularity.
 
 \textbf{Provenance: corroboration by a second source is the exception.}
 Every Source 1, Source 2, and Notes cell across all 40 runs was parsed
 to measure citation coverage and corroboration (see
-Figure~\ref{fig:coverage-certainty} for the full figure). OpenAI optimised is the
+Figure~\ref{fig:coverage-certainty} in \ref{sec:annex-exp2} for the full
+figure). OpenAI optimised is the
 only agent to achieve both high coverage (79--96 rows) and near-complete
 corroboration (77--88 rows with Source 2 — approaching the full
 diagonal). Qwen clusters near the diagonal at low coverage (22--45 rows
@@ -825,9 +835,7 @@ The analyses in this section were performed after the two experiments
 were presented at Econom'IA 2026, in response to questions from the
 audience: why is the task hard, can weak runs be screened without a
 reference, can runs be fused, and what system do the findings imply?
-They are exploratory, performed after the experiments were presented;
-each subsection summarises one analysis and points to the annex that
-develops it.
+They are exploratory; each subsection summarises one analysis.
 
 \subsection{Why is the task hard?}\label{sec:ext-difficulty}
 
@@ -1626,8 +1634,8 @@ tokens and simplify downstream parsing. Second, its status vocabulary
 follows Global Energy Monitor and offers no label for the reference's
 ``Proposed'' stratum (\textasciitilde\StatusProposedSharePct\% of rows) nor for ``Planned''
 — mechanically depressing measured status accuracy, as discussed in
-§\ref{sec:exp1}. Both are grounds for a revised-prompt rerun in the
-journal version.
+§\ref{sec:exp1}. The scores reported here measure the prompt as sent,
+with both limitations in place.
 
 In both cohorts, every API call carried the same system instruction
 explicitly forbidding web search (the two sweep configurations declare
@@ -2132,8 +2140,9 @@ Three reply strings, verbatim:
 
 Every user-side message after turn 1 carries a chat-text status prefix
 — \emph{``Status: remaining X.XK of 50K tokens, \$X.XX of \$3.00.
-Wall-clock elapsed Ys. Verify .''} — exposing both budget axes to the
-agent, and, where the provider exposes a metadata surface, a structured
+Wall-clock elapsed Ys. Verify Z.''} — exposing both budget axes to the
+agent (Z tracks the VERIFY-message state: pending, on this turn, or
+used), and, where the provider exposes a metadata surface, a structured
 metadata field carrying \texttt{cap\_tokens} and \texttt{cap\_usd}.
 After VERIFY's response is captured (or after TERMINAL's response), the
 loop terminates.

--- a/tests/test_manuscript_claims_alignment.py
+++ b/tests/test_manuscript_claims_alignment.py
@@ -1,0 +1,183 @@
+"""Ticket 0568 — claims/findings alignment guards.
+
+Conditional guard (S1): IF the abstract claims that only one of the four
+frontier agents improved over the memory-only query, THEN the §exp2 body
+must carry the per-agent memory-vs-web comparison explicitly — one
+paragraph naming all four agents, anchored to the memory/parametric
+baseline, with the four before-to-after value pairs. Conditional polarity
+per the 0557 test-polarity rule: nothing pins the abstract's authorial
+wording; weakening the abstract dissolves the obligation (the guard then
+skips).
+
+Mechanical checks (values re-derived from committed artifacts by an
+independent parse, per the 0557 polarity rule):
+
+- the cross-experiment per-agent comparison the abstract rests on is
+  re-derived from ``exp1_cross_eval.csv`` (same-lab flagship, parametric
+  arm) and ``tab_exp2_2x2.csv`` (naive, no-documents arm): exactly one
+  agent improves at the manuscript's 2-dp rounding;
+- the §exp2 multi-turn (no-documents) deltas support "degraded for three
+  of the four agents": exactly three of four naive→optimised deltas are
+  negative, and the body quotes each pair at 2 dp;
+- the §exp1 good-model F1 floor/ceiling literals match the
+  ``plot_exp1_reliability`` gate re-applied to ``exp1_cross_eval.csv``.
+"""
+
+import csv
+import re
+import statistics
+from pathlib import Path
+
+import pytest
+from manuscript_source import body_raw, normalized, raw, strip_comments
+
+from aedist.plot_exp1_reliability import N_REPS, is_good_run, load_rows
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+XEVAL_CSV = REPO_ROOT / "experiments" / "derived" / "exp1_cross_eval.csv"
+CSV_2X2 = REPO_ROOT / "experiments" / "derived" / "tab_exp2_2x2.csv"
+
+# The Exp2 agents and the same lab's flagship in the Exp1 parametric sweep.
+FLAGSHIPS = {
+    "anthropic": "claude-opus-4.6",
+    "openai": "gpt-5.5",
+    "mistral": "mistral-large-2512",
+    "qwen": "qwen3.7-max",
+}
+AGENT_NAMES = ("Anthropic", "OpenAI", "Mistral", "Qwen")
+
+# The abstract's coverage-story claim, in any of its phrasings. Structural
+# trigger only — the guard never requires this wording to be present.
+_ONLY_ONE_RE = re.compile(r"[Oo]nly one of (?:them|the four)")
+# A before-to-after value pair as the manuscript quotes them: "0.41 to 0.49".
+_PAIR_RE = re.compile(r"0\.\d{2} to 0\.\d{2}")
+
+
+def _abstract() -> str:
+    m = re.search(r"\\begin\{abstract\}(.*?)\\end\{abstract\}", raw(), re.DOTALL)
+    assert m, "no abstract environment in main.tex"
+    return normalized(m.group(1))
+
+
+def _exp2_paragraphs() -> list[str]:
+    """Blank-line-delimited paragraphs of §exp2, each normalized."""
+    text = strip_comments(body_raw())
+    start = text.find("\\label{sec:exp2}")
+    assert start != -1, "no \\label{sec:exp2} in main.tex body"
+    nxt = re.search(r"\\section\*?\{", text[start:])
+    sec = text[start : start + nxt.start()] if nxt else text[start:]
+    return [normalized(p) for p in re.split(r"\n\s*\n", sec) if p.strip()]
+
+
+def _exp2_text() -> str:
+    return " ".join(_exp2_paragraphs())
+
+
+def _exp1_flagship_means() -> dict[str, float]:
+    """Per-agent mean parametric F1 of the same lab's flagship (independent parse)."""
+    if not XEVAL_CSV.exists():
+        pytest.skip(f"{XEVAL_CSV} not generated")
+    by_model: dict[str, list[float]] = {m: [] for m in FLAGSHIPS.values()}
+    for r in csv.DictReader(XEVAL_CSV.open(encoding="utf-8")):
+        if r["arm"] == "parametric" and r["model"] in by_model:
+            by_model[r["model"]].append(float(r["accuracy_f1"]))
+    return {agent: statistics.mean(by_model[m]) for agent, m in FLAGSHIPS.items()}
+
+
+def _exp2_f1(arm: str) -> dict[str, float]:
+    """Per-agent mean F1 for one no-documents arm of the 2x2 CSV."""
+    if not CSV_2X2.exists():
+        pytest.skip(f"{CSV_2X2} not generated")
+    rows = list(csv.DictReader(CSV_2X2.open(encoding="utf-8")))
+    out = {r["agent"]: float(r["f1_mean"]) for r in rows if r["arm"] == arm and r["docs"] == "no"}
+    assert set(out) == set(FLAGSHIPS), f"2x2 CSV {arm}/no rows incomplete: {sorted(out)}"
+    return out
+
+
+def test_artifacts_support_only_one_agent_improving_over_memory():
+    """Exactly one agent's naive-arm F1 beats its lab's Exp1 flagship at 2 dp —
+    the data support for the abstract's coverage story, re-derived."""
+    exp1 = _exp1_flagship_means()
+    naive = _exp2_f1("naive")
+    improved = [a for a in FLAGSHIPS if round(naive[a], 2) > round(exp1[a], 2)]
+    assert len(improved) == 1, (
+        f"abstract coverage story expects exactly one improving agent, "
+        f"artifacts give {improved or 'none'}"
+    )
+
+
+def test_abstract_only_one_claim_backed_by_exp2_per_agent_comparison():
+    """S1 conditional guard: the abstract's only-one-of-four claim obliges the
+    §exp2 body to carry the per-agent comparison (four agent names + the
+    memory/parametric anchor + the four re-derived value pairs in one
+    paragraph)."""
+    if not _ONLY_ONE_RE.search(_abstract()):
+        pytest.skip("abstract no longer makes the only-one-of-four claim")
+    anchor_re = re.compile(r"memory|parametric|\\ref\{sec:exp1\}", re.IGNORECASE)
+    candidates = [
+        p
+        for p in _exp2_paragraphs()
+        if all(name in p for name in AGENT_NAMES)
+        and anchor_re.search(p)
+        and len(_PAIR_RE.findall(p)) >= len(AGENT_NAMES)
+    ]
+    assert candidates, (
+        "abstract claims only one of the four agents improved over the "
+        "memory-only query, but no §exp2 paragraph carries the per-agent "
+        "comparison (all four agent names, a memory/parametric baseline "
+        "anchor, and four before-to-after value pairs)"
+    )
+    # The quoted pairs are the artifact-derived ones, at 2-dp rounding.
+    exp1, naive = _exp1_flagship_means(), _exp2_f1("naive")
+    para = candidates[0]
+    for agent, name in zip(("anthropic", "openai", "mistral", "qwen"), AGENT_NAMES, strict=True):
+        pair = f"{round(exp1[agent], 2):.2f} to {round(naive[agent], 2):.2f}"
+        assert pair in para, f"{name} memory-vs-web pair {pair!r} missing from the comparison"
+
+
+def test_exp2_multiturn_deltas_match_artifact_and_three_of_four_decline():
+    """The multi-turn (no-documents) story: exactly three of four agents
+    decline naive→optimised, and §exp2 quotes each re-derived pair."""
+    naive, opt = _exp2_f1("naive"), _exp2_f1("optimised")
+    declined = [a for a in FLAGSHIPS if round(opt[a], 2) < round(naive[a], 2)]
+    assert len(declined) == 3, (
+        f"'degraded for three of the four agents' expects 3 declines, "
+        f"artifacts give {sorted(declined)}"
+    )
+    sec = _exp2_text()
+    for agent in FLAGSHIPS:
+        pair = f"{round(naive[agent], 2):.2f} to {round(opt[agent], 2):.2f}"
+        assert pair in sec, f"{agent} naive→optimised pair {pair!r} missing from §exp2"
+
+
+def test_exp1_good_model_f1_range_matches_gate():
+    """The §exp1 'F1 means of X--Y' literal for the nine good models matches
+    the reliability gate re-applied to the cross-eval artifact."""
+    if not XEVAL_CSV.exists():
+        pytest.skip(f"{XEVAL_CSV} not generated")
+    good_f1: dict[str, list[float]] = {}
+    counts: dict[str, int] = {}
+    for row in load_rows(XEVAL_CSV):
+        model = row["model"].strip()
+        counts.setdefault(model, 0)
+        if is_good_run(row):
+            counts[model] += 1
+            good_f1.setdefault(model, []).append(float(row["accuracy_f1"]))
+    means = [
+        statistics.mean(good_f1[m])
+        for m, n in counts.items()
+        if n >= N_REPS - 1  # the nine models with four or five good runs
+    ]
+    assert len(means) == 9, f"expected nine good models, gate gives {len(means)}"
+    literal = f"{min(means):.2f}–{max(means):.2f}"  # normalized() folds -- to –
+    text = strip_comments(body_raw())
+    start = text.find("\\label{sec:exp1}")
+    assert start != -1
+    nxt = re.search(r"\\section\*?\{", text[start:])
+    sec1 = normalized(text[start : start + nxt.start()] if nxt else text[start:])
+    assert literal in sec1, (
+        f"§exp1 good-model F1 range should read {literal!r} "
+        f"(re-derived from {XEVAL_CSV.name} under the reliability gate)"
+    )

--- a/tickets/0568-claims-findings-alignment-showstoppers.erg
+++ b/tickets/0568-claims-findings-alignment-showstoppers.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-06-12T15:55Z HDMX-coding-agent created
 
 2026-06-12T16:13Z HDMX-coding-agent note blocker 0567 closed — Blocked-by removed.
+2026-06-12T16:39Z HDMX-coding-agent note executed on branch t0568: S1 resolved by keeping the abstract claim (derivation holds: only Mistral improves vs same-lab Exp1 flagship) and adding the per-agent comparison + caveat to the §exp2 body; M1 deltas, E2 floor re-derived (0.4062 rounds to 0.41, text kept, guard added), M3 strip, M2 opener fix + dedupe, small fixes done; action 6 skipped (labels mandated by house convention and used by label-keyed tests). Guards in tests/test_manuscript_claims_alignment.py; make check green.
 --- body ---
 ## Context
 

--- a/tickets/0569-repetition-compression-restructure-seams.erg
+++ b/tickets/0569-repetition-compression-restructure-seams.erg
@@ -2,11 +2,11 @@
 Title: Repetition compression across the restructure seams
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0568
 
 --- log ---
 2026-06-12T15:55Z HDMX-coding-agent created
 
+2026-06-12T16:53Z HDMX-coding-agent note blocker 0568 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0572-convert-exp2-inline-f1-literal-pair-site.erg
+++ b/tickets/0572-convert-exp2-inline-f1-literal-pair-site.erg
@@ -1,0 +1,19 @@
+%erg 0.1
+Title: Convert §exp2 inline F1 literal-pair sites to generated macros
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T16:49Z HDMX-coding-agent created
+
+--- body ---
+## Context
+PR #1037 (ticket 0568) added a per-agent memory-vs-web comparison and per-agent multi-turn deltas to §exp2 as inline F1 literals guarded by re-derivation tests (tests/test_manuscript_claims_alignment.py), following the established pattern (tickets 0515/0501/0474). The verify-gate flagged the tension with the numbers-through-macros rule (ticket 0531, .claude/rules/writing.md). Orchestrator ruling 2026-06-12: guard pattern accepted for the PR; strict-macro uniformity deferred here. Related: open ticket 0566 covers the same conversion for the hand-typed ρ = 0.92.
+
+## Actions
+Extend the emitter that owns the exp2 fragment (see MANUSCRIPT_MACRO_FRAGMENTS in experiments/render.mk) to emit macros for all five §exp2 literal-pair sites (the four pre-existing equalization pairs included); replace inline literals with the macros; keep the re-derivation tests as cross-checks; coordinate with 0566 (same emitters) — consider executing both in one PR.
+
+## Exit criteria
+- [ ] no inline F1 literal pairs in §exp2
+- [ ] re-derivation tests still green
+- [ ] make check passes

--- a/tickets/closed/0568-claims-findings-alignment-showstoppers.erg
+++ b/tickets/closed/0568-claims-findings-alignment-showstoppers.erg
@@ -2,12 +2,14 @@
 Title: Claims/findings alignment — abstract coverage claim, degraded-vs-mixed, scaffolding strip, small fixes
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1037
 
 --- log ---
 2026-06-12T15:55Z HDMX-coding-agent created
 
 2026-06-12T16:13Z HDMX-coding-agent note blocker 0567 closed — Blocked-by removed.
 2026-06-12T16:39Z HDMX-coding-agent note executed on branch t0568: S1 resolved by keeping the abstract claim (derivation holds: only Mistral improves vs same-lab Exp1 flagship) and adding the per-agent comparison + caveat to the §exp2 body; M1 deltas, E2 floor re-derived (0.4062 rounds to 0.41, text kept, guard added), M3 strip, M2 opener fix + dedupe, small fixes done; action 6 skipped (labels mandated by house convention and used by label-keyed tests). Guards in tests/test_manuscript_claims_alignment.py; make check green.
+2026-06-12T16:53Z HDMX-coding-agent closed — autoclosed — PR #1037
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Author attention:** the abstract sentence now reads (one minimal addition, underlined here for visibility — the coverage claim itself is unchanged):

> Only one of them improved coverage over the memory-only query, and a harness giving them the opportunity to plan and execute a multi-step reply degraded the results **for three of the four**.

The only-one-of-four claim was KEPT: re-derived per-agent against the same lab's Experiment 1 flagship, it holds (see Derivations). The §exp2 body now carries that per-agent comparison explicitly, in the same paragraph as the independent-sweep caveat. The added qualifier "for three of the four" is the 3-of-4 degradation the 2×2 table supports. No other abstract text touched; abstract stays F1-free, em-dash-free, well under 300 words.

## What changed

- **S1 (showstopper)** — abstract claim kept; §exp2 body adds, right after the independent-sweep caveat sentence: per-agent naive-arm mean F1 vs the same lab's flagship in the §exp1 parametric sweep, naming all four agents with their value pairs, prefixed "Read with that caveat". Abstract, intro, body, and Conclusion now tell one story with the baseline explicit.
- **M1 (degraded vs mixed)** — abstract and intro keep "degrade" with the 3-of-4 qualification; the §exp2 body replaces "the contrast is mixed — modest gain for OpenAI, regression for Qwen" with the four per-agent F1 deltas from the committed 2×2 table.
- **E2 (F1 floor)** — re-derived floor is 0.4062, whose honest 2-dp rounding is 0.41, so the committed "0.41--0.67" already matches the artifact; text unchanged, a re-derivation guard now pins it (no emitter change needed — the macro route would have encoded a value the text already carries correctly).
- **M3 (scaffolding)** — "Both are grounds for a revised-prompt rerun in the journal version" → "The scores reported here measure the prompt as sent, with both limitations in place" (scoping, no venue promise; consistent with the no-companion-paper-promise brief entry).
- **M2 (Extensions opener)** — universal "points to the annex that develops it" dropped (ext-system has no annex; each subsection's own pointer does the work), and the duplicated participial "performed after the experiments were presented" deduplicated in the same paragraph.
- **Small fixes** — two §exp2 self-references (`§\ref{sec:exp2}`) → "this section"; "Verify ." is a truncated quote of the as-sent template (`format_status_line` in `experiments/sota/exp2_interactive_smoke.py:836-841`; archived turn files read "Verify pending.") → rendered as placeholder "Verify Z." with the state vocabulary (pending / on this turn / used) spelled out in prose, keeping the inline-quoted span count at 5; both §exp2 cites of `fig:coverage-certainty` now read "Figure~\ref{...} in \ref{sec:annex-exp2}" so the S2 number doesn't surprise.
- **Action 6 (orphan labels)** — deliberately skipped, not zero-cost: the house convention (`.claude/rules/writing.md`) mandates a label on every section heading and table, and `tests/test_abstract_numbers.py` keys its Conclusion extraction on `sec:conclusion`.
- **Tests** — `tests/test_manuscript_claims_alignment.py`, written red-first: conditional S1 guard (IF the abstract makes the only-one-of-four claim THEN a §exp2 paragraph must carry all four agent names + a memory/parametric anchor + the four artifact-derived value pairs; skips if the abstract is later weakened), plus three mechanical re-derivations (exactly one agent improves over memory; exactly three of four decline under the multi-turn protocol, pairs quoted; good-model F1 range matches the reliability gate).
- **Em-dash ratchet** — prose count drops 141 → 140 (one dash removed with the "mixed —" sentence; no new dashes added); ceiling file untouched.

## Derivations (artifact → value)

All values re-derived by the executor from the committed artifacts; the reviewers' numbers were treated as hypotheses and confirmed.

From `experiments/derived/exp1_cross_eval.csv` (parametric arm, mean accuracy_f1 over 5 reps, same-lab flagship):

| Exp1 flagship | mean F1 | 2 dp |
|---|---|---|
| claude-opus-4.6 | 0.6662 | 0.67 |
| gpt-5.5 | 0.6340 | 0.63 |
| mistral-large-2512 | 0.4062 | 0.41 |
| qwen3.7-max | 0.4078 | 0.41 |

From `report/inputs/generated/tab_exp2_2x2_agents.tex` (= `experiments/derived/tab_exp2_2x2.csv`), no-documents rows:

| Agent | naive | optimised | vs Exp1 flagship | multi-turn delta |
|---|---|---|---|---|
| Anthropic | 0.60 | 0.56 | 0.67→0.60 declined | −0.04 |
| Mistral | 0.49 | 0.39 | 0.41→0.49 **improved** | −0.10 |
| OpenAI | 0.63 | 0.65 | 0.63→0.63 flat | +0.02 |
| Qwen | 0.37 | 0.27 | 0.41→0.37 declined | −0.10 |

→ exactly one agent improves over the memory-only baseline (S1 claim holds per-agent); exactly three of four decline under the multi-turn harness (M1 "degraded for three of the four"). Under the "vs Exp1 best run" baseline nobody improves — the body comparison therefore names its baseline explicitly and sits beside the independent-sweep caveat.

From `experiments/derived/exp1_cross_eval.csv` under the `plot_exp1_reliability` gate (good run = no zero on any of the 12 reference-free dimensions; good model = ≥4 good runs of 5): nine good models, F1 means over good runs span 0.4062–0.6662 → honest 2-dp rendering 0.41–0.67, matching the committed text (E2: no change needed, guard added).

From `experiments/sota/exp2_interactive_smoke.py:836-841` and archived turn files (`experiments/outputs/sota_exp3_arm2_batch1/run01/anthropic_run01/anthropic_turn_02.user.txt`): the as-sent status prefix ends "Verify pending." / "on this turn." / "used." — the manuscript's "Verify ." was a truncated quote, now rendered as the placeholder "Verify Z." with the state vocabulary stated.

`make check` green (unit+adherence 2576 passed; integration tier 39 passed, 5 skipped; ruff clean; ERG CHECK PASS); manuscript builds with tectonic (`make -C slides manuscript`).

**Ticket:** tickets/0568-claims-findings-alignment-showstoppers.erg

Scope overflow: tickets/0572-convert-exp2-inline-f1-literal-pair-site.erg (macro-source §exp2 literal pairs — gate-escalated design question, orchestrator-accepted guard pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)