### PR TITLE
manuscript(0603+0604): recast intro para-4 subject, drop jargon

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -125,9 +125,8 @@ are sourced, reproducible, and auditable, and fluent but unsourced
 text does not qualify.
 
 This paper uses a concrete task — building a complete, sourced
-inventory of Vietnam's thermal power plants — as a lens for
-evaluating whether AI systems can yet produce research-grade
-statistical data.
+inventory of Vietnam's thermal power plants — to evaluate whether
+AI systems can yet produce research-grade statistical data.
 Computable benchmarks, tasks whose success criteria a machine can check,
 are how knowledge engineering and AI research have long measured
 progress, from knowledge-base construction with language models
@@ -154,18 +153,17 @@ models answering from memory and four agentic systems with web access,
 neither model memory nor web access yields a complete, well-sourced
 register, and a harness that lets the agents plan and execute a
 multi-step reply degrades rather than improves the result for most of
-them. The benchmark earns its keep by being usable without the gold
-reference: reference-free coherence criteria suffice to screen out the
-weakest runs and the weakest models, so the cheap part of the quality
-score can stand in for the expensive part when triaging which outputs
-deserve human attention.
+them. Reference-free coherence correlates with accuracy (Figure~\ref{fig:reliability}),
+so the cheap part of the quality score screens out the weakest runs and
+models and can stand in for the expensive part when triaging which outputs
+deserve attention.
 
-We situate the work against the existing open
-power-plant databases (§\ref{sec:related-empirical}), define a
-four-dimensional quality bar (§\ref{sec:quality}), survey AI
+The paper surveys the existing open
+power-plant databases (§\ref{sec:related-empirical}), defines a
+four-dimensional quality bar (§\ref{sec:quality}), surveys AI
 capabilities from chatbots to agentic systems (§\ref{sec:capability}),
-measure what model memory alone delivers across 14 language models
-(§\ref{sec:exp1}), and test the commercial frontier of mid-2026
+measures what model memory alone delivers across 14 language models
+(§\ref{sec:exp1}), and tests the commercial frontier of mid-2026
 (§\ref{sec:exp2}). Post-hoc analyses prompted by the conference
 presentation extend the experiments (§\ref{sec:extensions}). The
 Discussion (§\ref{sec:discussion})

--- a/tests/test_manuscript_0603_0604_intro.py
+++ b/tests/test_manuscript_0603_0604_intro.py
@@ -1,0 +1,55 @@
+"""Tickets 0603 + 0604 — intro prose guards.
+
+Negative guards only (CI polarity rule, 0557):
+
+- 0603: "The benchmark earns its keep" sentence is gone from intro para 4;
+  "human attention" is gone (subject shifts to correlation/consequence,
+  "human" qualifier dropped).
+- 0604: social-science jargon "as a lens for" and "We situate" are gone
+  from the intro; roadmap sentence uses plain English instead.
+"""
+
+import pytest
+from manuscript_source import body
+
+pytestmark = pytest.mark.adherence
+
+
+def _md() -> str:
+    return body()
+
+
+def test_no_earns_its_keep(md: str = "") -> None:
+    """0603: 'The benchmark earns its keep' sentence is dropped."""
+    md = _md()
+    assert "earns its keep" not in md, (
+        "'The benchmark earns its keep by being usable without the gold "
+        "reference' must be removed from the intro (ticket 0603)"
+    )
+
+
+def test_no_human_attention(md: str = "") -> None:
+    """0603: 'human attention' qualifier is dropped."""
+    md = _md()
+    assert "human attention" not in md, (
+        "'human attention' must be dropped from the intro — "
+        "plain 'attention' suffices (ticket 0603)"
+    )
+
+
+def test_no_as_a_lens_for(md: str = "") -> None:
+    """0604: 'as a lens for' social-science jargon is dropped from intro."""
+    md = _md()
+    assert "as a lens for" not in md, (
+        "'as a lens for' must be removed from the intro — "
+        "use plain English (ticket 0604)"
+    )
+
+
+def test_no_we_situate(md: str = "") -> None:
+    """0604: 'We situate' is dropped from the intro roadmap sentence."""
+    md = _md()
+    assert "We situate" not in md, (
+        "'We situate the work against' must be removed from the intro — "
+        "use plain English (ticket 0604)"
+    )

--- a/tickets/closed/0603-intro-para-4-recast-benchmark-earns-its.erg
+++ b/tickets/closed/0603-intro-para-4-recast-benchmark-earns-its.erg
@@ -2,10 +2,12 @@
 Title: Intro para 4: recast 'benchmark earns its keep' sentence (subject = correlation+consequence); drop 'human'
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1112
 
 --- log ---
 2026-06-15T07:30Z HDMX-coding-agent created
 
+2026-06-15T12:47Z HDMX-coding-agent closed — autoclosed — PR #1112
 --- body ---
 ## Context
 

--- a/tickets/closed/0604-intro-para-5-drop-social-science-jargon.erg
+++ b/tickets/closed/0604-intro-para-5-drop-social-science-jargon.erg
@@ -2,10 +2,12 @@
 Title: Intro para 5: drop social-science jargon 'lens' and 'situate'; plain English
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1112
 
 --- log ---
 2026-06-15T07:30Z HDMX-coding-agent created
 
+2026-06-15T12:47Z HDMX-coding-agent closed — autoclosed — PR #1112
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- 0603: Recast intro para-4 so the subject is reference-free coherence and its consequence (screens weak runs/models), not the benchmark. Drops "The benchmark earns its keep" framing and "human" before "attention". References \`Figure~\ref{fig:reliability}\` to carry the screening conclusion; no ρ coefficient reintroduced (consistent with 0598).
- 0604: Drop social-science jargon "as a lens for" (→ plain infinitive "to evaluate") and "We situate" (→ "The paper surveys"). Roadmap verbs updated for third-person agreement throughout.
- Negative guards added in `tests/test_manuscript_0603_0604_intro.py` (4 guards, all passing).

## Test plan
- [x] `make check-fast` green (2709 passed, 0 failed)
- [x] 4 new negative guards pass: no "earns its keep", no "human attention", no "as a lens for", no "We situate"

**Ticket:** tickets/0603-intro-para4-recast.erg
**Ticket:** tickets/0604-intro-jargon-drop.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)