### PR TITLE
chore: centralize value-matched AEDIST secrets via KEYS=, track openrouter decision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ report/inputs/feeds/*
 
 # Migration backups
 *.jsonl.bak-*
+# Secret-store migration backups of .env (ticket 0679) — never track these
+.env.bak-*
 
 # Derived markdown artifacts from SOTA experiment runs (ticket 0291)
 # These are extracted from raw JSON during post-processing, not primary data

--- a/tickets/0679-centralize-env-secrets-via-keys.erg
+++ b/tickets/0679-centralize-env-secrets-via-keys.erg
@@ -1,0 +1,115 @@
+%erg 0.1
+Title: Centralize value-matched AEDIST secrets via KEYS= mechanism
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T00:00Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+The harness `bash-env.sh` now supports a least-privilege provider-secret
+mechanism: a project declares `KEYS=<prov1,prov2>` in its `$PWD/.env`, and the
+harness sources only the named user-owned `~/.config/keys/<prov>.env` files
+(names validated `^[a-z0-9-]+$`, default-deny). The untrusted project `.env` is
+strict-parsed (never sourced) and any `GUARD_*`/`_GUARD_*` key is refused.
+
+`AEDIST/.env` currently holds inline copies of secrets that also live in the
+central store. This ticket deduplicates the cleanly value-matched ones into the
+central store's coverage and replaces them with a single `KEYS=` line, so the
+canonical value lives in one place.
+
+## Name map (central store -> AEDIST vars)
+
+| Central file           | Provides                                   |
+|------------------------|--------------------------------------------|
+| `github.env`           | `AGENT_GH_TOKEN`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL` |
+| `huggingface.env`      | `HF_TOKEN`                                  |
+| `zenodo.env`           | `ZENODO_TOKEN`                              |
+| `hal.env`              | `HAL_ID`, `HAL_PASSWORD`                    |
+| `openrouter.env`       | only suffixed keys (`OPENROUTER_API_KEY_AEDIST`, ...), no plain `OPENROUTER_API_KEY` |
+
+## Value-equality verdicts (booleans only; no secret values inspected)
+
+| Var                  | Central file       | Verdict  |
+|----------------------|--------------------|----------|
+| `AGENT_GH_TOKEN`     | `github.env`       | MISMATCH |
+| `AGENT_GIT_NAME`     | `github.env`       | MATCH    |
+| `AGENT_GIT_EMAIL`    | `github.env`       | MATCH    |
+| `HF_TOKEN`           | `huggingface.env`  | MATCH    |
+| `ZENODO_TOKEN`       | `zenodo.env`       | MATCH    |
+| `HAL_ID`             | `hal.env`          | MATCH    |
+| `HAL_PASSWORD`       | `hal.env`          | MATCH    |
+
+## Provider coverage decision
+
+A provider is eligible for the `KEYS=` line only if EVERY AEDIST var it supplies
+matched central. `github.env` supplies all three `AGENT_*` vars, and
+`AGENT_GH_TOKEN` MISMATCHES — sourcing `github.env` would overwrite the AEDIST
+token with the (different) central one. So `github` is excluded entirely and all
+three `AGENT_*` vars stay inline (the two matching ones are only reachable via
+`github.env`, which also carries the mismatched token).
+
+Fully-covered providers -> `KEYS=huggingface,zenodo,hal`
+Migrated vars (removed from `.env`): `HF_TOKEN`, `ZENODO_TOKEN`, `HAL_ID`, `HAL_PASSWORD`.
+Stayed inline: `AGENT_GH_TOKEN` (mismatch), `AGENT_GIT_NAME` + `AGENT_GIT_EMAIL`
+(match but tied to excluded `github`), `OPENROUTER_API_KEY` (see decision below).
+
+## Load-simulation result
+
+- Against the MERGED mechanism (`origin/main:scripts/bash-env.sh`): all 8
+  original vars resolve identically to the pre-migration backup. The mapping is
+  CORRECT.
+- Against the LIVE runtime (`/home/haduong/.claude/scripts/bash-env.sh`, the file
+  named by `settings.json` `BASH_ENV`): the 4 migrated vars are MISSING. The live
+  `~/.claude` checkout is ~29 commits behind `origin/main` and its `bash-env.sh`
+  still lacks KEYS support; local `main` could not fast-forward (dirty with
+  another session's memory work).
+
+Because the gate is defined against the live runtime and it FAILED, the `.env`
+edit was ROLLED BACK. AEDIST keeps its inline secrets (status quo); all 8 vars
+still load. The migration is verified-correct and ready to apply once the live
+`bash-env.sh` gains KEYS support (local `main` pulls `origin/main`).
+
+## Rollback
+
+`AEDIST/.env.bak-premigration` (git-ignored via `.env.bak-*`) is a byte-identical
+snapshot taken before the edit. The apply was reverted from it; it is kept as the
+snapshot to reuse when re-applying post-sync.
+
+## Re-apply procedure (once live bash-env.sh supports KEYS)
+
+1. Confirm `grep -c config/keys /home/haduong/.claude/scripts/bash-env.sh` > 0.
+2. Re-run the value-equality check (verdicts may have changed).
+3. Remove `HF_TOKEN`/`ZENODO_TOKEN`/`HAL_ID`/`HAL_PASSWORD` lines from `.env`,
+   add `KEYS=huggingface,zenodo,hal` near the top.
+4. Load-sim against the live `bash-env.sh` with `PWD=AEDIST`; keep only if all 8
+   vars resolve identically to the backup.
+
+## Decision needed: OPENROUTER_API_KEY
+
+The central `openrouter.env` holds only suffixed keys (`OPENROUTER_API_KEY_AEDIST`
+and other projects' keys) and no plain `OPENROUTER_API_KEY`, so it cannot supply
+AEDIST's `OPENROUTER_API_KEY` without either renaming or leaking other projects'
+keys into the AEDIST process. Options:
+
+- (a) Leave `OPENROUTER_API_KEY` inline in `AEDIST/.env` (status quo).
+- (b) Create a per-project `~/.config/keys/openrouter-aedist.env` holding the
+  canonical `OPENROUTER_API_KEY`, and add `openrouter-aedist` to the `KEYS=` line.
+  Keeps least-privilege, no cross-project key leak. RECOMMENDED.
+- (c) Rename/restructure the shared `openrouter.env` to expose a plain
+  `OPENROUTER_API_KEY`. REJECTED — sourcing it would load every other project's
+  OpenRouter key into the AEDIST process, defeating least-privilege.
+
+General finding: multi-key provider files (a single central file bundling several
+projects' keys under suffixed names) undercut the least-privilege intent of
+`KEYS=`, because a provider is an all-or-nothing source. Per-project provider
+files (option b's shape) are the least-privilege-preserving pattern.
+
+## Exit criteria
+
+- [ ] Live `bash-env.sh` supports KEYS (local `~/.claude` main synced).
+- [ ] Value-matched providers migrated to `KEYS=huggingface,zenodo,hal`;
+      load-sim against the live runtime passes for all 8 vars.
+- [ ] OpenRouter decision (a/b/c) made and applied.


### PR DESCRIPTION
## Summary

Deduplicates AEDIST's inline `.env` secrets into the central user store
(`~/.config/keys/<prov>.env`) using the harness `bash-env.sh` `KEYS=` mechanism.
No secret value was ever displayed; equality was checked as booleans only.

**Value-equality verdicts (central vs AEDIST inline):**

| Var | Provider | Verdict |
|-----|----------|---------|
| `AGENT_GH_TOKEN` | github | MISMATCH |
| `AGENT_GIT_NAME` | github | MATCH |
| `AGENT_GIT_EMAIL` | github | MATCH |
| `HF_TOKEN` | huggingface | MATCH |
| `ZENODO_TOKEN` | zenodo | MATCH |
| `HAL_ID` | hal | MATCH |
| `HAL_PASSWORD` | hal | MATCH |

**Fully-covered providers → `KEYS=huggingface,zenodo,hal`.** `github` is excluded
(its `AGENT_GH_TOKEN` mismatches central, and sourcing `github.env` would clobber
the token), so all three `AGENT_*` vars stay inline. `OPENROUTER_API_KEY` stays
inline (no plain central provider — decision pending).

## Load-simulation

- **Merged mechanism** (`origin/main:scripts/bash-env.sh`): all 8 vars resolve
  identically to the pre-migration backup → mapping CORRECT.
- **Live runtime** (`settings.json` `BASH_ENV` → `~/.claude/scripts/bash-env.sh`):
  the 4 KEYS vars are MISSING. The live `~/.claude` checkout is ~29 commits behind
  `origin/main` and lacks KEYS support; local `main` could not fast-forward (dirty
  with another session's work).

The gate is defined against the live runtime and it FAILED, so **the `.env` edit
was rolled back** — AEDIST keeps its inline secrets (status quo), all 8 vars still
load. The migration is ready to apply once the live `bash-env.sh` gains KEYS
support. `.env.bak-premigration` (now git-ignored via `.env.bak-*`) is the
byte-identical rollback snapshot.

## Diff scope

`.env` is git-ignored, so this PR carries only the tracking ticket plus a
one-line `.gitignore` hardening (`.env.bak-*`) protecting the secret backup. The
actual secret move is an untracked-file operation done (and reverted) on disk.

## OpenRouter decision (open)

Central `openrouter.env` has only suffixed keys (`OPENROUTER_API_KEY_AEDIST`,
plus other projects'), no plain `OPENROUTER_API_KEY`. Options: (a) leave inline
(status quo); (b) create `~/.config/keys/openrouter-aedist.env` and add
`openrouter-aedist` to `KEYS=` — **recommended**, least-privilege, no cross-project
leak; (c) restructure the shared file — rejected (leaks other projects' keys).
General finding: multi-key bundled provider files undercut `KEYS=` least-privilege.

Ticket stays open pending the OpenRouter decision and the harness re-sync.

Ticket-ref: tickets/0679-centralize-env-secrets-via-keys.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)