### PR TITLE
manuscript: cite Open Knowledge Format on the wiki side of the representation question

### DIFF
--- a/report/refs.bib
+++ b/report/refs.bib
@@ -505,6 +505,15 @@
   url          = {https://www.wri.org/research/global-database-power-plants},
 }
 
+@misc{GoogleCloud2026:okf,
+  author       = {{Google Cloud}},
+  title        = {{How the Open Knowledge Format Can Improve Data Sharing}},
+  year         = {2026},
+  url          = {https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/},
+  note         = {Open Knowledge Format (OKF) v0.1: a directory of Markdown
+                  files with YAML frontmatter, file path as concept identity},
+}
+
 @misc{PyPSAmeetsEarth2025:pypsa-asean,
   author       = {{PyPSA meets Earth}},
   title        = {{PyPSA-ASEAN: A Flexible Python-Based Open Optimisation Model

--- a/slides/manuscript/main.tex
+++ b/slides/manuscript/main.tex
@@ -1117,7 +1117,11 @@ mid-lifecycle, contested sources, multilingual records, conditional
 projections) are where language-model reasoning earns its place. This
 leaves open which representation should be canonical: the narrative asset
 page, the knowledge graph, or an append-only claim log of which both are
-projections. One design lesson the articulation findings already
+projections. The narrative-page option now has an open interchange
+format: the Open Knowledge Format \citep{GoogleCloud2026:okf} encodes
+such a wiki as a directory of Markdown files with YAML frontmatter, the
+file path carrying concept identity and inter-file links carrying
+relations. One design lesson the articulation findings already
 license: extracting structure from text is the lossy, measured
 direction; rendering text from structure is cheap. That asymmetry argues
 for extracting claims once at ingest and rendering derived


### PR DESCRIPTION
The Future-research discussion (§Future research) poses which representation should be canonical for the stateful knowledge base: the narrative asset page, the knowledge graph, or an append-only claim log. The narrative-page (wiki) side now has a concrete open interchange format — Google Cloud's **Open Knowledge Format** (OKF v0.1): a directory of Markdown files with YAML frontmatter, file path as concept identity, inter-file links as relations.

This adds one sentence naming OKF with a `\citep`, plus the `@misc` bib entry (named key, blog-post URL). Grounds the otherwise-notional "narrative asset page" option in an existing, citable spec.

Source: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/

**Verification**
- Manuscript builds clean (`tectonic -r 2`, 604 KiB); citation resolves with no undefined-reference warning.
- `tests/test_manuscript_crossref.py` + `tests/test_manuscript_em_dash.py` pass (8 passed).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)