### PR TITLE
fix(0638): annex 45pt overfull — texttt->fpath (breakable)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -2073,7 +2073,7 @@ access'' requirement. The cohort spans a vendor and geographic spread
 \addcontentsline{toc}{subsection}{Baseline reference for cross-comparison}
 
 The single-shot baseline that §\ref{sec:exp2} compares against is
-\textbf{not} §\ref{sec:exp1}'s \texttt{modelset\_exp1\_journal} sweep.
+\textbf{not} §\ref{sec:exp1}'s \fpath{modelset_exp1_journal} sweep.
 It is the pre-existing \fpath{experiments/outputs/direct_complete/}
 artifact from \fpath{sweep_direct_complete} over
 \fpath{modelset_frontier_10labs} — a wider lab survey at a single

--- a/tickets/0638-fix-45pt-annex-overfull-texttt-modelset.erg
+++ b/tickets/0638-fix-45pt-annex-overfull-texttt-modelset.erg
@@ -1,0 +1,21 @@
+%erg 0.1
+Title: Fix 45pt annex overfull: texttt{modelset_exp1_journal} -> fpath (breakable)
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T18:23Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Render-and-adjust pass found a 45pt overfull hbox in the Exp-2 annex
+"Baseline reference" paragraph: an unbreakable long \texttt token
+(\texttt{modelset\_exp1\_journal}) — the overfull source writing.md warns
+about. Line 1753 already uses the breakable \fpath form.
+
+## Action (done)
+- main.tex:2076 \texttt{modelset\_exp1\_journal} -> \fpath{modelset_exp1_journal}.
+- Rebuilt: 45pt overfull gone; only a 0.5pt sub-mm sliver remains (noise).
+
+## Exit criteria
+- No 45pt overfull; manuscript builds. (done)

--- a/tickets/closed/0638-fix-45pt-annex-overfull-texttt-modelset.erg
+++ b/tickets/closed/0638-fix-45pt-annex-overfull-texttt-modelset.erg
@@ -2,10 +2,12 @@
 Title: Fix 45pt annex overfull: texttt{modelset_exp1_journal} -> fpath (breakable)
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1128
 
 --- log ---
 2026-06-15T18:23Z HDMX-coding-agent created
 
+2026-06-15T18:29Z HDMX-coding-agent closed — autoclosed — PR #1128
 --- body ---
 ## Context
 Render-and-adjust pass found a 45pt overfull hbox in the Exp-2 annex


### PR DESCRIPTION
Render-and-adjust: converts the unbreakable \texttt{modelset\_exp1\_journal} to breakable \fpath (matches line 1753). 45pt overfull → gone.

**Ticket:** tickets/0638-fix-45pt-annex-overfull-texttt-modelset.erg