### PR TITLE
s2(0640): shave §2 — caption last sentence + OSM caveat, weakest prose aside

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -206,9 +206,7 @@ while an automated method can stay evergreen and capture data GEM
 does not carry. Beyond cost, the
 method is groundwork for information fusion across sources, for better
 energy-transition modelling, and for keeping statistical practice
-abreast of research automation. Two ancillary payoffs: the task doubles
-as a benchmark for AI information retrieval, and the build validates AI
-engineering patterns on a concrete case study.
+abreast of research automation.
 
 The hand-compiled
 reference that anchors this programme also stands on its own merits:
@@ -237,10 +235,7 @@ itself (all \LongtailReference{}), the Global Energy Monitor tracker (\LongtailG
 coverage (\LongtailWiki{}), and OpenStreetMap coverage (\LongtailOsm{} plants: existing,
 physically built infrastructure only). Well-documented operating plants
 appear in every layer; the under-documented tail — proposed and
-planned projects from the PDP8 pipeline — thins out layer by layer.
-OSM matching relies on name-only fuzzy search, so its sparser coverage
-reflects both genuine mapping gaps and the weaker matcher. Recognition-layer
-provenance is detailed in \ref{sec:annex-recognition}.}\label{fig:longtail}
+planned projects from the PDP8 pipeline — thins out layer by layer.}\label{fig:longtail}
 \end{figure}
 
 \textbf{Statistical perimeters by use case.} What counts as a

--- a/tickets/0640-shave-section-2-drop-fig-longtail-captio.erg
+++ b/tickets/0640-shave-section-2-drop-fig-longtail-captio.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: Shave section 2: drop fig:longtail caption last sentence + OSM caveat; cut weakest prose sentence
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T18:37Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Shave section 2 (Related Work). Author directives 2026-06-15.
+
+## Actions (done)
+- fig:longtail caption: dropped the last sentence (the \ref{sec:annex-recognition}
+  provenance pointer) AND the OSM matcher caveat (no caveat/hedging in captions —
+  saved as a standing rule). Caption now ends on the head/tail thinning message.
+- §2 prose: cut the weakest sentence — the 'Two ancillary payoffs: the task
+  doubles as a benchmark ... validates AI engineering patterns' aside (tangential,
+  the benchmark framing is already the paper's spine).
+- §2 prose OSM description KEPT (author: drop OSM details in caption, not prose).
+
+## Exit criteria
+- §2 shaved; caption caveat-free; build clean.

--- a/tickets/0640-shave-section-2-drop-fig-longtail-captio.erg
+++ b/tickets/0640-shave-section-2-drop-fig-longtail-captio.erg
@@ -2,10 +2,12 @@
 Title: Shave section 2: drop fig:longtail caption last sentence + OSM caveat; cut weakest prose sentence
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: section 2 shaved
 
 --- log ---
 2026-06-15T18:37Z HDMX-coding-agent created
 
+2026-06-15T18:38Z HDMX-coding-agent closed — section 2 shaved
 --- body ---
 ## Context
 Shave section 2 (Related Work). Author directives 2026-06-15.


### PR DESCRIPTION
Shave §2: fig:longtail caption drops its last sentence + OSM caveat (no caveats in captions); §2 prose drops the weakest 'ancillary payoffs' aside; prose OSM kept. Build clean.

**Ticket:** tickets/0640-shave-section-2-drop-fig-longtail-captio.erg