### PR TITLE
intro(0639): cut weakest passage (benchmark-genre framing), shave ~4 lines

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -127,13 +127,6 @@ text does not qualify.
 This paper uses a concrete task — building a complete, sourced
 inventory of Vietnam's thermal power plants — to evaluate whether
 AI systems can yet produce research-grade statistical data.
-Computable benchmarks, tasks whose success criteria a machine can check,
-are how knowledge engineering and AI research have long measured
-progress, from knowledge-base construction with language models
-\citep{Petroni-Fabio2019:lm-as-kb} to the
-benchmark suites that rank today's systems \citep{Hendrycks-Dan2021:mmlu,
-Ni-Shiwen2025:llm-benchmark-survey}; this paper extends the practice to
-national statistical registers.
 
 Our contribution is the benchmark, reusable beyond the Vietnamese
 case: to our knowledge, the first sourced evaluation of AI agents on

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -2073,7 +2073,7 @@ access'' requirement. The cohort spans a vendor and geographic spread
 \addcontentsline{toc}{subsection}{Baseline reference for cross-comparison}
 
 The single-shot baseline that §\ref{sec:exp2} compares against is
-\textbf{not} §\ref{sec:exp1}'s \texttt{modelset\_exp1\_journal} sweep.
+\textbf{not} §\ref{sec:exp1}'s \fpath{modelset_exp1_journal} sweep.
 It is the pre-existing \fpath{experiments/outputs/direct_complete/}
 artifact from \fpath{sweep_direct_complete} over
 \fpath{modelset_frontier_10labs} — a wider lab survey at a single

--- a/tickets/0638-fix-45pt-annex-overfull-texttt-modelset.erg
+++ b/tickets/0638-fix-45pt-annex-overfull-texttt-modelset.erg
@@ -1,0 +1,21 @@
+%erg 0.1
+Title: Fix 45pt annex overfull: texttt{modelset_exp1_journal} -> fpath (breakable)
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T18:23Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Render-and-adjust pass found a 45pt overfull hbox in the Exp-2 annex
+"Baseline reference" paragraph: an unbreakable long \texttt token
+(\texttt{modelset\_exp1\_journal}) — the overfull source writing.md warns
+about. Line 1753 already uses the breakable \fpath form.
+
+## Action (done)
+- main.tex:2076 \texttt{modelset\_exp1\_journal} -> \fpath{modelset_exp1_journal}.
+- Rebuilt: 45pt overfull gone; only a 0.5pt sub-mm sliver remains (noise).
+
+## Exit criteria
+- No 45pt overfull; manuscript builds. (done)

--- a/tickets/0639-intro-cut-the-weakest-passage-benchmark.erg
+++ b/tickets/0639-intro-cut-the-weakest-passage-benchmark.erg
@@ -2,10 +2,12 @@
 Title: Intro: cut the weakest passage (benchmark-genre framing) to shave ~4 lines
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: weakest intro passage cut
 
 --- log ---
 2026-06-15T18:27Z HDMX-coding-agent created
 
+2026-06-15T18:31Z HDMX-coding-agent closed — weakest intro passage cut
 --- body ---
 ## Context
 Challenge: remove the weakest part of the intro to shave ~4 lines.

--- a/tickets/0639-intro-cut-the-weakest-passage-benchmark.erg
+++ b/tickets/0639-intro-cut-the-weakest-passage-benchmark.erg
@@ -1,0 +1,29 @@
+%erg 0.1
+Title: Intro: cut the weakest passage (benchmark-genre framing) to shave ~4 lines
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T18:27Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Challenge: remove the weakest part of the intro to shave ~4 lines.
+
+## Judgment + action (done)
+Weakest passage = para-2 benchmark-genre sentence ("Computable benchmarks
+... are how knowledge engineering and AI research have long measured
+progress, from ... to ...; this paper extends the practice to national
+statistical registers"). Generic boilerplate, redundant with the
+contribution paragraph, tangential 3-cite list. Cut it; para 2 is now the
+crisp task statement alone. ~4-5 rendered lines shaved; build clean.
+
+## Citation consequence (flag for author)
+- Hendrycks MMLU: still cited (\S3, line ~297) — retained.
+- Petroni (lm-as-kb) and Ni (llm-benchmark-survey): were cited ONLY here
+  -> now UNCITED (drop out of the rendered bib). Petroni was kept as an
+  anchor in the 0630 cull; if the author wants it retained, re-cite it in
+  one clause. Bib is otherwise 2 lighter.
+
+## Exit criteria
+- Weakest intro passage removed; ~4 lines shaved; no dangling cite; builds.


### PR DESCRIPTION
Challenge response: removes the generic benchmark-genre sentence from intro para 2 (redundant with the contribution paragraph). ~4-5 rendered lines shaved; build clean. Orphans Petroni (lm-as-kb) + Ni-survey cites — MMLU retained via §3. Flag: Petroni was a kept anchor; say if you want it re-cited.

**Ticket:** tickets/0639-intro-cut-the-weakest-passage-benchmark.erg