### PR TITLE
manuscript(0626+0627): drop §7 para-1 closing sentence and §7.1 interpretation clause

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -830,7 +830,6 @@ The analyses in this section were performed after the two experiments
 were presented at Econom'IA 2026, in response to questions from the
 audience: why is the task hard, can weak runs be screened without a
 reference, can runs be fused, and what system do the findings imply?
-They are exploratory; each subsection summarises one analysis.
 
 \subsection*{Why is the task hard?}\label{sec:ext-difficulty}
 \addcontentsline{toc}{subsection}{Why is the task hard?}
@@ -842,8 +841,7 @@ proposed projects, and these have low visibility. Table~\ref{tbl:status-difficul
 shows the composition: proposed plants form the largest share of the
 list, and parametric memory cannot know them. Their average probability
 of being found by an Experiment 1 model run falls far below that of
-operational plants, so the low overall recognition is a property of the
-list's composition, not merely a model failure.
+operational plants.
 
 \begin{table}[htbp]
 \centering

--- a/tests/test_manuscript_0626_s7_drops.py
+++ b/tests/test_manuscript_0626_s7_drops.py
@@ -1,0 +1,47 @@
+"""Tickets 0626 + 0627 — §7 sentence drops.
+
+Negative guards only (CI polarity rule, 0557):
+
+- 0626: the §7 para-1 closing sentence "They are exploratory; each subsection
+  summarises one analysis." is dropped — the paragraph ends on the
+  audience-questions sentence.
+- 0627: the §7.1 trailing clause ", so the low overall recognition is a
+  property of the list's composition, not merely a model failure." is dropped —
+  the sentence ends at "falls far below that of operational plants."
+"""
+
+import pytest
+from manuscript_source import body
+
+pytestmark = pytest.mark.adherence
+
+
+def _md() -> str:
+    return body()
+
+
+def test_no_exploratory_subsection_sentence() -> None:
+    """0626: the 'They are exploratory' closing sentence is gone."""
+    md = _md()
+    assert "They are exploratory" not in md, (
+        "'They are exploratory; each subsection summarises one analysis.' "
+        "must be dropped from §7 para 1 (ticket 0626)"
+    )
+    assert "each subsection summarises one analysis" not in md, (
+        "'each subsection summarises one analysis' "
+        "must be dropped from §7 para 1 (ticket 0626)"
+    )
+
+
+def test_no_composition_not_model_failure_clause() -> None:
+    """0627: the 'not merely a model failure' clause is gone."""
+    md = _md()
+    assert "not merely a model failure" not in md, (
+        "', so the low overall recognition is a property of the list's "
+        "composition, not merely a model failure.' must be dropped from "
+        "§7.1 (ticket 0627)"
+    )
+    assert "list's composition, not merely" not in md, (
+        "the trailing 'list's composition, not merely a model failure' clause "
+        "must be dropped from §7.1 (ticket 0627)"
+    )

--- a/tickets/closed/0626-section-7-para-1-drop-the-last-sentence.erg
+++ b/tickets/closed/0626-section-7-para-1-drop-the-last-sentence.erg
@@ -2,10 +2,12 @@
 Title: Section 7 para 1: drop the last sentence 'They are exploratory...'
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1105
 
 --- log ---
 2026-06-15T09:03Z HDMX-coding-agent created
 
+2026-06-15T12:19Z HDMX-coding-agent closed — autoclosed — PR #1105
 --- body ---
 ## Context
 

--- a/tickets/closed/0627-section-7-para-2-drop-the-clause-so-the.erg
+++ b/tickets/closed/0627-section-7-para-2-drop-the-clause-so-the.erg
@@ -2,10 +2,12 @@
 Title: Section 7 para 2: drop the clause 'so the low overall recognition...'
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1105
 
 --- log ---
 2026-06-15T09:03Z HDMX-coding-agent created
 
+2026-06-15T12:19Z HDMX-coding-agent closed — autoclosed — PR #1105
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Drop "They are exploratory; each subsection summarises one analysis." from §7 para 1 — the paragraph ends cleanly on the audience-questions sentence.
- Drop ", so the low overall recognition is a property of the list's composition, not merely a model failure." from §7.1 — sentence ends at "falls far below that of operational plants."
- Negative guards in `tests/test_manuscript_0626_s7_drops.py` forbid both dropped phrasings.

## Test plan

- [x] `tests/test_manuscript_0626_s7_drops.py` — 2 new negative-guard tests, both pass
- [x] `make check-fast` — 2691 passed, 0 failures

**Ticket:** tickets/0626-section-7-para-1-drop-the-last-sentence.erg
**Ticket:** tickets/0627-section-7-para-2-drop-the-clause-so-the.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)