### PR TITLE
manuscript(0649): define the Exp2 document pack in §6

### DIFF
--- a/docs/editorial-brief.md
+++ b/docs/editorial-brief.md
@@ -558,3 +558,40 @@ out-of-sample validation are deferred (ticket 0657).
 **Ticket:** tickets/0648-reconcile-abstract-s7-screen-signal.erg
 
 **Status:** active
+
+## document-pack-not-the-answer
+
+**Decision:** §6 defines the Experiment 2 document pack in the main text: a
+near-ideal retrieval simulation of eighteen ministerial (PDP7/7A/8) and
+national-utility (EVN) lists (\fpath{data/rag_corpus/}), extracted and
+reformatted. The prose states the reference was compiled from these same
+sources yet the pack is not guaranteed to contain every reference plant —
+"handing the agent the sources is not handing it the answer."
+
+**Rationale:** Both student reviewers warned the documents result could
+reduce to "LLMs extract better when handed the answer." Naming the pack as
+the reference's source set (not the reference itself) makes the
+documents-arm gain interpretable; the pack's own coverage of the reference
+is a post-arXiv measurement (ticket 0662).
+
+**Ticket:** tickets/0649-define-document-pack-s6.erg
+
+**Status:** active
+
+## related-work-budget-frozen
+
+**Decision:** Related Work is not expanded with the literatures reviewers
+suggested (data fusion, entity resolution, RAG-eval, web-agent benchmarks,
+official-statistics frameworks). The bibliography is already large; new
+citations are added only when a specific argument requires a closely-related
+must-cite work, per the citation-budget rule in `writing.md`.
+
+**Rationale:** Author decision (2026-06-15): bibliography size is a binding
+constraint. Breadth-for-breadth's-sake citation does not serve the reader and
+violates the strict-citation-budget rule. The dropped candidates live in the
+peer-review texts (`slides/manuscript/attic/peer-reviews-2026-06-15/`), not
+the paper.
+
+**Ticket:** tickets/0653-expand-related-work.erg (declined)
+
+**Status:** active

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -654,6 +654,14 @@ corpus matters more than the model. This section reads the two
 no-documents arms; the documents axis is detailed in
 \ref{sec:annex-exp2}.
 
+The document pack simulates a near-ideal retrieval step: eighteen
+power-plant lists from ministerial Power Development Plans (PDP7/7A/8)
+and national-utility (EVN) reports, extracted from the source PDFs and
+reformatted. The reference was compiled from these same sources, yet the
+pack is not guaranteed to contain every reference plant: handing the
+agent the sources is not handing it the answer, and the pack's own
+coverage of the reference is not itself measured here.
+
 The single-shot arm differs from the §\ref{sec:exp1} parametric baseline
 in two controlled ways: web search is on (it was off in §\ref{sec:exp1}),
 and the call goes direct to each vendor's API rather than through

--- a/tickets/0644-peer-review-findings-tracker.erg
+++ b/tickets/0644-peer-review-findings-tracker.erg
@@ -30,7 +30,8 @@ measured.
 - 0650 Figure 1 entity-grain clarification + Figure 4/§5 cost–coverage consistency
 - 0651 Surface Exp1 caveats: status-vocabulary mismatch + prompt-impossibility/refusal scoring
 - 0652 Bibliography/consistency nits
-- 0653 Expand Related Work with missing literatures (within budget)
+- 0653 Expand Related Work — DECLINED (bibliography already large; author
+  decision 2026-06-15; see editorial-brief `related-work-budget-frozen`)
 
 ## Children — defer (new experiments / data)
 - 0654 Independent expert audit of the reference + inter-annotator agreement
@@ -41,6 +42,7 @@ measured.
 - 0659 Matcher/entity-resolution sensitivity analysis
 - 0660 Re-run Exp1 with status vocabulary aligned to the reference
 - 0661 Expand Exp2 (RAG baseline, broader systems, advanced fusion, multilingual/temporal)
+- 0662 Post-arXiv: fuse the document pack to measure its coverage of the reference
 
 ## Exit criteria
 - [ ] All prose children (0645–0653) closed via merge requests

--- a/tickets/0662-postarxiv-fuse-pack-coverage.erg
+++ b/tickets/0662-postarxiv-fuse-pack-coverage.erg
@@ -1,0 +1,31 @@
+%erg 0.1
+Title: Post-arXiv: fuse the document pack to measure its coverage of the reference
+Created: 2026-06-15
+Author: claude
+Label: deferred
+
+--- log ---
+2026-06-15T21:00Z claude created from peer-review tracker 0644 (post-arXiv)
+
+--- body ---
+## Context
+The Experiment 2 document pack (\fpath{data/rag_corpus/} — eighteen
+ministerial PDP7/7A/8 and national-utility EVN lists, extracted and
+reformatted) simulates a near-ideal retrieval step. The reference was
+compiled from these same sources, but the pack is not guaranteed to contain
+every one of the \NumRefPlants{} reference plants, and its own coverage of
+the reference is not yet measured. This bears directly on the reviewers'
+"documents may be too close to the answer" concern (now addressed in §6 prose
+by 0649): knowing the pack's coverage bounds how much of the documents-arm
+gain is retrieval vs extraction. Tracker: 0644. Author decision: do this
+post-publication (after the arXiv deposit).
+
+## Actions
+1. Fuse the eighteen pack lists into a single deduplicated plant set.
+2. Match it against the \NumRefPlants{}-plant reference (same matcher as Exp 1/2).
+3. Report the pack's coverage of the reference (how many reference plants the
+   pack contains), overall and by lifecycle status.
+
+## Exit criteria
+- [ ] Pack coverage of the reference reported; the documents-arm gain reframed
+      against that ceiling

--- a/tickets/closed/0653-expand-related-work.erg
+++ b/tickets/closed/0653-expand-related-work.erg
@@ -2,10 +2,12 @@
 Title: Expand Related Work with missing literatures (within citation budget)
 Created: 2026-06-15
 Author: claude
+Closed: declined: bibliography already large; do not expand Related Work (author decision 2026-06-15). Tracker 0644.
 
 --- log ---
 2026-06-15T20:09Z claude created from peer-review tracker 0644
 
+2026-06-15T20:44Z HDMX-coding-agent closed — declined: bibliography already large; do not expand Related Work (author decision 2026-06-15). Tracker 0644.
 --- body ---
 ## Context
 Reviewers flag thin related work in several areas: data fusion / truth discovery /


### PR DESCRIPTION
Defines the Experiment 2 document pack in §6 (peer-review finding 0649): a near-ideal retrieval simulation of eighteen ministerial (PDP7/7A/8) + national-utility (EVN) lists from `data/rag_corpus/`, extracted and reformatted. States the reference was compiled from these same sources but the pack does not guarantee every reference plant is present — "handing the agent the sources is not handing it the answer." Directly answers the reviewers' "documents may be too close to the answer" concern.

Also: declines 0653 (do not expand Related Work — bibliography already large) and files post-arXiv ticket 0662 (fuse the pack to measure its coverage). Decisions recorded in `docs/editorial-brief.md`.

Build clean; 253 manuscript adherence tests pass; erg check PASS.

**Ticket:** tickets/0649-define-document-pack-s6.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)