### PR TITLE
Clarify evaluation methodology and document matching limitations

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1847,7 +1847,8 @@ two units as a single combined row (e.g.\ ``Kiên Giang~1 \& 2''), the
 row can match at most one of the two reference entries and the other is
 recorded as a false positive. A post-hoc audit of Exp.~2 false
 positives identified five such combined-unit cases; they are classified
-as reconciliation artefacts rather than model hallucination.
+as reconciliation artefacts — a reference entry left unmatched by row
+aggregation — rather than plants invented by the model.
 
 Metrics recorded per run:
 

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1827,19 +1827,30 @@ report ours as an observation rather than a primacy claim.
 \subsection*{Evaluation}
 \addcontentsline{toc}{subsection}{Evaluation}
 
-Each run is evaluated against the reference by
-\texttt{src/aedist/evaluate.py}. Plant pairs are matched by
-mixed-integer linear programming (MILP) — the LP matcher in
-\texttt{src/aedist/matching/lp.py} (ADR-2) — minimising a cost that
-combines (i) rapidfuzz \texttt{partial\_ratio} name similarity, with
-candidate pairs requiring \texttt{similarity\_threshold\ ≥\ 90} (integer
-0--100 scale), and (ii) a small capacity-difference term
-(\texttt{capacity\_weight\ ·\ |Δcapacity\_MWe|},
-default weight 0.001). Province and fuel are deliberately not part of
-the matching cost (ADR-3); they are scored separately as cell-level
-attribute accuracy on the matched pairs. The optimal one-to-one
-assignment is then solved globally rather than picked greedily. Metrics
-recorded per run:
+Each run is evaluated against the reference using a minimum-cost
+bipartite assignment formulated as a mixed-integer linear programme
+(LP~matcher). Each candidate pair $(i,j)$ receives a cost combining
+(i)~a name-similarity term — zero for exact matches, one when the
+\texttt{partial\_ratio} score reaches~90 on the integer 0--100 scale,
+and a large penalty otherwise — and (ii)~a small capacity-difference
+term (default weight $10^{-3}$ per MWe). Binary slack variables allow
+any record to be left unmatched at a fixed penalty rather than forced
+into a poor pairing; the global optimum is found by a branch-and-bound
+solver rather than greedily. This formulation is mathematically
+equivalent to a minimum-cost flow problem on a bipartite supply-demand
+graph with unit capacities. Province and fuel are deliberately excluded
+from the matching cost; they are scored separately as cell-level
+attribute accuracy on the matched pairs.
+
+The one-to-one assignment is a known limitation: when a reference entry
+names a power centre while the model enumerates its individual units
+(e.g.\ ``Kiên Giang~1 \& 2'' reported as a single row), the combined
+row cannot simultaneously match both reference units and is recorded as
+a false positive. A post-hoc audit of Exp.~2 false positives identified
+five such aggregate-vs-split cases; they are classified as
+reconciliation artefacts rather than model hallucination.
+
+Metrics recorded per run:
 
 \begin{longtable}[]{@{}
   >{\raggedright\arraybackslash}p{(\linewidth - 4\tabcolsep) * \real{0.3333}}

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1842,13 +1842,12 @@ graph with unit capacities. Province and fuel are deliberately excluded
 from the matching cost; they are scored separately as cell-level
 attribute accuracy on the matched pairs.
 
-The one-to-one assignment is a known limitation: when a reference entry
-names a power centre while the model enumerates its individual units
-(e.g.\ ``Kiên Giang~1 \& 2'' reported as a single row), the combined
-row cannot simultaneously match both reference units and is recorded as
-a false positive. A post-hoc audit of Exp.~2 false positives identified
-five such aggregate-vs-split cases; they are classified as
-reconciliation artefacts rather than model hallucination.
+The one-to-one assignment is a known limitation: when a model reports
+two units as a single combined row (e.g.\ ``Kiên Giang~1 \& 2''), the
+row can match at most one of the two reference entries and the other is
+recorded as a false positive. A post-hoc audit of Exp.~2 false
+positives identified five such combined-unit cases; they are classified
+as reconciliation artefacts rather than model hallucination.
 
 Metrics recorded per run:
 

--- a/tickets/0591-sweep-codenames-code-refs.erg
+++ b/tickets/0591-sweep-codenames-code-refs.erg
@@ -6,6 +6,7 @@ Blocked-by: 0590
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 8, 22, 23, 24); flow-vs-MILP discrepancy flagged for verification
+2026-06-13T08:40Z finding 23 (matcher naming) partially addressed: Evaluation paragraph in main.tex (ex-L1830) rewritten. New prose names the method "minimum-cost bipartite assignment (MILP)", adds the flow-equivalence sentence, removes ADR-2/ADR-3 codenames and \texttt file/function references, and documents the 1:1 limitation with the five aggregate-vs-split cases from the Exp.2 FP audit. Remaining work: findings 8, 22, 24 (full codename sweep, code refs in §1–§9).
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary
Rewrites the Evaluation section in the manuscript to improve clarity of the matching methodology and document known limitations discovered during analysis.

## Key Changes
- **Renamed matching method**: Changed from internal codename references (ADR-2, ADR-3) to descriptive terminology: "minimum-cost bipartite assignment (LP matcher)" with explicit mention of the mixed-integer linear programme formulation
- **Enhanced mathematical description**: Added clearer explanation of the cost function structure, including how name similarity is scored (zero for exact matches, one at partial_ratio=90, large penalty otherwise) and capacity difference weighting
- **Added flow equivalence**: Included note that the formulation is mathematically equivalent to a minimum-cost flow problem on a bipartite supply-demand graph
- **Documented 1:1 matching limitation**: Added new paragraph explaining that the one-to-one assignment constraint causes issues when models report combined units (e.g., "Kiên Giang 1 & 2") as single rows, which can only match one reference entry. Documented five such cases identified in Experiment 2 false positive audit, classified as reconciliation artefacts rather than model hallucination
- **Removed implementation details**: Eliminated file/function references (\texttt{src/aedist/...}) and internal ADR codenames to focus on methodology rather than code structure

## Implementation Details
The changes maintain the same evaluation logic while improving exposition for readers. The new paragraph on combined-unit limitations provides important context for interpreting false positive metrics and distinguishes between genuine model errors and structural matching constraints.

https://claude.ai/code/session_01HUBv2NqM5b1uUeiSJRM6SR

Ticket-ref: tickets/0591-sweep-codenames-code-refs.erg
