### PR TITLE
manuscript(0635): more vspace between glossary and Figure 2 (float page)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -464,6 +464,8 @@ row-level F1 scores how well an extracted plant list matches the
 reference inventory.
 \end{quote}
 
+\vspace{1.5cm}
+
 \vfill
 
 \includegraphics[width=\linewidth]{../../report/inputs/generated/fig_capability_timeline.pdf}

--- a/tickets/0635-float-page-4-more-vspace-between-glossar.erg
+++ b/tickets/0635-float-page-4-more-vspace-between-glossar.erg
@@ -1,0 +1,28 @@
+%erg 0.1
+Title: Float page §4: more vspace between glossary and Figure 2
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T16:15Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Follow-up to [[0611]]: the §4 floats page (Figure 2 + Glossary on a `[p]`
+page) had only a bare `\vfill` between the glossary `quote` block and the
+`\includegraphics`, leaving them too close. Author: add more vspace
+between the glossary and the figure.
+
+## Action
+
+Added `\vspace{1.5cm}` after the glossary `\end{quote}` (before the
+`\vfill`) in `slides/manuscript/main.tex` — a guaranteed minimum gap on
+top of the flexible fill. Author can tune the 1.5cm.
+
+## Verification
+- [ ] Floats page shows clear separation between glossary and Figure 2.
+- [ ] Manuscript builds (`tectonic -r 2`).
+
+## Exit criteria
+- More vspace between glossary and Figure 2 on the §4 floats page; builds.

--- a/tickets/closed/0635-float-page-4-more-vspace-between-glossar.erg
+++ b/tickets/closed/0635-float-page-4-more-vspace-between-glossar.erg
@@ -2,10 +2,12 @@
 Title: Float page §4: more vspace between glossary and Figure 2
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1125
 
 --- log ---
 2026-06-15T16:15Z HDMX-coding-agent created
 
+2026-06-15T17:40Z HDMX-coding-agent closed — autoclosed — PR #1125
 --- body ---
 ## Context
 


### PR DESCRIPTION
Follow-up to 0611: adds \vspace{1.5cm} between the §4 glossary and Figure 2 on the floats page. Builds clean.

**Ticket:** tickets/0635-float-page-4-more-vspace-between-glossar.erg