### PR TITLE
tickets(0666): close — GitHub release published

### DIFF
--- a/tickets/0663-dissemination-tracker.erg
+++ b/tickets/0663-dissemination-tracker.erg
@@ -20,7 +20,8 @@ independent, the rest chain off the HAL deposit (0664).
 ## Children
 - 0664 HAL deposit of the manuscript (SWORD) — root of the chain
 - 0665 arXiv via HAL (enable arXiv push from the HAL record) — Blocked-by 0664
-- 0666 GitHub release on tag `economia-2026-report` with the diffused PDF
+- 0666 GitHub release on tag `economia-2026-report` with the diffused PDF — DONE
+  (published 2026-06-16: releases/tag/economia-2026-report)
 - 0667 Homepage / Ha-Duong.bib entry — Blocked-by 0664 (needs the HAL id)
 - 0668 CIRED dissemination (lab page / HAL collection) — Blocked-by 0664
 

--- a/tickets/closed/0666-github-release.erg
+++ b/tickets/closed/0666-github-release.erg
@@ -2,10 +2,12 @@
 Title: GitHub release on tag economia-2026-report with the diffused PDF
 Created: 2026-06-15
 Author: claude
+Closed: GitHub release published on tag economia-2026-report with the diffused PDF (2026-06-16).
 
 --- log ---
 2026-06-15T22:03Z claude created from dissemination tracker 0663
 
+2026-06-15T22:05Z HDMX-coding-agent closed — GitHub release published on tag economia-2026-report with the diffused PDF (2026-06-16).
 --- body ---
 ## Context
 Cut a GitHub release on the existing tag `economia-2026-report` (commit


### PR DESCRIPTION
GitHub release cut on tag `economia-2026-report` with the diffused PDF. Closes 0666; marks it done on tracker 0663.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)