### PR TITLE
manuscript(0615): retire "answer key" → "coverage bar"; reshape Fig 3 caption

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -509,11 +509,9 @@ thermal reference: each bar is one run; family-coloured segments to the
 right are correctly identified plants (TP), red segments to the left are
 unmatched plants (FP: extracted but not in the reference). The dashed
 green line marks the \NumRefPlants-plant reference; the light-grey dotted line
-marks Wikipedia's light-reviewed coverage of all \NumRefPlants{} reference plants
-(\WikiReviewedPct\%, \WikiReviewed/\NumRefPlants) —
-the answer key every model should recover, since that content sat
-in the training corpus. Models grouped on the vertical
-axis.}\label{fig:direct-base}
+marks Wikipedia's coverage of \WikiReviewed{} assets
+(\WikiReviewedPct\% of our reference list) — the coverage bar that
+models could be expected to pass.}\label{fig:direct-base}
 \end{figure}
 
 \textbf{Experiment 1 — Parametric baseline.} We query the fourteen
@@ -532,9 +530,9 @@ row-level precision, recall, and F1; fuel type, operational status, and
 province accuracy are scored at the cell level for matched rows. Cost in
 USD and wall-clock time are recorded per run.
 
-\textbf{An answer key already in the training corpus.} These scores
+\textbf{A coverage bar already in the training corpus.} These scores
 need an upper bound the reader can judge them against. We call that
-upper bound the \emph{answer key}: the share of the reference a model
+upper bound the \emph{coverage bar}: the share of the reference a model
 could have recovered from public training text alone, because the
 content was already there to read. Before the experiment, the author's
 group published a
@@ -551,7 +549,7 @@ increasing its coverage; verifiable in the page history, revision
 \texttt{902510278}), and \emph{List of coal power stations in Vietnam}
 was split off on 5 July 2019 (provenance and diff documented with the
 reference dataset). Both events predate the 2026-era
-model cohort by roughly six and a half years, so the answer key's
+model cohort by roughly six and a half years, so the coverage bar's
 validity is not in doubt for the cohort; we report the comparison
 directionally because the project does not record per-model cutoff
 dates.
@@ -560,12 +558,12 @@ One caveat on coverage: the
 built fleet (operating, retired) has been on these pages since mid-2019,
 while much of the forward-looking
 pipeline is PDP8-era (post-2019) content added after the June 2019
-injection, so those rows may postdate some cutoffs. The answer key is
+injection, so those rows may postdate some cutoffs. The coverage bar is
 therefore firm for the built fleet and an upper-bound
 heuristic for the pipeline tail. Wikipedia coverage of the reference is
-thus the answer key a competent parametric model ought to recover, and
+thus the coverage bar a competent parametric model ought to recover, and
 grading recall against it is not circular, because it measures retrieval,
-not justification. The answer key has two regimes (light-reviewed,
+not justification. The coverage bar has two regimes (light-reviewed,
 \ref{sec:annex-exp1}): the built fleet is covered at a 92\% mean
 (operating 95\%, construction 80\%, permitted 100\%), while the
 forward-looking pipeline sits at 55\% (proposed and announced; 73\%

--- a/tests/test_manuscript_0615_coverage_bar.py
+++ b/tests/test_manuscript_0615_coverage_bar.py
@@ -1,0 +1,50 @@
+"""Negative guards for the 'answer key' → 'coverage bar' rename (ticket 0615).
+
+Reading-3 retires the term 'answer key' (a reading-2 coinage) in favour of
+'coverage bar'. These are negative guards only, per the CI polarity rule
+(`.claude/rules/writing.md`): we forbid the obsolete term and the two
+trailing caption clauses that ticket 0615 dropped. We never pin the new
+positive authorial wording — that would break on the next legitimate
+rewrite.
+
+- The literal string 'answer key' (any case) must not survive anywhere in
+  `main.tex`.
+- The Figure 3 caption (`fig:direct-base`) must no longer carry the dropped
+  tail: neither "every model should recover" nor "Models grouped on the
+  vertical axis" — a structural assertion that the caption was shortened.
+"""
+
+import re
+
+import pytest
+from manuscript_source import raw, strip_comments
+
+pytestmark = pytest.mark.adherence
+
+_FIG3_RE = re.compile(
+    r"\\caption\{(?P<body>.*?)\}\\label\{fig:direct-base\}",
+    re.DOTALL,
+)
+
+
+def test_answer_key_term_absent():
+    """The obsolete 'answer key' term must not appear in main.tex."""
+    body = strip_comments(raw())
+    assert "answer key" not in body.lower(), (
+        "'answer key' was retired by ticket 0615 in favour of 'coverage bar'; "
+        "a surviving occurrence means the rename is incomplete."
+    )
+
+
+def test_fig3_caption_dropped_trailing_clauses():
+    """Figure 3 caption no longer carries the clauses ticket 0615 removed."""
+    text = strip_comments(raw())
+    m = _FIG3_RE.search(text)
+    assert m is not None, "fig:direct-base caption not found in main.tex"
+    caption = m.group("body")
+    for dropped in ("every model should recover", "Models grouped"):
+        assert dropped not in caption, (
+            f"Figure 3 caption still contains the dropped clause {dropped!r}; "
+            "ticket 0615 shortened the caption to end on the coverage-bar "
+            "definition."
+        )

--- a/tickets/closed/0615-replace-answer-key-concept-with-coverage.erg
+++ b/tickets/closed/0615-replace-answer-key-concept-with-coverage.erg
@@ -2,10 +2,12 @@
 Title: Replace 'answer key' concept with 'coverage bar'; Figure 3 caption defines it (Wikipedia 130 = 73% of reference)
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1100
 
 --- log ---
 2026-06-15T08:11Z HDMX-coding-agent created
 
+2026-06-15T11:05Z HDMX-coding-agent closed — autoclosed — PR #1100
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Reading-3 sweep (tracker 0605). Retires the reading-2 term **answer key** in favour of **coverage bar** throughout `slides/manuscript/main.tex`, and reshapes the Figure 3 (`fig:direct-base`) caption to define the coverage bar and stop there.

### A. Term rename (8 sites)
- §5 subsection heading: "An answer key already in the training corpus." → "A coverage bar already in the training corpus."
- 7 prose occurrences: "the answer key" → "the coverage bar", with grammar fixes ("the answer key's" → "the coverage bar's", "The answer key has two regimes" → "The coverage bar has two regimes", the `\emph{answer key}` definition → `\emph{coverage bar}`).

### B. Figure 3 caption
Dotted-line gloss re-anchored on the coverage bar (`\WikiReviewed` = 130 assets, `\WikiReviewedPct` = 73% of the reference list, both macro-sourced; literal em dash). The caption now ends on the coverage-bar sentence — dropping the "answer key every model should recover…" clause and the orphan "Models grouped on the vertical axis." sentence.

### Test
New `tests/test_manuscript_0615_coverage_bar.py` (`@pytest.mark.adherence`), **negative guards only** per the CI polarity rule:
- "answer key" must not appear anywhere in `main.tex`;
- the Fig 3 caption must not contain the two dropped clauses ("every model should recover", "Models grouped").

No positive new wording is pinned. No empirical numbers hand-typed (macro-sourced). `make check-fast` green.

**Ticket:** tickets/0615-replace-answer-key-concept-with-coverage.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)