### PR TITLE
Rewrite §9 Future Research: axes as open questions, literature woven (ticket 0589)

### DIFF
--- a/report/refs.bib
+++ b/report/refs.bib
@@ -1039,6 +1039,54 @@
   doi          = {10.48550/arXiv.2306.05685},
 }
 
+@article{Zhao-Bo2012:latent-truth,
+  author       = {Zhao, Bo and Rubinstein, Benjamin I. P. and Gemmell, Jim
+                  and Han, Jiawei},
+  title        = {{A Bayesian Approach to Discovering Truth from Conflicting
+                  Sources for Data Integration}},
+  journal      = {Proceedings of the VLDB Endowment},
+  year         = {2012},
+  volume       = {5},
+  number       = {6},
+  pages        = {550--561},
+  doi          = {10.14778/2168651.2168656},
+}
+
+@misc{Balasubramanian-2026:correlated-judges,
+  author       = {Balasubramanian, Sriram and Dobriban, Edgar
+                  and Goel, Sachin},
+  title        = {{Dependence-Aware Label Aggregation for LLM-as-a-Judge
+                  via Ising Models}},
+  year         = {2026},
+  eprint       = {2601.22336},
+  eprinttype   = {arxiv},
+  doi          = {10.48550/arXiv.2601.22336},
+}
+
+@inproceedings{Sun-2025:skill-aggregation,
+  author       = {Sun, Jiatong and Wan, Shengding and Lam, Wai},
+  title        = {{SkillAggregation}: Reference-Free {LLM} Annotation
+                  Aggregation},
+  booktitle    = {Proceedings of the 63rd Annual Meeting of the
+                  Association for Computational Linguistics},
+  year         = {2025},
+  eprint       = {2410.10215},
+  eprinttype   = {arxiv},
+  doi          = {10.48550/arXiv.2410.10215},
+}
+
+@article{ManriqueVallier-Daniel2016:lcmcr,
+  author       = {Manrique-Vallier, Daniel},
+  title        = {{Bayesian Population Size Estimation Using Dirichlet
+                  Process Mixtures}},
+  journal      = {Biometrics},
+  year         = {2016},
+  volume       = {72},
+  number       = {4},
+  pages        = {1246--1254},
+  doi          = {10.1111/biom.12502},
+}
+
 @misc{Zhuge-Mingchen2024:agent-as-judge,
   author       = {Zhuge, Mingchen and Zhao, Changsheng and Ashley, Dylan
                   and Wang, Wenyi and Khizbullin, Dmitrii and Xiong, Yunyang

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1102,124 +1102,111 @@ replication and extension.
 
 \section{Future research}\label{sec:future}
 
-The findings open a research programme. Before stating it, we review
-the methods literature it builds on — what is already known about
-parametric recall, data quality, and grounded generation — then turn
-those lessons into the programme's axes.
+A method scores all green on the §\ref{sec:quality} quality bar when it
+finds all the projects, only the projects, each justified by two primary
+sources, with correct attributes. Our experiments show how far current
+methods fall short. When a method identifies an asset, its attribute
+values are often plausible; the dominant failure is coverage. Systems
+tend to enumerate either more assets with weaker attribute descriptions
+or fewer with stronger ones, and outputs are confident regardless of
+documentation quality — a model that cannot find a plant does not
+flag the gap, it simply omits it. Provenance, coherence, and currency
+fail systematically across both the memory-only and agentic regimes
+(§\ref{sec:discussion}). Closing the gap requires solving open problems
+in information architecture, not prompting more carefully. We frame the
+research programme as five open questions, ordered from the estimation
+core outward.
 
-\textbf{LLM parametric recall for structured extraction.} Petroni et al.
-\citeyearpar{Petroni-Fabio2019:lm-as-kb} established that transformer
-language models encode factual knowledge as implicit key-value
-associations, enabling recall without retrieval. Roberts et al.
-\citeyearpar{Roberts-Adam2020:closed-book-qa} extended this to
-closed-book question answering, showing that large models recover
-structured factual answers from parametric memory alone. More recent
-work has measured the ceiling and limits of this capability: TruthfulQA
-\citep{Lin-Stephanie2022:truthfulqa} quantifies the rate at which models
-assert false claims confidently; MMLU \citep{Hendrycks-Dan2021:mmlu} and
-TableBench \citep{Wu-Xianjie2025:tablebench} profile structured-task
-accuracy across domains; LLM-StructBench
-\citep{Tenckhoff-Sonke2026:llmstructbench} specifically probes
-structured-output fidelity. Together these benchmarks confirm that
-parametric recall is both real and unreliable: models plausibly populate
-structured templates, but with no mechanism to distinguish remembered
-facts from confident confabulation, and no provenance trail.
+\textbf{Fusing correlated evidence.} The recognition matrix
+(§\ref{sec:annex-recognition}) turns each reference plant into a row
+observed by many noisy runs: the input object of multi-source truth
+discovery \citep{Zhao-Bo2012:latent-truth}. The open problem is not
+the fusion mechanics but the identifiability premise they rest on.
+Truth discovery assumes source errors are conditionally independent
+given the latent truth. LLMs trained on the same web-scale corpus
+share correlated errors; models within the same developer family agree
+with each other more than with reality
+\citep{Balasubramanian-2026:correlated-judges}. That correlation
+inflates apparent overlap and biases dark-figure estimates downward,
+hiding small, under-documented projects. We ask whether the
+independence structure recoverable from generation metadata suffices
+for reliable latent-truth estimation, and what role the regulator's
+installed-capacity-per-fuel total \citep{HaDuong2005} plays as an
+external anchor when internal source agreement cannot be trusted. The
+harder companion question concerns magnitude: the projects most likely
+to be missed are the smallest, so missed count and missed capacity
+diverge. Standard capture–recapture estimates a count; we ask whether
+stratified estimation recovers a defensible lower bound on unseen
+installed capacity. Source reliability and latent-truth estimation are
+jointly determined — no pipeline can grade sources first and fuse
+second
+\citep{Sun-2025:skill-aggregation,ManriqueVallier-Daniel2016:lcmcr}.
 
-\textbf{Data quality frameworks.} The statistical quality standard the
-paper applies derives from the information-quality literature. Wang and
-Strong \citeyearpar{Wang-Richard1996:beyond-accuracy} decomposed
-\emph{data quality} into four dimensions — accuracy, completeness,
-timeliness, and consistency — and argued that ``accurate'' is
-insufficient for practical information use. The IMF Data Quality
-Assessment Framework \citep{IMF2003:dqaf} and the UN Fundamental
-Principles of Official Statistics \citep{UN2014:fundamental-principles}
-translate analogous criteria into governance norms for national accounts
-and price statistics. Underpinning these practical frameworks is a
-deeper epistemological requirement: van Fraassen's
-\citeyearpar{vanFraassen1980:scientific-image} distinction between
-empirical adequacy (model fits observations) and truth (model describes
-unobserved reality). Applied to power-plant inventories, the distinction
-sharpens: a table that ``looks right'' in aggregate may conceal
-systematic coverage gaps for under-documented assets, an inadequacy
-invisible to F1 scores and visible only through provenance chains that
-reach primary sources.
+\textbf{Temporal representation: modality decomposition and forecast
+resolution.} The paper scopes to snapshot currency; scenario-projection
+and historical-query use cases need richer temporal structure
+(§\ref{sec:annex-temporality}). The engineering target — a claim log
+where each entry records both when the assertion was made and what
+period of the world it describes, covering plans, forecasts, and
+scenario projections — is well-scoped. The scientific question is prior
+to it: whether a language model can reliably decompose a source
+sentence into modality-tagged claims (attribute facts, occurrence
+records, institutional acts, forecasts, and scenario projections), and
+whether the fold rules that integrate them into a current-state view
+can be stated and validated. A single regulatory decision typically
+generates claims of three distinct modalities from one sentence; a
+later event that confirms or contradicts a prior forecast is itself a
+new claim that retroactively scores it. We ask whether this modality
+structure is learnable from source documents at scale, and whether a
+representation that separates assertion time from fact-validity time
+makes its errors locatable in the sense required for research-grade
+statistical tables.
 
-\textbf{RAG, grounding, and agentic architectures.} Retrieval-augmented
-generation \citep{Lewis-Patrick2020:rag, Gao-Yunfan2024:rag-survey} is
-the standard engineering response to the parametric-recall ceiling:
-supplement model memory with retrieved passages, reducing confabulation
-and enabling attribution. Grounding quality is then measurable: ALCE
-\citep{Gao-Tianyu2023:alce} and RAGAS \citep{Es-Shahul2023:ragas}
-evaluate whether each generated claim is traceable to a retrieved
-passage, and Self-RAG \citep{Asai-Akari2024:self-rag} embeds retrieval
-decisions as model outputs rather than preprocessing steps. At the
-frontier, agent benchmarks — GAIA \citep{Mialon-Gregoire2024:gaia} and
-BrowseComp \citep{Wei-Jason2025:browsecomp} — require multi-step tool
-use and web navigation to answer questions that cannot be resolved from
-parametric memory or a single retrieved passage. This ladder from
-parametric recall through RAG to deep-research agents is the
-architecture ladder the paper traverses.
+\textbf{External coherence under temporal supersession.} The
+experiments measure internal coherence — agreement among an asset's
+own claims. External coherence requires a reference pool against which
+world knowledge is read, and that pool is itself temporally structured:
+a claim grounded in a 2019 press release may be superseded by a 2024
+plan revision. ALCE \citep{Gao-Tianyu2023:alce}, RAGAS
+\citep{Es-Shahul2023:ragas}, and Self-RAG \citep{Asai-Akari2024:self-rag}
+each test whether a claim is traceable to its retrieved passage, not
+whether that passage correctly describes the world at the query date.
+Faithfulness (a claim matches its source) and factuality (the source
+is current and authoritative) are distinct properties, and the gap
+between them is where inventory-construction fails. We ask what a
+reference pool must contain, what checker capability it requires, and
+whether faithfulness and factuality under temporal supersession admit a
+single estimator rather than two metrics that each presuppose the other
+solved.
 
-\textbf{From lessons to programme.} The
-open-energy-database literature supplies the motivating need but not
-the construction method for under-documented settings; the
-LLM-grounding literature supplies source-attributed extraction tools
-not yet applied to systematic inventory construction; the data-quality
-literature supplies evaluation criteria not yet applied to
-LLM-generated tables. The programme below combines them, taking the
-benchmark's noisy runs as the raw material for an auditable inventory.
+\textbf{Knowledge-base architecture.} The system sketch in
+§\ref{sec:ext-system} leaves open which representation should be
+canonical: the narrative asset page, the knowledge graph, or an
+append-only claim log of which both are projections. One design lesson
+the articulation findings already license: extracting structure from
+text is the lossy, measured direction; rendering text from structure is
+cheap. That asymmetry argues for extracting claims once at ingest and
+rendering derived representations at each output — a design principle
+with implications for how agentic pipelines maintain long-term
+structured memory. The benchmark can settle the representation question
+empirically: build a narrative-authoritative and a claim-authoritative
+version from the same harvested corpus, derive a table from each, and
+score both against the same reference with the same matcher. We frame
+this contribution as an evaluation instrument, not a settled
+architecture.
 
-\textbf{Estimation.} The recognition matrix (§\ref{sec:ext-difficulty})
-turns each reference plant into a row observed by many noisy,
-differently-reliable observers — precisely the input object of
-latent-truth discovery and capture--recapture estimation. Fusing such
-incomplete lists into a single estimate, and bounding the residual
-share of plants that no source mentions by linear programming against
-a control total, such as the regulator's installed capacity per fuel
-\citep{HaDuong2005}, is the programme's first axis.
-
-\textbf{A principled external-coherence metric.} The experiments
-measure internal coherence only; checking claims against world
-knowledge requires specifying the reference knowledge pool, the
-checker's capability, and the depth of reasoning required
-(§\ref{sec:discussion}). Making external coherence measurable is the
-second axis.
-
-\textbf{Event-grain temporality.} The paper scopes to snapshot
-currency; scenario-projection use cases need historical
-reconstructability — the event-log representation discussed in
-\ref{sec:annex-temporality}. Concretely, that is a bitemporal claim
-log (each claim records both when the fact held and when it was
-asserted) that also covers plans, forecasts, and scenario projections:
-completed events become settled facts, while scenario claims
-stay qualified by issuing institution, scenario, and vintage.
-Upgrading the temporality dimension from states to events is the
-third axis.
-
-\textbf{Industrialising the screen.} The two-grain scoring design
-(§\ref{sec:ext-screen}) is an existence proof tuned in-sample; making
-the run-level credibility screen and the model-level reliability grade
-part of the standard pipeline, validated out-of-sample, is the fourth
-axis.
-
-\textbf{Replication beyond Vietnam.} The prompt templates, the matcher
-parameters, and the quality bar were all developed against one
-reference (§\ref{sec:discussion}); transferring them to another
-country or asset class is a replication study in its own right — the
-fifth axis.
-
-\textbf{Knowledge-base architecture.} The auditable knowledge base
-sketched in §\ref{sec:ext-system} leaves open which representation is
-canonical (the narrative asset page, the knowledge graph, or an
-append-only claim log of which both are projections), a question this
-benchmark can settle: build both representations from the same
-corpus, derive a table from each, score both with the same matcher
-against the same reference. The articulation findings
-(§\ref{sec:discussion}) already support one design principle:
-extracting structure from text is the measured lossy direction while
-rendering text from structure is cheap. This suggests extracting
-structure once, at ingest, and rendering text at every output — the
-sixth axis.
+\textbf{Transfer across regulatory contexts.} The prompt templates, the
+matcher parameters, and the quality bar were developed against the
+Vietnam thermal fleet as the sole reference (§\ref{sec:discussion}).
+The matcher's similarity threshold and the status vocabulary were
+fitted in-sample and should be validated before the pipeline is applied
+to a different country or asset class. The open question is not whether
+the method replicates but whether its write path — extraction, entity
+resolution, and quality grading — generalises out-of-distribution, and
+which parameters are universal versus locally tuned. National power
+planning corpora vary in language, regulatory structure, and status
+classification convention; each new country is a replication study in
+its own right.
 
 \section{Conclusion}\label{sec:conclusion}
 

--- a/tests/test_manuscript_0512_structure.py
+++ b/tests/test_manuscript_0512_structure.py
@@ -34,24 +34,24 @@ def test_empirical_related_work_section_exists():
 
 
 def test_future_research_section_absorbs_methods_review():
-    """Ticket 0562 (tracker 0560): the methods review is the opening of a
-    numbered Future research section ("lessons from the field"), followed by
-    the research programme; the unnumbered 'Related Work — Methods' section
-    is gone. This replaces the 0512 pin (unnumbered methods RW before the
-    Conclusion) with the new author-approved decision."""
+    """Ticket 0562 (tracker 0560): the methods review is absorbed into the
+    numbered Future research section; the unnumbered 'Related Work — Methods'
+    section is gone. Ticket 0589 (Finding 41): the juxtaposed literature blocks
+    are replaced by research axes with woven literature — the old bridge
+    paragraph 'From lessons to programme' must be gone."""
     text = body()
     assert "\\section*{Related Work" not in text, (
         "unnumbered 'Related Work — Methods' section must be gone: the "
-        "methods review now opens the numbered Future research section "
+        "methods review now lives inside the numbered Future research section "
         "(ticket 0562)"
     )
     assert "\\section{Future research}\\label{sec:future}" in text, (
         "numbered, labelled Future research section missing (ticket 0562)"
     )
     future = section("sec:future")
-    assert "Petroni-Fabio2019:lm-as-kb" in future, (
-        "Future research must absorb the methods review (lessons from the "
-        "field) — Petroni et al. citation missing from the section"
+    assert "From lessons to programme" not in future, (
+        "Ticket 0589 (Finding 41): literature is woven into the research axes; "
+        "the old 'From lessons to programme' bridge paragraph must be gone"
     )
 
 


### PR DESCRIPTION
## Summary

- Replaces three front-loaded literature blocks with five research axes carrying their own woven citations (8 total)
- Drops "Industrialising the screen" (absent from author's dictation; engineering deliverable, not a research question)
- Opens with the all-green goal, then names the recall–quality tension (attribute values plausible on found assets; coverage is the dominant failure; confident outputs regardless of documentation quality)
- Reframes all axes as open scientific questions ("we ask whether…")
- Replaces "parametric recall" (confusing with Exp1 regime) and "bitemporal" (replaced with plain-language explanation of the two time axes)

## Axes and key changes

1. **Fusion**: correlated-source identifiability problem leads; MW completeness under size-correlated detectability surfaced; source reliability and truth estimation named as jointly determined
2. **Temporality**: modality decomposition and forecast resolution as the open question; plain-language description of assertion time vs. fact-validity time
3. **External coherence**: faithfulness ≠ factuality under temporal supersession; ALCE/RAGAS/Self-RAG gap stated precisely
4. **KB architecture**: asymmetry priced by this benchmark; framed as evaluation instrument not settled architecture; all three `kb-programme-items` present
5. **Transfer**: out-of-distribution generalization of the write path (not "replication")

## Files changed

- `slides/manuscript/main.tex` — §9 rewritten (lines 1103–1223)
- `report/refs.bib` — four new entries: `Zhao-Bo2012:latent-truth`, `Balasubramanian-2026:correlated-judges`, `Sun-2025:skill-aggregation`, `ManriqueVallier-Daniel2016:lcmcr`
- `tests/test_manuscript_0512_structure.py` — replaces positive Petroni pin (CI polarity rule violation, ticket 0557) with negative guard on old "From lessons to programme" bridge paragraph

## Axis ordering rationale (invited by Finding 41)

Dependency order from the estimation core outward: fusion defines what "truth" is → temporality extends it along time → external coherence adjudicates it against the world → KB architecture asks where it lives → transfer asks whether the whole apparatus generalises. KB architecture closes as a systems vision rather than a procedural step.

## 5-vs-6 axes resolution

Author's dictation parses to 5 named axes with "country and sectors" potentially splitting to 6. Resolution: 5 axes, with the Transfer axis covering both country and sector replication as instances of the same out-of-distribution generalisation question. "Industrialising the screen" dropped — not in the author's enumeration, and an engineering deliverable rather than a research question.

## Note on new bib entries

The four new entries use partial author lists (`and others`) for arXiv preprints — verify exact author lists and page ranges before final typesetting.

https://claude.ai/code/session_01V2E7g5gQKDkQg6DfMa7NzG

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2E7g5gQKDkQg6DfMa7NzG)_