### PR TITLE
tickets: post-tag dissemination + spring-cleanup reorganization

### DIFF
--- a/tickets/0663-dissemination-tracker.erg
+++ b/tickets/0663-dissemination-tracker.erg
@@ -1,0 +1,29 @@
+%erg 0.1
+Title: Post-tag dissemination of the AEDIST technical report
+Created: 2026-06-15
+Author: claude
+
+--- log ---
+2026-06-15T22:00Z claude created dissemination tracker after tag economia-2026-report
+
+--- body ---
+## Context
+The manuscript was diffused to Econom'IA 2026 participants and tagged
+`economia-2026-report` (commit 2da83d04, 65 pp, widow-free, peer-review
+calibrated). This tracker covers the formal dissemination channels. The
+talk's precedent is the tag `economia-2026-cergy` (HAL hal-05644906, GitHub
+release with PDF, Ha-Duong.bib entry) — mirror that for the report.
+
+This is a **tracking ticket**. Children below; the GitHub release (0666) is
+independent, the rest chain off the HAL deposit (0664).
+
+## Children
+- 0664 HAL deposit of the manuscript (SWORD) — root of the chain
+- 0665 arXiv via HAL (enable arXiv push from the HAL record) — Blocked-by 0664
+- 0666 GitHub release on tag `economia-2026-report` with the diffused PDF
+- 0667 Homepage / Ha-Duong.bib entry — Blocked-by 0664 (needs the HAL id)
+- 0668 CIRED dissemination (lab page / HAL collection) — Blocked-by 0664
+
+## Exit criteria
+- [ ] All five children closed
+- [ ] HAL id + arXiv id recorded in the economia-2026 memory and Ha-Duong.bib

--- a/tickets/0664-hal-deposit-manuscript.erg
+++ b/tickets/0664-hal-deposit-manuscript.erg
@@ -1,0 +1,27 @@
+%erg 0.1
+Title: HAL deposit of the AEDIST technical report (SWORD)
+Created: 2026-06-15
+Author: claude
+
+--- log ---
+2026-06-15T22:01Z claude created from dissemination tracker 0663
+
+--- body ---
+## Context
+Deposit the diffused manuscript (tag `economia-2026-report`, commit 2da83d04)
+on HAL, mirroring the talk's deposit (hal-05644906). The `/update-publist`
+IDH skill performs HAL deposit via SWORD and is gated on author payload
+review before any outward call. Tracker: 0663.
+
+## Relevant files
+- `publications/.../main.pdf` (currently `slides/manuscript/main.pdf`) — the artifact to deposit
+- `~/CNRS/html/src/Ha-Duong.bib` — publication metadata source
+- `/update-publist` skill — HAL SWORD + homepage
+
+## Actions
+1. Build the final PDF from the tag; confirm metadata (title, authors, abstract).
+2. Run `/update-publist <pdf> --hal-only`; review the SWORD payload before sending.
+3. Record the returned HAL id.
+
+## Exit criteria
+- [ ] Manuscript live on HAL; HAL id recorded (memory + Ha-Duong.bib)

--- a/tickets/0665-arxiv-via-hal.erg
+++ b/tickets/0665-arxiv-via-hal.erg
@@ -1,0 +1,26 @@
+%erg 0.1
+Title: arXiv deposit via HAL
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0664
+
+--- log ---
+2026-06-15T22:02Z claude created from dissemination tracker 0663
+
+--- body ---
+## Context
+Push the manuscript to arXiv from the HAL record (HAL→arXiv transfer), so the
+preprint has an arXiv id. Requires the HAL deposit (0664) to exist first.
+The deferred experiment tickets (0654–0662) are explicitly post-arXiv, so the
+manuscript is in a coherent "preprint now, experiments later" state. Tracker: 0663.
+
+## Actions
+1. From the HAL record, enable the arXiv transfer (category: cs.CL / cs.AI or
+   econ.GN as fits); confirm the arXiv metadata and license.
+2. Review the arXiv submission before release; record the arXiv id.
+
+## Invariants
+- The arXiv version must match the HAL/tag PDF (commit 2da83d04) exactly.
+
+## Exit criteria
+- [ ] arXiv id assigned and recorded (memory + Ha-Duong.bib)

--- a/tickets/0666-github-release.erg
+++ b/tickets/0666-github-release.erg
@@ -1,0 +1,24 @@
+%erg 0.1
+Title: GitHub release on tag economia-2026-report with the diffused PDF
+Created: 2026-06-15
+Author: claude
+
+--- log ---
+2026-06-15T22:03Z claude created from dissemination tracker 0663
+
+--- body ---
+## Context
+Cut a GitHub release on the existing tag `economia-2026-report` (commit
+2da83d04) and attach the diffused PDF, mirroring the `economia-2026-cergy`
+release. Lets participants/readers download the exact diffused file.
+Tracker: 0663. Independent of the HAL chain.
+
+## Actions
+1. Rebuild the PDF from the tag (`tectonic -r 2`) to attach a clean artifact.
+2. `gh release create economia-2026-report <pdf> --title "..." --notes "..."`
+   (forge-agnostic: a release on the report tag with the PDF asset).
+3. Note in the release the preprint status and that experiments are deferred
+   (tracker 0644 children 0654–0662).
+
+## Exit criteria
+- [ ] Release published on tag economia-2026-report with the PDF attached

--- a/tickets/0667-homepage-publist-entry.erg
+++ b/tickets/0667-homepage-publist-entry.erg
@@ -1,0 +1,27 @@
+%erg 0.1
+Title: Homepage / Ha-Duong.bib entry for the report
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0664
+
+--- log ---
+2026-06-15T22:04Z claude created from dissemination tracker 0663
+
+--- body ---
+## Context
+Add the report to the personal publication list and homepage, mirroring the
+talk's `Ha-Duong2026:economia` entry. Needs the HAL id (0664) and, ideally,
+the arXiv id (0665). `/update-publist --page-only` regenerates the page.
+Tracker: 0663.
+
+## Relevant files
+- `~/CNRS/html/src/Ha-Duong.bib` — add the report entry (HAL + arXiv ids, tag)
+- `/update-publist` skill — page regeneration
+
+## Actions
+1. Add a bib entry (e.g. `Ha-Duong2026:aedist-report`) with HAL + arXiv ids and
+   the GitHub release URL.
+2. `/update-publist <pdf> --page-only`; verify the rendered page.
+
+## Exit criteria
+- [ ] Report listed on the homepage with HAL + arXiv links

--- a/tickets/0668-cired-dissemination.erg
+++ b/tickets/0668-cired-dissemination.erg
@@ -1,0 +1,22 @@
+%erg 0.1
+Title: CIRED dissemination of the report
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0664
+
+--- log ---
+2026-06-15T22:05Z claude created from dissemination tracker 0663
+
+--- body ---
+## Context
+Announce/disseminate the report through CIRED channels (lab working-paper page,
+HAL CIRED collection, internal seminar list as appropriate). Funding is
+CIRED/CNRS (acknowledged in the manuscript). Needs the HAL record (0664) so the
+CIRED collection/link points at the canonical deposit. Tracker: 0663.
+
+## Actions
+1. Attach the HAL deposit to the CIRED HAL collection.
+2. Add to the CIRED working-paper / publications page as house style dictates.
+
+## Exit criteria
+- [ ] Report appears in the CIRED HAL collection / lab page

--- a/tickets/0669-spring-cleanup-tracker.erg
+++ b/tickets/0669-spring-cleanup-tracker.erg
@@ -1,0 +1,37 @@
+%erg 0.1
+Title: Post-release spring cleanup — repo reorganization
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0663
+
+--- log ---
+2026-06-15T22:06Z claude created post-release reorganization tracker
+
+--- body ---
+## Context
+After the report is disseminated (tracker 0663), reorganize the repo. The root
+is crowded (12 dirs + 12 top-level files), the manuscript lives unnaturally
+under `slides/`, `publications/` is under-used, and `data/`/`derived/` are
+duplicated at the root and under `experiments/` (with a symlink
+`experiments/data/rag_corpus -> ../../data/rag_corpus`). Author decisions
+(2026-06-15):
+- Rehome publication artifacts under `publications/`: `report/`, the decks
+  (`slides/`), and the manuscript as `publications/Economia-2026-Manuscrit/`.
+- Move `data/` and `derived/` under `experiments/` (single pipeline-I/O home;
+  drop the symlink).
+
+**Blocked-by 0663:** do NOT move files until HAL/arXiv/release deposits are
+done — they reference the manuscript at its current path.
+
+## Children
+- 0670 Rehome `report/`, `slides/` decks, and the manuscript under `publications/`
+- 0671 Move root `data/` + `derived/` under `experiments/`
+- 0672 Tidy crowded project root (top-level files)
+
+## Related (not a child)
+- 0297 `measurements.jsonl` at root leaves via the MART-v2 migration (0297 +
+  0475/0476/0477/0489/0493) — track there, not here.
+
+## Exit criteria
+- [ ] All three children closed; `make` (root + slides/manuscript) builds clean
+- [ ] No dangling paths (asset includes, Makefile DAG, tests, CI) after the moves

--- a/tickets/0670-rehome-publications.erg
+++ b/tickets/0670-rehome-publications.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Rehome report/, slides/ decks, and the manuscript under publications/
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0663
+
+--- log ---
+2026-06-15T22:07Z claude created from spring-cleanup tracker 0669
+
+--- body ---
+## Context
+Move the publication artifacts into `publications/` (which today holds only
+`journal-article/`). Target layout:
+- `report/`                     → `publications/report/`
+- `slides/{slides,slides-en}.{tex,pdf}`, `slides/Makefile`, `slides/inputs/`
+                                → `publications/slides/`
+- `slides/manuscript/`          → `publications/Economia-2026-Manuscrit/`
+Do the three moves together: the manuscript's asset paths are relative to both
+`report/` and its own location, so they must be updated once, atomically.
+Tracker: 0669. **Post-release only** (0663) — deposits reference the old path.
+
+## Relevant files / what breaks
+- `slides/manuscript/main.tex` — asset includes `../../report/inputs/generated/…`
+  become `../report/inputs/generated/…` once both move under `publications/`.
+  Sweep every `\includegraphics`/`\input`/`\InputIfFileExists`.
+- `slides/Makefile` and the manuscript build rule (`make -C slides manuscript/main.pdf`).
+- `experiments/render.mk` — `MANUSCRIPT_MACRO_FRAGMENTS` consolidation writes to
+  `report/inputs/generated/` → repoint to `publications/report/inputs/generated/`.
+- `tests/test_manuscript_*.py`, `test_no_inline_plots.py`, `test_manuscript_crossref/
+  em_dash/macros.py` — all hardcode `slides/manuscript/main.tex`; repoint.
+- `.claude/rules/writing.md` (project) — references `slides/manuscript/main.tex`.
+- CI workflows referencing `slides/` or `report/` paths.
+- `.gitignore` entries for `inputs/generated`, `report/inputs/generated`.
+- Root `Makefile` targets that build `report.pdf` / call into `slides/`.
+- `slides/manuscript/attic/` (incl. peer-reviews-2026-06-15) moves with the manuscript.
+
+## Actions
+1. `git mv` the three trees to their `publications/` homes.
+2. Update all asset paths, Makefiles (root + slides + render.mk), test paths,
+   CI, .gitignore, and the project writing rule in one commit.
+3. Rebuild: root `make` and the manuscript (`tectonic -r 2`) — both clean.
+
+## Invariants
+- Manuscript builds byte-clean (0 undefined refs; overfull unchanged).
+- Full adherence suite green (the manuscript tests now point at the new path).
+- Makefile DAG intact: `make -B -n` shows correct prereqs (clean-room test).
+
+## Exit criteria
+- [ ] report/, slides/ decks, manuscript rehomed under publications/
+- [ ] root `make` + manuscript build clean; all tests green; no dangling paths

--- a/tickets/0671-data-derived-under-experiments.erg
+++ b/tickets/0671-data-derived-under-experiments.erg
@@ -1,0 +1,48 @@
+%erg 0.1
+Title: Move root data/ and derived/ under experiments/
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0663
+
+--- log ---
+2026-06-15T22:08Z claude created from spring-cleanup tracker 0669
+
+--- body ---
+## Context
+`data/` and `derived/` exist both at the root and under `experiments/`, with a
+symlink `experiments/data/rag_corpus -> ../../data/rag_corpus`. Author decision:
+treat data & derived as pipeline I/O and keep a single home under `experiments/`.
+Frees two root dirs. Tracker: 0669. **Post-release only** (0663).
+
+## Current state
+- root `data/`: rag_corpus/, reference/, capability_timeline.csv, README.md
+- root `derived/`: audit/, fusion_proto/, verification/, verification_multi/,
+  *.json (sourced_evidence_summary, variance_decomposition)
+- `experiments/data/`: converter_test/, rag_corpus -> ../../data/rag_corpus, web_portal_test.md
+- `experiments/derived/`: arm{1..4}_flat/, rag_consistency/, verification/, aggregation_sweep.csv, README.md
+
+## Relevant files / what breaks
+- The `rag_corpus` symlink — collapse to a single real dir under experiments/.
+- `experiments/experiments.toml` (`sweeps.rag.corpus`), `experiments/acquire.mk`
+  (`CORPUS_OUTPUT`), and any `make` recipe reading `data/` or `derived/`.
+- `src/aedist/plot_*.py` and tabulators reading `data/reference/*.csv` or
+  `derived/*` (e.g. capability_timeline.csv, variance_decomposition.json).
+- The manuscript only includes `report/inputs/generated/…`, but the emitters
+  (render.mk → plot/tabulate scripts) read `data/`/`derived/` — fix their paths.
+- `.gitignore` rules for derived outputs.
+
+## Actions
+1. Decide the merged layout (e.g. `experiments/data/{reference,rag_corpus,…}`,
+   `experiments/derived/…`); `git mv` root trees in, replacing the symlink with
+   the real corpus.
+2. Update all readers/writers (toml, *.mk, scripts) to the new paths.
+3. Rebuild the artifact chain: `make tables` / render targets regenerate cleanly.
+
+## Invariants
+- Generated artifacts under `report/inputs/generated/` are byte-identical after
+  regeneration (paths changed, data did not).
+- `make -B -n` clean-room check passes; no script reads a stale `data/`/`derived/` root path.
+
+## Exit criteria
+- [ ] Single data/ and derived/ home under experiments/; symlink gone
+- [ ] Pipeline regenerates identical artifacts; tests green

--- a/tickets/0672-tidy-project-root.erg
+++ b/tickets/0672-tidy-project-root.erg
@@ -1,0 +1,34 @@
+%erg 0.1
+Title: Tidy the crowded project root (top-level files)
+Created: 2026-06-15
+Author: claude
+Blocked-by: 0663
+
+--- log ---
+2026-06-15T22:09Z claude created from spring-cleanup tracker 0669
+
+--- body ---
+## Context
+After the dir moves (0670 report/slides/manuscript → publications/; 0671
+data/derived → experiments/), the root is much lighter. Finish by tidying the
+remaining top-level files. Tracker: 0669. **Post-release only** (0663).
+
+## Current top-level files
+ADR.md, CITATION.cff, measurements.jsonl, AGENTS.md, pyproject.toml, STATE.md,
+README.md, Makefile, MASTERPLAN.md, LICENCE, CLAUDE.md, uv.lock
+
+## Actions
+1. Keep at root (tooling/convention requires it): README.md, LICENCE,
+   Makefile, pyproject.toml, uv.lock, CITATION.cff, CLAUDE.md, AGENTS.md, STATE.md.
+2. Candidates to relocate into `docs/`: ADR.md, MASTERPLAN.md (and any other
+   long-form planning docs) — update cross-references (CLAUDE.md/AGENTS.md/README links).
+3. `measurements.jsonl` leaves root via the MART-v2 migration — see 0297; do NOT
+   move it here, just confirm it is gone or ticket-tracked.
+
+## Invariants
+- No broken links to the relocated docs (grep the repo for their names).
+- Build + tests unaffected (these are docs, not pipeline inputs).
+
+## Exit criteria
+- [ ] Root holds only tooling/convention files + the dirs; planning docs in docs/
+- [ ] measurements.jsonl removal confirmed (via 0297) or explicitly tracked


### PR DESCRIPTION
Two trackers from the post-tag planning session.

**Dissemination (0663):** HAL (0664) → arXiv-via-HAL (0665), GitHub release (0666), homepage (0667), CIRED (0668).

**Spring cleanup (0669, post-release):** rehome report/ + slides/ decks + manuscript → publications/ (0670), data/+derived/ → experiments/ (0671), tidy root (0672). measurements.jsonl handled by the existing MART-v2 chain (0297).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)