### PR TITLE
0569: repetition compression across the restructure seams

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -163,9 +163,8 @@ capabilities from chatbots to agentic systems (§\ref{sec:capability}),
 measure what model memory alone delivers across 14 language models
 (§\ref{sec:exp1}), and test the commercial frontier of mid-2026
 (§\ref{sec:exp2}). Post-hoc analyses prompted by the conference
-presentation extend the experiments (§\ref{sec:extensions}): why the
-task is hard, screening runs without a reference, fusing runs, and the
-system the findings imply. The Discussion (§\ref{sec:discussion})
+presentation extend the experiments (§\ref{sec:extensions}). The
+Discussion (§\ref{sec:discussion})
 examines why a single aggregate score cannot certify fitness for use,
 and §\ref{sec:future} turns the lessons of the methods literature into
 a research programme before we conclude.
@@ -904,10 +903,8 @@ four frontier models to agree nearly eliminates false positives — F1
 = \FusionRTwoEOneFFrac{} with \FusionRTwoEOneFP{} false positives on the Experiment 1 cohort, F1 = \FusionRTwoETwoOneDFFrac{}
 with \FusionRTwoETwoOneDFP{} on the Experiment 2 naive arm (full results in
 \ref{sec:annex-fusion}). Both levers reuse existing runs; the
-structural answer to the single-model ceiling is a stateful pipeline
-that invests in the corpus rather than the model — a managed,
-auditable knowledge base maintaining a sourced narrative inventory,
-from which the statistical table derives as a dated snapshot
+structural answer to the ceiling no single model breaks is a stateful
+pipeline that invests in the corpus rather than the model
 (§\ref{sec:ext-system}). To our knowledge, no published benchmark or
 system targets open-world enumeration of a national asset class with
 per-cell provenance at this granularity. Nor did we find a published
@@ -919,12 +916,12 @@ conjunction remains future work.
 
 The single-model ceiling motivates a stateful architecture: one that
 keeps an organised memory between runs instead of starting from scratch
-at each prompt. The equalisation result in §\ref{sec:exp2} sharpens the
-target: once the agents share a good document set, single-shot
-performance converges and the binding constraint appears to shift from
-model capability to document quality. The value may therefore lie in the corpus
-and the sourcing process — assembling, curating, and resolving the
-documents — rather than in chasing a stronger model. That is precisely
+at each prompt. Once the agents share a good document set, single-shot
+performance converges (§\ref{sec:exp2}) and the binding constraint
+appears to shift from model capability to document quality. The value
+may therefore lie in the corpus and the sourcing process — assembling,
+curating, and resolving the documents — rather than in chasing a
+stronger model. That is precisely
 what a stateful pipeline invests in: a managed, auditable knowledge base
 rather than a one-shot prompt against whatever model is current. The
 §\ref{sec:quality} quality dimensions measure \emph{output}: accuracy,
@@ -953,15 +950,11 @@ projections — are where language-model reasoning adds genuine value.
 
 \section{Discussion}\label{sec:discussion}
 
-The two experiments and the post-hoc extensions support a consistent
-reading. Memory alone is incomplete and volatile (§\ref{sec:exp1});
-web access at the commercial frontier buys coverage but not provenance
-or reproducibility, and a curated document set equalises the agents
-(§\ref{sec:exp2}); a reference-free screen rejects the weakest runs,
-pooling existing runs recovers coverage, and a two-model agreement
-gate restores precision (§\ref{sec:extensions}). This section examines
-what the measuring instrument can and cannot support in that reading:
-the F1 metric, its variance sources, and the single-case design.
+The two experiments (§\ref{sec:exp1}, §\ref{sec:exp2}) and the post-hoc
+extensions (§\ref{sec:extensions}) support a consistent reading,
+summarised in the Introduction. This section examines what the
+measuring instrument can and cannot support in that reading: the F1
+metric, its variance sources, and the single-case design.
 
 \textbf{F1 is a useful but opaque aggregate.} Row-level F1 is the
 primary metric in §\ref{sec:exp1} and §\ref{sec:exp2}: it is the
@@ -1215,10 +1208,9 @@ agents a curated document set in a single query equalises three of the
 four, though the multi-turn protocol does not replicate the effect
 (§\ref{sec:exp2}). Two levers already deliver without any new data
 collection. The reference-free screen rejects the weakest outputs
-without ground truth: within-run capacity variability tracks
-reference-based F1 (Spearman ρ = 0.92, pooled across models and
-in-sample; within-model signal positive but modest,
-\ref{sec:annex-screen}). Fusion recovers coverage: pooling runs across
+without ground truth (Spearman ρ = 0.92 against reference-based F1,
+pooled across models and in-sample; within-model signal positive but
+modest, \ref{sec:annex-screen}). Fusion recovers coverage: pooling runs across
 models finds plants no single model reliably finds, and requiring two
 models to agree nearly eliminates false positives (§\ref{sec:fusion}).
 If the constraint is indeed the documents, the path to research-grade
@@ -1711,12 +1703,11 @@ Opus 4.6 is preferred over the newer 4.7 for the parametric baseline
 because 4.7's verbosity exceeds the \texttt{max\_tokens} budget on the
 full Vietnam plant table. \textbf{GPT-5.5 declined this task on 3 of 5
 reps in this archived baseline sweep (prompt \texttt{p1\_base})},
-opening with ``I can't honestly produce a complete, primary-sourced
-inventory\ldots{}'' and refusing to fabricate URLs or source citations
-from parametric knowledge alone; the \texttt{modelset\_exp1\_batch2}
-re-run reported in the body resolved compliance. We retained the
-declined responses as data: a model viewpoint on the request's
-epistemic standard, not extraction noise.
+refusing to fabricate URLs or source citations from parametric
+knowledge alone; the \texttt{modelset\_exp1\_batch2} re-run reported in
+the body resolved compliance. The declined replies, quoted and read
+against the provenance bar, are taken up in the Discussion
+(§\ref{sec:discussion}).
 
 \subsection*{Run parameters}
 \addcontentsline{toc}{subsection}{Run parameters}
@@ -2359,11 +2350,11 @@ under-construction ones); page 3 lists the \ExpOneMatrixFPs{} most frequent fals
 The table below shares the same data derivation as the figure (library
 \texttt{aedist.exp1\_recognition}: common cause, no
 producer--consumer chaining) and decomposes the difficulty by status.
-The reference list is dominated by proposed plants — the largest share
-— which parametric memory cannot know; their mean recognition rate is
-far below that of operational plants. The low overall recognition is
-therefore structural, a property of the list's composition, not merely a
-model failure.
+Proposed plants form the largest share of the rows, and parametric
+memory cannot know them; their mean recognition rate falls far below
+that of operational plants. The low overall recognition is thus
+structural: it reflects the composition of the list, not merely model
+failure.
 
 \begin{table}[htbp]
 \centering

--- a/tickets/0569-repetition-compression-restructure-seams.erg
+++ b/tickets/0569-repetition-compression-restructure-seams.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-06-12T15:55Z HDMX-coding-agent created
 
 2026-06-12T16:53Z HDMX-coding-agent note blocker 0568 closed — Blocked-by removed.
+2026-06-12T17:15Z HDMX-coding-agent note executed: 5 MAJOR + 3 MINOR compressed; em-dash prose count 140->137 (ceiling 141 untouched); ext-system keeps the hedged constraint-shift clause (fusion-hedge brief anchor); make check green
 --- body ---
 ## Context
 

--- a/tickets/0570-tone-polish-paragraph-splits.erg
+++ b/tickets/0570-tone-polish-paragraph-splits.erg
@@ -2,11 +2,11 @@
 Title: Tone polish to the author's prose style + split overlong paragraphs
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0569
 
 --- log ---
 2026-06-12T15:55Z HDMX-coding-agent created
 
+2026-06-12T17:21Z HDMX-coding-agent note blocker 0569 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0569-repetition-compression-restructure-seams.erg
+++ b/tickets/closed/0569-repetition-compression-restructure-seams.erg
@@ -2,12 +2,14 @@
 Title: Repetition compression across the restructure seams
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1038
 
 --- log ---
 2026-06-12T15:55Z HDMX-coding-agent created
 
 2026-06-12T16:53Z HDMX-coding-agent note blocker 0568 closed — Blocked-by removed.
 2026-06-12T17:15Z HDMX-coding-agent note executed: 5 MAJOR + 3 MINOR compressed; em-dash prose count 140->137 (ceiling 141 untouched); ext-system keeps the hedged constraint-shift clause (fusion-hedge brief anchor); make check green
+2026-06-12T17:21Z HDMX-coding-agent closed — autoclosed — PR #1038
 --- body ---
 ## Context
 


### PR DESCRIPTION
The 0562 restructure left the same content stated 2-3 times across the section seams. Principle: keep the structurally-primary occurrence, compress secondaries to a clause + \ref pointer. **No number, hedge, or claim altered** — 0568 froze them; this diff only removes redundant restatement.

## What changed (per item)

| # | Repetition | Kept where (primary) | Compressed where |
|---|-----------|----------------------|------------------|
| M1 | ρ = 0.92 identical gloss | §ext-screen (full mechanism: within-run capacity variability, 70 runs, threshold rule) | Conclusion: mechanism gloss dropped; keeps value + pooled/in-sample caveat + `\ref{sec:annex-screen}` exactly as the `rho-caveat-conclusion` brief entry mandates |
| M2 | Curated documents equalise the agents (3×) | §exp2 (full development, all numbers) | §ext-system: one citing sentence ("Once the agents share a good document set, single-shot performance converges (§exp2)…"); Conclusion keeps its one-sentence version; the Discussion echo went with M3 |
| M3 | Discussion opener re-narrates all three results | Intro (three-results paragraph) + the sections themselves | Discussion opener: one orienting sentence + the scope statement (what the instrument can and cannot support) |
| M4 | Managed, auditable KB / dated snapshot formula | §ext-system (the system subsection: full formula, derived projection, claim structure) | §fusion: reduced to a forward-reference clause "(§\ref{sec:ext-system})" — one em dash dropped |
| M5 | Four-extension enumeration (intro roadmap vs §7 opener) | Extensions opener (does presentational work: the audience questions) | Intro roadmap: "Post-hoc analyses … extend the experiments (§\ref{sec:extensions})." — enumeration dropped |
| m6 | Status-composition conclusion (§ext-difficulty vs recognition annex) | Both stay (acceptable summary/full split) | Annex sentences reworded so they are no longer verbatim; two em dashes dropped |
| m7 | GPT-5.5 refusal told 3× | §exp1 reports the event (already a pointer); Discussion interprets it (quote stays there) | Exp1 annex: verbatim refusal quote dropped, becomes a pointer to the Discussion (§\ref{sec:discussion}); facts (3/5 reps, p1_base, refusal-to-fabricate, batch2 re-run resolved compliance) all retained |
| m8 | "Single-model ceiling" echo | §ext-system keeps the canonical phrase (subsection topic sentence) | §fusion reworded to "the ceiling no single model breaks"; the annex-fusion pointer is distant and unchanged |

## Items already resolved by 0567/0568 (verified by grep before touching)

- **Extensions-opener duplicated participial** ("performed after the experiments were presented" twice) — deduplicated by 0568 (M2 of that ticket); confirmed gone, nothing to do.
- **m8 Conclusion occurrence** — the Conclusion no longer carries "single-model ceiling" at all (reads "not through a stronger model or a single heroic prompt"); resolved before this ticket.
- **m7 §exp1 body occurrence** — already compressed to an event report + Discussion pointer in the current text; only the annex occurrence still carried the duplicate quote.
- All other listed repetitions verified still present in the current text before compression.

## Deviation from the ticket's letter (M2)

The ticket's example sentence for §ext-system drops the constraint-shift clause. I **kept** "and the binding constraint appears to shift from model capability to document quality" there: the `fusion-hedge` editorial-brief entry anchors that hedged claim to `sec:ext-system`, and the ticket's own invariant freezes claims and hedges — deleting it would orphan the brief entry. The re-announcement scaffolding ("The equalisation result in §exp2 sharpens the target:") is what was cut.

## Verification

- **No new adherence test**: semantic repetition is not CI-testable under the 0557 polarity rule (a positive pin on compressed phrasing would break on every legitimate rewrite). Verification is by the PR reviewer reading the four seams: intro→Extensions, fusion→ext-system, Extensions→Discussion, Discussion→Conclusion.
- Every fact still stated somewhere (per-item table above); claim strength and hedges untouched.
- `make check` green: 2576 passed + 39 slow passed, 5 skipped, 1 xfailed; lint, ticket structure, erg check all PASS.
- Manuscript builds under tectonic (582 KiB PDF).
- Em-dash ratchet: prose count 140 → **137**, ceiling 141 untouched (0568 precedent: count reduction without ceiling churn).

**Ticket:** tickets/0569-repetition-compression-restructure-seams.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)