### PR TITLE
s2(0641): cull non-essential OSM/Wikipedia claims; drop Petroni/Ni-survey entries

### DIFF
--- a/report/refs.bib
+++ b/report/refs.bib
@@ -430,19 +430,6 @@
   eprinttype   = {arxiv},
 }
 
-@article{Ni-Shiwen2025:llm-benchmark-survey,
-  author       = {Ni, Shiwen and Chen, Guhong and Li, Shuaimin and Chen, Xuanang
-                  and Li, Siyi and Wang, Bingli and Wang, Qiyao and Wang, Xingjian
-                  and Zhang, Yifan and Fan, Liyang and Li, Chengming and Xu, Ruifeng
-                  and Sun, Le and Yang, Min},
-  title        = {{A Survey on Large Language Model Benchmarks}},
-  journal      = {arXiv preprint},
-  year         = {2025},
-  doi          = {10.48550/arXiv.2508.15361},
-  eprint       = {2508.15361},
-  eprinttype   = {arxiv},
-}
-
 @article{Tenckhoff-Sonke2026:llmstructbench,
   author       = {Tenckhoff, S{\"o}nke and Koddenbrock, Mario and Rodner, Erik},
   title        = {{LLMStructBench: Benchmarking Large Language Model Structured Data Extraction}},
@@ -808,19 +795,6 @@
   eprinttype   = {arxiv},
 }
 
-@inproceedings{Petroni-Fabio2019:lm-as-kb,
-  author       = {Petroni, Fabio and Rockt{\"a}schel, Tim and Lewis, Patrick
-                  and Bakhtin, Anton and Wu, Yuxiang and Miller, Alexander H.
-                  and Riedel, Sebastian},
-  title        = {{Language Models as Knowledge Bases?}},
-  booktitle    = {Proceedings of the 2019 Conference on Empirical Methods in
-                  Natural Language Processing},
-  date         = {2019},
-  year         = {2019},
-  eprint       = {1909.01066},
-  eprinttype   = {arxiv},
-  doi          = {10.48550/arXiv.1909.01066},
-}
 
 @misc{Rein-David2023:gpqa,
   author       = {Rein, David and Hou, Betty Li and Cooper Stickland, Asa

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -177,12 +177,9 @@ Coal Plant Tracker \citep{GEM2026:gcpt}; \emph{powerplantmatching}
 sources for European grids through deterministic entity-resolution
 rules. All three solve the aggregation problem for documented,
 large-capacity units in well-resourced contexts. Two community sources
-complement these curated trackers. OpenStreetMap tags power plants
-(\texttt{power=plant}, queryable through the Overpass API) but covers
-only physically existing infrastructure: it answers presence questions
-for built sites, carries no forward-looking pipeline, and offers no
-per-cell sourcing. Wikipedia maintains structured lists of power
-stations, again without provenance. Both serve below as recognition
+complement these curated trackers: OpenStreetMap, which covers only
+physically existing infrastructure, and Wikipedia, which maintains
+structured lists of power stations. Both serve below as recognition
 layers in Figure~\ref{fig:longtail}.
 
 The closest prior country-specific compilation is

--- a/tickets/0641-section-2-para-1-cull-non-essential-osm.erg
+++ b/tickets/0641-section-2-para-1-cull-non-essential-osm.erg
@@ -2,10 +2,12 @@
 Title: Section 2 para 1: cull non-essential OSM/Wikipedia claims + remove no-provenance assertion; drop Petroni + Ni-survey bib entries
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: section 2 para 1 OSM/Wikipedia culled; Petroni/Ni dropped
 
 --- log ---
 2026-06-15T18:43Z HDMX-coding-agent created
 
+2026-06-15T18:43Z HDMX-coding-agent closed — section 2 para 1 OSM/Wikipedia culled; Petroni/Ni dropped
 --- body ---
 ## Context
 Shave §2 para 1 (Open power-plant databases). Author directives 2026-06-15.

--- a/tickets/0641-section-2-para-1-cull-non-essential-osm.erg
+++ b/tickets/0641-section-2-para-1-cull-non-essential-osm.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: Section 2 para 1: cull non-essential OSM/Wikipedia claims + remove no-provenance assertion; drop Petroni + Ni-survey bib entries
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T18:43Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Shave §2 para 1 (Open power-plant databases). Author directives 2026-06-15.
+
+## Actions (done)
+- OSM/Wikipedia: culled non-essential claims — dropped the \texttt{power=plant}/Overpass
+  detail, the 'presence questions / no forward-looking pipeline / no per-cell
+  sourcing' elaboration, and the 'without provenance' assertions. Kept the
+  essential: two community sources, OSM = built infrastructure, Wikipedia = lists,
+  both recognition layers in Figure 1.
+- Dropped Petroni (lm-as-kb) and the Ni benchmark survey bib entries — orphaned by
+  the intro trim (0639), author confirmed 'drop Petroni'. Both were uncited.
+
+## Exit criteria
+- §2 para 1 carries only essential OSM/Wikipedia claims; no dead bib entries; builds.


### PR DESCRIPTION
§2 para 1: OSM/Wikipedia trimmed to essential (dropped Overpass/power=plant detail, elaborating clauses, no-provenance assertions). Removed the orphaned Petroni + Ni-survey bib entries (author: drop Petroni). Builds clean.

**Ticket:** tickets/0641-section-2-para-1-cull-non-essential-osm.erg