### PR TITLE
tickets: reading-3 — new 0608 (§3 draws-on) 0609 (slides count drift) 0610 (§3 drop redundant para); amend 0602 (split Scoring Annex A) + 0606 (canonical finding-22: standalone text+captions, code only in annexes); update tracker 0605

### DIFF
--- a/tickets/0602-intro-para-3-deliver-four-dimension-math.erg
+++ b/tickets/0602-intro-para-3-deliver-four-dimension-math.erg
@@ -7,6 +7,43 @@ Author: HDMX-coding-agent
 2026-06-15T07:19Z HDMX-coding-agent created
 
 --- body ---
+## SCOPE EXPANSION (author, 2026-06-15): this is the §3 ticket — split out a Scoring Annex A
+
+The four-dimension score is not just to be documented but RESTRUCTURED:
+
+- **Split the Evaluation material into a standalone Scoring annex = Annex
+  A in its own right.** Source material is the `\subsection*{Evaluation}`
+  currently inside the Exp-1 spec annex (`main.tex:1766`, `sec:annex-exp1`).
+- **§3 references that annex as THE IMPLEMENTATION — not as a "detail".**
+  Wording must frame the scoring as implemented in the Scoring annex
+  (e.g. "the scoring is implemented in Annex …"), never "details in
+  Annex …".
+- **The Scoring annex describes, in order:**
+  1. the HIERARCHICAL nature of the scoring (cell → row/run → model
+     levels — the two/three-level structure already hinted at
+     `main.tex:901–902`, `:1031–1046`);
+  2. each of the four dimensions IN TURN — q1 accuracy (= F1), q2
+     coherence, q3 provenance, q4 temporality — with the formula,
+     transcribed to MATCH the code (`score_mechanical.py`, `coherence.py`,
+     `metrics.py`);
+  3. it OWNS **figure S1** (identify the first `\thefigure = S\arabic`
+     figure after `main.tex:1272`; confirm it is the scoring-related
+     figure, not the recognition matrix).
+- **Because the annex now carries the detail, shorten the S1 caption
+  substantially.**
+- Mark the annex **version 0.1 of the benchmark, to be improved**.
+- **Annex-ordering caveat:** making Scoring the new Annex A reorders the
+  appendix (current order A=Exp1-spec, B=Exp2-spec, C=recognition, …).
+  Confirm the `\appendix` section order, fix knock-on annex-letter
+  references via `\ref` only (house rule: never hardcode annex letters),
+  and re-check all `\ref{sec:annex-…}` call sites.
+
+The "## Context"/"## Actions" below remain valid for the maths content
+and the corroboration/citation-hedge fixes; this section upgrades the
+delivery from "a four-paragraph section somewhere" to "a dedicated,
+hierarchical Scoring Annex A that owns S1 and is referenced from §3 as
+the implementation".
+
 ## Context
 
 Intro paragraph 3 (`slides/manuscript/main.tex:146–150`) makes two

--- a/tickets/0605-reading-3-wave-tracking-ticket-intro-7-8.erg
+++ b/tickets/0605-reading-3-wave-tracking-ticket-intro-7-8.erg
@@ -44,8 +44,26 @@ is merged and verified — same discipline as the reading-2 tracker 0578.
 - [[0607]] — §3 opener: "Datasets can be assessed on four dimensions" →
   "We benchmark model-produced datasets on four dimensions" (active,
   benchmark-framed; aligns with 0602).
+- [[0608]] — §3 para 1: "The decomposition compresses three traditions" →
+  "draws on".
+- [[0609]] — Slides count drift: `macros_slides` `\NumRefPlants` 173 vs
+  manuscript 177 — reconcile living deck to current reference (archived
+  talk untouched).
+- [[0610]] — §3: drop the redundant closing paragraph (restates the four
+  dimensions).
 
 (More children may be appended as the reading continues.)
+
+## Cross-cutting policy (reading-3)
+
+- **Standalone text + captions; code only in annexes** (canonical
+  re-articulation of finding 22, see [[0606]]): main text and captions
+  are standalone at the maths/ideas level with `\ref` to annexes; only
+  annexes reference the code implementation. Goes in docs/editorial-brief.md.
+- **§3 restructure** ([[0602]]): split the Evaluation material into a
+  standalone Scoring Annex A (hierarchical scoring + four dimensions in
+  turn + owns figure S1, shortened caption), referenced from §3 as the
+  implementation. Reorders the appendix — watch annex-letter refs.
 
 ## Wave plan (mirrors 0578)
 

--- a/tickets/0606-figure-1-fig-longtail-rethink-caption-le.erg
+++ b/tickets/0606-figure-1-fig-longtail-rethink-caption-le.erg
@@ -32,11 +32,24 @@ other public source holds." and ends "Counts re-derived from
    / OSM) and the unique-tail value point; just reorder so the gold-register
    message leads.
 
-## B. No filenames in main body AND captions (POLICY CHANGE — flag)
+## B. Standalone text + captions; only annexes reference code (canonical re-articulation of finding 22)
 
-The author wants NO filenames anywhere in the main body OR captions. This
-**reverses finding 22 / ticket 0591's caption exemption** (which allowed
-captions to reference code/paths). Action:
+Author's clean re-articulation (2026-06-15; finding 22 was "poorly
+articulated"): **the main text and the figure/table captions must be
+standalone at the MATHS / IDEAS level, with references to the annexes for
+detail. Only the annexes may reference the code implementation** (file
+paths, function/module names, config keys). So:
+- Main text + captions: self-contained on the maths and ideas, using
+  `\ref` to annexes where detail is needed; NO code/filenames.
+- Annexes: may reference the code implementation.
+
+This refines (does not merely "reverse") finding 22 / ticket 0591: 0591
+removed code from the *body* but left captions exempt; the true intent is
+that captions are held to the same standalone standard, with code
+references confined to annexes. Record this as the canonical policy in
+`docs/editorial-brief.md` (supersedes the 0591 caption exemption).
+
+Action:
 - Remove the filename from the Figure 1 caption (covered by A).
 - Sweep ALL figure/table captions in `main.tex` for `\texttt{…}`/`\fpath{}`
   filenames and remove/relocate them (the source CSV belongs in the

--- a/tickets/0608-section-3-para-1-the-decomposition-compr.erg
+++ b/tickets/0608-section-3-para-1-the-decomposition-compr.erg
@@ -1,0 +1,42 @@
+%erg 0.1
+Title: Section 3 para 1: 'The decomposition compresses three traditions' -> 'draws on'
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T07:51Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Reading-3 (tracker [[0605]]). §3 para 1 (`slides/manuscript/main.tex:278`):
+
+> The decomposition compresses three traditions: data-quality
+> engineering …, official-statistics governance …, and
+> philosophy-of-science empirical adequacy …
+
+"compresses" overstates; the author wants "draws on".
+
+## Actions
+
+1. Replace "compresses" → "draws on" at `:278` ("The decomposition draws
+   on three traditions: …"). Keep the three citations intact.
+
+## Relevant files
+
+- `slides/manuscript/main.tex:278`.
+
+## Test
+
+- Red first: `@pytest.mark.adherence` negative guard — assert "compresses
+  three traditions" is absent from §3 (CI polarity: forbid the old word;
+  do not pin the replacement).
+
+## Verification
+
+- [ ] §3 para 1 reads "draws on three traditions"; citations intact.
+- [ ] `make check` passes.
+
+## Exit criteria
+
+- "compresses" → "draws on" at `:278`; `make check` green.

--- a/tickets/0609-slides-count-drift-macros-slides-numrefp.erg
+++ b/tickets/0609-slides-count-drift-macros-slides-numrefp.erg
@@ -1,0 +1,65 @@
+%erg 0.1
+Title: Slides count drift: macros_slides NumRefPlants 173 vs manuscript 177 — reconcile living deck to current reference
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T07:51Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Reading-3 (tracker [[0605]]). The reference-plant count has drifted across
+generated macros:
+
+- `report/inputs/generated/macros.tex:5` — `\NumRefPlants` = **177**
+- `report/inputs/generated/macros_slides.tex:5` — `\NumRefPlants` = **173**
+- (manuscript `macros_manuscript.tex` / `macros_longtail.tex`
+  `\LongtailReference` = 177 — manuscript is internally consistent.)
+
+The living slides deck carries a stale 173. The current reference is 177.
+
+## Caveat (do not break the archived talk)
+
+The Econom'IA 2026 talk was delivered and archived (tag
+`economia-2026-cergy`, HAL `hal-05644906`, release PDF). That archived
+artifact is frozen as-presented and must NOT be retro-edited. This ticket
+fixes the **living** slides source so future builds match the current
+reference — it does not touch the archived release.
+
+## Actions
+
+1. Find why `macros_slides.tex` emits 173 (which emitter / data snapshot)
+   vs 177 in `macros.tex`. They should share one source of truth for the
+   reference count.
+2. Reconcile the living slides macro to the current reference (177),
+   regenerating via the proper `make` target — do not hand-edit the
+   generated file. Verify 177 is the correct current reference count
+   against the reference data (derive-from-artifact).
+3. If the slides intentionally pin an as-presented number somewhere in
+   prose (the talk said ~163/173), confirm with the author before
+   changing that prose; the macro itself should track current data.
+
+## Relevant files
+
+- `report/inputs/generated/macros_slides.tex`, `macros.tex` (generated —
+  fix the emitter, not the file).
+- the emitter/`make` target that produces `macros_slides.tex`.
+
+## Test
+
+- Red first: `@pytest.mark.adherence` guard re-deriving `\NumRefPlants`
+  from the reference data and asserting the slides and manuscript macros
+  agree (single source of truth).
+
+## Verification
+
+- [ ] `macros_slides.tex` `\NumRefPlants` == manuscript value (177),
+      regenerated from the emitter.
+- [ ] Archived talk release untouched.
+- [ ] `make check` passes.
+
+## Exit criteria
+
+- Slides and manuscript reference counts agree (177), sourced from one
+  generator; archived talk untouched; `make check` green.

--- a/tickets/0610-section-3-drop-redundant-last-paragraph.erg
+++ b/tickets/0610-section-3-drop-redundant-last-paragraph.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: Section 3: drop redundant last paragraph
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T07:52Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Reading-3 (tracker [[0605]]). §3's last paragraph
+(`slides/manuscript/main.tex:363–368`):
+
+> The task is not simply to generate a plausible inventory-shaped answer.
+> The statistical object is a dated, sourced, internally reconciled set
+> of claims … Accuracy determines whether the claims are correct;
+> coherence determines whether they can coexist; provenance determines
+> whether they are auditable; and temporality determines what period of
+> the world they describe.
+
+It restates the four dimensions already defined in the enumerate list and
+the preceding reference-free-asymmetry paragraph. Redundant — drop it.
+
+## Actions
+
+1. Delete the §3 closing paragraph (`:363–368`). Confirm §3 then ends on
+   the reference-free-asymmetry paragraph (`:354–361`), which carries the
+   screening logic forward to §\ref{sec:exp1} — a clean hand-off to §4.
+
+## Relevant files
+
+- `slides/manuscript/main.tex:363–368`.
+
+## Test
+
+- Red first: `@pytest.mark.adherence` negative guard — assert the
+  paragraph's signature phrase ("not simply to generate a plausible
+  inventory-shaped answer") is absent (CI polarity: forbid the dropped
+  text).
+
+## Verification
+
+- [ ] §3 closing paragraph removed; §3 ends cleanly on the
+      reference-free-asymmetry paragraph.
+- [ ] No dangling \ref created by the deletion.
+- [ ] `make check` passes; manuscript builds.
+
+## Exit criteria
+
+- Redundant §3 final paragraph gone; `make check` green.


### PR DESCRIPTION
Opened via scripts/quickpr.sh.