### PR TITLE
manuscript: fold §7 recognition-matrix paragraph into a reference (page-21 widow)

### DIFF
--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -821,7 +821,8 @@ category is found by a random run of the experiment — averaged over the
 two regimes: Experiment 1 (all models, memory only; 70 runs) and the
 Experiment 2 with-documents arm (20 runs). Operational plants are easy: almost every run finds them. The proposed
 and planned long tail is hard. Giving the models documents lifts the
-whole list, the tail most of all.
+whole list, the tail most of all; the per-plant recognition matrix
+decomposes this difficulty plant by plant (\ref{sec:annex-recognition}).
 
 \begin{table}[htbp]
 \centering
@@ -831,11 +832,6 @@ likelihood. Experiment 1 includes all models; Experiment 2 is the
 single-shot with-documents arm. Source: author.}
 {\small\setlength{\tabcolsep}{4pt}\input{../../report/inputs/generated/tab_status_difficulty_en.tex}}
 \end{table}
-
-The per-plant recognition matrix in \ref{sec:annex-recognition}
-decomposes this difficulty plant by plant: famous plants form dense
-rows, obscure ones sparse, and the operational core separates visibly
-from the project-dominated tail.
 
 \subsection*{Screening without a reference}\label{sec:ext-screen}
 \addcontentsline{toc}{subsection}{Screening without a reference}


### PR DESCRIPTION
Replaces the standalone §7 recognition-matrix paragraph with a short reference folded into the preceding difficulty paragraph. Shaves ~2 lines and clears the page-21 widow; verified by rendering page 21. Build clean; 254 adherence tests pass.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)