### PR TITLE
manuscript(0591): codenames out, no code refs in §1–§9, matcher named

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -492,11 +492,8 @@ scientific quality standards. Numbers shift between runs, citations are
 absent or fabricated, and there is no way to tell which cells one should
 trust.
 
-\textbf{Cohorts.} The sweep dispatched 16 models (the
-\texttt{modelset\_exp1\_journal} set in
-\texttt{experiments/experiments.toml}). Two — \texttt{qwen3.6-27b} and
-\texttt{qwen3.6-plus} — were dropped before analysis, leaving the
-14-model analysis cohort (\texttt{modelset\_exp1\_batch2}) that backs
+\textbf{Cohorts.} The sweep dispatched 16 models. Two were dropped before
+analysis, leaving the 14-model analysis cohort that backs
 every per-model number, Figure~\ref{fig:direct-base},
 Figure~\ref{fig:cost-quality}, and Figure~\ref{fig:reliability}. Every
 figure caption below names the cohort it draws on.
@@ -518,12 +515,11 @@ in the training corpus. Models grouped on the vertical
 axis.}\label{fig:direct-base}
 \end{figure}
 
-\textbf{Experiment 1 — Parametric baseline.} We query fourteen
-language models from the \emph{modelset\_exp1\_batch2} set; they are
+\textbf{Experiment 1 — Parametric baseline.} We query the fourteen
+analysis-cohort language models; they are
 listed on Figure~\ref{fig:reliability} and include Claude, DeepSeek,
 Mistral and Qwen at various sizes from workstation to frontier, with a
-fixed inventory-specification prompt (the full Doc-07 naive prompt,
-\texttt{experiments/sota/protocol\_07\_naive\_prompt.md}, reproduced
+fixed inventory-specification prompt (the naive prompt, reproduced
 verbatim in \ref{sec:annex-exp1}). No documents are
 provided; models draw exclusively on parametric knowledge and receive a
 system instruction forbidding web search. Each model is queried five
@@ -552,8 +548,8 @@ author's group injected reference-derived content into the pre-existing
 \emph{List of power stations in Vietnam} on 19 June 2019 (significantly
 increasing its coverage; verifiable in the page history, revision
 \texttt{902510278}), and \emph{List of coal power stations in Vietnam}
-was split off on 5 July 2019 (provenance and diff in
-\texttt{data/reference/PROVENANCE.md}). Both events predate the 2026-era
+was split off on 5 July 2019 (provenance and diff documented with the
+reference dataset). Both events predate the 2026-era
 model cohort by roughly six and a half years, so the answer key's
 validity is not in doubt for the cohort; we report the comparison
 directionally because the project does not record per-model cutoff
@@ -611,7 +607,7 @@ experiment cost is \$\CensusCostTotal{}.
 
 An earlier sweep surfaced refusals rather than scores: in the archived
 baseline sweep, GPT-5.5 declined the task on 3 of its 5 reps before the
-\texttt{modelset\_exp1\_batch2} re-run reported above resolved
+analysis-cohort re-run reported above resolved
 compliance. We retain the declined responses as data; the episode and
 its reading against the §\ref{sec:quality} provenance bar are taken up
 in the Discussion.
@@ -1358,9 +1354,9 @@ reconciliation is deferred (post-arXiv).}
 \subsection*{Prompts}
 \addcontentsline{toc}{subsection}{Prompts}
 
-\textbf{Analysis-cohort prompt (Doc-07).} The fourteen-model analysis
+\textbf{Analysis-cohort prompt.} The fourteen-model analysis
 cohort (\texttt{modelset\_exp1\_batch2}, the cohort behind every
-per-model number in §\ref{sec:exp1}) received the full Doc-07 naive
+per-model number in §\ref{sec:exp1}) received the full naive
 prompt — \fpath{experiments/sota/protocol_07_naive_prompt.md} —
 verbatim as the sole user message, at temperature 0, seed 42,
 \texttt{max\_tokens} 65536, web access off; this was verified against
@@ -2345,8 +2341,8 @@ This experiment is script-based, not sweep-based. No
 \addcontentsline{toc}{subsection}{Evaluation}
 
 Phase B outputs are evaluated against the \NumRefPlants-plant reference using the
-same \texttt{src/aedist/evaluate.py} machinery as §\ref{sec:exp1} (LP
-matcher, ADR-2/3, \texttt{similarity\_threshold\ =\ 90},
+same \texttt{src/aedist/evaluate.py} machinery as §\ref{sec:exp1} (the LP
+matcher with \texttt{similarity\_threshold\ =\ 90},
 \texttt{capacity\_weight\ =\ 0.001}), yielding row-level F1 and
 per-attribute accuracies. Rubric peer scoring of each output on the four
 §\ref{sec:quality} dimensions — which would need a judging model — is

--- a/tests/test_manuscript_codenames_coderefs.py
+++ b/tests/test_manuscript_codenames_coderefs.py
@@ -1,0 +1,122 @@
+"""Ticket 0591 — global sweep: internal codenames out, no code refs in §1–§9.
+
+Reading-2 findings 8, 22, 23, 24 (tracker 0578). Negative/structural guards
+only (CI test polarity rule, ticket 0557): each assertion forbids a *defect
+class* — an internal codename or a code reference where it does not belong —
+never pins a positive authorial phrasing.
+
+Two scopes:
+
+- **Codenames** (``Doc-07`` / ``Doc-NN``, ``ADR-N``) are internal repo
+  identifiers and must not appear anywhere in the manuscript body — not in the
+  numbered sections, not in the annexes, not in the verbatim prompt boxes
+  (the shipped prompts never carried these labels; they are doc cross-refs the
+  manuscript invented and the sweep removed). Class guard, whole body.
+
+- **Code references** (file paths, module/function/script names, config keys)
+  belong in annexes, figure/table captions, and the Data-&-Code backmatter
+  only. The numbered sections §1–§9 + Conclusion — the region from
+  ``\\section{Introduction}`` up to ``\\section*{Acknowledgements}``, with
+  ``\\caption{…}`` blocks excised — must be free of them.
+
+Exempt, and deliberately NOT matched by the code-ref patterns: reader-facing
+data tokens that are not code — the OpenStreetMap ``power=plant`` tag, the
+Wikipedia revision id, the controlled status vocabulary. These are data the
+reader queries or reads, not repo artifacts.
+"""
+
+import re
+
+import pytest
+from manuscript_source import body_raw, strip_comments
+
+pytestmark = pytest.mark.adherence
+
+# Internal codename classes. ``Doc-07`` and any ``ADR-N`` are repo-doc
+# identifiers; a reader of the paper has no referent for them.
+_CODENAME_RE = re.compile(r"\bDoc-?\d|\bADR[ -]?\d")
+
+# Code-reference signatures: \fpath, source trees, source-file extensions,
+# config-set / sweep-dir identifiers. None of these should surface in §1–§9.
+_CODEREF_PATTERNS = [
+    r"\\fpath\{",
+    r"\bsrc/aedist",
+    r"experiments/",
+    r"data/reference/",
+    r"report/inputs/",
+    r"\.py\b",
+    r"\.toml\b",
+    r"\.csv\b",
+    r"\.json\b",
+    r"\.yaml\b",
+    r"\.md\b",
+    r"modelset_",
+    r"\bexp[12]_",
+]
+
+
+# Build directives that embed a generated artifact by path — these are
+# typesetting mechanics, not prose, so the artifact path inside them is not a
+# prose code reference.
+_INCLUDE_RE = re.compile(r"\\(?:includegraphics(?:\[[^\]]*\])?|input|bibliography)\{[^}]*\}")
+
+
+def _strip_captions(text: str) -> str:
+    """Remove every ``\\caption{…}`` block (brace-balanced) and every figure/
+    table include directive (``\\includegraphics``/``\\input``/``\\bibliography``).
+
+    Captions may carry code references (ticket 0591 scope), and include
+    directives are build mechanics rather than prose; excising both leaves only
+    the running prose of the section."""
+    text = _INCLUDE_RE.sub("", text)
+    out: list[str] = []
+    i = 0
+    needle = r"\caption{"
+    while True:
+        m = re.search(re.escape(needle), text[i:])
+        if not m:
+            out.append(text[i:])
+            break
+        start = i + m.start()
+        out.append(text[i:start])
+        j = start + len(needle)
+        depth = 1
+        while j < len(text) and depth:
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+            j += 1
+        i = j
+    return "".join(out)
+
+
+def _numbered_sections() -> str:
+    """The §1–§9 + Conclusion prose: Introduction .. Acknowledgements, comments
+    and caption blocks removed."""
+    body = strip_comments(body_raw())
+    start = body.index(r"\section{Introduction}")
+    end = body.index(r"\section*{Acknowledgements}")
+    return _strip_captions(body[start:end])
+
+
+def test_no_internal_codenames_anywhere_in_body():
+    """``Doc-07`` / ``ADR-N`` codenames appear nowhere in the manuscript body
+    (findings 8, 24). The shipped prompts never carried them, so the verbatim
+    prompt boxes are not an exception."""
+    body = strip_comments(body_raw())
+    hits = _CODENAME_RE.findall(body)
+    assert not hits, f"internal codename(s) leaked into the manuscript: {hits}"
+
+
+@pytest.mark.parametrize("pattern", _CODEREF_PATTERNS)
+def test_no_code_refs_in_numbered_sections(pattern):
+    """§1–§9 + Conclusion (caption blocks excised) carry no code reference —
+    file paths, source modules, config keys (finding 22). Annexes, captions,
+    and the Data-&-Code backmatter are out of scope and may carry them."""
+    main = _numbered_sections()
+    hits = re.findall(pattern, main)
+    assert not hits, (
+        f"code reference {pattern!r} found in §1–§9 prose: {hits}. "
+        "Move the detail to an annex or a caption, or reword it out."
+    )

--- a/tickets/0592-sweep-register-noise-promises.erg
+++ b/tickets/0592-sweep-register-noise-promises.erg
@@ -2,11 +2,11 @@
 Title: Global sweep: lab-journal register, noise phrases, promises, instruction-cruft
 Created: 2026-06-12
 Author: HDMX-coding-agent
-Blocked-by: 0591
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 13-class, 17-class, 25, 26, 33-class, 38); last ticket of the wave
 
+2026-06-14T02:46Z HDMX-coding-agent note blocker 0591 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/closed/0591-sweep-codenames-code-refs.erg
+++ b/tickets/closed/0591-sweep-codenames-code-refs.erg
@@ -2,12 +2,14 @@
 Title: Global sweep: internal codenames out, no code references in main text, name the matcher
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1064
 
 --- log ---
 2026-06-12T21:52Z HDMX-coding-agent created child of 0578 (findings 8, 22, 23, 24); flow-vs-MILP discrepancy flagged for verification
 2026-06-13T08:40Z finding 23 (matcher naming) partially addressed: Evaluation paragraph in main.tex (ex-L1830) rewritten. New prose names the method "minimum-cost bipartite assignment (MILP)", adds the flow-equivalence sentence, removes ADR-2/ADR-3 codenames and \texttt file/function references, and documents the 1:1 limitation with the five aggregate-vs-split cases from the Exp.2 FP audit. Remaining work: findings 8, 22, 24 (full codename sweep, code refs in §1–§9).
 
 2026-06-14T02:21Z HDMX-coding-agent note blocker 0590 closed — Blocked-by removed.
+2026-06-14T02:46Z HDMX-coding-agent closed — autoclosed — PR #1064
 --- body ---
 ## Context
 


### PR DESCRIPTION
Global sweep over the settled `main.tex` (reading-2 findings 8, 22, 23, 24, tracker 0578), run last over the whole document.

## Per class

**Codenames (8, 24).** Removed every internal repo identifier from reader-facing prose:
- `Doc-07` on the §exp1 baseline-prompt mention (L525) and on the Annex A analysis-cohort prompt heading (L1361/L1363).
- `ADR-2/3` in the Annex B Evaluation paragraph (L2345).

The verbatim prompt boxes never carried these labels, so none were touched there. Whole-body grep for `Doc-?\d` / `ADR[ -]?\d` is now zero (even in comments).

**Code refs in §1–§9 + Conclusion (22).** The §exp1 Cohorts/baseline prose carried config-set names (`modelset_exp1_journal`, `modelset_exp1_batch2`), a config path (`experiments/experiments.toml`), two dropped-model ids, the prompt-file path, and `data/reference/PROVENANCE.md` — all reworded to reader-facing prose. Numbered-section region (Introduction..Acknowledgements, captions + include directives excised) is now zero code-refs. Annexes, figure/table captions, and the Data-&-Code backmatter keep their code references — in scope per the ticket. Reader-facing data tokens deliberately kept: the OSM `power=plant` tag, the Wikipedia revision id `902510278`, the controlled status vocabulary.

**Matcher naming (23) — DISCREPANCY RESOLVED.** The author flagged the name might be "flow". Evidence: `src/aedist/matching/lp.py` is unambiguously a **MILP assignment** (PuLP + CBC branch-and-bound solver; module docstring and README both say "Mixed-Integer Linear Programming"). It is NOT implemented as min-cost-flow. PR #1047 already named it "minimum-cost bipartite assignment formulated as a mixed-integer linear programme (LP matcher)" in the Evaluation annex and added the **flow-equivalence** sentence (assignment problems are mathematically equivalent to min-cost flow on a bipartite graph — true, but it's the math identity, not the implementation name). I kept the code-attested MILP/LP naming and reconciled the ADR-codename edit against #1047's wording. **No matcher rename** — "flow" is not the established name; the equivalence is already stated once where it belongs.

**Instruction-cruft ("names read left to right" class) — ZERO residual hits.** Earlier reading-2 children already cleaned it. The one surviving "Reading left to right" string (L771) is a legitimate figure-caption reading guide, not leaked generation instruction. No edit.

## Test
`tests/test_manuscript_codenames_coderefs.py` (`@pytest.mark.adherence`), negative/structural only (polarity 0557): a codename class guard over the whole body, and a per-pattern code-ref guard scoped to §1–§9+Conclusion (caption + `\includegraphics`/`\input` directives excised). Fang-checked: codename + code-ref reintroduction into §1 prose turns it red; restore green.

## Invariants
- §9 (`sec:future`, PR #1048) and the §evaluation matcher paragraph (#1047) untouched.
- No figure-PDF churn (text-only edits + one new test file). No empirical-number / macro edits. No `\ref`/`\label` touched — crossref test green. No other ticket `.erg` edited.
- `make check` exit 0; the 61 manuscript adherence tests pass (new guard + cohort-count + crossref + em-dash + macros).

**Ticket:** tickets/0591-sweep-codenames-code-refs.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)