### PR TITLE
doc(coherence.py): add retention note — ticket 0634 premise was wrong

### DIFF
--- a/src/aedist/coherence.py
+++ b/src/aedist/coherence.py
@@ -24,6 +24,16 @@ decides severity — the checks report, they don't filter.
 
 Design: expandable. Add new checks by appending to the relevant
 function. Each check is a simple predicate on one or more rows.
+
+---
+
+Retention note (ticket 0634, 2026-06-15):
+This module was suspected dead (only tests/test_coherence.py appeared to
+import it). Removal was blocked by a real production dependency:
+``src/aedist/tabulate_coherence.py`` imports ``IssueLevel`` and
+``check_coherence`` from this module and is invoked by the
+``experiments/render.mk`` target ``tab_coherence.tex``.  Do not delete
+this module until ``tabulate_coherence.py`` is removed or refactored.
 """
 
 from __future__ import annotations

--- a/tickets/closed/0634-remove-dead-coherence-py-v1-module-only.erg
+++ b/tickets/closed/0634-remove-dead-coherence-py-v1-module-only.erg
@@ -2,10 +2,12 @@
 Title: Remove dead coherence.py (v1 module; only its own test imports it, production scorer uses score_mechanical)
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1110
 
 --- log ---
 2026-06-15T11:30Z HDMX-coding-agent created
 
+2026-06-15T12:11Z HDMX-coding-agent closed — autoclosed — PR #1110
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Ticket 0634 claimed `src/aedist/coherence.py` is dead (only its own test imports it) and asked for deletion.
- Production-importer check found the premise wrong: `src/aedist/tabulate_coherence.py` imports `IssueLevel` and `check_coherence` from this module.
- `experiments/render.mk` line 601 also lists `coherence.py` as an explicit prerequisite for the `tab_coherence.tex` target.
- Per ticket step 3: module retained, docstring added explaining the blocker.
- `make check` passes: 2689 passed, 5 skipped, 1 xfailed.

**Ticket:** tickets/0634-remove-dead-coherence-py-v1-module-only.erg