### PR TITLE
manuscript(0633): text + captions standalone; code refs only in annexes

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -372,3 +372,32 @@ review panel against manuscript diffs.
 **Ticket:** tickets/0565-future-research-kb-design-items-insert.erg
 
 **Status:** active
+
+## text-and-captions-standalone
+
+**Decision:** The main text AND the figure/table captions are standalone at
+the maths/ideas level: no code references — file paths, module/function/script
+names, config keys, filenames — appear in §1–§9, the Conclusion, the
+backmatter, or any caption among them (everything before `\appendix`).
+Load-bearing implementation detail is relocated to the relevant annex and
+reached by `\ref{sec:annex-…}`. Code references are allowed only in the
+annexes (after `\appendix`). This SUPERSEDES ticket 0591's caption exemption:
+0591 cleaned §1–§9 prose but excised `\caption{…}` blocks from its scan; 0633
+brings captions into scope. Carve-out — reader-facing data tokens that are not
+repo artifacts stay (the OpenStreetMap `power=plant` tag, the Wikipedia
+revision id, the controlled status vocabulary).
+
+**Rationale:** A reader of the paper and its captions should follow the
+ideas without consulting the codebase; repo artifacts are an annex concern.
+Canonical re-articulation of finding 22 (author, 2026-06-15). CI keeps the
+negative class guard
+(`test_manuscript_0633_caption_coderefs.py`): code-reference signatures are
+forbidden in body captions and in the body before `\appendix`; the annexes are
+out of scope. The 0591 caption-exempting guard
+(`test_manuscript_codenames_coderefs.py`) remains for the §1–§9 prose scope it
+already covered.
+
+**Ticket:** tickets/0633-global-caption-sweep-text-and-captions-s.erg
+(supersedes ticket 0591's caption exemption)
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -242,9 +242,8 @@ physically built infrastructure only). Well-documented operating plants
 appear in every layer; the under-documented tail — proposed and
 planned projects from the PDP8 pipeline — thins out layer by layer.
 This tail is the reference's unique contribution, and the segment where
-investing in a sourcing pipeline adds the most value. Counts re-derived
-from
-\texttt{data/reference/tab\_longtail\_layers.csv}.}\label{fig:longtail}
+investing in a sourcing pipeline adds the most value. Recognition-layer
+provenance is detailed in \ref{sec:annex-recognition}.}\label{fig:longtail}
 \end{figure}
 
 \textbf{Statistical perimeters by use case.} What counts as a
@@ -621,12 +620,12 @@ inventory. Plants correctly identified vs cost per call across the
 Experiment 1 lineup, split by architectural family across two panels
 with shared axes: \textbf{panel (a)} Claude, GPT, Mistral; \textbf{panel
 (b)} Qwen, DeepSeek. Each of the fourteen
-\texttt{modelset\_exp1\_batch2} models contributes a filled square at
+models contributes a filled square at
 its pooled median true-positive count and a marker at every individual
 rep, plotted at the rep's own per-call cost (cents USD, log scale); the
 dashed line at \NumRefPlants{} marks the full Vietnam thermal inventory. Marker
 shapes, colour palette, the per-rep cohort split, and the audit artifact
-(\texttt{report/inputs/generated/cost\_quality.csv}) are detailed in
+are detailed in
 \ref{sec:annex-exp1}.}\label{fig:cost-quality}
 \end{figure}
 
@@ -663,8 +662,8 @@ reference data. Y axis: accuracy, the mean row-level F1 against the
 \NumRefPlants-plant reference over the good runs; for the three models with zero
 good runs (claude-haiku-4.5, gpt-oss-20b, qwen3.6-35b-a3b), no good run
 exists, so the mean is taken over \textbf{all} five runs. Source
-artifact: \texttt{experiments/derived/exp1\_cross\_eval.csv}; gate
-sensitivity in \ref{sec:annex-exp1}.}\label{fig:reliability}
+artifact and gate
+sensitivity are detailed in \ref{sec:annex-exp1}.}\label{fig:reliability}
 \end{figure}
 
 \section{Experiment 2: frontier agents fall short on the measured quality dimensions}\label{sec:exp2}
@@ -1259,7 +1258,7 @@ compiled the \NumRefPlants-plant reference list, and an intern in the author's
 group, working under the author's supervision, seeded reference-derived
 content into the relevant Wikipedia pages in June 2019; the author also
 made minor edits to those pages directly (§\ref{sec:exp1}; provenance in
-\texttt{data/reference/PROVENANCE.md}). Both the benchmark reference and
+\ref{sec:annex-exp1}). Both the benchmark reference and
 part of its Wikipedia coverage therefore originate from the author's
 group; this dual role is disclosed, and the reference list is provided
 as a supplementary artifact with per-plant source citations.

--- a/tests/test_manuscript_0633_caption_coderefs.py
+++ b/tests/test_manuscript_0633_caption_coderefs.py
@@ -1,0 +1,122 @@
+"""Ticket 0633 — global caption sweep: text AND captions standalone at the
+maths/ideas level; code references (file paths, module/function/script names,
+config keys, filenames) live ONLY in the annexes.
+
+Canonical re-articulation of finding 22 (author, 2026-06-15): the main text and
+the figure/table captions must be self-contained at the level of ideas, with
+``\\ref`` to the annexes for implementation detail. This SUPERSEDES ticket
+0591's caption exemption (``test_manuscript_codenames_coderefs.py`` excised
+``\\caption{…}`` blocks before scanning; this sweep brings captions into scope).
+
+Negative/structural guards only (CI test polarity rule, ticket 0557): every
+assertion forbids a *defect class* — a code reference where it does not belong —
+and never pins a positive authorial phrasing.
+
+Boundary: the document body up to ``\\appendix`` (§1–§9, Conclusion, the
+backmatter blocks, and every figure/table caption among them). Code references
+are allowed AFTER ``\\appendix`` (the annexes) and are not scanned here.
+
+Exempt, and deliberately NOT matched by the code-ref patterns: reader-facing
+data tokens that are not code — the OpenStreetMap ``power=plant`` tag, the
+Wikipedia revision id, the controlled status vocabulary. These are data the
+reader queries or reads, not repo artifacts; the patterns below target paths,
+source-file extensions, and config/sweep identifiers, none of which those
+tokens carry.
+"""
+
+import re
+
+import pytest
+from manuscript_source import body_raw, strip_comments
+
+pytestmark = pytest.mark.adherence
+
+# Code-reference signatures: \fpath, source trees, source-file extensions,
+# config-set / sweep-dir identifiers. None of these belongs in the body or in a
+# body caption — they are repo artifacts the annexes own.
+_CODEREF_PATTERNS = [
+    r"\\fpath\{",
+    r"\bsrc/aedist",
+    r"experiments/",
+    r"data/reference/",
+    r"data/rag_corpus/",
+    r"report/inputs/",
+    r"docs/",
+    r"\.py\b",
+    r"\.toml\b",
+    r"\.csv\b",
+    r"\.json\b",
+    r"\.yaml\b",
+    r"\.md\b",
+    r"modelset_",
+    r"\bexp[12]_",
+]
+
+# Build directives that embed a generated artifact by path — typesetting
+# mechanics, not prose, so the artifact path inside them is not a code reference
+# (\includegraphics resolves the figure PDF; \input/\bibliography load files).
+_INCLUDE_RE = re.compile(
+    r"\\(?:includegraphics(?:\[[^\]]*\])?|input|bibliography)\{[^}]*\}"
+)
+
+
+def _body_before_appendix() -> str:
+    """Document body from \\begin{document} up to \\appendix, comments dropped
+    and build-mechanics include directives removed.
+
+    This is the region that must be standalone at the maths/ideas level:
+    §1–§9 + Conclusion, the backmatter, and EVERY figure/table caption among
+    them. The annexes (after \\appendix) are out of scope."""
+    body = strip_comments(body_raw())
+    cut = re.search(r"\\appendix(?![A-Za-z])", body)
+    if cut:
+        body = body[: cut.start()]
+    return _INCLUDE_RE.sub("", body)
+
+
+def _captions(text: str) -> list[str]:
+    """Every brace-balanced ``\\caption{…}`` block found in `text`."""
+    out: list[str] = []
+    needle = r"\caption{"
+    i = 0
+    while True:
+        m = re.search(re.escape(needle), text[i:])
+        if not m:
+            return out
+        start = i + m.start() + len(needle)
+        depth = 1
+        j = start
+        while j < len(text) and depth:
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+            j += 1
+        out.append(text[start : j - 1])
+        i = j
+
+
+@pytest.mark.parametrize("pattern", _CODEREF_PATTERNS)
+def test_no_code_refs_in_body_captions(pattern):
+    """No figure/table caption before \\appendix carries a code reference —
+    file path, source module, config key, or filename. Load-bearing detail is
+    relocated to the relevant annex and reached by \\ref (ticket 0633,
+    superseding 0591's caption exemption)."""
+    captions = "\n".join(_captions(_body_before_appendix()))
+    hits = re.findall(pattern, captions)
+    assert not hits, (
+        f"code reference {pattern!r} found in a body caption: {hits}. "
+        "Move the detail to an annex and \\ref it; keep captions standalone."
+    )
+
+
+@pytest.mark.parametrize("pattern", _CODEREF_PATTERNS)
+def test_no_code_refs_in_body_before_appendix(pattern):
+    """The whole body up to \\appendix — §1–§9, Conclusion, backmatter, AND
+    the captions among them — carries no code reference. Annexes (after
+    \\appendix) are out of scope and may carry them (ticket 0633)."""
+    hits = re.findall(pattern, _body_before_appendix())
+    assert not hits, (
+        f"code reference {pattern!r} found in the body before \\appendix: "
+        f"{hits}. Move the detail to an annex or reword it out."
+    )

--- a/tickets/closed/0633-global-caption-sweep-text-and-captions-s.erg
+++ b/tickets/closed/0633-global-caption-sweep-text-and-captions-s.erg
@@ -2,10 +2,12 @@
 Title: Global caption sweep: text and captions standalone at maths/ideas level; code/filenames only in annexes (canonical finding-22)
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1101
 
 --- log ---
 2026-06-15T10:41Z HDMX-coding-agent created
 
+2026-06-15T11:04Z HDMX-coding-agent closed — autoclosed — PR #1101
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Reading-3 global sweep (tracker 0605), one of the three sweeps-first tickets. Makes the main text **and** the figure/table captions standalone at the maths/ideas level: code references (file paths, module/script names, config keys, filenames) now live **only in the annexes** (after `\appendix`). This supersedes ticket 0591's caption exemption.

## Caption / body sites cleaned (`slides/manuscript/main.tex`)

| Site | What was removed | Where the detail now lives |
|------|------------------|----------------------------|
| `fig:longtail` caption | `\texttt{data/reference/tab_longtail_layers.csv}` | `\ref{sec:annex-recognition}` (recognition-layer provenance) |
| `fig:cost-quality` caption | `\texttt{modelset_exp1_batch2}` config id + `\texttt{report/inputs/generated/cost_quality.csv}` | `\ref{sec:annex-exp1}` (already details cohort split + artifact) |
| `fig:reliability` caption | `\texttt{experiments/derived/exp1_cross_eval.csv}` | `\ref{sec:annex-exp1}` (source artifact + gate sensitivity) |
| Author-contributions backmatter | `\texttt{data/reference/PROVENANCE.md}` | `\ref{sec:annex-exp1}` (annex documents PROVENANCE.md) |

**Kept** the ticket's carve-out content tokens (not repo artifacts): the OSM `power=plant` tag, the Wikipedia revision id `902510278`, and the controlled status vocabulary. **Annexes untouched** — all changes are before `\appendix` (line 1270).

## Negative guard

`tests/test_manuscript_0633_caption_coderefs.py` (`@pytest.mark.adherence`), class-regex, no positive pins:
- `test_no_code_refs_in_body_captions` — no code-ref signature in any caption before `\appendix`.
- `test_no_code_refs_in_body_before_appendix` — no code-ref signature anywhere in the body before `\appendix` (captions included).

Code-ref signatures: `\fpath{`, source trees, `.py/.toml/.csv/.json/.yaml/.md` extensions, `modelset_`, `exp[12]_`, etc. The carve-out tokens match none of these. Verified **RED** on the pre-edit source (9 failures across both tests) and **GREEN** after the edits.

## Policy

Recorded in `docs/editorial-brief.md` → `text-and-captions-standalone` (Decision/Rationale/Ticket/Status), explicitly superseding 0591's caption exemption. The 0591 guard (`test_manuscript_codenames_coderefs.py`) stays for the §1–§9 prose scope it already covered.

## Tests

`make check-fast` green (exit 0). Related: `test_manuscript_codenames_coderefs.py`, `test_manuscript_crossref.py` pass (new `\ref`s all resolve).

**Ticket:** tickets/0633-global-caption-sweep-text-and-captions-s.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)