### PR TITLE
manuscript: clear float before §6 so Figure 5 stays in §5

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -625,6 +625,7 @@ good runs (claude-haiku-4.5, gpt-oss-20b, qwen3.6-35b-a3b) anchor the
 lower-left. Source: author; see \ref{sec:annex-exp1}.}\label{fig:reliability}
 \end{figure}
 
+\clearpage
 \section{Experiment 2: frontier agents fall short on the measured quality dimensions}\label{sec:exp2}
 
 How well do state-of-the-art tools perform at producing research-grade


### PR DESCRIPTION
`fig:reliability` (Reliability–accuracy scatter, Figure 5) has no `[p]` placement specifier and could float past the Experiment 2 (§6) heading. A `\clearpage` before `\section{Experiment 2}` flushes pending floats so Figure 5 lands in Experiment 1 (§5).

Build: tectonic clean, 0 undefined refs, overfull unchanged.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)