### PR TITLE
manuscript(0580): rework intro to one page, single benchmark contribution

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -255,18 +255,27 @@ immutable.
 
 ## intro-contributions-runin
 
-**Decision:** §1 closes with the contributions woven into prose (author
-intro restructure, 2026-06-12, PR #1023); the earlier bold
-"Contributions." run-in label with a three-item list (0513) is no longer
-pinned. CI keeps only the negative guard: contributions never get their
-own section heading.
+**Decision:** §1 contributes a single thing — THE BENCHMARK — woven
+into prose, never a three-contributions-plus-three-results enumeration
+(reading-2 finding 27, ticket 0580). The four-dimension quality score
+is presented as the benchmark's computable metric, not as a separate
+contribution. The intro drops the two-grain credibility/reliability
+framing and the STANAG 2511 / NATO Admiralty vocabulary (those live in
+the screening subsection `sec:ext-screen`, pinned by entry
+novelty-two-grain) and drops the "targeted pipeline design narrows the
+gap" framing. The screening message reads as "reference-free criteria
+suffice to screen out the weakest runs and models". The earlier bold
+"Contributions." run-in label with a three-item list (0513) is no
+longer pinned. CI keeps only the negative guard: contributions never
+get their own section heading.
 
-**Rationale:** Authorial phrasing/structure choice — positive pin
-demoted per the CI polarity rule (0557). The framing history lives here,
-not in a test.
+**Rationale:** Authorial phrasing/structure choice — positive pins
+demoted per the CI polarity rule (0557). One-contribution framing reads
+as a focused benchmark paper rather than a checklist; the framing
+history lives here, not in a test.
 
-**Ticket:** 0513; demoted during PR #1023 gate (residual missed by 0559
-sweep, which covered test_manuscript_0512_structure.py only).
+**Ticket:** 0580 (one-page benchmark rework); 0513 (earlier run-in
+demotion during PR #1023 gate).
 
 **Status:** active
 

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -126,35 +126,29 @@ benchmark suites that rank today's systems \citep{Hendrycks-Dan2021:mmlu,
 Ni-Shiwen2025:llm-benchmark-survey}; this paper extends the practice to
 national statistical registers.
 
-This paper makes three contributions, each reusable beyond the
-Vietnamese case. The first is the benchmark itself: to our knowledge,
-the first sourced evaluation of AI agents on national power-plant
-inventory construction, scored against a hand-compiled, fully sourced
-reference, with per-row citation coverage and corroboration measured
-(the paper counts and checks the presence of citations; it does not
-verify each cited source against each cell). We use \emph{benchmark}
-in the narrow sense: a frozen task definition, a public gold
-reference, and a computable metric — not a suite or a leaderboard —
-and the design measures training-data contamination as a
-parametric ceiling rather than trying to prevent it. The second is a
-four-dimension quality bar: per-row scoring of LLM-generated
-statistical tables on accuracy, coherence, provenance, and
-temporality. The third is two-grain credibility/reliability scoring:
-a run-level credibility screen and a model-level reliability grade,
-by analogy with the NATO Admiralty grading of STANAG 2511, which
-rates the credibility of each report separately from the reliability
-of its source.
+Our contribution is the benchmark, reusable beyond the Vietnamese
+case: to our knowledge, the first sourced evaluation of AI agents on
+national power-plant inventory construction, scored against a
+hand-compiled, fully sourced reference. We use \emph{benchmark} in the
+narrow sense of a frozen task definition, a public gold reference, and
+a computable metric, not a suite or a leaderboard; the design measures
+training-data contamination as a parametric ceiling rather than trying
+to prevent it. The computable metric is a four-dimension quality score:
+per-row scoring of an LLM-generated statistical table on accuracy,
+coherence, provenance, and temporality, with citation coverage and
+corroboration measured. The paper counts and checks the presence of
+citations; it does not verify each cited source against each cell.
 
-Three empirical results stand out. First, the task is hard for
-today's AI systems: neither model memory nor web access yields a
-complete, well-sourced register, and a harness that lets the agents
-plan and execute a multi-step reply degrades rather than improves the
-result for three of the four agents. Second, reference-free coherence criteria suffice to screen
-out the weakest runs. Third, targeted pipeline design narrows the
-gap: provisioning the agents with a curated document set improves
-coverage, and fusion reuses existing runs to good effect — pooling
-runs across models more than doubles recall, while requiring
-cross-model agreement nearly eliminates false positives.
+We find the task hard for today's AI systems. Across fourteen language
+models answering from memory and four agentic systems with web access,
+neither model memory nor web access yields a complete, well-sourced
+register, and a harness that lets the agents plan and execute a
+multi-step reply degrades rather than improves the result for most of
+them. The benchmark earns its keep by being usable without the gold
+reference: reference-free coherence criteria suffice to screen out the
+weakest runs and the weakest models, so the cheap part of the quality
+score can stand in for the expensive part when triaging which outputs
+deserve human attention.
 
 We situate the work against the existing open
 power-plant databases (§\ref{sec:related-empirical}), define a

--- a/tickets/0581-s3-s5-micro-edits-annex-f-note.erg
+++ b/tickets/0581-s3-s5-micro-edits-annex-f-note.erg
@@ -2,12 +2,12 @@
 Title: §3–§5 micro-edits (bar→answer key, AI-English, Figure 3 float, cohort) + Annex F swarm note
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0580
 Blocked-by: 0577
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 12, 28–35)
 
+2026-06-13T21:48Z HDMX-coding-agent note blocker 0580 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0580-intro-rework-one-page-benchmark.erg
+++ b/tickets/closed/0580-intro-rework-one-page-benchmark.erg
@@ -2,10 +2,12 @@
 Title: Intro rework: one page, contribute THE BENCHMARK, drop two-grain and STANAG
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1052
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (finding 27); head of the main.tex chain
 
+2026-06-13T21:48Z HDMX-coding-agent closed — autoclosed — PR #1052
 --- body ---
 ## Context
 


### PR DESCRIPTION
Reading-2 finding 27 (tracker 0578). Reworks §1 to ~one page with a single
contribution — THE BENCHMARK — and the four-dimension quality score presented
as its computable metric, replacing the three-contributions-plus-three-results
enumeration.

## What changed (`sec:intro`)
- One benchmark contribution; the four-dimension quality score is now its
  computable metric, not a separate contribution.
- Dropped two-grain credibility/reliability framing and the STANAG 2511 / NATO
  Admiralty vocabulary from the intro (kept in `sec:ext-screen`, untouched).
- Difficulty paragraph lands "reference-free criteria suffice to screen out the
  weakest runs and models".
- Dropped the "targeted pipeline design narrows the gap" phrasing.
- Brief entry `intro-contributions-runin` amended (no positive CI pin, polarity rule).

Intro ~590 → ~504 words; reworked paragraphs use no em dashes (net −3 vs
origin/main, ratchet stays under ceiling). No test contract changed — no test
pinned the removed intro phrasings.

`make check` green (exit 0); 63 manuscript adherence tests pass.

**Ticket:** tickets/0580-intro-rework-one-page-benchmark.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)