### PR TITLE
manuscript(0606): rework fig:longtail caption — lead with gold-register goal, add OSM caveat

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -231,16 +231,17 @@ layer.
 \begin{figure}
 \centering
 \includegraphics[width=\linewidth]{../../report/inputs/generated/fig_longtail_recognition.pdf}
-\caption{The reference inventory covers plants that no other public
-source holds. The \LongtailReference{} plants, sorted by descending visibility, are
+\caption{The task goal is a gold reference register of Vietnam's thermal
+power sector: \LongtailReference{} records, more comprehensive than all other publicly
+available inventories. The plants are sorted by descending visibility and
 checked against four recognition layers: the hand-compiled reference
 itself (all \LongtailReference{}), the Global Energy Monitor tracker (\LongtailGem{}), Wikipedia
 coverage (\LongtailWiki{}), and OpenStreetMap coverage (\LongtailOsm{} plants: existing,
 physically built infrastructure only). Well-documented operating plants
 appear in every layer; the under-documented tail — proposed and
 planned projects from the PDP8 pipeline — thins out layer by layer.
-This tail is the reference's unique contribution, and the segment where
-investing in a sourcing pipeline adds the most value. Recognition-layer
+OSM matching relies on name-only fuzzy search, so its sparser coverage
+reflects both genuine mapping gaps and the weaker matcher. Recognition-layer
 provenance is detailed in \ref{sec:annex-recognition}.}\label{fig:longtail}
 \end{figure}
 

--- a/tickets/closed/0606-figure-1-fig-longtail-rethink-caption-le.erg
+++ b/tickets/closed/0606-figure-1-fig-longtail-rethink-caption-le.erg
@@ -2,11 +2,13 @@
 Title: Figure 1 (fig:longtail): rethink caption (lead with 177-record gold register, no filenames, drop last sentence); decide GEM-not-in-GOLD + matcher-shippability
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1117
 
 --- log ---
 2026-06-15T07:37Z HDMX-coding-agent created
 
 2026-06-15T11:30Z AUTHOR DECISIONS C/D: keep Figure 1 reference-anchored (GEM-only tail = 13 cancelled/proposed, deferred to 0498); ship as-is + add ONE caption sentence noting OSM uses name-only fuzzy matching (its sparser coverage = real gaps + weaker matcher). Holes audit recorded in 0632 + 0498. A (caption) + this caveat remain to execute; B is now 0633.
+2026-06-15T13:56Z HDMX-coding-agent closed — autoclosed — PR #1117
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Rework `fig:longtail` caption to lead with the task goal: a `\LongtailReference{}`-record gold reference register of Vietnam's thermal power sector, more comprehensive than all other publicly available inventories (part A).
- Drop the old final sentence ("This tail is the reference's unique contribution…"); keep layer explanation (reference / GEM / Wikipedia / OSM).
- Add one sentence noting OSM matching uses name-only fuzzy search, so its sparser coverage reflects both genuine mapping gaps and the weaker matcher (part D, per author decision in ticket log).
- Em-dash density kept within 2-per-paragraph cap by using a colon after "power sector" rather than an em dash.

## Test plan

- [x] `make check-fast` green (2720 passed, 0 failed)
- [x] `test_em_dash_paragraph_cap` passes — figure block stays at 2 em dashes
- [x] No filenames in caption (CSV filename already removed by 0633)
- [x] Negative guards only — no positive wording pinned

**Ticket:** tickets/0606-figure-1-fig-longtail-rethink-caption-le.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)