### PR TITLE
manuscript(0607/0608/0610): tighten §3 opener, decomposition verb, drop closing para

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -273,8 +273,8 @@ yardstick, which §\ref{sec:quality} defines.
 
 \section{Quality dimensions for research-grade statistical datasets}\label{sec:quality}
 
-Datasets can be assessed on four dimensions: accuracy, coherence,
-provenance, and temporality. The decomposition compresses three
+We benchmark model-produced datasets on four dimensions: accuracy, coherence,
+provenance, and temporality. The decomposition draws on three
 traditions: data-quality engineering
 \citep{Wang-Richard1996:beyond-accuracy}, official-statistics governance
 \citep{IMF2003:dqaf, UN2014:fundamental-principles}, and
@@ -358,13 +358,6 @@ that asymmetry: where reference-free indicators correlate with accuracy,
 they can estimate it — screening out weak outputs without the
 reference. The experiments exercise this logic directly
 (§\ref{sec:exp1}).
-
-The task is not simply to generate a plausible inventory-shaped answer.
-The statistical object is a dated, sourced, internally reconciled set of
-claims about energy-system assets and events. Accuracy determines
-whether the claims are correct; coherence determines whether they can
-coexist; provenance determines whether they are auditable; and
-temporality determines what period of the world they describe.
 
 \section{AI capability landscape: from chatbots to agentic systems}\label{sec:capability}
 

--- a/tests/test_manuscript_0607_s3_opener.py
+++ b/tests/test_manuscript_0607_s3_opener.py
@@ -1,0 +1,37 @@
+"""Tickets 0607, 0608, 0610 — §3 prose tightening.
+
+Negative guards only (CI polarity rule, ticket 0557):
+- 0607: old §3 opener "Datasets can be assessed on four dimensions" is gone.
+- 0608: old phrasing "The decomposition compresses three" is gone.
+- 0610: dropped closing paragraph signature "The task is not simply to generate
+  a plausible inventory-shaped answer" is absent from the body.
+"""
+
+import pytest
+from manuscript_source import body
+
+pytestmark = pytest.mark.adherence
+
+
+def test_old_s3_opener_absent() -> None:
+    """0607: generic opener replaced; old phrasing must not reappear."""
+    assert "Datasets can be assessed on four dimensions" not in body(), (
+        "old §3 opener 'Datasets can be assessed on four dimensions' must be "
+        "absent — replaced by 'We benchmark model-produced datasets …' (ticket 0607)"
+    )
+
+
+def test_old_decomposition_compresses_absent() -> None:
+    """0608: 'compresses three' replaced by 'draws on'; old form must not reappear."""
+    assert "The decomposition compresses three" not in body(), (
+        "old phrasing 'The decomposition compresses three' must be absent — "
+        "replaced by 'draws on' (ticket 0608)"
+    )
+
+
+def test_dropped_s3_closing_paragraph_absent() -> None:
+    """0610: redundant §3 closing paragraph dropped; signature phrase must be gone."""
+    assert "The task is not simply to generate a plausible inventory-shaped answer" not in body(), (
+        "dropped §3 closing paragraph signature must be absent from the body "
+        "(ticket 0610)"
+    )

--- a/tickets/closed/0607-section-3-opener-datasets-can-be-assesse.erg
+++ b/tickets/closed/0607-section-3-opener-datasets-can-be-assesse.erg
@@ -2,10 +2,12 @@
 Title: Section 3 opener: 'Datasets can be assessed on four dimensions' -> 'We benchmark model-produced datasets on four dimensions'
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1104
 
 --- log ---
 2026-06-15T07:38Z HDMX-coding-agent created
 
+2026-06-15T12:12Z HDMX-coding-agent closed — autoclosed — PR #1104
 --- body ---
 ## Context
 

--- a/tickets/closed/0608-section-3-para-1-the-decomposition-compr.erg
+++ b/tickets/closed/0608-section-3-para-1-the-decomposition-compr.erg
@@ -2,10 +2,12 @@
 Title: Section 3 para 1: 'The decomposition compresses three traditions' -> 'draws on'
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1104
 
 --- log ---
 2026-06-15T07:51Z HDMX-coding-agent created
 
+2026-06-15T12:12Z HDMX-coding-agent closed — autoclosed — PR #1104
 --- body ---
 ## Context
 

--- a/tickets/closed/0610-section-3-drop-redundant-last-paragraph.erg
+++ b/tickets/closed/0610-section-3-drop-redundant-last-paragraph.erg
@@ -2,10 +2,12 @@
 Title: Section 3: drop redundant last paragraph
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1104
 
 --- log ---
 2026-06-15T07:52Z HDMX-coding-agent created
 
+2026-06-15T12:12Z HDMX-coding-agent closed — autoclosed — PR #1104
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- **0607**: §3 opener changed from generic "Datasets can be assessed on four dimensions" to active "We benchmark model-produced datasets on four dimensions"
- **0608**: "The decomposition compresses three traditions" → "draws on three traditions" (less mechanical framing, citations preserved)
- **0610**: Drop §3 redundant closing paragraph ("The task is not simply to generate a plausible inventory-shaped answer … temporality determines what period of the world they describe") — §3 now ends on the reference-free-asymmetry paragraph

Adds three negative-guard adherence tests (polarity rule, ticket 0557).

**Ticket:** tickets/0607-section-3-opener-datasets-can-be-assesse.erg
**Ticket:** tickets/0608-section-3-para-1-the-decomposition-compr.erg
**Ticket:** tickets/0610-section-3-drop-redundant-last-paragraph.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)