### PR TITLE
tickets: renumber 0677→0678 — resolve dup-ID collision

### DIFF
--- a/tickets/0675-imagine-publication-strategy-spring-cleaning.erg
+++ b/tickets/0675-imagine-publication-strategy-spring-cleaning.erg
@@ -68,7 +68,7 @@ TL;DR priority list. The 2026-06-16 conversation builds on it.
 - [ ] MASTERPLAN updated with a dissemination/publications layer.
 - [ ] 0665 arXiv decision confirmed or revised.
 - [ ] Preprint/v2 manuscript cites the Zenodo concept DOI in Data & Code
-      Availability + sets the CITATION.cff DOI to the arXiv id ([[0677]]).
+      Availability + sets the CITATION.cff DOI to the arXiv id ([[0678]]).
 
 ## Links
 

--- a/tickets/0678-manuscript-cite-zenodo-concept-doi.erg
+++ b/tickets/0678-manuscript-cite-zenodo-concept-doi.erg
@@ -6,6 +6,7 @@ Blocked-by: 0665
 
 --- log ---
 2026-06-16T09:30Z HDMX-coding-agent created — durable reminder for the ~2-month preprint pass; auto-surfaces in `erg ready` when 0665 (arXiv) closes.
+2026-06-16T10:40Z HDMX-coding-agent note Renumbered 0677→0678: a parallel session merged 0677-add-claude-rules-map with the same ID (erg optimistic-allocation collision). The 0675 cross-ref was updated; the rules-map ticket keeps 0677.
 
 --- body ---
 ## Context


### PR DESCRIPTION
erg check + make check fail on main with duplicate ID 0677 (parallel session merged 0677-add-claude-rules-map alongside my 0677-manuscript-cite-zenodo). Renumber mine to 0678, fix the one cross-ref in 0675. Rules-map keeps 0677.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)