### PR TITLE
manuscript(0584): Annex B agents table — drop Country column, fix Qwen3.7 Max

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -702,7 +702,7 @@ commercial frontier, each with extended reasoning and web access,
 queried over direct vendor APIs (no browser automation): Anthropic
 Claude Opus 4.6 (US, web\_search + adaptive thinking), OpenAI GPT-5.5
 (US, Responses API + web\_search + reasoning), Mistral Large 2512 (FR,
-Agents API + web\_search connector), and Qwen3-Max via DashScope (CN,
+Agents API + web\_search connector), and Qwen3.7 Max via DashScope (CN,
 web\_search inside thinking mode). The fourth slot is
 hypothesis-relevant rather than decorative: Chinese-language investor
 and trade documents on Vietnamese power assets are under-indexed by
@@ -2023,35 +2023,20 @@ Four direct-API agents, ordered by ascending baseline smoke cost.
 OpenRouter is not used here — vendor-direct invocation keeps
 web-search billing transparent.
 
-\begin{longtable}[]{@{}
-  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2000}}
-  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2000}}
-  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2000}}
-  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2000}}
-  >{\raggedright\arraybackslash}p{(\linewidth - 8\tabcolsep) * \real{0.2000}}@{}}
+\begin{longtable}[]{@{}lll>{\raggedright\arraybackslash}p{0.48\linewidth}@{}}
 \toprule\noalign{}
-\begin{minipage}[b]{\linewidth}\raggedright
-\#
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
-Vendor
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
-Model
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
-Country
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
-Surface
-\end{minipage} \\
+\# & Vendor & Model & Surface \\
 \midrule\noalign{}
 \endhead
 \bottomrule\noalign{}
 \endlastfoot
-1 & Mistral & Mistral Large 2512 & FR & Agents API +
+1 & Mistral & Mistral Large 2512 & Agents API +
 \texttt{web\_search} connector \\
-2 & Alibaba & Qwen3-Max & CN & DashScope, \texttt{web\_search} inside
+2 & Alibaba & Qwen3.7 Max & DashScope, \texttt{web\_search} inside
 thinking mode \\
-3 & OpenAI & GPT-5.5 & US & Responses API + \texttt{web\_search} +
+3 & OpenAI & GPT-5.5 & Responses API + \texttt{web\_search} +
 reasoning \\
-4 & Anthropic & Claude Opus 4.6 & US & Anthropic API +
+4 & Anthropic & Claude Opus 4.6 & Anthropic API +
 \fpath{web_search_20250305} + adaptive thinking \\
 \end{longtable}
 

--- a/tests/test_manuscript_agents_table.py
+++ b/tests/test_manuscript_agents_table.py
@@ -1,0 +1,102 @@
+"""Ticket 0584 — Annex B agents table: drop Country column, fix Qwen version.
+
+The Annex B "Agents" longtable (under ``\\subsection*{Agents}`` in
+``slides/manuscript/main.tex``) lists the four cloud agents used in
+Experiment 2. Two adherence invariants are pinned here:
+
+1. **Structural** — the table has no "Country" column. The country facts are
+   stated inline in the §6 prose; the table column was redundant and was
+   dropped (the remaining columns size naturally, no fixed ``\\real{0.20}``
+   widths).
+
+2. **Artifact-derived model identity** — the Exp 2 Qwen agent is the
+   ``qwen3.7-max-2026-05-20`` entry in ``experiments/models.yaml`` (and the
+   ``"model": "qwen3.7-max-2026-05-20"`` recorded in the Exp 3/sota run
+   records). The manuscript must name it with the version the artifact
+   attests (``Qwen3.7 Max``), never the stale ``Qwen3-Max``. The expected
+   display token is *re-derived from models.yaml*, so a future version bump
+   in the registry cannot leave this guard silently stale (project rule:
+   derive prose from artifacts, never from memory).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANUSCRIPT = REPO_ROOT / "slides" / "manuscript" / "main.tex"
+MODELS_PATH = REPO_ROOT / "experiments" / "models.yaml"
+
+# The models.yaml slug for the Exp 2 Qwen agent (cross-checked against the
+# sota run records: ``"model": "qwen3.7-max-2026-05-20"``).
+EXP2_QWEN_SLUG = "qwen3.7-max-2026-05-20"
+
+
+def _agents_table() -> str:
+    """The ``\\begin{longtable}...\\end{longtable}`` block whose header lists
+    the agent columns (# / Vendor / Model / Surface)."""
+    text = MANUSCRIPT.read_text(encoding="utf-8")
+    for m in re.finditer(r"\\begin\{longtable\}.*?\\end\{longtable\}", text, re.DOTALL):
+        block = m.group(0)
+        if "Vendor" in block and "Surface" in block:
+            return block
+    raise AssertionError("agents longtable (Vendor/Surface header) not found in main.tex")
+
+
+def _expected_qwen_display() -> str:
+    """Re-derive the human display token (``Qwen3.7 Max``) from the model
+    slug in models.yaml, so the manuscript value tracks the registry."""
+    models = yaml.safe_load(MODELS_PATH.read_text(encoding="utf-8"))
+    entry = next((e for e in models if e.get("name") == EXP2_QWEN_SLUG), None)
+    assert entry is not None, (
+        f"Exp 2 Qwen slug {EXP2_QWEN_SLUG!r} no longer in models.yaml — "
+        "the manuscript agents table must track the registry; update both."
+    )
+    # slug 'qwen3.7-max-2026-05-20' -> version 'qwen3.7', kind 'max'
+    version, kind = entry["name"].split("-", 2)[:2]
+    return f"{version.capitalize()} {kind.capitalize()}"
+
+
+def test_agents_table_no_country_column():
+    """The agents table dropped the Country column."""
+    block = _agents_table()
+    header = block.split("\\midrule", 1)[0]
+    assert "Country" not in header, (
+        "agents table still has a Country column — ticket 0584 dropped it "
+        "(country facts stay inline in the §6 prose)"
+    )
+
+
+def test_agents_table_widths_not_fixed_equal():
+    """Column widths size naturally — the five forced-equal ``\\real{0.2000}``
+    colspecs were removed."""
+    block = _agents_table()
+    colspec = block.split("\\toprule", 1)[0]
+    assert "\\real{0.2000}" not in colspec, (
+        "agents table colspec still forces equal 0.20 widths — ticket 0584 "
+        "switched to natural column widths"
+    )
+
+
+def test_qwen_version_matches_models_yaml():
+    """The Qwen agent is named with the version models.yaml attests."""
+    expected = _expected_qwen_display()  # 'Qwen3.7 Max'
+    block = _agents_table()
+    assert expected in block, (
+        f"agents table does not name the Qwen agent {expected!r} (the version "
+        f"derived from models.yaml slug {EXP2_QWEN_SLUG!r})"
+    )
+
+
+def test_no_stale_qwen_version_in_manuscript():
+    """Negative guard: the stale ``Qwen3-Max`` string must not appear anywhere
+    in the manuscript (the artifact says 3.7, not 3)."""
+    text = MANUSCRIPT.read_text(encoding="utf-8")
+    assert "Qwen3-Max" not in text, (
+        "stale 'Qwen3-Max' string present in main.tex — the Exp 2 Qwen agent "
+        f"is {EXP2_QWEN_SLUG!r} (Qwen3.7 Max) per models.yaml and the run records"
+    )

--- a/tickets/0585-s71-annex-c-recognition-story.erg
+++ b/tickets/0585-s71-annex-c-recognition-story.erg
@@ -2,11 +2,11 @@
 Title: §7.1 + Annex C rework: plain difficulty story, move composition table into §7.1, drop cruft
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0584
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 13–17)
 
+2026-06-14T00:29Z HDMX-coding-agent note blocker 0584 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0584-annex-b-agents-table-qwen-version.erg
+++ b/tickets/closed/0584-annex-b-agents-table-qwen-version.erg
@@ -2,11 +2,13 @@
 Title: Annex B agents table: drop Country column, auto colwidth; fix Qwen version to 3.7 per artifacts
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1057
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 2, 3); Qwen ground truth pre-verified
 
 2026-06-14T00:11Z HDMX-coding-agent note blocker 0583 closed — Blocked-by removed.
+2026-06-14T00:29Z HDMX-coding-agent closed — autoclosed — PR #1057
 --- body ---
 ## Context
 


### PR DESCRIPTION
Two changes to the Experiment 2 "Agents" longtable in `slides/manuscript/main.tex` (Annex B), per reading-2 findings 2-3 (tracker 0578).

## 1. Drop the Country column, natural widths
The five forced-equal `\real{0.2000}` colspecs become natural widths: `@{}lll>{\raggedright\arraybackslash}p{0.48\linewidth}@{}`. The #/Vendor/Model columns size to content; the Surface column wraps in the remaining width. (0.48 keeps the row within the text block — 0.55 overflowed 21.8pt.) Country facts (US/FR/CN) already appear inline in the §6 prose, so no information is lost.

## 2. Fix Qwen version — artifact-derived
Stale `Qwen3-Max` → `Qwen3.7 Max`, in both the table and the §6 prose. Ground truth:
- `experiments/models.yaml` Exp 2 entry: `name: qwen3.7-max-2026-05-20`, `display_name: "Qwen3.7 Max (DashScope direct, web_search)"`.
- sota run records (e.g. `experiments/outputs/sota_exp3_arm1_batch1/run01/summary.json`): `"model": "qwen3.7-max-2026-05-20"`.

The author's recall ("3.7") matched the artifacts; the manuscript text was the stale value.

## Guard test
`tests/test_manuscript_agents_table.py`:
- Qwen display token re-derived from the `models.yaml` slug (registry version bumps can't leave the test stale).
- Negative guard: `Qwen3-Max` forbidden anywhere in `main.tex`.
- Structural: Country column dropped, fixed-equal `\real{0.2000}` colspecs gone.

`make check` green (exit 0). Manuscript builds; the agents-table overfull hbox is resolved; only one pre-existing 0.5pt overfull elsewhere remains.

**Ticket:** tickets/0584-annex-b-agents-table-qwen-version.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)