### PR TITLE
s3+s4(0643): shave §3/§4 — drop non-essential clauses + tighten

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -283,8 +283,7 @@ philosophy-of-science empirical adequacy
   At the cell level, accuracy asks whether the attributes attached to
   each asset are correct: capacity, fuel type, location, operator,
   commissioning year, status, and so on. A system can therefore be good
-  at finding the right assets but weak at describing them, or conversely
-  reliable on attributes once the correct asset has been identified.
+  at finding the right assets but weak at describing them.
   Plausibility is not truth: confidently-stated fabrications are the
   failure mode this dimension polices.
 \item
@@ -298,14 +297,11 @@ philosophy-of-science empirical adequacy
   rather than silently overwriting them. A weak working test is whether
   repeated runs of the same system agree with one another; the stronger requirement is
   inferential closure: the system derives and exposes all
-  consequences of the available documents and accounting rules. This
-  paper measures weak-internal coherence; the external axis is deferred
-  to the Discussion.
+  consequences of the available documents and accounting rules.
 \item
   \emph{Provenance} requires a pedigree for each data item: every row,
   and ideally every cell, traces back to specific passages, tables, or
-  records in specific sources. Strong provenance means more than
-  attaching a plausible citation: the cited source must actually
+  records in specific sources. The cited source must actually
   support the value claimed
   \citep{Gao-Tianyu2023:alce, Asai-Akari2024:self-rag, Es-Shahul2023:ragas}.
   We distinguish \emph{verifiable} provenance (a citation is present
@@ -341,29 +337,24 @@ philosophy-of-science empirical adequacy
 
 Of the four dimensions, accuracy is the only one whose measurement
 requires a held-out gold reference. Coherence, provenance, and
-temporality are reference-free: they can be assessed from the dataset
-and its sources alone. The screening logic of this paper follows from
-that asymmetry: where reference-free indicators correlate with accuracy,
+temporality are reference-free: they can be assessed from the model
+reply alone. Where reference-free indicators correlate with accuracy,
 they can estimate it — screening out weak outputs without the
 reference. The experiments exercise this logic directly
-(§\ref{sec:exp1}).
-
-The scoring is implemented in \ref{sec:annex-scoring}, which writes out the
-per-dimension formulas and the cell--run--model hierarchy as version~0.1 of
-the benchmark.
+(§\ref{sec:exp1}). The scoring is implemented in \ref{sec:annex-scoring},
+which writes out the per-dimension formulas.
 
 \section{AI capability landscape: from chatbots to agentic systems}\label{sec:capability}
 
 Between 2022 and 2025, AI capability advanced as an industry-wide
 \emph{envelope}: the set of capabilities commercially attainable at a
 given date, across labs. The systems that define this envelope vary
-along four axes: \emph{training objective} (from raw text completion
+on: \emph{training objective} (from raw text completion
 through instruction-following to extended reasoning), \emph{input and
 output media} (text, vision, audio, video), \emph{tool access} (none,
 web browser, code execution, computer control), and \emph{product
 workflow} (simple chat, single-task agent, deep research, coding agent,
-autonomous task runner). The first two are properties of the model; the
-last two are properties of the software that wraps it.
+autonomous task runner).
 Figure~\ref{fig:capability-timeline} shows one projection of this
 coordinate system: when each of eight capability surfaces first shipped
 in a consumer-facing product, the threshold at which a working analyst

--- a/tickets/0643-shave-section-3-drop-weak-internal-coher.erg
+++ b/tickets/0643-shave-section-3-drop-weak-internal-coher.erg
@@ -2,10 +2,12 @@
 Title: Shave section 3: drop weak-internal-coherence deferral, 'reliable on attributes' clause, 'Strong provenance means more than' opener
 Created: 2026-06-15
 Author: HDMX-coding-agent
+Closed: §3/§4 shaved
 
 --- log ---
 2026-06-15T18:51Z HDMX-coding-agent created
 
+2026-06-15T18:55Z HDMX-coding-agent closed — §3/§4 shaved
 --- body ---
 ## Context
 Shave §3 (Quality dimensions). Author directives 2026-06-15: drop three non-essential bits.

--- a/tickets/0643-shave-section-3-drop-weak-internal-coher.erg
+++ b/tickets/0643-shave-section-3-drop-weak-internal-coher.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: Shave section 3: drop weak-internal-coherence deferral, 'reliable on attributes' clause, 'Strong provenance means more than' opener
+Created: 2026-06-15
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-15T18:51Z HDMX-coding-agent created
+
+--- body ---
+## Context
+Shave §3 (Quality dimensions). Author directives 2026-06-15: drop three non-essential bits.
+
+## Actions (done)
+- Accuracy item: dropped 'or conversely reliable on attributes once the correct asset has been identified.'
+- Coherence item: dropped 'This paper measures weak-internal coherence; the external axis is deferred to the Discussion.'
+- Provenance item: dropped the opener 'Strong provenance means more than attaching a plausible citation:' (sentence now opens 'The cited source must actually support the value claimed').
+
+## Exit criteria
+- Three §3 phrases gone; build clean.
+
+## Additional edits (same shave pass)
+- §3: 'dataset and its sources' -> 'model reply'; dropped 'The screening logic of this paper follows from that asymmetry:' opener; dropped 'and the cell-run-model hierarchy as version 0.1 of the benchmark' + blended the scoring-annex sentence into the previous paragraph.
+- §4: 'varies along four axes:' -> 'varies on:'; dropped 'The first two are properties of the model; the last two are properties of the software that wraps it.'


### PR DESCRIPTION
§3: drop 3 clauses (reliable-on-attributes, weak-internal-coherence deferral, Strong-provenance opener); 'dataset and its sources'→'model reply'; drop screening-logic opener; drop cell-run-model/version-0.1 + blend. §4: 'varies along four axes:'→'varies on:'; drop 'first two/last two properties' sentence. Build clean.

**Ticket:** tickets/0643-shave-section-3-drop-weak-internal-coher.erg