### PR TITLE
manuscript(0599): method quality is a process property, not table quality

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -397,3 +397,29 @@ already covered.
 (supersedes ticket 0591's caption exemption)
 
 **Status:** active
+
+## three-scoring-levels-perpendicular
+
+**Decision:** The three scoring levels in §discussion ("A result is scored at
+three levels") are genuinely perpendicular axes — process, output, source. In
+particular, \emph{method quality} is a property of the *process*, not of any
+output it produces: whether the procedure is auditable, reproducible, and
+cost-predictable independent of which model runs it (the definition set at the
+end of §ext-system). It must NOT be defined through the quality of the table
+the method returns. The cost-versus-F1 figure *relates* method cost to result
+(run/table) quality across two distinct axes; it does not *define* method
+quality as table quality. Run quality scores one output table; model quality
+aggregates runs into a source-reliability grade.
+
+**Rationale:** Reading-2 finding 40 (author, 2026-06-14): the prior wording
+defined method quality as the cost-vs-table-quality relation while also
+defining run quality as the quality of one table, so the two shared the
+table-quality axis and "perpendicular" was internally inconsistent. The
+method/model distinction was already established at the end of §ext-system;
+§discussion builds on it rather than re-conflating. The three-quality spine of
+the paper (data / answer / method) treats method quality as a distinct axis,
+not a function of answer/table quality.
+
+**Ticket:** tickets/0599-discussion-section-conflates-method-qual.erg
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1007,10 +1007,14 @@ after the unit-number veto, and the scored runs realise
 
 \textbf{A result is scored at three levels.} The benchmark separates
 three questions that an aggregate F1 ranking elides. \emph{Method
-quality} asks what the resources buy: the cost-versus-F1 relation
-(Figure~\ref{fig:cost-quality}) reads the time and money a method
-spends against the quality of the table it returns, and a method that
-spends more without returning more is dominated regardless of its rank.
+quality} is a property of the process, not of any one output it
+produces: whether the procedure is auditable, reproducible, and
+cost-predictable independent of which model runs it
+(§\ref{sec:ext-system}). The cost-versus-F1 relation
+(Figure~\ref{fig:cost-quality}) does not define this axis; it
+\emph{relates} it to the next one, plotting the time and money a method
+spends against the table quality it achieves, so that a method spending
+more without achieving more is dominated regardless of its rank.
 \emph{Run quality} scores one table — a single model's single run —
 on the four §\ref{sec:quality} dimensions, the cell-level accuracy of
 its matched rows together with its coherence, provenance, and currency.
@@ -1018,8 +1022,8 @@ its matched rows together with its coherence, provenance, and currency.
 model as a source: a version whose runs are repeatedly incoherent is
 disqualified as a source even when an occasional run scores well
 (§\ref{sec:ext-screen}, Figure~\ref{fig:reliability}). The three are
-perpendicular, and conflating them is how a single number flatters an
-expensive or erratic system.
+perpendicular (process, output, source), and conflating them is how a
+single number flatters an expensive or erratic system.
 
 \textbf{Interday drift is an unquantified variance source.} Beyond the
 5-rep within-session spread, provider-side silent movement (routing

--- a/tests/test_manuscript_0588_discussion.py
+++ b/tests/test_manuscript_0588_discussion.py
@@ -37,6 +37,29 @@ def test_consistent_reading_summary_sentence_dropped() -> None:
     )
 
 
+def test_method_quality_not_defined_via_table_quality() -> None:
+    """Ticket 0599: method quality must not be defined through table quality.
+
+    Reading-2 finding 40: the scoring-levels paragraph defined \\emph{method
+    quality} as the cost-versus-table-quality relation while \\emph{run
+    quality} was the quality of one table — so the two shared the
+    table-quality axis and "perpendicular" was internally inconsistent. Method
+    quality is a process/resource property (auditable, reproducible,
+    cost-predictable, independent of which model runs it; set at the end of
+    §ext-system). Pure negative guard: the conflating signature must not
+    reappear. Positive intent lives in docs/editorial-brief.md
+    (three-scoring-levels-perpendicular), per the CI polarity rule (0557).
+    """
+    disc = section("sec:discussion")
+    forbidden = re.compile(r"against the quality of the table it returns", re.IGNORECASE)
+    assert not forbidden.search(disc), (
+        "§8 (sec:discussion) must not define method quality 'against the "
+        "quality of the table it returns' — that conflates method quality "
+        "with table/run quality, the two axes the paragraph calls "
+        "perpendicular (ticket 0599, finding 40)"
+    )
+
+
 def test_discussion_scoring_levels_cite_their_anchors() -> None:
     """The scoring-levels discussion cites the figures/subsection it rests on.
 

--- a/tickets/closed/0599-discussion-section-conflates-method-qual.erg
+++ b/tickets/closed/0599-discussion-section-conflates-method-qual.erg
@@ -2,11 +2,13 @@
 Title: Discussion section conflates method quality and table quality
 Created: 2026-06-14
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1107
 
 --- log ---
 2026-06-14T09:48Z HDMX-coding-agent created
 
 2026-06-15T07:28Z Context add (author): the method/model distinction is established at the END OF THE PREVIOUS SECTION — sec:ext-system (end of §7, ~main.tex:966: 'method quality: whether the process is auditable, reproducible, cost-predictable independent of which model runs it'). §8's three-levels paragraph should BUILD ON that distinction, not re-conflate method with table quality.
+2026-06-15T12:25Z HDMX-coding-agent closed — autoclosed — PR #1107
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

§8's "A result is scored at three levels" paragraph defined **method quality** as the cost-vs-table-quality relation while **run quality** was the quality of one table — the two shared the table-quality axis, so the "perpendicular" claim was internally inconsistent (reading-2 finding 40).

The rewrite makes method quality a property of the *process* (auditable, reproducible, cost-predictable independent of which model runs it), building on the definition already set at the end of §ext-system. The cost-versus-F1 figure now *relates* method cost to run/table quality across two distinct axes rather than *defining* one through the other. The three are kept perpendicular (process, output, source).

## Polarity (CI rule 0557)
- **Negative guard** added to `tests/test_manuscript_0588_discussion.py`: forbids the conflating `against the quality of the table it returns` phrasing in §discussion.
- **Positive intent** recorded in `docs/editorial-brief.md` (`three-scoring-levels-perpendicular`), checked at review time by /review-pr-prose.

No empirical numbers changed; the cost-vs-F1 figure and its data are untouched.

`make check-fast`: green (2690 passed, ruff clean, erg check PASS).

**Ticket:** tickets/0599-discussion-section-conflates-method-qual.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)