### PR TITLE
tickets: close dissemination 0664/0667/0668, defer 0665

### DIFF
--- a/tickets/0663-dissemination-tracker.erg
+++ b/tickets/0663-dissemination-tracker.erg
@@ -18,13 +18,19 @@ This is a **tracking ticket**. Children below; the GitHub release (0666) is
 independent, the rest chain off the HAL deposit (0664).
 
 ## Children
-- 0664 HAL deposit of the manuscript (SWORD) — root of the chain
-- 0665 arXiv via HAL (enable arXiv push from the HAL record) — Blocked-by 0664
-- 0666 GitHub release on tag `economia-2026-report` with the diffused PDF — DONE
-  (published 2026-06-16: releases/tag/economia-2026-report)
-- 0667 Homepage / Ha-Duong.bib entry — Blocked-by 0664 (needs the HAL id)
-- 0668 CIRED dissemination (lab page / HAL collection) — Blocked-by 0664
+- 0664 HAL deposit of the manuscript (SWORD) — **CLOSED 2026-06-16**
+  (hal-05658462, at moderation)
+- 0665 arXiv via HAL (enable arXiv push from the HAL record) — **DEFERRED**
+  to the article preprint (~2 months out); tripwire ~mid-August. The lone
+  outstanding child; this tracker stays open until it resolves. See 0675.
+- 0666 GitHub release on tag `economia-2026-report` with the diffused PDF —
+  **CLOSED** (published 2026-06-16: releases/tag/economia-2026-report)
+- 0667 Homepage / Ha-Duong.bib entry — **CLOSED 2026-06-16** (live with
+  clickable HAL link hal-05658462)
+- 0668 CIRED dissemination (lab page / HAL collection) — **CLOSED 2026-06-16**
+  (colleague email drafted to send; HAL deposit surfaces in the CIRED
+  collection post-moderation)
 
 ## Exit criteria
-- [ ] All five children closed
-- [ ] HAL id + arXiv id recorded in the economia-2026 memory and Ha-Duong.bib
+- [x] 4 of 5 children closed (0664, 0666, 0667, 0668); 0665 deferred by choice
+- [ ] arXiv id recorded once 0665 resolves (HAL id hal-05658462 already in Ha-Duong.bib)

--- a/tickets/0665-arxiv-via-hal.erg
+++ b/tickets/0665-arxiv-via-hal.erg
@@ -2,13 +2,13 @@
 Title: arXiv deposit via HAL
 Created: 2026-06-15
 Author: claude
-Blocked-by: 0664
 Label: deferred
 
 --- log ---
 2026-06-15T22:02Z claude created from dissemination tracker 0663
 2026-06-16T08:30Z HDMX-coding-agent note Deferred to the article preprint (~2 months out): this report and the article will overlap heavily, so post ONE canonical arXiv record (the article) rather than report-then-replace. TRIPWIRE: if the article preprint is not clearly on track by ~mid-August 2026, post THIS report to arXiv then (this ticket) instead of waiting — arXiv `replace` handles the later article. Decision + reasoning: see the publication-strategy Imagine [[0675]] and docs/2026-06-09-review.md §1.
 
+2026-06-16T08:52Z HDMX-coding-agent note blocker 0664 closed — Blocked-by removed.
 --- body ---
 ## Context
 Push the manuscript to arXiv from the HAL record (HAL→arXiv transfer), so the

--- a/tickets/closed/0664-hal-deposit-manuscript.erg
+++ b/tickets/closed/0664-hal-deposit-manuscript.erg
@@ -2,10 +2,12 @@
 Title: HAL deposit of the AEDIST technical report (SWORD)
 Created: 2026-06-15
 Author: claude
+Closed: HAL deposit done — hal-05658462 assigned and recorded in Ha-Duong.bib; at moderation (HAL-side process, not author task)
 
 --- log ---
 2026-06-15T22:01Z claude created from dissemination tracker 0663
 
+2026-06-16T08:52Z HDMX-coding-agent closed — HAL deposit done — hal-05658462 assigned and recorded in Ha-Duong.bib; at moderation (HAL-side process, not author task)
 --- body ---
 ## Context
 Deposit the diffused manuscript (tag `economia-2026-report`, commit 2da83d04)

--- a/tickets/closed/0667-homepage-publist-entry.erg
+++ b/tickets/closed/0667-homepage-publist-entry.erg
@@ -2,11 +2,13 @@
 Title: Homepage / Ha-Duong.bib entry for the report
 Created: 2026-06-15
 Author: claude
-Blocked-by: 0664
+Closed: Homepage entry live with clickable HAL link hal-05658462 (own standalone entry in index.html); verified 2026-06-16. Link resolves once moderation clears
 
 --- log ---
 2026-06-15T22:04Z claude created from dissemination tracker 0663
 
+2026-06-16T08:52Z HDMX-coding-agent note blocker 0664 closed — Blocked-by removed.
+2026-06-16T08:52Z HDMX-coding-agent closed — Homepage entry live with clickable HAL link hal-05658462 (own standalone entry in index.html); verified 2026-06-16. Link resolves once moderation clears
 --- body ---
 ## Context
 Add the report to the personal publication list and homepage, mirroring the

--- a/tickets/closed/0668-cired-dissemination.erg
+++ b/tickets/closed/0668-cired-dissemination.erg
@@ -2,11 +2,13 @@
 Title: CIRED dissemination of the report
 Created: 2026-06-15
 Author: claude
-Blocked-by: 0664
+Closed: CIRED dissemination — colleague announcement email drafted for the author to send; HAL deposit carries CIRED/CNRS affiliation so it surfaces in the CIRED HAL collection once moderation clears
 
 --- log ---
 2026-06-15T22:05Z claude created from dissemination tracker 0663
 
+2026-06-16T08:52Z HDMX-coding-agent note blocker 0664 closed — Blocked-by removed.
+2026-06-16T08:52Z HDMX-coding-agent closed — CIRED dissemination — colleague announcement email drafted for the author to send; HAL deposit carries CIRED/CNRS affiliation so it surfaces in the CIRED HAL collection once moderation clears
 --- body ---
 ## Context
 Announce/disseminate the report through CIRED channels (lab working-paper page,


### PR DESCRIPTION
Closes the HAL deposit, homepage, and CIRED dissemination children of tracker 0663 (closes baked in via erg close). 0665 (arXiv) deferred to the article preprint; 0663 stays open on it.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)