### PR TITLE
chore(0679): close — env-secret migration applied and verified

### DIFF
--- a/tickets/closed/0679-centralize-env-secrets-via-keys.erg
+++ b/tickets/closed/0679-centralize-env-secrets-via-keys.erg
@@ -2,9 +2,12 @@
 Title: Centralize value-matched AEDIST secrets via KEYS= mechanism
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: migration applied and verified; centralized via KEYS= least-privilege, dead GH token replaced by valid central
 
 --- log ---
 2026-07-14T00:00Z Minh Ha-Duong created
+2026-07-14T16:13Z Minh Ha-Duong note migration applied+verified; inline AGENT_GH_TOKEN was dead(401), replaced by valid central token via github:AGENT_GH_TOKEN(200); openrouter via explicit KEYS selection, no new files; all 8 vars resolve
+2026-07-14T16:13Z Minh Ha-Duong closed — migration applied and verified; centralized via KEYS= least-privilege, dead GH token replaced by valid central
 
 --- body ---
 ## Context
@@ -87,29 +90,54 @@ snapshot to reuse when re-applying post-sync.
 4. Load-sim against the live `bash-env.sh` with `PWD=AEDIST`; keep only if all 8
    vars resolve identically to the backup.
 
-## Decision needed: OPENROUTER_API_KEY
+## Outcome: applied and verified (2026-07-14)
 
-The central `openrouter.env` holds only suffixed keys (`OPENROUTER_API_KEY_AEDIST`
-and other projects' keys) and no plain `OPENROUTER_API_KEY`, so it cannot supply
-AEDIST's `OPENROUTER_API_KEY` without either renaming or leaking other projects'
-keys into the AEDIST process. Options:
+The migration is APPLIED and VERIFIED against the live runtime. The project `.env`
+now carries only a non-secret selection line (all inline secrets removed):
 
-- (a) Leave `OPENROUTER_API_KEY` inline in `AEDIST/.env` (status quo).
-- (b) Create a per-project `~/.config/keys/openrouter-aedist.env` holding the
-  canonical `OPENROUTER_API_KEY`, and add `openrouter-aedist` to the `KEYS=` line.
-  Keeps least-privilege, no cross-project key leak. RECOMMENDED.
-- (c) Rename/restructure the shared `openrouter.env` to expose a plain
-  `OPENROUTER_API_KEY`. REJECTED — sourcing it would load every other project's
-  OpenRouter key into the AEDIST process, defeating least-privilege.
+```
+KEYS=huggingface,zenodo,hal,github:AGENT_GH_TOKEN,github:AGENT_GIT_NAME,github:AGENT_GIT_EMAIL,openrouter:OPENROUTER_API_KEY_AEDIST=OPENROUTER_API_KEY
+```
 
-General finding: multi-key provider files (a single central file bundling several
-projects' keys under suffixed names) undercut the least-privilege intent of
-`KEYS=`, because a provider is an all-or-nothing source. Per-project provider
-files (option b's shape) are the least-privilege-preserving pattern.
+Load-simulation via the live `bash-env.sh` (with `PWD=repo`) confirms all 8
+required vars resolve: `AGENT_GH_TOKEN`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL`,
+`OPENROUTER_API_KEY`, `HF_TOKEN`, `ZENODO_TOKEN`, `HAL_ID`, `HAL_PASSWORD`.
+
+Refinement over the earlier plan: the `KEYS=` grammar supports per-key selection
+(`provider:VAR`) and rename-on-select (`provider:SRC=DST`). This supersedes the
+all-or-nothing provider exclusion of the "Provider coverage decision" section
+above — `github` is no longer excluded. Its three `AGENT_*` vars are pulled by
+explicit per-key selection, so the mismatched-token concern is moot: the central
+value is chosen deliberately.
+
+Latent-bug fix: the inline `AGENT_GH_TOKEN` in the project `.env` was DEAD —
+GitHub returned HTTP 401 Bad credentials (despite a comment claiming expiry
+2027-01-03). Replacing it with the valid central `~/.config/keys/github.env`
+token via `github:AGENT_GH_TOKEN` verified HTTP 200 (login MinhHaDuong). The
+migration also fixed a broken-auth bug. Note (non-blocking, out of scope): the
+valid central token is the personal MinhHaDuong identity while
+`AGENT_GIT_NAME`/`AGENT_GIT_EMAIL` name the HDMX-coding-agent machine user; the
+author may optionally mint a dedicated machine-user PAT later.
+
+## Decision: OPENROUTER_API_KEY — resolved
+
+Resolved to explicit per-key selection with rename, no new key file: the shared
+`openrouter.env` is selected for exactly one key via
+`openrouter:OPENROUTER_API_KEY_AEDIST=OPENROUTER_API_KEY`. This is option
+(b)-equivalent (least-privilege preserved, no cross-project key leak) WITHOUT
+creating `~/.config/keys/openrouter-aedist.env` — the per-key selection grammar
+makes the extra file unnecessary. Only the AEDIST key enters the process; sibling
+keys in `openrouter.env` never do. Option (c) stays rejected.
+
+General finding retained: a provider file is an all-or-nothing *source* only when
+selected by bare provider name; the `provider:VAR` grammar restores per-key
+least-privilege on multi-key central files, so no per-project file split is
+needed.
 
 ## Exit criteria
 
-- [ ] Live `bash-env.sh` supports KEYS (local `~/.claude` main synced).
-- [ ] Value-matched providers migrated to `KEYS=huggingface,zenodo,hal`;
+- [x] Live `bash-env.sh` supports KEYS (local `~/.claude` main synced).
+- [x] Value-matched providers migrated to a `KEYS=` selection line;
       load-sim against the live runtime passes for all 8 vars.
-- [ ] OpenRouter decision (a/b/c) made and applied.
+- [x] OpenRouter decision made and applied (explicit `provider:SRC=DST` selection,
+      no new file).


### PR DESCRIPTION
Closes ticket 0679: the KEYS= least-privilege secret-centralization migration is now **applied and verified** against the live runtime.

## Outcome
- Project `.env` now carries only a non-secret `KEYS=` selection line; all inline secrets removed.
- Load-simulation via the live `bash-env.sh` (with `PWD=repo`) resolves all 8 required vars: `AGENT_GH_TOKEN`, `AGENT_GIT_NAME`, `AGENT_GIT_EMAIL`, `OPENROUTER_API_KEY`, `HF_TOKEN`, `ZENODO_TOKEN`, `HAL_ID`, `HAL_PASSWORD`.
- **OpenRouter decision resolved**: explicit per-key selection with rename (`openrouter:OPENROUTER_API_KEY_AEDIST=OPENROUTER_API_KEY`) — least-privilege preserved, no new key file, sibling keys never enter the process.
- **Latent bug fixed**: the inline `AGENT_GH_TOKEN` was dead (GitHub HTTP 401 Bad credentials despite a comment claiming 2027 expiry); replaced by the valid central `github.env` token via `github:AGENT_GH_TOKEN`, verified HTTP 200 (login MinhHaDuong).

This PR only records the ticket closure (moved to `tickets/closed/`); no secret values are touched. The ticket was closed in the commit, so this references without re-closing.

Ticket-ref: tickets/0679-centralize-env-secrets-via-keys.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)