### PR TITLE
slides(0609): regenerate macros_slides.tex — NumRefPlants 173→177

### DIFF
--- a/report/inputs/generated/macros_slides.tex
+++ b/report/inputs/generated/macros_slides.tex
@@ -2,14 +2,14 @@
 \newcommand{\NumModelsTested}{173}
 \newcommand{\NumCloudModels}{162}
 \newcommand{\NumLocalModels}{11}
-\newcommand{\NumRefPlants}{173}
+\newcommand{\NumRefPlants}{177}
 \newcommand{\BestModelName}{Qwen3.5 122B A10B}
 \newcommand{\BestModelFOne}{65.5}
 \newcommand{\BestModelFOneCI}{[65.5, 65.5]}
 \newcommand{\BestLocalName}{Padme Glm 4.7 Flash}
 \newcommand{\BestLocalFOne}{24.4}
 \newcommand{\MinBaselinePlants}{0}
-\newcommand{\MaxBaselinePlants}{113}
+\newcommand{\MaxBaselinePlants}{116}
 \newcommand{\HeadlineModelName}{DeepSeek V3.2}
 \newcommand{\HeadlineMeanFOne}{68.6}
 \newcommand{\HeadlineCILo}{60.7}

--- a/tests/test_slides_macros_numrefplants.py
+++ b/tests/test_slides_macros_numrefplants.py
@@ -1,0 +1,52 @@
+"""Adherence guard: macros_slides.tex \\NumRefPlants agrees with the reference data.
+
+Ticket 0609: macros_slides.tex carried a stale 173-plant count while
+macros.tex and macros_manuscript.tex already reflected the current 177-plant
+reference. This guard re-derives the count from the reference CSV (single
+source of truth) and asserts slides == manuscript == reference data.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from aedist.evaluate import reference_plant_count
+
+pytestmark = pytest.mark.adherence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GEN = REPO_ROOT / "report" / "inputs" / "generated"
+MACROS_SLIDES = GEN / "macros_slides.tex"
+MACROS_MANUSCRIPT = GEN / "macros_manuscript.tex"
+
+
+def _extract_numrefplants(tex_file: Path) -> int:
+    """Parse \\newcommand{\\NumRefPlants}{N} from a generated macros file."""
+    text = tex_file.read_text(encoding="utf-8")
+    m = re.search(r"\\newcommand\{\\NumRefPlants\}\{(\d+)\}", text)
+    assert m is not None, f"\\NumRefPlants not found in {tex_file}"
+    return int(m.group(1))
+
+
+def test_slides_numrefplants_matches_reference_data():
+    """macros_slides.tex \\NumRefPlants equals reference_plant_count() (derived from CSV)."""
+    expected = reference_plant_count()
+    actual = _extract_numrefplants(MACROS_SLIDES)
+    assert actual == expected, (
+        f"macros_slides.tex \\NumRefPlants={actual} "
+        f"but reference CSV has {expected} plants — "
+        "regenerate via: uv run python -m aedist.tabulate_macros --census "
+        "--output report/inputs/generated/macros_slides.tex"
+    )
+
+
+def test_slides_numrefplants_matches_manuscript():
+    """macros_slides.tex and macros_manuscript.tex carry the same \\NumRefPlants."""
+    slides_n = _extract_numrefplants(MACROS_SLIDES)
+    manuscript_n = _extract_numrefplants(MACROS_MANUSCRIPT)
+    assert slides_n == manuscript_n, (
+        f"slides \\NumRefPlants={slides_n} "
+        f"≠ manuscript \\NumRefPlants={manuscript_n} — "
+        "single source of truth violated; regenerate the stale file"
+    )

--- a/tickets/closed/0609-slides-count-drift-macros-slides-numrefp.erg
+++ b/tickets/closed/0609-slides-count-drift-macros-slides-numrefp.erg
@@ -2,10 +2,12 @@
 Title: Slides count drift: macros_slides NumRefPlants 173 vs manuscript 177 — reconcile living deck to current reference
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1111
 
 --- log ---
 2026-06-15T07:51Z HDMX-coding-agent created
 
+2026-06-15T12:16Z HDMX-coding-agent closed — autoclosed — PR #1111
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- `macros_slides.tex` carried a stale `\NumRefPlants{173}` from ticket 0445 (v2.1 reference); current reference CSV has 177 plants (v2.4)
- Regenerated via `uv run python -m aedist.tabulate_macros --census --output ...` — the emitter already uses `reference_plant_count()` correctly; no emitter code change needed
- Adds `tests/test_slides_macros_numrefplants.py`: two `@pytest.mark.adherence` guards re-deriving the count from the reference CSV and asserting slides == reference data and slides == manuscript

## Test plan

- [x] `make check-fast` green (2691 passed, 0 failed)
- [x] New test `test_slides_numrefplants_matches_reference_data` passes
- [x] New test `test_slides_numrefplants_matches_manuscript` passes
- [x] `macros_slides.tex` now shows `\NumRefPlants{177}`
- [x] Archived Econom'IA 2026 talk (tag `economia-2026-cergy`, HAL `hal-05644906`) untouched

**Ticket:** tickets/0609-slides-count-drift-macros-slides-numrefp.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)