### PR TITLE
manuscript(0587): unnumber §7 subsection headings (house style)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -857,7 +857,8 @@ audience: why is the task hard, can weak runs be screened without a
 reference, can runs be fused, and what system do the findings imply?
 They are exploratory; each subsection summarises one analysis.
 
-\subsection{Why is the task hard?}\label{sec:ext-difficulty}
+\subsection*{Why is the task hard?}\label{sec:ext-difficulty}
+\addcontentsline{toc}{subsection}{Why is the task hard?}
 
 The task is hard because the reference list is a long-tail
 distribution. As the introduction notes, the existing power plants are
@@ -882,7 +883,8 @@ decomposes this difficulty plant by plant: famous plants form dense
 rows, obscure ones sparse, and the operational core separates visibly
 from the project-dominated tail.
 
-\subsection{Screening without a reference}\label{sec:ext-screen}
+\subsection*{Screening without a reference}\label{sec:ext-screen}
+\addcontentsline{toc}{subsection}{Screening without a reference}
 
 Internal coherence rejects the weakest runs without any
 reference. The reference list grades runs from the outside; an
@@ -916,9 +918,10 @@ these same runs, so this is an existence proof rather than a validated
 detector. Treating models as information sources and runs as information
 packages, this same source-reliability grade is a natural input to
 fusion: a low-reliability model can be down-weighted or excluded before
-its runs are pooled (§\ref{sec:fusion}).
+its runs are pooled (the fusion discussion that follows).
 
-\subsection{Can runs be fused?}\label{sec:fusion}
+\subsection*{Can runs be fused?}\label{sec:fusion}
+\addcontentsline{toc}{subsection}{Can runs be fused?}
 
 The experiments in §\ref{sec:exp1} and §\ref{sec:exp2} establish that
 the gap is real: recall from model memory is incomplete and volatile;
@@ -939,14 +942,15 @@ with \FusionRTwoETwoOneDFP{} on the Experiment 2 naive arm (full results in
 \ref{sec:annex-fusion}). Both levers reuse existing runs; the
 structural answer to the ceiling no single model breaks is a stateful
 pipeline that invests in the corpus rather than the model
-(§\ref{sec:ext-system}). To our knowledge, no published benchmark or
+(the stateful-pipeline discussion that follows). To our knowledge, no published benchmark or
 system targets open-world enumeration of a national asset class with
 per-cell provenance at this granularity. Nor did we find a published
 demonstration of the conjunction of per-cell provenance with per-cell
 temporal validity in LLM-augmented inventories; demonstrating that
 conjunction remains future work.
 
-\subsection{What system do the findings imply?}\label{sec:ext-system}
+\subsection*{What system do the findings imply?}\label{sec:ext-system}
+\addcontentsline{toc}{subsection}{What system do the findings imply?}
 
 The single-model ceiling motivates a stateful architecture: one that
 keeps an organised memory between runs instead of starting from scratch

--- a/tests/test_manuscript_0587_extensions.py
+++ b/tests/test_manuscript_0587_extensions.py
@@ -1,0 +1,75 @@
+"""Ticket 0587 — §7 (Extensions) subsection headings use the house style.
+
+Reading-2 finding 21 (tracker 0578). Every section in the manuscript follows
+the writing guide (no numbered subsections); §7 was the lone exception. Its
+four subsections are now the starred house form (`\\subsection*{...}` +
+`\\addcontentsline`), with their stable labels kept attached
+(label-stability-contract).
+
+Negative / structural guards only (CI polarity rule, 0557):
+- no numbered ``\\subsection{`` survives inside §7 (sec:extensions);
+- each of the four §7 subsection labels stays attached to a heading.
+"""
+
+import re
+
+import pytest
+from manuscript_source import raw
+
+pytestmark = pytest.mark.adherence
+
+# The four §7 subsection labels — the label-stability contract for this section.
+EXTENSIONS_SUBSECTION_LABELS = (
+    "sec:ext-difficulty",
+    "sec:ext-screen",
+    "sec:fusion",
+    "sec:ext-system",
+)
+
+
+def _extensions_source() -> str:
+    """Raw LaTeX of §7, from ``\\section{Extensions}`` to the next ``\\section``.
+
+    Structural scan needs the raw source (heading syntax), not normalized prose.
+    """
+    text = raw()
+    start = text.index("\\section{Extensions}")
+    nxt = re.search(r"\\section\*?\{|\\appendix(?![A-Za-z])", text[start + 1 :])
+    end = start + 1 + nxt.start() if nxt else len(text)
+    return text[start:end]
+
+
+def test_no_numbered_subsection_in_extensions() -> None:
+    """Finding 21: §7 carries no numbered ``\\subsection{`` heading.
+
+    A numbered subsection in §7 would render ``§7.N`` while every other
+    section uses the unnumbered house form — the defect this ticket fixes.
+    Starred ``\\subsection*{`` is the allowed form and does not match.
+    """
+    src = _extensions_source()
+    numbered = re.findall(r"\\subsection\{[^}]*\}", src)
+    assert not numbered, (
+        "§7 (sec:extensions) must use the unnumbered house subsection form "
+        "(\\subsection*{...} + \\addcontentsline); numbered \\subsection{...} "
+        f"headings found: {numbered} (ticket 0587, finding 21)"
+    )
+
+
+def test_extensions_subsection_labels_attached() -> None:
+    """The four §7 subsection labels stay attached to starred headings.
+
+    Label-stability contract (editorial-brief label-stability-contract): the
+    headings may be retitled or unnumbered, but the labels must survive so
+    every ``§\\ref{sec:ext-*}`` / ``§\\ref{sec:fusion}`` call site resolves.
+    """
+    src = _extensions_source()
+    for label in EXTENSIONS_SUBSECTION_LABELS:
+        assert re.search(
+            r"\\subsection\*?\{(?:[^{}]|\{[^{}]*\})*\}\s*\\label\{"
+            + re.escape(label)
+            + r"\}",
+            src,
+        ), (
+            f"label {label!r} must stay attached to its §7 subsection heading "
+            "(label-stability-contract, ticket 0587)"
+        )

--- a/tickets/0588-s8-discussion-condense.erg
+++ b/tickets/0588-s8-discussion-condense.erg
@@ -2,11 +2,11 @@
 Title: §8 Discussion: condense to 1.5 pages, new opening, add scoring-levels discussion
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0587
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (finding 40)
 
+2026-06-14T01:35Z HDMX-coding-agent note blocker 0587 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0587-s7-unnumber-subsections.erg
+++ b/tickets/closed/0587-s7-unnumber-subsections.erg
@@ -2,11 +2,13 @@
 Title: §7: convert numbered subsection headings to house style (unnumbered)
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1061
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (finding 21); runs after the §7 prose tickets so headings are converted once
 
 2026-06-14T01:15Z HDMX-coding-agent note blocker 0586 closed — Blocked-by removed.
+2026-06-14T01:35Z HDMX-coding-agent closed — autoclosed — PR #1061
 --- body ---
 ## Context
 


### PR DESCRIPTION
Reading-2 finding 21 (tracker 0578). §7 (Extensions) was the only section with NUMBERED subsection headings; every other section follows the writing guide (no numbered subsections). This converts §7's four subsections to the starred house form.

## What changed
- Four `\subsection{...}\label{...}` → `\subsection*{...}\label{...}` + `\addcontentsline{toc}{subsection}{...}` (the Annex pattern). All four labels preserved.
- A `\label` on a starred subsection resolves to the enclosing §7 counter. The two **in-§7 self-references** (`§\ref{sec:fusion}`, `§\ref{sec:ext-system}` from inside §7) are reworded to named "the … discussion that follows" pointers so the rendered text stays truthful (no self-pointing "§7"). The eight out-of-§7 refs keep their symbolic `\ref` form and render "§7" correctly.
- New structural guard `tests/test_manuscript_0587_extensions.py`: no numbered `\subsection{` survives in §7; each of the four labels stays attached. Negative/structural only (CI polarity rule 0557). RED on origin/main, GREEN here.

## Verification
- `make check` GREEN (coverage 2608 passed + test-slow 39 passed + lint + erg check PASS).
- Label-keyed tests unchanged and green: `test_manuscript_source_section.py` (uses a synthetic fixture, untouched), `test_manuscript_cohort_and_caveats.py` (keys `section("sec:fusion")` / `section("sec:ext-screen")` by label — the extractor already handles starred forms), `test_manuscript_crossref.py` (all refs resolve).
- PDF builds with **zero undefined references**, no multiply-defined destinations; the four headings render unnumbered with TOC bookmarks intact.

**Ticket:** tickets/0587-s7-unnumber-subsections.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)