### PR TITLE
manuscript: §6 (Exp 2) prose cleanup — 0618 + 0619 + 0621

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -679,17 +679,6 @@ Monitor, covers only \GemReviewedPct\% of the reference after light review
 (\ref{sec:annex-exp1}); the frontier agents are therefore measured
 against an inventory no single open database fully reproduces.
 
-The quality dimensions this section measures are the
-\emph{operational and accuracy} ones: row-level F1 against the
-reference, coverage (plants enumerated), and per-row provenance counts
-(Source 1 / Source 2 citation presence,
-Figure~\ref{fig:coverage-certainty} in \ref{sec:annex-exp2}). The
-§\ref{sec:quality} dimensions that require \emph{peer cross-evaluation}
-— coherence, provenance support, and temporality scored on a rubric by
-judging agents — are out of scope here; this section's claims rest on
-the F1, coverage, and citation-count metrics, which are computed
-mechanically without a judging model.
-
 \textbf{Experiment 2 — frontier agents (\ref{sec:annex-exp2}).} We
 conduct an experiment with four cloud AI agents at the May-2026
 commercial frontier, each with extended reasoning and web access,
@@ -697,10 +686,7 @@ queried over direct vendor APIs (no browser automation): Anthropic
 Claude Opus 4.6 (US, web\_search + adaptive thinking), OpenAI GPT-5.5
 (US, Responses API + web\_search + reasoning), Mistral Large 2512 (FR,
 Agents API + web\_search connector), and Qwen3.7 Max via DashScope (CN,
-web\_search inside thinking mode). The fourth slot is
-hypothesis-relevant rather than decorative: Chinese-language investor
-and trade documents on Vietnamese power assets are under-indexed by
-Western search. Each agent is run through a 2×2 factorial,
+web\_search inside thinking mode). Each agent is run through a 2×2 factorial,
 crossing \emph{query mode} (single-shot vs multi-turn) with \emph{documents}
 (absent vs a curated reference pack), N=5 per cell, four arms in all
 (Table~\ref{tbl:exp2-2x2}). The \emph{single-shot} mode sends a single
@@ -715,11 +701,14 @@ corpus matters more than the model. This section reads the two
 no-documents arms; the documents axis is detailed in
 \ref{sec:annex-exp2}.
 
-The single-shot arm is an independent sweep, not a
-re-run of the §\ref{sec:exp1} parametric protocol, so its scores are not
-directly comparable to §\ref{sec:exp1}'s per-model numbers;
-within-Experiment-2 comparisons all use this common arm-1 sweep as their
-baseline. Read with that caveat, setting each agent's single-shot-arm mean F1
+The single-shot arm differs from the §\ref{sec:exp1} parametric baseline
+in two controlled ways: web search is on (it was off in §\ref{sec:exp1}),
+and the call goes direct to each vendor's API rather than through
+OpenRouter (\ref{sec:annex-exp2}). The provider actually running the
+model is uncontrolled either way — OpenRouter routes, and a vendor-direct
+call still lands on the vendor's shifting infrastructure. Within
+Experiment 2, comparisons use this common arm-1 sweep as their baseline.
+Setting each agent's single-shot-arm mean F1
 (Table~\ref{tbl:exp2-2x2}) against the same lab's flagship in the
 §\ref{sec:exp1} parametric sweep, only Mistral improved
 (\ExpTwoFOneMistralMemory{} to \ExpTwoFOneMistralNaive): Anthropic
@@ -1997,9 +1986,8 @@ Anthropic is pinned to Opus 4.6 (not 4.7): identical call shape at
 lower per-call cost. Kimi K2.6 is disqualified — vendor docs
 document \texttt{thinking} and \texttt{\$web\_search} as mutually
 exclusive, fatal for §\ref{sec:exp2}'s ``extended reasoning AND web
-access'' requirement. Geographic / corpus spread (US × 2 + FR + CN) is
-hypothesis-relevant: Chinese-language investor and trade documents on
-Vietnamese power assets are under-indexed by Western search.
+access'' requirement. The cohort spans a vendor and geographic spread
+(US × 2 + FR + CN).
 
 \subsection*{Baseline reference for cross-comparison}
 \addcontentsline{toc}{subsection}{Baseline reference for cross-comparison}

--- a/tests/test_manuscript_s6_bundle.py
+++ b/tests/test_manuscript_s6_bundle.py
@@ -1,0 +1,93 @@
+"""Tickets 0618 / 0619 / 0621 — §6 (Experiment 2) prose cleanup.
+
+Reading-3 (tracker 0605). Three §6 edits, each guarded by a NEGATIVE pin only
+(CI polarity rule, 0557 — forbid the dropped phrasing, never pin the new
+wording):
+
+- 0618: the §6 second paragraph (which-quality-dimensions-we-don't-measure
+  scope caveat) is dropped — its "require \\emph{peer cross-evaluation}" /
+  "are out of scope here" signature is absent from §6, and the figure it
+  cited (fig:coverage-certainty) is not orphaned (still referenced elsewhere).
+- 0619: the unsupported "under-indexed by Western search" claim is gone from
+  the whole body (§6 body AND the annex echo).
+- 0621: the "independent sweep, not a … baseline" / "Read with that caveat"
+  not-comparable hand-wave is absent from §6.
+"""
+
+import re
+
+import pytest
+from manuscript_source import body, section
+
+pytestmark = pytest.mark.adherence
+
+
+def test_0618_exp2_scope_caveat_paragraph_dropped() -> None:
+    """The §6 second paragraph's scope-caveat signature is gone.
+
+    Negative guard: the dropped paragraph's distinctive phrasings — the
+    "require peer cross-evaluation" qualifier and the "out of scope here"
+    disclaimer — must not survive in §6 (sec:exp2). The implied scope lives
+    in the section title and the later restatement; this paragraph is the
+    one removed.
+    """
+    exp2 = section("sec:exp2")
+    assert "peer cross-evaluation" not in exp2, (
+        "the dropped §6 second paragraph's 'require \\emph{peer "
+        "cross-evaluation}' signature must not reappear in §6 (ticket 0618)"
+    )
+    assert "out of scope here" not in exp2, (
+        "the dropped §6 second paragraph's 'are out of scope here' disclaimer "
+        "must not reappear in §6 (ticket 0618)"
+    )
+
+
+def test_0618_coverage_certainty_figure_not_orphaned() -> None:
+    """Dropping the §6 second paragraph must not orphan its figure ref.
+
+    Structural guard: fig:coverage-certainty is defined in the annex and was
+    cited by the dropped paragraph; it must still be referenced somewhere in
+    the body (the Provenance paragraph carries it).
+    """
+    text = body()
+    assert "\\label{fig:coverage-certainty}" in text, (
+        "fig:coverage-certainty must still be defined (ticket 0618)"
+    )
+    assert "\\ref{fig:coverage-certainty}" in text, (
+        "fig:coverage-certainty must still be referenced somewhere in the "
+        "body after dropping the §6 second paragraph — not orphaned "
+        "(ticket 0618)"
+    )
+
+
+def test_0619_under_indexed_claim_gone_everywhere() -> None:
+    """The unsupported "under-indexed by Western search" claim is gone.
+
+    Negative guard: the claim appeared twice (§6 body and annex). Lack of
+    evidence means it must survive in neither place — scan the whole body.
+    """
+    text = body()
+    assert "under-indexed by Western search" not in text, (
+        "the unsupported 'under-indexed by Western search' claim must not "
+        "appear anywhere in the manuscript body (ticket 0619)"
+    )
+
+
+def test_0621_not_comparable_handwave_gone() -> None:
+    """The single-shot-arm "not comparable / read with that caveat" framing is gone.
+
+    Negative guard: the not-comparable hand-wave ("independent sweep, not a
+    … baseline" plus "Read with that caveat") is replaced by a positive
+    explanation of the Exp-1 difference. Forbid the hand-wave; do not pin the
+    new wording.
+    """
+    exp2 = section("sec:exp2")
+    assert "Read with that caveat" not in exp2, (
+        "the dropped 'Read with that caveat' not-comparable hand-wave must "
+        "not reappear in §6 (ticket 0621)"
+    )
+    handwave = re.compile(r"independent sweep,\s*not a", re.IGNORECASE)
+    assert not handwave.search(exp2), (
+        "the dropped 'independent sweep, not a … baseline' not-comparable "
+        "framing must not reappear in §6 (ticket 0621)"
+    )

--- a/tickets/closed/0618-section-6-exp-2-drop-the-second-paragrap.erg
+++ b/tickets/closed/0618-section-6-exp-2-drop-the-second-paragrap.erg
@@ -2,10 +2,12 @@
 Title: Section 6 (Exp 2): drop the second paragraph about quality dimensions we don't measure
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: §6 para 2 dropped (PR)
 
 --- log ---
 2026-06-15T08:30Z HDMX-coding-agent created
 
+2026-06-15T11:55Z HDMX-coding-agent closed — §6 para 2 dropped (PR)
 --- body ---
 ## Context
 

--- a/tickets/closed/0619-section-6-exp-2-drop-unsupported-fourth.erg
+++ b/tickets/closed/0619-section-6-exp-2-drop-unsupported-fourth.erg
@@ -2,10 +2,12 @@
 Title: Section 6 (Exp 2): drop unsupported 'fourth slot ... under-indexed by Western search' sentence
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: under-indexed claim dropped both sites (PR)
 
 --- log ---
 2026-06-15T08:31Z HDMX-coding-agent created
 
+2026-06-15T11:55Z HDMX-coding-agent closed — under-indexed claim dropped both sites (PR)
 --- body ---
 ## Context
 

--- a/tickets/closed/0621-section-6-the-naive-arm-the-single-turn.erg
+++ b/tickets/closed/0621-section-6-the-naive-arm-the-single-turn.erg
@@ -2,10 +2,12 @@
 Title: Section 6: 'The naive arm...' -> 'The single-turn arm...'; positively explain the Exp1 difference (web search ON, direct vendor API vs OpenRouter; provider uncontrolled in both)
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: single-shot arm framing → positive Exp1 difference (PR)
 
 --- log ---
 2026-06-15T08:42Z HDMX-coding-agent created
 
+2026-06-15T11:55Z HDMX-coding-agent closed — single-shot arm framing → positive Exp1 difference (PR)
 --- body ---
 ## Context
 


### PR DESCRIPTION
Reading-3 (tracker 0605). Three §6 (Experiment 2) prose edits in
`slides/manuscript/main.tex`, bundled. Lines re-grepped after the 0620
naive→single-shot query-mode rename.

## 0618 — drop §6 second paragraph (scope caveat)
Dropped the operational/accuracy vs peer-cross-evaluation
which-dimensions-we-don't-measure paragraph. Scope is already implied by
the section title ("measured quality dimensions") and restated later in
the section. `fig:coverage-certainty` stays referenced by the Provenance
paragraph (not orphaned; crossref test green). No editorial-brief caveat
depends on it.

## 0619 — drop unsupported "under-indexed by Western search" claim
Removed in **both** sites: §6 body and the annex agents echo. No evidence
for the under-indexed assertion. The annex keeps only the evidenced
vendor/geographic spread (US × 2 + FR + CN).

## 0621 — single-shot arm: positive Exp-1 difference
Replaced the "independent sweep, not a comparable baseline / read with
that caveat" hand-wave with the positive explanation: web search ON (off
in Exp 1), direct vendor API vs OpenRouter, provider uncontrolled either
way. Arm keeps the 0620-reconciled name **single-shot** (not "single-turn",
which would clash with the established single-shot/multi-turn axis); annex
carries the OpenRouter mechanics.

## Tests
`tests/test_manuscript_s6_bundle.py` — negative guards only (CI polarity
rule): forbids the dropped phrasings; does not pin the new wording.
`make check-fast` green (2693 passed, 0 failed); crossref / em-dash /
cohort-and-caveats adherence tests pass.

**Ticket:** tickets/closed/0618-section-6-exp-2-drop-the-second-paragrap.erg
**Ticket:** tickets/closed/0619-section-6-exp-2-drop-unsupported-fourth.erg
**Ticket:** tickets/closed/0621-section-6-the-naive-arm-the-single-turn.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)