### PR TITLE
manuscript(0585): plain §7.1 difficulty story + move composition table, drop Annex C cruft

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -859,20 +859,28 @@ They are exploratory; each subsection summarises one analysis.
 
 \subsection{Why is the task hard?}\label{sec:ext-difficulty}
 
-The per-plant recognition matrix in \ref{sec:annex-recognition}
-decomposes the difficulty plant by plant: each reference plant becomes
-a row observed by many noisy runs. Within-model and across-model
-coherence can be read directly from the row densities (famous plants
-form dense rows, obscure ones sparse), and the operational core
-separates visibly from the project-dominated tail.
+The task is hard because the reference list is a long-tail
+distribution. As the introduction notes, the existing power plants are
+easy to know, but the list also holds many abandoned or recently
+proposed projects, and these have low visibility. Table~\ref{tbl:status-difficulty}
+shows the composition: proposed plants form the largest share of the
+list, and parametric memory cannot know them. Their average probability
+of being found by an Experiment 1 model run falls far below that of
+operational plants, so the low overall recognition is a property of the
+list's composition, not merely a model failure.
 
-The status composition of the reference list explains why the low
-recognition is structural: the list is dominated by proposed plants,
-which parametric memory cannot know, and their mean recognition rate
-is far below that of operational plants. Low overall recognition is
-therefore a property of the list's composition, not merely a model
-failure. The full matrix and the status-by-status decomposition are in
-\ref{sec:annex-recognition}.
+\begin{table}[htbp]
+\centering
+\caption{\label{tbl:status-difficulty}Composition of the reference list
+by status, and the average probability of a plant being found by an
+Experiment 1 model run (direct method: 14 models × 5 repetitions).}
+\input{../../report/inputs/generated/tab_status_difficulty_en.tex}
+\end{table}
+
+The per-plant recognition matrix in \ref{sec:annex-recognition}
+decomposes this difficulty plant by plant: famous plants form dense
+rows, obscure ones sparse, and the operational core separates visibly
+from the project-dominated tail.
 
 \subsection{Screening without a reference}\label{sec:ext-screen}
 
@@ -2436,22 +2444,15 @@ not detected.
 
 \clearpage
 
-\section{Experiment 1: per-plant recognition matrix and the status composition of task difficulty}\label{sec:annex-recognition}
+\section{Experiment 1: per-plant recognition matrix}\label{sec:annex-recognition}
 
 Figure~\ref{fig:recognition-matrix} places each of the \ExpOneMatrixPlants{} reference
-plants on its own row (names read left-to-right, no rotation) against
-the \ExpOneMatrixRuns{} Experiment 1 runs (14 models × 5 repetitions) as columns. A blue
-cell marks a recognised plant (true positive); an empty cell, a miss.
-Rows are grouped by status, then by decreasing capacity, using the same
-status categories as the difficulty table below. To keep plant names
-legible at print scale, the matrix is split across pages by lifecycle
-stage. A final page lists the \ExpOneMatrixFPs{} most frequent false positives across
-all runs, sorted by decreasing occurrence, in red — the paper's
-false-positive convention (unmatched: extracted but not in the
-reference; possibly real, not necessarily fabricated). Unlike
-Figure~\ref{fig:direct-base}, which only counts each run's recognised
-plants, the fixed-row alignment reveals \emph{which} plants each model
-misses: famous plants form dense rows, obscure ones sparse rows.
+plants on its own row against the \ExpOneMatrixRuns{} Experiment 1 runs as
+columns. Unlike Figure~\ref{fig:direct-base}, which only counts each
+run's recognised plants, the fixed-row alignment reveals \emph{which}
+plants each model misses: famous plants form dense rows, obscure ones
+sparse rows. The status composition behind this difficulty is in
+Table~\ref{tbl:status-difficulty}.
 
 \refstepcounter{figure}\label{fig:recognition-matrix}
 \noindent\emph{Figure \thefigure. (Next three pages.) Experiment 1 recognition
@@ -2465,24 +2466,6 @@ count. Blue = plant recognised. Pages 1--2 split the plants by lifecycle stage
 under-construction ones); page 3 lists the \ExpOneMatrixFPs{} most frequent false positives
 (red).}
 \includepdf[pages=-,pagecommand={\thispagestyle{plain}}]{../../report/inputs/generated/fig_exp1_recognition_matrix_portrait.pdf}
-
-The table below shares the same data derivation as the figure (library
-\texttt{aedist.exp1\_recognition}: common cause, no
-producer--consumer chaining) and decomposes the difficulty by status.
-Proposed plants form the largest share of the rows, and parametric
-memory cannot know them; their mean recognition rate falls far below
-that of operational plants. The low overall recognition is thus
-structural: it reflects the composition of the list, not merely model
-failure.
-
-\begin{table}[htbp]
-\centering
-\caption{\label{tbl:status-difficulty}Composition of the reference list
-by status, and mean recognition rate (Experiment 1, direct method: 14
-models × 5 repetitions). The rate is the share of run × plant cells
-recognised among plants of that status.}
-\input{../../report/inputs/generated/tab_status_difficulty_en.tex}
-\end{table}
 
 \clearpage
 

--- a/tests/test_manuscript_0585_difficulty.py
+++ b/tests/test_manuscript_0585_difficulty.py
@@ -1,0 +1,55 @@
+"""Ticket 0585 — §7.1 plain difficulty story + Annex C cruft removal.
+
+Reading-2 findings 13–17 (tracker 0578). Negative guards only (CI polarity
+rule, 0557): two generation-instruction / data-flow literals that leaked into
+the Annex C prose must not survive, and the composition table's stable
+``\\label`` must stay attached to its content as it moves into §7.1.
+
+Findings:
+- 13: "names read left-to-right, no rotation" — a generation instruction
+  surviving as prose — is dropped.
+- 14: the "(… producer--consumer chaining)" parenthesis — a data-flow
+  organisation detail — is dropped.
+- 16: ``tbl:status-difficulty`` keeps its label (label-stability contract,
+  editorial-brief entry label-stability-contract).
+"""
+
+import pytest
+from manuscript_source import body
+
+pytestmark = pytest.mark.adherence
+
+
+def _md() -> str:
+    return body()
+
+
+def test_no_left_to_right_generation_instruction() -> None:
+    """Finding 13: the leftover generation instruction is gone."""
+    md = _md()
+    assert "left-to-right, no rotation" not in md, (
+        "generation instruction 'names read left-to-right, no rotation' "
+        "must not survive as prose (finding 13)"
+    )
+    assert "no rotation" not in md, (
+        "the 'no rotation' generation instruction must be dropped (finding 13)"
+    )
+
+
+def test_no_producer_consumer_dataflow_parenthesis() -> None:
+    """Finding 14: the producer--consumer data-flow detail is gone."""
+    md = _md()
+    # normalized() folds the TeX '--' to an en dash, so match both surfaces.
+    assert "producer–consumer chaining" not in md and "producer-consumer chaining" not in md, (
+        "the '(... producer--consumer chaining)' data-flow parenthesis "
+        "must be dropped (finding 14)"
+    )
+
+
+def test_status_difficulty_table_keeps_label() -> None:
+    """Finding 16: the composition table keeps its stable label after the move."""
+    md = _md()
+    assert "\\label{tbl:status-difficulty}" in md, (
+        "tbl:status-difficulty must keep its label as the table moves into "
+        "§7.1 (label-stability-contract)"
+    )

--- a/tickets/0586-screening-story-drop-annex-e.erg
+++ b/tickets/0586-screening-story-drop-annex-e.erg
@@ -2,11 +2,11 @@
 Title: Screening story: drop Annex E, retarget §7.2 to Figure 5, rewrite Conclusion evidence
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0585
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 18, 39, 42); test+brief coupling mapped
 
+2026-06-14T00:49Z HDMX-coding-agent note blocker 0585 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0585-s71-annex-c-recognition-story.erg
+++ b/tickets/closed/0585-s71-annex-c-recognition-story.erg
@@ -2,11 +2,13 @@
 Title: §7.1 + Annex C rework: plain difficulty story, move composition table into §7.1, drop cruft
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1059
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 13–17)
 
 2026-06-14T00:29Z HDMX-coding-agent note blocker 0584 closed — Blocked-by removed.
+2026-06-14T00:49Z HDMX-coding-agent closed — autoclosed — PR #1059
 --- body ---
 ## Context
 


### PR DESCRIPTION
Reading-2 findings 13–17 (tracker 0578). Rewrites §7.1 and trims Annex C.

**Finding 17** — §7.1 rewritten to the author's plain, difficulty-first voice: the task is hard because the reference list is a long-tail distribution; existing plants are easy to know, but many abandoned or recently proposed projects have low visibility. Overcomplicated tone cut; pointer back to the intro.

**Finding 16** — the status composition table (`tbl:status-difficulty`, label preserved) moved from Annex C into §7.1 as the justification. The obscure 'recognition rate' is redefined in the table caption + prose as *the average probability of a plant being found by an Experiment 1 model run*.

**Finding 15** — Annex C intro shortened: it was duplicating the figure caption; now a short pointer to the matrix, with the status composition deferred to `Table~\ref{tbl:status-difficulty}`. The recognition-matrix `\includepdf` block and its `\refstepcounter`/`\label` are kept (house rules).

**Finding 14** — dropped the '(… producer--consumer chaining)' data-flow parenthesis.

**Finding 13** — dropped 'names read left-to-right, no rotation' (leftover generation instruction) locally. The class-sweep is ticket 0591/0592.

Cross-refs symbolic (`Table~\ref`); no hand-typed numbers; table `\input` artifact untouched (display move only). New negative-guard test `tests/test_manuscript_0585_difficulty.py` (two cruft literals + label-stability). `make check` green; tectonic builds.

**Ticket:** tickets/0585-s71-annex-c-recognition-story.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)