### PR TITLE
test(0673): land NumRefPlants single-source adherence guard

### DIFF
--- a/tests/test_reference_count.py
+++ b/tests/test_reference_count.py
@@ -10,8 +10,21 @@ when the release changes (v1 = 163 → v2 = 170 was exactly such a latent bug).
 that derivation and assert every module-level mirror agrees with it.
 """
 
+import re
+from pathlib import Path
+
+import pytest
+
 from aedist.config import VN_THERMAL_PLANTS_RELEASE_CSV
 from aedist.evaluate import load_plants_csv, reference_plant_count
+
+_GEN = Path(__file__).resolve().parent.parent / "report" / "inputs" / "generated"
+
+
+def _read_numrefplants(path: Path) -> int | None:
+    """Parse \\newcommand{\\NumRefPlants}{N} from a generated macros file."""
+    m = re.search(r"\\newcommand\{\\NumRefPlants\}\{(\d+)\}", path.read_text(encoding="utf-8"))
+    return int(m.group(1)) if m else None
 
 
 def test_reference_plant_count_matches_release():
@@ -45,3 +58,38 @@ def test_all_module_constants_track_the_release():
     assert plot_exp2_arms_comparison.N_REFERENCE_PLANTS == n
     assert plot_exp2_coverage_certainty._N_REFERENCE_PLANTS == n
     assert build_exp2_mart_views._N_REFERENCE_PLANTS == n
+
+
+@pytest.mark.adherence
+def test_slides_and_manuscript_numrefplants_agree():
+    """Single-source-of-truth guard (ticket 0609): macros_slides.tex \\NumRefPlants
+    must equal macros_manuscript.tex \\NumRefPlants and both must equal
+    reference_plant_count() (derived from the reference CSV).
+
+    Catches the class of drift where a generated artifact is not regenerated
+    after the reference data changes — exactly the 173→177 slip 0609 fixed.
+    """
+    n = reference_plant_count()
+
+    slides_path = _GEN / "macros_slides.tex"
+    manuscript_path = _GEN / "macros_manuscript.tex"
+
+    if not slides_path.exists():
+        pytest.skip(f"{slides_path} not generated")
+    if not manuscript_path.exists():
+        pytest.skip(f"{manuscript_path} not generated")
+
+    slides_n = _read_numrefplants(slides_path)
+    manuscript_n = _read_numrefplants(manuscript_path)
+
+    assert slides_n is not None, r"\NumRefPlants missing from macros_slides.tex"
+    assert manuscript_n is not None, r"\NumRefPlants missing from macros_manuscript.tex"
+    assert slides_n == n, (
+        f"macros_slides.tex \\NumRefPlants={slides_n} != reference_plant_count()={n} "
+        f"— regenerate via: uv run python -m aedist.tabulate_macros --census "
+        f"--output report/inputs/generated/macros_slides.tex"
+    )
+    assert manuscript_n == n, (
+        f"macros_manuscript.tex \\NumRefPlants={manuscript_n} != reference_plant_count()={n} "
+        f"— regenerate via: make -f experiments/render.mk report-tables"
+    )

--- a/tickets/closed/0673-land-numrefplants-agreement-adherence-test.erg
+++ b/tickets/closed/0673-land-numrefplants-agreement-adherence-test.erg
@@ -2,10 +2,12 @@
 Title: Land the NumRefPlants single-source adherence test that ticket 0609 mandated but PR #1111 dropped
 Created: 2026-06-16
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #1153
 
 --- log ---
 2026-06-16T06:00Z HDMX-coding-agent created — found during /lair worktree sweep
 
+2026-06-16T07:28Z HDMX-coding-agent closed — autoclosed — PR #1153
 --- body ---
 ## Context
 


### PR DESCRIPTION
Lands the adherence guard ticket 0609 mandated but PR #1111 dropped (it autoclosed 0609 with only the macros data fix, never the drift-prevention test). Recovered from uncommitted WIP on branch t0609; fixed a latent NameError (decorator referenced \`pytest\` before its in-function import).

The guard asserts `macros_slides.tex`, `macros_manuscript.tex`, and `reference_plant_count()` agree on `\NumRefPlants`.

**Verification**
- GREEN on current main (4 passed in test_reference_count.py).
- RED when `macros_slides.tex` perturbed to 173 (clear, actionable assertion) — proven, not tautological.
- `make check-fast` green (2735 passed, ruff clean, erg check PASS).
- No `macros_slides.tex` diff — main already at 177.

**Ticket:** tickets/0673-land-numrefplants-agreement-adherence-test.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)