### PR TITLE
manuscript(0590): Annex A prompts cleanup — findings 9–12

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -250,19 +250,21 @@ load-bearing.
 
 ## annex-quote-anchor
 
-**Decision:** The Annex baseline-prompt quote reproduces the as-sent
-Doc-07 prompt faithfully, including the sentences "primary-sourced
-reference inventory" and "Actual or expected commercial operation date".
+**Decision:** The Annex analysis-cohort prompt quote reproduces the
+as-sent Doc-07 prompt faithfully (the boxed `promptbox` reformat is
+typographic only). The archived-baseline prompt block was deleted
+(reading-2 finding 9, ticket 0590) — its results were never presented.
 
 **Rationale:** Content fidelity of a fixed external document, not
 authorial prose — the annex quotes what was actually sent to the models,
-so the verbatim anchors are KEPT in CI
-(`test_annex_baseline_prompt_carries_as_sent_status_vocabulary`,
-`test_annex_carries_doc07_prompt_verbatim_anchors`). Recorded here so a
-reviewer rewording the annex framing knows the quoted block itself is
-immutable.
+so the verbatim anchors of the kept Doc-07 prompt are KEPT in CI
+(`test_annex_carries_doc07_prompt_verbatim_anchors`,
+`test_analysis_cohort_prompt_matches_shipped_record`). The deleted
+archived-baseline block is now negatively guarded
+(`test_annex_baseline_prompt_block_removed`). Recorded here so a reviewer
+rewording the annex framing knows the quoted prompt itself is immutable.
 
-**Ticket:** 0511; triaged keep-in-CI by 0557.
+**Ticket:** 0511; triaged keep-in-CI by 0557; baseline block removed by 0590.
 
 **Status:** active
 

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1358,57 +1358,15 @@ reconciliation is deferred (post-arXiv).}
 \subsection*{Prompts}
 \addcontentsline{toc}{subsection}{Prompts}
 
-\textbf{Archived baseline prompt (2026-05-20 cohort).} The archived
-baseline sweep — the earlier cohort in which the GPT-5.5 refusals
-occurred — used the locked composition of two modules from
-\fpath{experiments/prompts/modules/}: \texttt{2\_goal.txt} (task
-declaration) and \texttt{5\_table.txt} (structured table specification).
-These are the implicit ``always'' pair: every sweep includes them;
-ablations opt in to additional modules. The assembled prompt is the
-concatenation in filename lex order, joined by a blank line:
-
-\begin{quote}
-\textbf{\#\# Goal}
-
-Produce a complete, primary-sourced reference inventory of Vietnam's
-past, present and future thermal generation assets (>
-30MWe) structured as follows:
-
-\textbf{\#\# Structured power plants table}
-
-Tabulate for every thermal power plant in Vietnam:
-
-Name (Vietnamese) | Name (English) | Province
-| Fuel | Technology | Units × MW |
-Total MWe | Status | COD | Owner/Developer
-| Source 1 | Source 2 | Notes |
-
-Where: - Fuel: Coal / Domestic gas / Imported LNG - Technology (coal):
-Subcritical / Supercritical / USC - Technology (gas): CCGT / OCGT -
-Status: Approved / Planned / Operational / Under construction /
-Suspended / Cancelled / Retired - Total MWe: Include units >
-30MWe. - COD: Actual or expected commercial operation date - Sources:
-specify where in the document, include URL
-
-Output format: Markdown.
-\end{quote}
-
-No persona, no narratives, no quality bullets — those land in ablation
-sweeps, not the archived baseline. The status enumeration above is the
-as-sent text from the archived records; the \texttt{5\_table.txt} module
-file was aligned to the Global Energy Monitor status vocabulary only
-after this cohort ran, which the analysis-cohort prompt below reflects.
-
 \textbf{Analysis-cohort prompt (Doc-07).} The fourteen-model analysis
 cohort (\texttt{modelset\_exp1\_batch2}, the cohort behind every
 per-model number in §\ref{sec:exp1}) received the full Doc-07 naive
 prompt — \fpath{experiments/sota/protocol_07_naive_prompt.md} —
-verbatim as the sole user message (trailing newline stripped by the
-worker), at temperature 0, seed 42, \texttt{max\_tokens} 65536, web
-access off; this was verified against the archived per-run records. The
-prompt in full:
+verbatim as the sole user message, at temperature 0, seed 42,
+\texttt{max\_tokens} 65536, web access off; this was verified against
+the archived per-run records. The prompt in full:
 
-\begin{quote}\small
+\begin{promptbox}
 \textbf{\# GOAL}
 
 Produce a complete, primary-sourced reference inventory of Vietnam's
@@ -1638,7 +1596,7 @@ follow the table and are selective: write one only for assets that are
 major, disputed, ambiguous, or historically important. For
 straightforward operational assets a compact Notes cell in the table is
 sufficient; do not repeat it as a separate note.
-\end{quote}
+\end{promptbox}
 
 Two prompt-design limitations are acknowledged. First, although the
 prompt asks the model to ``begin the document directly with the
@@ -1661,32 +1619,31 @@ Answer from parametric knowledge only.''}
 \addcontentsline{toc}{subsection}{Models}
 
 Sixteen models from \fpath{modelset_exp1_journal} (v2, defined in
-\fpath{experiments/experiments.toml}), organised around three language
-families with multiple labs per family:
+\fpath{experiments/experiments.toml}):
 
-\begin{longtable}[]{@{}lllll@{}}
+\begin{longtable}[]{@{}llll@{}}
 \toprule\noalign{}
-Model & Lab & Family & Size class & Reasoning tokens* \\
+Model & Lab & Size class & Reasoning tokens* \\
 \midrule\noalign{}
 \endhead
 \bottomrule\noalign{}
 \endlastfoot
-claude-opus-4.6 & Anthropic & EN & frontier & 0 \\
-claude-sonnet-4.6 & Anthropic & EN & frontier & 0 \\
-claude-haiku-4.5 & Anthropic & EN & mid & 0 \\
-gpt-5.5 & OpenAI & EN & frontier & 1,537 \\
-gpt-oss-120b & OpenAI & EN & large & 35 \\
-gpt-oss-20b & OpenAI & EN & mid & 18 \\
-mistral-small-2603 & Mistral & FR & mid & 0 \\
-mistral-medium-3-5 & Mistral & FR & mid & 0 \\
-mistral-large-2512 & Mistral & FR & frontier & 0 \\
-qwen3.6-27b & Alibaba & ZH & mid & 5,735 \\
-qwen3.6-35b-a3b & Alibaba & ZH & mid & 8,143 \\
-qwen3.6-flash & Alibaba & ZH & mid & 7,971 \\
-qwen3.6-plus & Alibaba & ZH & frontier & 6,677 \\
-qwen3-max-thinking & Alibaba & ZH & frontier & 0 \\
-deepseek-v4-pro & DeepSeek & ZH & frontier & 16,774 \\
-deepseek-v4-flash & DeepSeek & ZH & mid & 775 \\
+claude-opus-4.6 & Anthropic & frontier & 0 \\
+claude-sonnet-4.6 & Anthropic & frontier & 0 \\
+claude-haiku-4.5 & Anthropic & mid & 0 \\
+gpt-5.5 & OpenAI & frontier & 1,537 \\
+gpt-oss-120b & OpenAI & large & 35 \\
+gpt-oss-20b & OpenAI & mid & 18 \\
+mistral-small-2603 & Mistral & mid & 0 \\
+mistral-medium-3-5 & Mistral & mid & 0 \\
+mistral-large-2512 & Mistral & frontier & 0 \\
+qwen3.6-27b & Alibaba & mid & 5,735 \\
+qwen3.6-35b-a3b & Alibaba & mid & 8,143 \\
+qwen3.6-flash & Alibaba & mid & 7,971 \\
+qwen3.6-plus & Alibaba & frontier & 6,677 \\
+qwen3-max-thinking & Alibaba & frontier & 0 \\
+deepseek-v4-pro & DeepSeek & frontier & 16,774 \\
+deepseek-v4-flash & DeepSeek & mid & 775 \\
 \end{longtable}
 
 * Median over 3 runs.

--- a/tests/test_manuscript_cohort_and_caveats.py
+++ b/tests/test_manuscript_cohort_and_caveats.py
@@ -377,55 +377,16 @@ def test_body_no_longer_attributes_modules_prompt_to_cohort():
     )
 
 
-BASELINE_RUN_RECORD = (
-    REPO_ROOT
-    / "experiments"
-    / "archive"
-    / "outputs"
-    / "exp1"
-    / "baseline"
-    / "claude-haiku-4.5-run1.json"
-)
-
-
-def test_annex_baseline_prompt_carries_as_sent_status_vocabulary():
-    """The archived-baseline prompt quoted in the annex matches the as-sent
-    text, re-derived from an archived per-run record (all 133 baseline+topup
-    records carry the identical prompt). The 5_table.txt module was aligned to
-    GEM vocabulary only AFTER this cohort ran (cba3ffc5, 2026-05-24), so the
-    annex quote must show the pre-alignment status enumeration, not the
-    module file's current text (post-merge review blocker on #983)."""
-    assert BASELINE_RUN_RECORD.exists(), (
-        f"{BASELINE_RUN_RECORD} missing: the baseline drift guard would be "
-        "silently disabled — update this path if the record was relocated"
-    )
-    prompt = json.loads(BASELINE_RUN_RECORD.read_text(encoding="utf-8"))["prompt"]
-    # Re-derive the as-sent status enumeration from the record.
-    status_line = next(
-        line for line in prompt.splitlines() if line.startswith("- Status:")
-    )
-    statuses = [s.strip() for s in status_line.removeprefix("- Status:").split("/")]
-    assert "Planned" in statuses, "as-sent baseline enum expected to contain Planned"
+def test_annex_baseline_prompt_block_removed():
+    """The archived-baseline prompt subsection was deleted from Annex A
+    (reading-2 finding 9, ticket 0590): its results were never presented, so
+    the coding-archeology block is gone. Negative guard — the block must not
+    reappear."""
     annex = body().split("\\appendix")[1]
-    quote = annex.split("Archived baseline prompt")[1].split("Analysis-cohort prompt")[0]
-    for status in statuses:
-        assert status in quote, (
-            f"as-sent baseline status {status!r} missing from the annex's "
-            "archived-baseline prompt quote"
-        )
-    # The GEM-aligned enum belongs to the analysis cohort, not this quote.
-    for gem_only in ("Announced", "Pre-permit", "Permitted", "Operating", "Shelved"):
-        assert gem_only not in quote, (
-            f"GEM-vocabulary status {gem_only!r} leaked into the baseline "
-            "prompt quote; the cohort ran before the GEM alignment"
-        )
-    # Two further distinctive as-sent sentences, re-derived from the record.
-    for sentence in (
-        "primary-sourced reference inventory",
-        "Actual or expected commercial operation date",
-    ):
-        assert sentence in prompt, f"anchor not in record prompt: {sentence!r}"
-        assert sentence in quote, f"as-sent anchor missing from annex quote: {sentence!r}"
+    assert "Archived baseline prompt" not in annex, (
+        "the archived-baseline prompt block was deleted (ticket 0590); "
+        "it must not reappear in Annex A"
+    )
 
 
 def test_annex_carries_doc07_prompt_verbatim_anchors():

--- a/tickets/0591-sweep-codenames-code-refs.erg
+++ b/tickets/0591-sweep-codenames-code-refs.erg
@@ -2,12 +2,12 @@
 Title: Global sweep: internal codenames out, no code references in main text, name the matcher
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0590
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 8, 22, 23, 24); flow-vs-MILP discrepancy flagged for verification
 2026-06-13T08:40Z finding 23 (matcher naming) partially addressed: Evaluation paragraph in main.tex (ex-L1830) rewritten. New prose names the method "minimum-cost bipartite assignment (MILP)", adds the flow-equivalence sentence, removes ADR-2/ADR-3 codenames and \texttt file/function references, and documents the 1:1 limitation with the five aggregate-vs-split cases from the Exp.2 FP audit. Remaining work: findings 8, 22, 24 (full codename sweep, code refs in §1–§9).
 
+2026-06-14T02:21Z HDMX-coding-agent note blocker 0590 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0590-annex-a-prompts-cleanup.erg
+++ b/tickets/closed/0590-annex-a-prompts-cleanup.erg
@@ -2,11 +2,13 @@
 Title: Annex A prompts cleanup: delete archived-baseline block, sans-serif the analysis-cohort prompt
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1063
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 9–11); test+brief coupling mapped
 
 2026-06-13T20:16Z HDMX-coding-agent note blocker 0589 closed — Blocked-by removed.
+2026-06-14T02:21Z HDMX-coding-agent closed — autoclosed — PR #1063
 --- body ---
 ## Context
 


### PR DESCRIPTION
Reading-2 findings 9–12 (tracker 0578), Annex A (Experiment 1 spec) in `slides/manuscript/main.tex`.

- **Finding 9** — deleted the "Archived baseline prompt (2026-05-20 cohort)" subsubsection entirely (coding archeology; its results are never presented).
- **Finding 10** — reformatted the kept analysis-cohort (Doc-07) prompt from `\begin{quote}\small` into the shared sans-serif page-breakable `promptbox` environment (added by ticket 0582 for Phase A, intended for reuse here). Prompt text byte-identical.
- **Finding 11** — dropped the "(trailing newline stripped by the worker)" implementation detail.
- **Finding 12** — dropped the language-family considerations: removed the "three language families with multiple labs per family" claim and the EN/FR/ZH Family column from the Models table (models are natively multilingual; framing was irrelevant and false, including the claim of multiple representatives for all three languages).

**Contract bundle (verify-gate):**
- The deleted block's positive-pin test `test_annex_baseline_prompt_carries_as_sent_status_vocabulary` (plus the orphaned `BASELINE_RUN_RECORD` constant) is replaced by a negative guard `test_annex_baseline_prompt_block_removed` (polarity 0557). The kept Doc-07 verbatim-anchor test stays green.
- `docs/editorial-brief.md` `annex-quote-anchor` entry retargeted at the kept Doc-07 prompt and notes the baseline block's deletion.

`make check` GREEN. No figure PDFs, no other ticket-state edits, no broken refs.

**Ticket:** tickets/0590-annex-a-prompts-cleanup.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)