### PR TITLE
manuscript(0602): deliver four-dimension scoring as Annex A; drop unmeasured corroboration claim

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -423,3 +423,36 @@ not a function of answer/table quality.
 **Ticket:** tickets/0599-discussion-section-conflates-method-qual.erg
 
 **Status:** active
+
+## scoring-annex-v0-1
+
+**Decision:** The four-dimension quality score is delivered as a dedicated
+Scoring annex (`sec:annex-scoring`), the FIRST `\appendix` section (Annex A),
+which owns figure S1 (`fig:quality-floor`). It writes out, in order, the
+cell--run--model hierarchy and each dimension's formula (q1 accuracy = F1,
+q2 coherence, q3 provenance, q4 temporality), transcribed to match the code
+(`score_mechanical.py`, `score_coherence_level.py`, `metrics.py`). It is
+marked version 0.1 of the benchmark, to be improved. §3 (`sec:quality`)
+references it as THE IMPLEMENTATION ("the scoring is implemented in …"),
+never as a "detail". Cost/run-bookkeeping detail stays in the Exp1 annex
+(it scores method quality, not the benchmark's run/model output); the
+reliability-gate sensitivity sweep also stays in the Exp1 annex
+(gate-robustness diagnostic, not the benchmark definition).
+
+**Rationale:** Ticket 0602 (author, 2026-06-15). The intro promised a
+four-dimension score whose math the body delivered only qualitatively;
+the annex makes the promise resolve to real formulas aligned to the
+scorer. Scoring is Annex A because it delivers the promised benchmark
+(semantic ordering); figure numbering follows, keeping the quality-floor
+heatmap as S1. The benchmark does NOT measure corroboration (no
+`corroborat*` in `src/aedist/score_*.py`), so the intro's "and
+corroboration measured" claim was dropped; the Exp2 sections retain
+"corroboration" where they legitimately report Source-2 double-sourcing.
+The operational citation hedge ("counts and checks presence … does not
+verify each cited source against each cell") moved from the intro to §3's
+provenance discussion, where it scopes the verifiable-vs-verified
+distinction.
+
+**Ticket:** tickets/0602-intro-para-3-deliver-four-dimension-math.erg
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -144,9 +144,7 @@ a computable metric, not a suite or a leaderboard; the design measures
 training-data contamination as a parametric ceiling rather than trying
 to prevent it. The computable metric is a four-dimension quality score:
 per-row scoring of an LLM-generated statistical table on accuracy,
-coherence, provenance, and temporality, with citation coverage and
-corroboration measured. The paper counts and checks the presence of
-citations; it does not verify each cited source against each cell.
+coherence, provenance, and temporality.
 
 We find the task hard for today's AI systems. Across fourteen language
 models answering from memory and four agentic systems with web access,
@@ -322,9 +320,11 @@ philosophy-of-science empirical adequacy
   and could in principle be checked) from \emph{verified} provenance
   (the citation was retrieved and confirmed to support the stated
   value). Verified provenance is the stronger standard; verifiable is the
-  minimum floor. When sources contradict one another, the resolution —
-  which source was preferred and why — is itself part of the
-  provenance record.
+  minimum floor. The scoring in this paper counts and checks the presence
+  of citations; it does not verify each cited source against each cell, so
+  it measures verifiable rather than verified provenance. When sources
+  contradict one another, the resolution — which source was preferred and
+  why — is itself part of the provenance record.
 \item
   \emph{Temporality} is not metadata added after the fact; it is part of
   the statistical fact itself. Energy infrastructure changes over time:
@@ -355,6 +355,10 @@ that asymmetry: where reference-free indicators correlate with accuracy,
 they can estimate it — screening out weak outputs without the
 reference. The experiments exercise this logic directly
 (§\ref{sec:exp1}).
+
+The scoring is implemented in \ref{sec:annex-scoring}, which writes out the
+per-dimension formulas and the cell--run--model hierarchy as version~0.1 of
+the benchmark.
 
 \section{AI capability landscape: from chatbots to agentic systems}\label{sec:capability}
 
@@ -614,7 +618,7 @@ The disqualified set is essentially stable
 under the gate's tuning choices — indicator set and pass threshold —
 as the sensitivity sweep in \ref{sec:annex-exp1} shows; the
 per-criterion breakdown behind the grade (which dimension each model
-zeroes) is the quality-floor heatmap, also in \ref{sec:annex-exp1}.
+zeroes) is the quality-floor heatmap in \ref{sec:annex-scoring}.
 
 \begin{figure}
 \centering
@@ -1238,6 +1242,153 @@ as a supplementary artifact with per-plant source citations.
 
 \clearpage
 
+\section{Scoring}\label{sec:annex-scoring}
+
+This annex is version~0.1 of the benchmark scoring, to be improved: it
+records the four-dimension quality score exactly as the current code
+computes it. The §\ref{sec:quality} dimensions are stated qualitatively
+there; here each is written out as the formula the scorer evaluates.
+
+\subsection*{Hierarchy: cell, run, model}
+\addcontentsline{toc}{subsection}{Hierarchy: cell, run, model}
+
+Scoring is hierarchical across three levels. A \emph{cell} score judges
+one attribute of one row (e.g.\ whether the fuel value is in the
+controlled vocabulary, or whether a matched row carries the correct
+province). A \emph{run} score is one model's single answer table: most
+run-level scores are the fraction of rows or cells that pass a per-row
+predicate, and accuracy is the run's row-level F1 against the reference.
+A \emph{model} score aggregates a model version's runs into a
+reference-free reliability grade: a version whose runs are repeatedly
+incoherent is disqualified as a source even when an occasional run scores
+well. Run-level scores below are fractions in $[0,1]$ (higher is better);
+the model tier is defined at the end of this annex.
+
+\subsection*{Accuracy (q1): row-level F1}
+\addcontentsline{toc}{subsection}{Accuracy (q1): row-level F1}
+
+Accuracy is measured against the reference by a minimum-cost bipartite
+assignment formulated as a mixed-integer linear programme (LP~matcher).
+Each candidate pair $(i,j)$ receives a cost combining (i)~a
+name-similarity term — zero for exact matches, one when the
+\texttt{partial\_ratio} score reaches~90 on the integer 0--100 scale,
+and a large penalty otherwise — and (ii)~a small capacity-difference
+term (default weight $10^{-3}$ per MWe). Binary slack variables allow
+any record to be left unmatched at a fixed penalty rather than forced
+into a poor pairing; the global optimum is found by a branch-and-bound
+solver rather than greedily. This formulation is mathematically
+equivalent to a minimum-cost flow problem on a bipartite supply-demand
+graph with unit capacities. Province and fuel are deliberately excluded
+from the matching cost; they are scored separately as cell-level
+attribute accuracy on the matched pairs.
+
+The one-to-one assignment is a known limitation: when a model reports
+two units as a single combined row (e.g.\ ``Kiên Giang~1 \& 2''), the
+row can match at most one of the two reference entries and the other is
+recorded as a false positive. A post-hoc audit of Exp.~2 false
+positives identified five such combined-unit cases; they are classified
+as reconciliation artefacts — a reference entry left unmatched by row
+aggregation — rather than plants invented by the model.
+
+Let $M$ be the matched pairs, $R$ the reference rows, $S$ the system
+rows. Coverage (recall) is $|M|/|R|$, precision is $|M|/|S|$, and the
+headline accuracy score is their harmonic mean,
+\[
+  \mathrm{F1} = \frac{2\,\mathrm{coverage}\cdot\mathrm{precision}}
+                     {\mathrm{coverage}+\mathrm{precision}},
+\]
+zero when either component is zero. Cell-level attribute accuracy is the
+fraction of matched rows whose fuel, lifecycle status, or province agrees
+with the reference; a run that finds the right plants can still score low
+here if it describes them wrongly. Plant-name matching is a named-entity
+recognition problem, and the LP matcher is not a general solution to it —
+nor is it claimed as one. It was developed iteratively against the
+Vietnam reference list; the similarity threshold (≥ 90 on the rapidfuzz
+integer scale) and the capacity-difference weight (0.001) were chosen to
+minimise false-positive matches on this specific reference, and both
+parameters should be validated before applying the pipeline to a
+different country or asset class. Run outcomes other than \texttt{ok}
+(refusal, empty, parse error) are recorded with $\mathrm{F1}=0$.
+
+\subsection*{Coherence (q2): reference-free consistency}
+\addcontentsline{toc}{subsection}{Coherence (q2): reference-free consistency}
+
+Coherence is scored without the reference, as a set of per-row predicates
+each reported as the fraction of rows that pass. Vocabulary adherence is
+the fraction of rows whose fuel is in the controlled fuel set, and
+status-vocabulary adherence the fraction whose lifecycle status is in the
+controlled status set. Row atomicity is the fraction of rows whose name
+does \emph{not} carry a unit-merge marker (two identifiers joined in one
+name, e.g.\ ``3 \& 4'', ``I \& II'', ``1 và 2''). Capacity
+non-negativity is the fraction of rows with a parseable, non-negative
+capacity. Two level-conditioned predicates check internal
+self-consistency given the level the model declared: capacity is
+plausible for the declared level when it falls under the level's cap
+(Unit~≤~1350~MW, Plant~≤~3200~MW, Block~≥~1300~MW, Complex uncapped),
+and the level is consistent with the name when none of three name-pattern
+rules fires (a merge-marker name cannot be a Unit; a bare-site name with
+no number cannot be a Unit or Plant; a site-plus-number name implies a
+Plant, not a Unit). Each predicate scores $(\text{rows passing})/
+(\text{rows scoreable})$.
+
+At the run level a coherence \emph{veto} flags a degenerate table: a run
+is vetoed when its capacity column has at most four distinct values
+\emph{or} its status column has at most one distinct value
+($\texttt{cap\_distinct}\le 4 \;\lor\; \texttt{status\_distinct}\le 1$).
+The veto was calibrated in-sample on the Experiment~1 runs and is the
+reference-free screen feeding the model-level grade below.
+
+\subsection*{Provenance (q3): citation presence}
+\addcontentsline{toc}{subsection}{Provenance (q3): citation presence}
+
+Provenance is scored from the citation cells alone. Source presence is
+the fraction of rows carrying at least one source (Source~1 or
+Source~2). Among rows the model marks \texttt{HIGH} confidence,
+high-confidence dual-sourcing is the fraction that carry both Source~1
+and Source~2. Source diversity rewards drawing on many distinct
+references, $\min(d/20,\,1)$ where $d$ is the number of distinct
+non-empty Source~1 values, and source spread measures concentration,
+$1 - c_{\max}/n$ where $c_{\max}$ is the count of the most frequent
+source and $n$ the number of cited rows. Consistent with §\ref{sec:quality},
+this is verifiable rather than verified provenance: the scorer counts and
+checks that citations are present, it does not retrieve each cited source
+and confirm it supports the cell.
+
+\subsection*{Temporality (q4): as-of dating}
+\addcontentsline{toc}{subsection}{Temporality (q4): as-of dating}
+
+Temporality is scored from the dating cells. As-of presence is the
+fraction of rows carrying an as-of date. Among those, plausible-range is
+the fraction whose extracted year falls in $[1980, 2100]$; a uniform
+as-of year is not treated as degenerate, since a single freshness date
+for a parametric dump is an honest claim, while an implausible uniform
+year still scores zero through the plausible fraction. Commissioning-date
+plausibility is the fraction of commissioning-date values whose year
+falls in $[1960, 2035]$, scored zero when every value is identical.
+
+\subsection*{Per-criterion breakdown and model-level grade}
+\addcontentsline{toc}{subsection}{Per-criterion breakdown and model-level grade}
+
+Figure~\ref{fig:quality-floor} breaks the quality bar down criterion by
+criterion, showing which dimension each model zeroes. The model-level
+reliability grade (Figure~\ref{fig:reliability}) aggregates the
+reference-free run scores: a version whose runs are repeatedly vetoed is
+disqualified as a source.
+
+\begin{figure}
+\centering
+\includegraphics[width=\linewidth]{../../report/inputs/generated/fig_quality_floor_heatmap_exp1.pdf}
+\caption{Per-criterion breakdown of the quality bar (Experiment~1,
+14 models × 5 runs): each cell is a per-model mean sub-score on a
+red→green scale, and a dark-red cell anywhere in a column disqualifies
+that model, since the bar is a conjunction. Rows span Accuracy,
+Coherence, Provenance, and Temporality; only discriminating sub-scores
+are shown. Full per-dimension formulas are above in this
+annex.}\label{fig:quality-floor}
+\end{figure}
+
+\clearpage
+
 \section{Experiment 1: Technical specification}\label{sec:annex-exp1}
 
 \subsection*{Task}
@@ -1724,31 +1875,14 @@ quantification of day-scale F1 drift at fixed deterministic call
 parameters for production LLM APIs on structured extraction tasks; we
 report ours as an observation rather than a primacy claim.
 
-\subsection*{Evaluation}
-\addcontentsline{toc}{subsection}{Evaluation}
+\subsection*{Run bookkeeping and gate sensitivity}
+\addcontentsline{toc}{subsection}{Run bookkeeping and gate sensitivity}
 
-Each run is evaluated against the reference using a minimum-cost
-bipartite assignment formulated as a mixed-integer linear programme
-(LP~matcher). Each candidate pair $(i,j)$ receives a cost combining
-(i)~a name-similarity term — zero for exact matches, one when the
-\texttt{partial\_ratio} score reaches~90 on the integer 0--100 scale,
-and a large penalty otherwise — and (ii)~a small capacity-difference
-term (default weight $10^{-3}$ per MWe). Binary slack variables allow
-any record to be left unmatched at a fixed penalty rather than forced
-into a poor pairing; the global optimum is found by a branch-and-bound
-solver rather than greedily. This formulation is mathematically
-equivalent to a minimum-cost flow problem on a bipartite supply-demand
-graph with unit capacities. Province and fuel are deliberately excluded
-from the matching cost; they are scored separately as cell-level
-attribute accuracy on the matched pairs.
-
-The one-to-one assignment is a known limitation: when a model reports
-two units as a single combined row (e.g.\ ``Kiên Giang~1 \& 2''), the
-row can match at most one of the two reference entries and the other is
-recorded as a false positive. A post-hoc audit of Exp.~2 false
-positives identified five such combined-unit cases; they are classified
-as reconciliation artefacts — a reference entry left unmatched by row
-aggregation — rather than plants invented by the model.
+The four-dimension scoring — the LP~matcher, the per-dimension formulas,
+and the cell--run--model hierarchy — is implemented in
+\ref{sec:annex-scoring}. This subsection records the bookkeeping fields
+logged alongside the scores for each run and the sensitivity of the
+reliability gate.
 
 Metrics recorded per run:
 
@@ -1783,58 +1917,8 @@ correct province \\
 \texttt{tokens\_out} & run & Output tokens consumed \\
 \end{longtable}
 
-Run outcomes other than \texttt{ok} (refusal, empty, parse error) are
-recorded with \texttt{f1\ =\ 0} and flagged in \texttt{status}.
-
-Plant-name matching is a named-entity recognition problem, and the LP
-matcher is not a general solution to it — nor is it claimed as one.
-It was developed iteratively against the Vietnam reference list. The
-similarity threshold (≥ 90 on the rapidfuzz integer scale) and the
-capacity-difference weight (0.001) were chosen to minimise
-false-positive matches on this specific reference; both parameters
-should be validated before applying the pipeline to a different country
-or asset class.
-
-\textbf{Per-criterion breakdown.} Figure~\ref{fig:quality-floor} is the
-diagnostic behind the §\ref{sec:exp1} reliability grade
-(Figure~\ref{fig:reliability}): it breaks the quality bar down criterion
-by criterion, showing \emph{which} dimension each model zeroes.
-
-\begin{figure}
-\centering
-\includegraphics[width=\linewidth]{../../report/inputs/generated/fig_quality_floor_heatmap_exp1.pdf}
-\caption{Per-criterion breakdown of the quality bar: which dimension
-each model fails. The bar is a conjunction, so a dark-red cell anywhere
-in a column disqualifies that model. Quality-floor heatmap for
-Experiment 1 (parametric arm, 14 models × 5 runs). Columns are the same
-fourteen models as Figure~\ref{fig:direct-base}, laid out in the same
-order — architectural family (Claude, DeepSeek, GPT, Mistral, Qwen)
-then size descending (larger first) — with DeepSeek included. Rows are
-the sub-score criteria, grouped by dimension and derived
-programmatically from the scoring CSV. Only \textbf{discriminating}
-sub-scores are shown: a criterion every model clears uniformly carries
-no quality-floor signal and is dropped automatically when its
-across-model spread falls below 0.1 (on the current data this drops
-capacity sanity, core/capacity completeness, source presence,
-dual-source, and as-of presence; and with the latter rows, the whole
-Field-completeness dimension). The surviving rows span Accuracy,
-Coherence, Provenance, and Temporality. Each cell is the
-\textbf{per-model mean} of that sub-score across the five runs, rendered
-on a continuous red→green scale (0 = every run fails the criterion, 1 =
-every run clears it); the simple mean suffices because a model that
-systematically zeros a free criterion averages to ≈0 and reads dark red,
-the §\ref{sec:quality} ``too weak to clear the bar'' signal. The
-§\ref{sec:exp1} internal-coherence screen (the reference-free
-veto, \texttt{cap\_distinct\ ≤\ 4\ OR\ status\_distinct\ ≤\ 1}) is
-\textbf{merged into the Coherence dimension} as its positive complement
-(\texttt{1\ −\ veto}, the ``Internal coherence'' row), so higher is
-better in lockstep with every other sub-score rather than occupying a
-separate disqualifying column. The §\ref{sec:quality} quality bar is a
-conjunction: a near-zero (dark red) cell anywhere in a model's column
-means the bar is not cleared. Model labels are family-coloured and
-dimension-separation lines isolate the criterion
-groups.}\label{fig:quality-floor}
-\end{figure}
+The matcher, the scoring formulas, and the per-criterion quality-floor
+breakdown (Figure~\ref{fig:quality-floor}) are in \ref{sec:annex-scoring}.
 
 \textbf{Reliability-gate sensitivity.} The Figure~\ref{fig:reliability}
 grade depends on two tuning choices: the indicator set (which

--- a/tests/test_manuscript_0602_scoring_annex.py
+++ b/tests/test_manuscript_0602_scoring_annex.py
@@ -1,0 +1,69 @@
+"""Ticket 0602 — Scoring annex + intro corroboration/hedge guards.
+
+CI polarity rule (0557): negative guards + loose structural anchors only,
+never a pinned positive authorial sentence.
+
+- Negative guard: the unmeasured "corroboration" claim is gone from the
+  intro's benchmark definition. (The Exp2 sections legitimately report
+  Source-2 double-sourcing as "corroboration", so the guard is scoped to
+  the Introduction, not the whole document.)
+- Negative guard: the operational citation hedge no longer sits in the
+  intro.
+- Loose structural anchor: a Scoring annex (sec:annex-scoring) exists,
+  marks itself version 0.1, and names all four dimension markers — a
+  vocabulary the author does not own, not a sentence the author wrote.
+- Loose structural anchor: §3 references the Scoring annex as the
+  implementation (the symbolic \\ref is present in sec:quality).
+"""
+
+import pytest
+from manuscript_source import section
+
+pytestmark = pytest.mark.adherence
+
+
+def test_intro_drops_corroboration_claim() -> None:
+    """0602: the intro no longer claims corroboration is measured."""
+    intro = section("sec:intro")
+    assert "corroborat" not in intro.lower(), (
+        "the benchmark does not measure corroboration (no corroborat* in "
+        "src/aedist/score_*.py) — drop the claim from the Introduction"
+    )
+
+
+def test_intro_drops_operational_citation_hedge() -> None:
+    """0602: the per-cell citation hedge moved out of the intro."""
+    intro = section("sec:intro")
+    assert "does not verify each cited source against each cell" not in intro, (
+        "the operational citation hedge belongs in §3's provenance "
+        "discussion, not the Introduction"
+    )
+
+
+def test_scoring_annex_exists_marked_v0_1() -> None:
+    """0602 (loose anchor): a Scoring annex exists and marks itself v0.1."""
+    annex = section("sec:annex-scoring")
+    assert "version 0.1" in annex, (
+        "the Scoring annex must mark itself version 0.1 of the benchmark"
+    )
+
+
+def test_scoring_annex_names_four_dimensions() -> None:
+    """0602 (loose anchor): the four dimension markers are present in the annex.
+
+    Anchors on the four-dimension vocabulary (accuracy/coherence/provenance/
+    temporality) the §3 quality bar defines — not on any authored sentence.
+    """
+    annex = section("sec:annex-scoring").lower()
+    for marker in ("accuracy", "coherence", "provenance", "temporality"):
+        assert marker in annex, (
+            f"Scoring annex must cover the {marker} dimension"
+        )
+
+
+def test_section3_references_scoring_annex() -> None:
+    """0602 (loose anchor): §3 points at the Scoring annex as the implementation."""
+    quality = section("sec:quality")
+    assert "\\ref{sec:annex-scoring}" in quality, (
+        "§3 (sec:quality) must reference the Scoring annex (sec:annex-scoring)"
+    )

--- a/tickets/closed/0602-intro-para-3-deliver-four-dimension-math.erg
+++ b/tickets/closed/0602-intro-para-3-deliver-four-dimension-math.erg
@@ -2,11 +2,13 @@
 Title: Intro para 3: deliver four-dimension math in annex (v0.1); drop unmeasured corroboration claim; move citation hedge to main text
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1118
 
 --- log ---
 2026-06-15T07:19Z HDMX-coding-agent created
 
 2026-06-15T11:30Z AUTHOR DECISIONS: Scoring = Annex A, FIRST (semantic — it delivers the promised benchmark; figure numbering follows, S1 = fig:quality-floor). Keep annex FOCUSED on scoring: the 4 dimensions + hierarchy + S1 only. COST is OUT (methods-quality scoring, not the benchmark's run/model scoring). Reliability-sensitivity stays in the Exp1 annex (gate-robustness diagnostic, not the benchmark definition). Transcribe q2 from score_mechanical.py + score_coherence_level.py, NOT the dead coherence.py. Include corroboration-drop + citation-hedge-move (parts b).
+2026-06-15T14:15Z HDMX-coding-agent closed — autoclosed — PR #1118
 --- body ---
 ## SCOPE EXPANSION (author, 2026-06-15): this is the §3 ticket — split out a Scoring Annex A
 


### PR DESCRIPTION
**Ticket:** tickets/0602-intro-para-3-deliver-four-dimension-math.erg

## What

Restructures the four-dimension quality score into a dedicated **Scoring annex** and fixes two intro defects.

### Scoring annex (new Annex A)
- New `\section{Scoring}\label{sec:annex-scoring}`, the FIRST `\appendix` section, so it owns figure **S1** (`fig:quality-floor`) and the S-series numbering is unchanged.
- Describes, in order: the **cell→run→model hierarchy**, then each dimension's formula transcribed to match the code:
  - **q1 accuracy = F1** — LP/MILP bipartite matcher (moved from the Exp1 annex) + `metrics.py` (coverage = |M|/|R|, precision = |M|/|S|, F1 harmonic mean; cell-level fuel/status/province accuracy on matched rows).
  - **q2 coherence** — `score_mechanical.score_coherence` + `score_coherence_level` (vocab adherence, status-vocab, row atomicity, capacity non-negativity, capacity-plausible-for-level caps, level-consistent-with-name R1/R2/R3) + the run-level veto (`cap_distinct ≤ 4 OR status_distinct ≤ 1`). Transcribed from `score_coherence_level.py`, not the dead `coherence.py`.
  - **q3 provenance** — source presence, HIGH-confidence dual-source, source diversity `min(d/20,1)`, source spread `1 − c_max/n`.
  - **q4 temporality** — as-of presence, plausible-range year ∈ [1980,2100], COD plausibility year ∈ [1960,2035].
- Marked **version 0.1 of the benchmark, to be improved**.
- S1 caption substantially shortened (the annex now carries the detail).
- Cost/run bookkeeping detail and the reliability-gate sensitivity sweep **stay in the Exp1 annex** (method-quality / gate-robustness, not the benchmark definition).

### §3 (sec:quality)
- Now references the Scoring annex as **THE IMPLEMENTATION** ("the scoring is implemented in …"), never "details in".

### Intro para 3
- Dropped "and corroboration measured" — no `corroborat*` in `src/aedist/score_*.py` (the Exp2 sections keep "corroboration" where they legitimately report Source-2 double-sourcing).
- Moved the citation-hedge sentence out of the intro into §3's provenance discussion.

## Tests / build
- New `tests/test_manuscript_0602_scoring_annex.py` — negative guards (corroboration + hedge gone from intro) + loose structural anchors (annex exists, v0.1, four dimensions, §3 ref). CI polarity rule respected; no positive prose pinned.
- Annex letters + figure number resolve via `\ref` only; `test_manuscript_crossref.py` and `test_manuscript_figure_numbering.py` pass.
- Manuscript + scoring test surface: 369 passed, 0 failed. `make check-fast` green.
- Manuscript builds with `tectonic -r 2` (only pre-existing h-box warnings).

Decision recorded in `docs/editorial-brief.md` (`scoring-annex-v0-1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)