### PR TITLE
manuscript(0600): Exp 2 costs framed as un-optimised upper bound

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -456,3 +456,23 @@ distinction.
 **Ticket:** tickets/0602-intro-para-3-deliver-four-dimension-math.erg
 
 **Status:** active
+
+## exp2-costs-upper-bound
+
+**Decision:** The Exp 2 cost figures (§6, fig:exp2-arms-cost paragraph) are
+explicitly framed as an upper bound on production cost, not a minimised
+floor. The prose states that the harness applies no prompt caching or
+context reuse and resents the reference documents on every call. Production
+cache management — especially across documents-arm calls that share an
+identical reference pack — is named as a cost-reduction lever, hedged as
+"can materially reduce" without asserting a measured saving.
+
+**Rationale:** Reporting costs without this caveat risks readers treating
+them as a floor estimate. The measurement is honest about what it captures
+(un-optimised API spend); the caveat preserves that honesty without
+requiring new experiments or numbers. All dollar values remain
+macro-sourced (\ExpTwoCost* family); no hand-typed figures.
+
+**Ticket:** tickets/0600-report-exp-2-costs-were-not-minimized-pr.erg
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -745,7 +745,14 @@ protocol imposed a strict dual-source admissibility filter that
 constrains coverage from Turn 1). The multi-turn protocol costs 2--4×
 more per run than single-shot across all agents
 (Figure~\ref{fig:exp2-arms-cost}); OpenAI's ratio is most
-extreme (median \$\ExpTwoCostOpenAIOptimised{} multi-turn vs \$\ExpTwoCostOpenAINaive{} single-shot). On row-level F1
+extreme (median \$\ExpTwoCostOpenAIOptimised{} multi-turn vs \$\ExpTwoCostOpenAINaive{} single-shot).
+These costs are not minimised: the harness applies no prompt caching or
+context reuse, and the reference documents are resent on every call; they
+are an upper bound on production cost rather than a floor. In production,
+cache management across turns and arms (particularly for the
+documents-arm calls that share an identical reference pack) can
+materially reduce this, though we did not measure the saving.
+On row-level F1
 (Table~\ref{tbl:exp2-2x2}, no-documents rows), the multi-turn protocol
 degraded three of the four agents (Anthropic \ExpTwoFOneAnthropicNaive{}
 to \ExpTwoFOneAnthropicOptimised, Mistral \ExpTwoFOneMistralNaive{} to

--- a/tests/test_manuscript_0600_exp2_cost_caveat.py
+++ b/tests/test_manuscript_0600_exp2_cost_caveat.py
@@ -1,0 +1,36 @@
+"""Ticket 0600 — Exp 2 costs reported as un-optimised upper bound.
+
+Loose structural anchor (CI polarity rule, ticket 0557): the Exp 2 cost
+region (§6, near fig:exp2-arms-cost) must carry a caching/upper-bound
+caveat. We assert presence of caveat vocabulary in the §6 body — NOT a
+pinned sentence, so any legitimate rewrite of the wording passes.
+
+The caveat vocabulary class: "upper bound", "not minimis", "no prompt
+caching", or "cache management". At least one of these must appear in §6.
+"""
+
+import pytest
+from manuscript_source import section
+
+pytestmark = pytest.mark.adherence
+
+_CAVEAT_MARKERS = [
+    "upper bound",
+    "not minimis",
+    "no prompt caching",
+    "cache management",
+]
+
+
+def test_exp2_cost_upper_bound_caveat_present() -> None:
+    """§6 must contain a caching/upper-bound caveat in the cost region."""
+    sec6 = section("sec:exp2")
+    found = any(marker in sec6 for marker in _CAVEAT_MARKERS)
+    assert found, (
+        "§6 (sec:exp2) must carry an un-optimised/upper-bound cost caveat "
+        "(ticket 0600). Expected at least one of: "
+        + ", ".join(repr(m) for m in _CAVEAT_MARKERS)
+        + " — none found. The reported Exp 2 costs are un-optimised "
+        "(no caching, reference pack resent every call) and must be "
+        "framed as an upper bound on production cost, not a floor."
+    )

--- a/tickets/closed/0600-report-exp-2-costs-were-not-minimized-pr.erg
+++ b/tickets/closed/0600-report-exp-2-costs-were-not-minimized-pr.erg
@@ -2,10 +2,12 @@
 Title: Report Exp 2 costs were not minimized; production caching can reduce them
 Created: 2026-06-14
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1123
 
 --- log ---
 2026-06-14T09:50Z HDMX-coding-agent created
 
+2026-06-15T14:55Z HDMX-coding-agent closed — autoclosed — PR #1123
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add caveat in §6 cost paragraph (near fig:exp2-arms-cost) stating reported Exp 2 costs are not minimised: no prompt caching, reference documents resent every call — they are an upper bound on production cost, not a floor.
- Name production cache management (especially for documents-arm calls sharing an identical reference pack) as a cost-reduction lever, hedged without asserting unmeasured figures.
- Record editorial decision in `docs/editorial-brief.md` (entry: `exp2-costs-upper-bound`).
- Add loose structural-presence guard `tests/test_manuscript_0600_exp2_cost_caveat.py` (CI polarity rule, ticket 0557): asserts §6 contains caveat vocabulary (`upper bound`, `not minimis`, `no prompt caching`, or `cache management`) — never pins a wording.

## Test plan

- [x] `make check-fast` green (2735 passed)
- [x] New adherence test passes: `test_exp2_cost_upper_bound_caveat_present`
- [x] No em-dash count violation (parenthetical used instead)
- [x] All `\ExpTwoCost*` macro references intact; no hand-typed dollar figures

**Ticket:** tickets/0600-report-exp-2-costs-were-not-minimized-pr.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)