### PR TITLE
chore: absorb benchmark manuscript and engineering docs from papiers/

### DIFF
--- a/docs/alignment_analysis.md
+++ b/docs/alignment_analysis.md
@@ -1,0 +1,167 @@
+# Alignement : repos existants ↔ aedist-bench
+
+## 1. Cartographie des repos existants
+
+### `aedist-feasibility-demonstrator/` (code)
+
+| Composant | Fichier(s) | Fonction | État |
+|---|---|---|---|
+| **Query LLM** | `src/query.py` | Interroge N modèles via OpenRouter, sauve JSON (prompt + réponse + usage) | ✅ Fonctionnel |
+| **Modèles** | `src/models.yaml` | Registre de 15 modèles (Claude, GPT-4o, DeepSeek, Llama, Qwen, Grok, etc.) | ✅ Complet |
+| **Prompt** | `src/prompts/prompt1.txt` | Prompt simple (single-shot CSV) | ✅ Prompt 1 seul ; prompt 2 et relances absents du repo |
+| **Convert→LaTeX** | `src/convert.py` | Compte les lignes CSV dans les réponses, génère macros + tables LaTeX | ✅ Partiel : données relances/RAG hardcodées |
+| **Nettoyage** | `compare/PowerPlantDataframeCleaner/` | Normalise noms, provinces, fuels, capacités, statuts via config JSON | ✅ Robuste, config-driven |
+| **Matching LP** | `compare/Matching/lp.py` | MILP (PuLP) : fuzzy names + capacité → assignement optimal | ✅ Sophistiqué |
+| **Matching phased** | `compare/Matching/phased.py` | Alternative : exact → fuzzy en 2 passes | ✅ Non utilisé (commenté) |
+| **Réconciliation** | `compare/reconcile.py` | Orchestre : load CSV → clean → group by (province, fuel) → match → CSV résultat | ✅ Fonctionnel |
+| **Référence** | `compare/input/HDM.csv` | 251 lignes (unités), 5 colonnes | ✅ Niveau unité |
+| **Référence agrégée** | `compare/input/HDM_aggregated.csv` | 164 lignes (centrales), 6 colonnes | ✅ Niveau central |
+| **Outputs LLM** | `compare/input/Claude_*.csv` | 4 fichiers : concise, normal, RAG18, relance | ✅ Claude seul |
+| **GEM** | `compare/input/GEM.csv` + `GEM_aggregated.csv` | 308/153 lignes, Global Energy Monitor | ✅ Comparateur externe |
+| **PDF→MD** | `pdfOCR2md/pdfOCR2md.py` | Pipeline PDF → OCR → Markdown | ✅ Prototype |
+
+### `aedist-technical-report/` (rapport)
+
+| Composant | Fichier(s) | Fonction | État |
+|---|---|---|---|
+| **Rapport** | `report.tex` | ~1600 lignes LaTeX, 9 chapitres | ✅ Complet mais à restructurer (cf TODO.md) |
+| **Biblio** | `refs.bib` | Références | ✅ |
+| **Build** | `Makefile` | `make query`, `make tables`, `make` (tectonic) | ✅ |
+| **Inputs** | `inputs/` | Zotero list, energy stats knowledge | ✅ |
+| **TODO** | `TODO.md` | Plan de révision détaillé | ✅ Aligné avec notre discussion |
+
+**Lien report→code** : Le Makefile du rapport invoque `aedist/src/query.py` et `aedist/src/convert.py` — il attend le repo code comme sous-dossier `aedist/`.
+
+---
+
+## 2. Matrice d'alignement : existant ↔ aedist-bench
+
+| Fonction aedist-bench | Existant dans les repos | Écart | Action |
+|---|---|---|---|
+| **Schema Pydantic** (`schema.py`) | Implicite dans les colonnes CSV + `config.json` | Le code existant n'a pas de schéma formel ; les colonnes sont {name, province, fuel, capacity, status} | **Créer** le schéma Pydantic comme couche au-dessus du cleaner existant |
+| **Normalisation** (`normalize.py`) | `PowerPlantDataframeCleaner` (config-driven, diacritics strip, regex) | Le cleaner existant est plus complet (config JSON extensible, roman→arabic). Notre `normalize.py` est plus simple. | **Adopter** le cleaner existant comme backend, wrapper Pydantic par-dessus |
+| **Matching** (`match.py`) | `Matching/lp.py` (MILP optimal) + `Matching/phased.py` (greedy 2-pass) | Notre match.py est un greedy 2-pass similaire à `phased.py`. Le LP est strictement supérieur (optimal global). | **Adopter** `lp.py` comme matcher par défaut, garder greedy comme fallback rapide |
+| **Métriques** (`metrics.py`) | Compteurs dans `reconcile.py` (matched/fuzzy/only_in_file1/file2) | Les métriques existantes sont des comptes bruts. Il manque : coverage/precision/F1, fuel/status accuracy, taxonomie d'erreurs. | **Étendre** : ajouter le calcul de métriques formelles sur les résultats existants |
+| **Runner CLI** (`runner.py`) | `reconcile.py` (argparse file1 file2) | Le runner existant compare 2 fichiers quelconques. Le nôtre évalue un système vs référence fixe. | **Adapter** : spécialiser pour l'usage benchmark (référence = HDM, système = output LLM) |
+| **Référence dataset** | `HDM.csv` (251 unités) + `HDM_aggregated.csv` (164 centrales) | Le dataset existe mais : (a) pas versionné formellement, (b) pas de COD, (c) statuts codés "3 permitted" pas "planned" | **Nettoyer** HDM_aggregated → `vietnam_thermal_v1.csv` avec schéma canonique |
+| **Outputs LLM** | 4 fichiers Claude uniquement | Manquent : GPT-4o, DeepSeek, o3-mini, Llama, RAG configs | **Compléter** via `query.py` (prompt 1 déjà automatisé) + collecter manuellement les runs RAG |
+| **Prompts** | `prompt1.txt` seul | Manquent : prompt2 (structuré), prompt relance | **Ajouter** au repo |
+| **LaTeX generation** | `convert.py` → macros + tables | Données relances/RAG hardcodées avec TODO pour automation | **Connecter** aux métriques de aedist-bench une fois calculées |
+| **Groupement province×fuel** | `reconcile.py` groupe par (province, fuel) avant matching | Notre bench ne groupe pas — matching global | **Décision** : le groupement est-il souhaitable ? Avantage : réduit les faux positifs cross-province. Inconvénient : rate les erreurs de province. |
+
+---
+
+## 3. Décisions architecturales
+
+### 3.1 Mono-repo vs multi-repo
+
+**État actuel** : 2 repos séparés, le rapport inclut le code comme sous-dossier.
+
+**Options** :
+
+| Option | Pro | Contra |
+|---|---|---|
+| A. Garder 2 repos, ajouter `aedist-bench` comme 3e | Séparation des responsabilités | 3 repos à synchroniser |
+| B. Fusionner code + bench dans un repo, rapport séparé | Un seul repo pour tout le code Python | Rapport continue à pointer vers sous-dossier |
+| **C. Mono-repo : rapport + code + bench** | Tout ensemble, Makefile simplifié | Repo plus gros mais cohérent |
+
+**Recommandation** : **Option B** — fusionner `aedist-feasibility-demonstrator` et `aedist-bench` dans un seul repo `aedist`. Le rapport reste séparé (il a sa propre logique de build LaTeX) et pointe vers le repo code.
+
+### 3.2 Réutiliser vs réécrire le matching
+
+**Recommandation** : Réutiliser `lp.py` (MILP). C'est une contribution technique du projet — le matching optimal par programmation linéaire est plus rigoureux que le greedy et publiable. Ajouter les métriques formelles (coverage, precision, F1) par-dessus.
+
+**Adaptation nécessaire** : `lp.py` attend des DataFrames avec colonnes `name_clean`, `capacity_clean`. Il faut :
+1. Un adaptateur Pydantic `list[Plant]` → DataFrame avec colonnes attendues
+2. Un adaptateur retour DataFrame résultats → `list[ReconciliationEntry]`
+
+### 3.3 Granularité : unité vs centrale
+
+**État actuel** : HDM.csv est au niveau unité (251 lignes), HDM_aggregated au niveau centrale (164). Les outputs LLM sont au niveau central.
+
+**Recommandation** : Le benchmark opère au **niveau central** (cohérent avec ce que les LLMs produisent). Garder HDM_aggregated comme référence. Documenter la règle d'agrégation (strip "Unit N" suffix, sum capacities within same plant+status).
+
+### 3.4 Groupement province×fuel
+
+**Le code existant** groupe par (province, fuel) avant matching — ce qui empêche de matcher "Vĩnh Tân" si le LLM met la mauvaise province.
+
+**Recommandation** : Le benchmark ne doit **pas** grouper. Le matching global (sur tout le dataset) est plus fidèle à la tâche réelle. Les erreurs de province/fuel sont capturées séparément dans les métriques d'attributs.
+
+---
+
+## 4. Plan de migration concret
+
+### Phase 1 : Consolider le dataset de référence
+
+```
+HDM_aggregated.csv  →  data/reference/vietnam_thermal_v1.csv
+```
+
+- Renommer colonnes → schéma canonique (Name→name, Capacity→capacity_mwe, etc.)
+- Normaliser statuts : "5 operating"→"operational", "9 cancelled"→"cancelled", etc.
+- Ajouter COD là où disponible (source : rapport chap. 5)
+- Versionner (git tag v1.0)
+
+### Phase 2 : Adapter le matching existant
+
+```python
+# Nouveau fichier : src/aedist_bench/match_lp.py
+# Wrapper autour de compare/Matching/lp.py
+
+def reconcile_lp(reference: list[Plant], system: list[Plant], ...) -> list[ReconciliationEntry]:
+    """Adapte lp.reconcile() pour l'interface Pydantic du benchmark."""
+    ref_df = plants_to_dataframe(reference)   # → colonnes name, name_clean, capacity_clean
+    sys_df = plants_to_dataframe(system)
+    result_df = lp.reconcile(ref_df, sys_df)
+    return dataframe_to_entries(result_df)     # → list[ReconciliationEntry]
+```
+
+- Réutiliser `PowerPlantDataframeCleaner` pour la normalisation
+- Réutiliser `lp.py` pour le matching
+- Supprimer le groupement province×fuel (matching global)
+- Ajouter `metrics.py` par-dessus
+
+### Phase 3 : Collecter les outputs manquants
+
+| Configuration | Source | Fichier cible |
+|---|---|---|
+| LLM direct (prompt 1) × 15 modèles | `query.py` via OpenRouter | `outputs/llm_direct/{model}.csv` |
+| LLM multi-turn (prompt 2 + relances) | Manuellement (les relances ne sont pas automatisables via API simple) | `outputs/llm_multiturn/{model}_prompt2_relance{n}.csv` |
+| RAG curated | Manuellement (requires doc injection) | `outputs/rag_curated/{model}.csv` |
+| RAG extended | Manuellement | `outputs/rag_extended/{model}.csv` |
+
+### Phase 4 : Générer les résultats pour le papier
+
+```bash
+# Évaluer chaque output
+for f in outputs/**/*.csv; do
+    aedist-bench evaluate "$f" --format json >> results/summary/all_metrics.json
+done
+
+# Générer les tables LaTeX pour le rapport
+aedist-bench report --output paper/tables/
+```
+
+### Phase 5 : Aligner le rapport
+
+Le `TODO.md` du rapport est déjà aligné avec cette stratégie. Changements clés :
+- Chap 2+3 fusionnés → référencer les métriques du benchmark
+- `convert.py` → remplacer les données hardcodées par lecture de `results/summary/`
+- Conclusion → couper le grant proposal, garder les findings
+
+---
+
+## 5. Fichiers à déplacer / renommer
+
+| Source | Destination dans aedist-bench | Action |
+|---|---|---|
+| `compare/input/HDM_aggregated.csv` | `data/reference/vietnam_thermal_v1.csv` | Nettoyer + renommer colonnes |
+| `compare/input/HDM.csv` | `data/reference/vietnam_thermal_units_v1.csv` | Garder comme référence unités |
+| `compare/input/GEM_aggregated.csv` | `data/reference/gem_thermal.csv` | Comparateur externe |
+| `compare/input/Claude_*.csv` | `outputs/llm_*/claude_sonnet_*.csv` | Renommer par configuration |
+| `compare/Matching/lp.py` | `src/aedist_bench/match_lp.py` | Adapter interface |
+| `compare/PowerPlantDataframeCleaner/` | `src/aedist_bench/cleaner/` | Réutiliser tel quel |
+| `compare/PowerPlantDataframeCleaner/config.json` | `src/aedist_bench/cleaner/config.json` | Idem |
+| `src/query.py` | `src/aedist_bench/query.py` | Réutiliser |
+| `src/models.yaml` | `models.yaml` | Réutiliser |
+| `src/prompts/prompt1.txt` | `prompts/prompt_1_singleshot.txt` | Renommer |

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -1,0 +1,64 @@
+# aedist-bench — Benchmark for AI-Assisted Production of Economic Statistics
+
+## Repository Structure
+
+```
+aedist-bench/
+├── README.md
+├── pyproject.toml
+├── src/
+│   └── aedist_bench/
+│       ├── __init__.py
+│       ├── schema.py          # Pydantic canonical schema
+│       ├── normalize.py       # Name/capacity/status normalization
+│       ├── match.py           # Exact + fuzzy matching pipeline
+│       ├── metrics.py         # Coverage, precision, justification, error taxonomy
+│       ├── reconcile.py       # Reconciliation table generation
+│       ├── runner.py          # Standardized interface to run & evaluate any system
+│       └── report.py          # Summary statistics + reconciliation CSV/Parquet output
+├── data/
+│   ├── reference/
+│   │   ├── vietnam_thermal_v1.csv       # Expert-compiled gold standard
+│   │   └── README.md                    # Dataset documentation, versioning notes
+│   ├── corpus/
+│   │   ├── curated/                     # Markdown tables from PDP7/7A/8, EVN reports
+│   │   ├── extended/                    # + additional EVN annual reports, GEM tables
+│   │   └── README.md                    # Corpus manifest: source, date, token count
+│   └── aliases/
+│       ├── plant_aliases.csv            # Known name variants → canonical name
+│       └── province_aliases.csv         # Province name normalization table
+├── prompts/
+│   ├── prompt_1_singleshot.txt
+│   ├── prompt_2_structured.txt
+│   └── prompt_relance.txt
+├── outputs/                             # System outputs (one CSV per run)
+│   ├── llm_direct/
+│   ├── llm_multiturn/
+│   ├── rag_curated/
+│   └── rag_extended/
+├── results/
+│   ├── reconciliation/                  # Per-run reconciliation tables
+│   └── summary/                         # Aggregate metrics tables
+├── tests/
+│   ├── test_schema.py
+│   ├── test_normalize.py
+│   ├── test_match.py
+│   └── test_metrics.py
+├── paper/
+│   ├── paper_benchmark_merged.md        # Article source
+│   └── figures/
+└── tasks.py                             # Invoke tasks: run, evaluate, report
+```
+
+## Quick Start
+
+```bash
+# Install
+uv sync
+
+# Evaluate a system output against the reference
+aedist-bench evaluate outputs/rag_curated/claude_sonnet_run1.csv
+
+# Run all baselines and generate summary
+aedist-bench run-all --output results/
+```

--- a/manuscripts/benchmark/attic/options.md
+++ b/manuscripts/benchmark/attic/options.md
@@ -1,0 +1,89 @@
+Voici trois façons (assez différentes) de vous y prendre pour **coder un benchmark de système agentique de statistique économique**, en restant aligné avec vos critères de stats (exhaustivité, cohérence, provenance, mise à jour temporelle) et vos métriques (coverage/precision/justification).  
+
+## Approche 1 — “Benchmark d’abord” (pipeline d’évaluation robuste, agents en boîte noire)
+
+Idée : vous construisez un **harness d’évaluation** impeccable et reproductible, et vous branchez dedans n’importe quel système (LLM direct, multi-tour, RAG, agentique), traité comme une boîte noire qui produit une table.
+
+Briques à coder
+
+* **Schéma canonique** (pydantic) : Plant(name, fuel, status, cod_date, province, capacity_mwe, + provenance fields).
+* **Normalisation** : nettoyage unités, dates, alias de noms, mapping statuts (planned/under construction/operational/retired/cancelled), etc.
+* **Matching à la référence** :
+
+  * exact + fuzzy sur noms,
+  * tolérance sur capacités (ex. +/- x%),
+  * règles “plant vs unit vs project”.
+* **Métriques** : coverage (recall), precision, justification rate (sur échantillon) + typologie d’erreurs (hallucination, mauvais fuel/statut, double comptage). 
+* **Outputs** : tables de réconciliation + tableaux de synthèse + artefacts reproductibles (CSV/Parquet + rapport).
+
+Ce que ça vous donne
+
+* Vous pouvez comparer proprement : génération directe vs multi-turn vs RAG vs agentique, et mesurer le trade-off coverage/precision que vous avez déjà observé. 
+* C’est la voie la plus “science expérimentale” : stable, CI-friendly, portable.
+
+Technos suggérées (Python)
+
+* `pydantic`, `pandas`, `rapidfuzz`, `duckdb` (ou sqlite) ; packaging `uv`, qualité `ruff`.
+* Un runner type `invoke`/`typer` + GitHub Actions pour rejouer les expériences.
+
+## Approche 2 — “Agentique instrumenté” (benchmark = évaluer un processus, pas juste une table)
+
+Idée : vous ne benchmarkez pas seulement le résultat final, mais **la chaîne de production** (découverte de sources → extraction → résolution d’entités → consolidation → table), avec logs et états inspectables.
+
+Briques à coder
+
+* **Interface Agent** (contrat) : `run(task, state) -> {table, evidence_graph, logs}`.
+* **State store** (persistant) : tout ce que l’agent “sait” (entités déjà vues, hypothèses, conflits, décisions).
+* **Trace/provenance obligatoire** : chaque cellule de table doit pointer vers un ou plusieurs “supports” (quote + doc_id + date + score confiance). 
+* **Nouvelles métriques de benchmark** (en plus de precision/recall) :
+
+  * **provenance completeness** : % de cellules sourcées,
+  * **conflict handling** : capacité à conserver versions contradictoires (temporellement datées) sans écraser,
+  * **update ability** : après ajout d’un document plus récent, mesure de la révision correcte (diff attendu).
+* **Test d’“auditabilité”** : rejouer l’agent sur le même corpus => mêmes sorties (ou variance explicitée).
+
+Ce que ça vous donne
+
+* Vous testez exactement ce que vous proposez dans votre architecture “stateful, agentic, graph-based” : accumulation, révision, cohérence temporelle, validation humaine tôt dans le pipeline. 
+
+Technos suggérées
+
+* Stockage : SQLite/DuckDB au début, puis éventuellement graph (Neo4j / RDF / TypeDB) si utile.
+* “Evidence graph” minimal : nodes = (doc, claim, entity, attribute, time), edges = “supports/contradicts/updates”.
+
+## Approche 3 — “Benchmark par scénarios de corpus” (document-driven, avec tests d’update et de dérive)
+
+Idée : vous fabriquez un **mini-monde contrôlé** de documents (ou un corpus réel figé), et vous évaluez l’agent sur des scénarios : ajout d’un plan révisé, retrait d’un projet, changement de COD, renommage, etc. C’est idéal pour tester la mise à jour et la cohérence temporelle.
+
+Briques à coder
+
+* **Corpus packagé** (versionné) :
+
+  * `corpus/v1/` (baseline),
+  * `corpus/v2/` (+ nouveaux docs),
+  * `corpus/v3/` (docs contradictoires, corrections).
+* **Truth au fil du temps** : référence `gold_v1`, `gold_v2`, `gold_v3` (pas une seule “vérité”).
+* **Runner de scénarios** :
+
+  * exécute l’agent sur v1 → score,
+  * puis “ingère delta” v2 → score d’update,
+  * puis v3 → score de résolution de conflits.
+* **Métriques dédiées update** :
+
+  * exactitude des deltas (changements attendus vs observés),
+  * stabilité des invariants (ce qui ne devait pas bouger ne bouge pas),
+  * coût (tokens/temps) par amélioration de coverage.
+
+Ce que ça vous donne
+
+* Un benchmark qui répond directement à votre exigence “statistiques = objet accumulatif et révisable” plutôt que génération one-shot. 
+* Une façon très convaincante de montrer pourquoi les systèmes stateless (RAG QA) plafonnent sur la maintenance de tables. 
+
+Si vous voulez choisir vite
+
+* Vous voulez publier/itérer vite et comparer des systèmes hétérogènes : **Approche 1**.
+* Vous voulez tester “agentique + mémoire + provenance” comme contribution centrale : **Approche 2**.
+* Vous voulez démontrer la supériorité sur la **mise à jour** et la **cohérence temporelle** : **Approche 3** (souvent la plus persuasive en papier).
+
+Si vous me dites quel niveau d’agentique vous visez (simple multi-outils vs graphe + état persistant), je peux vous proposer un squelette de repo (arborescence, modèles Pydantic, format des logs, et un runner de scénarios) directement calé sur vos métriques coverage/precision/justification + temporal update.
+

--- a/manuscripts/benchmark/attic/paper_1_benchmark_llm_economic_statistics.md
+++ b/manuscripts/benchmark/attic/paper_1_benchmark_llm_economic_statistics.md
@@ -1,0 +1,79 @@
+---
+title: "Benchmarking Large Language Models for the Generation of Economic Statistics"
+author: "Minh Ha-Duong"
+date: "2025-12-17"
+format:
+  pdf:
+    documentclass: article
+    papersize: a4
+    fontsize: 11pt
+    number-sections: true
+    geometry: margin=2.5cm
+abstract: |
+  This paper introduces a reproducible benchmark to evaluate the ability of large language models (LLMs) to generate economic statistics. Using the concrete task of enumerating thermal power plants in Vietnam, we compare model outputs against an expert-compiled reference dataset. We define quantitative indicators capturing precision, coverage, and the ability to justify generated figures. The benchmark is implemented as open, executable code and applied to a range of model sizes, tuning styles, and prompting strategies. Results show that current LLMs systematically under-produce statistical tables and trade coverage against hallucination, even at large scale. The benchmark highlights structural limits of prompt-based approaches and provides a diagnostic tool for future AI-assisted statistical systems.
+---
+
+## 1. Introduction
+
+Economic statistics require exhaustiveness, internal consistency, correct units, and traceability. These properties sharply contrast with the design objectives of conversational large language models (LLMs), which prioritise brevity and plausibility. Recent progress has raised expectations that LLMs could automate parts of statistical production, especially in data-scarce contexts. This paper evaluates that expectation empirically.
+
+We propose a benchmark focused on a realistic and technically demanding task: producing a complete table of thermal power plants in Vietnam. An expert-made reference list exists, making it possible to quantify performance. Our contribution is methodological: we define a benchmark, metrics, and evaluation pipeline that can be reused for other economic domains.
+
+## 2. Related Work
+
+LLM evaluation has focused on question answering, reasoning, and factual recall. Benchmarks rarely address the generation of structured statistical tables against a gold standard. In economics, evaluation typically concerns forecasting or numerical reasoning rather than data compilation. Our work fills this gap by targeting statistical completeness and reliability.
+
+## 3. Task Definition
+
+The task is to generate a table listing all thermal power plants in Vietnam, with one plant per row. Required attributes include:
+
+- Plant name (canonical)
+- Fuel type (coal, local gas, imported LNG)
+- Status (operational, retired, under construction, planned, cancelled)
+- Connection date (realised or expected COD)
+- Province
+- Installed capacity (MWe)
+
+The task involves ambiguity (plants vs units, projects vs realised assets) and domain-specific knowledge (fuel cycles, naming conventions).
+
+## 4. Reference Dataset
+
+The reference dataset was compiled manually by the author from official planning documents, utility reports, open databases, and long-term expert monitoring. It represents the best available open-source approximation of a national inventory. While not error-free, it provides a consistent benchmark against which model outputs can be compared.
+
+## 5. Benchmark Design
+
+### 5.1 Metrics
+
+We define three core indicators:
+
+- **Coverage (Recall):** share of reference plants identified by the model.
+- **Precision:** share of model-generated plants that correspond to real entries.
+- **Justification ability:** proportion of sampled rows for which the model can provide a plausible source reference.
+
+Errors are further classified (hallucinated plants, wrong fuel, wrong status).
+
+### 5.2 Formalisation
+
+The benchmark is implemented in Python. Model outputs are normalised to a canonical schema and compared to the reference using exact and fuzzy matching on names and capacities. The pipeline produces reconciliation tables and summary statistics.
+
+## 6. Experimental Setup
+
+We test multiple families of models:
+
+- Large proprietary models
+- Open-weight models around 70B parameters
+- Reasoning-oriented variants
+
+Prompting strategies include single-shot queries, structured prompts, and multi-turn conversational elicitation. All outputs are requested in CSV format and processed identically.
+
+## 7. Results
+
+Single-shot prompts typically recover only 25–40% of the reference list. Larger and more recent models perform better but remain far from exhaustive. Multi-turn prompting increases coverage substantially, at the cost of more errors and longer responses. Precision decreases as coverage increases, revealing a structural trade-off.
+
+## 8. Discussion
+
+The results show that LLMs do not behave like statistical instruments. They possess partial knowledge but lack mechanisms to ensure completeness or systematic enumeration. Prompt engineering improves recall but cannot guarantee reliability. These limits are not model-specific but structural.
+
+## 9. Conclusion
+
+We introduce a benchmark for evaluating AI systems on the generation of economic statistics. Applied to thermal power plants in Vietnam, it reveals persistent limitations of current LLMs. The benchmark provides a foundation for evaluating more advanced architectures, including document-augmented and knowledge-based systems, which are explored in the companion paper.

--- a/manuscripts/benchmark/attic/paper_2_is_rag_enough_economic_statistics.md
+++ b/manuscripts/benchmark/attic/paper_2_is_rag_enough_economic_statistics.md
@@ -1,0 +1,80 @@
+---
+title: "Is Retrieval-Augmented Generation Enough to Produce Economic Statistics?"
+author: "Minh Ha-Duong"
+date: "2025-12-17"
+format:
+  pdf:
+    documentclass: article
+    papersize: a4
+    fontsize: 11pt
+    number-sections: true
+    geometry: margin=2.5cm
+abstract: |
+  Retrieval-Augmented Generation (RAG) is often presented as a solution to the unreliability of large language models when producing factual information. This paper evaluates whether RAG is sufficient to generate economic statistics, using the same benchmark and case study as a companion paper: the inventory of thermal power plants in Vietnam. We compare direct LLM generation with several RAG configurations, measuring coverage, precision, and traceability. While RAG substantially improves performance, significant gaps remain. We show that document augmentation alone cannot ensure statistical completeness or consistency, and argue for hybrid architectures combining RAG with explicit data models, entity resolution, and accumulation over time.
+---
+
+## 1. Introduction
+
+Economic statistics demand not only factual correctness but also completeness, stability over time, and explicit sourcing. While Retrieval-Augmented Generation (RAG) improves grounding by providing documents to LLMs, it remains unclear whether this is sufficient for statistical production. This paper addresses that question empirically.
+
+Using the same benchmark as our companion paper, we isolate the effect of RAG on statistical performance and analyse its remaining limitations.
+
+## 2. Background
+
+RAG combines information retrieval with text generation by injecting relevant documents into the model context. It has shown strong results in knowledge-intensive tasks. However, RAG systems are typically optimised for answering questions, not for constructing exhaustive datasets.
+
+## 3. Benchmark and Metrics
+
+We reuse the benchmark introduced in the companion paper, including:
+
+- the expert reference dataset,
+- coverage and precision metrics,
+- reconciliation-based error analysis.
+
+This ensures comparability between LLM-only and RAG-based approaches.
+
+## 4. RAG Configurations
+
+We evaluate several RAG styles:
+
+- **Curated RAG:** a small, manually selected set of authoritative documents.
+- **Extended RAG:** curated documents plus open databases and encyclopaedic sources.
+- **Multi-turn RAG:** iterative prompting with document context retained.
+
+Retrieval is performed at document or table level, and generation is constrained to structured CSV outputs.
+
+## 5. Experimental Protocol
+
+For each configuration, we run the same prompts as in the LLM-only setting, adding retrieved documents to the context. Outputs are normalised and evaluated using the same pipeline. This design isolates the marginal contribution of RAG.
+
+## 6. Results
+
+RAG consistently improves coverage relative to direct generation, in some cases doubling the number of correctly identified plants. Precision generally improves as well, with fewer hallucinated entries. However, even the best configurations remain significantly incomplete relative to the reference.
+
+Models frequently omit plants that are present in the provided documents, misinterpret tables, or conflate units and complexes. Source citation improves but is often superficial.
+
+## 7. Error Analysis
+
+Three persistent failure modes emerge:
+
+1. **Enumeration failure:** models fail to systematically traverse tables.
+2. **Entity resolution errors:** multiple names for the same plant are mishandled.
+3. **Temporal inconsistency:** retired or cancelled projects are inconsistently treated.
+
+These errors are not solved by retrieval alone.
+
+## 8. Beyond RAG
+
+Our results suggest that RAG is a necessary but insufficient component of a statistical system. Additional layers are required:
+
+- explicit data models and ontologies,
+- entity resolution and data fusion,
+- provenance tracking at the row level,
+- accumulation and revision over time.
+
+These features lie outside the scope of standard RAG pipelines.
+
+## 9. Conclusion
+
+RAG significantly improves the ability of LLMs to generate economic statistics, but it does not close the gap to expert-level datasets. Economic statistics require systems that treat data as first-class objects rather than as text to be summarised. RAG should be seen as one component in a broader hybrid architecture, not as a complete solution.
+

--- a/manuscripts/benchmark/paper_benchmark_merged.md
+++ b/manuscripts/benchmark/paper_benchmark_merged.md
@@ -1,0 +1,301 @@
+---
+title: "Can AI Produce Economic Statistics? A Benchmark on Energy Infrastructure Inventories"
+author: "Minh Ha-Duong"
+date: "2026"
+format:
+  pdf:
+    documentclass: article
+    papersize: a4
+    fontsize: 11pt
+    number-sections: true
+    geometry: margin=2.5cm
+abstract: |
+  Economic statistics demand exhaustiveness, internal consistency, explicit provenance, and the ability to be updated over time. These requirements sharply contrast with the design objectives of large language models and Retrieval-Augmented Generation systems. This paper introduces a reproducible benchmark to evaluate whether AI systems can produce economic statistics, using the concrete task of inventorying thermal power plants in Vietnam. We define quantitative metrics—coverage, precision, and justification ability—and apply them to a range of model families, prompting strategies, and RAG configurations. Results show that multi-turn prompting triples the coverage of single-shot queries, and RAG doubles it further, but even the best configurations remain significantly incomplete relative to an expert-compiled reference of ~135 plants. Three persistent failure modes—enumeration errors, entity resolution failures, and temporal inconsistency—are not resolved by retrieval alone. We argue that economic statistics require stateful architectures treating data as first-class objects rather than text to be summarised, and release the benchmark as an open evaluation framework.
+keywords:
+  - economic statistics
+  - large language models
+  - retrieval-augmented generation
+  - benchmark
+  - energy transition
+  - Vietnam
+---
+
+# 1. Introduction
+
+<!-- ~1.5 pages -->
+
+Economic statistics are a core infrastructure for applied economics, policy analysis, and quantitative modelling. Unlike question answering or summarisation, statistical production requires exhaustiveness, internal consistency, temporal coherence, explicit provenance, and updatability.
+
+This paper asks: **can current AI systems—LLMs and RAG pipelines—produce economic statistics?**
+
+We answer empirically, using a demanding test case: inventorying all thermal power plants in Vietnam (~135 documented plants, coal/gas, all statuses from retired to cancelled). An expert-compiled reference dataset exists, enabling quantitative evaluation.
+
+**Contributions:**
+
+1. A reproducible benchmark for evaluating AI systems on the production of structured economic statistics, with metrics capturing exhaustiveness, precision, and traceability.
+2. A systematic comparison of direct LLM generation, multi-turn prompting, and several RAG configurations—within a unified evaluation framework.
+3. An error analysis identifying three structural failure modes that persist across all approaches, demonstrating that RAG is necessary but insufficient.
+4. An open-source evaluation pipeline and reference dataset.
+
+<!-- Distinguish from standard NLP benchmarks (QA, reasoning, factual recall) -->
+<!-- Motivate the energy transition modelling angle: outdated data → invalid PyPSA scenarios -->
+<!-- Cite Gotzens et al. 2019 on data quality in power plant databases -->
+
+**Outline.** Section 2 reviews related work. Section 3 defines the task, reference dataset, and metrics. Section 4 describes the experimental setup. Section 5 presents results. Section 6 analyses errors. Section 7 discusses implications. Section 8 concludes.
+
+
+# 2. Related Work
+
+<!-- ~1 page -->
+
+## 2.1 LLM Evaluation
+
+<!-- Standard benchmarks (MMLU, HellaSwag, etc.) focus on QA, reasoning, factual recall -->
+<!-- Gap: no benchmark targets the generation of structured statistical tables against a gold standard -->
+<!-- Mention data extraction benchmarks (e.g., information extraction, table understanding) as adjacent but distinct -->
+
+## 2.2 RAG for Knowledge-Intensive Tasks
+
+<!-- Lewis et al. 2021: RAG improves factual grounding -->
+<!-- RAG optimised for answering questions, not constructing exhaustive datasets -->
+<!-- Recent progress: agentic RAG, deep research systems -->
+
+## 2.3 AI for Economic and Energy Data
+
+<!-- In economics, evaluation typically concerns forecasting or numerical reasoning, not data compilation -->
+<!-- Energy data quality: Gotzens et al. 2019 -->
+<!-- Global Energy Monitor, WRI, S&P Platts — existing databases and their limitations -->
+<!-- No prior benchmark for AI-assisted statistical table production -->
+
+
+# 3. Benchmark Design
+
+<!-- ~2.5 pages -->
+
+## 3.1 Task Definition
+
+The task is to generate a structured table listing all thermal power plants in Vietnam. Required attributes per plant:
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `name` | Canonical plant name (local script) | Phả Lại 2 |
+| `fuel` | coal / local gas / imported LNG | coal |
+| `status` | operational / retired / constructing / planned / proposed / cancelled | operational |
+| `cod` | Connection date (realised or expected) | 2001 |
+| `province` | Vietnamese province | Hải Dương |
+| `capacity_mwe` | Installed capacity in MWe | 600 |
+
+**Ambiguities inherent to the task:**
+
+- Plant vs. unit vs. complex (e.g., Phú Mỹ 1–4: one complex, six plants, multiple units)
+- Project vs. realised asset (e.g., Phú Mỹ 3.1 proposed in draft PDP8 but not retained)
+- Naming conventions (diacritics, transliteration variants, abbreviations)
+- Temporal evolution of status (planned → constructing → operational; or planned → cancelled)
+
+## 3.2 Reference Dataset
+
+<!-- Expert-compiled from official planning documents (PDP7, PDP7A, PDP8), utility reports (EVN annual reports), open databases (Wikipedia, GEM), and long-term expert monitoring -->
+<!-- ~135 plants, 6 attributes -->
+<!-- Not error-free but consistent; represents the best available open-source approximation -->
+<!-- Versioned; available as CSV in the benchmark repository -->
+<!-- Discuss limitations: some small captive plants may be missing; operational dates approximate -->
+
+## 3.3 Metrics
+
+**Coverage (Recall):** Share of reference plants correctly identified by the system.
+
+$$\text{Coverage} = \frac{|\text{Reference} \cap \text{System}|}{|\text{Reference}|}$$
+
+**Precision:** Share of system-generated plants that correspond to real entries.
+
+$$\text{Precision} = \frac{|\text{Reference} \cap \text{System}|}{|\text{System}|}$$
+
+**Justification Rate:** Proportion of sampled rows for which the system provides a verifiable source reference.
+
+**Error Taxonomy:**
+
+- Hallucinated plant (no corresponding reference entry)
+- Wrong fuel type
+- Wrong status
+- Duplicate (same plant listed multiple times under different names)
+- Wrong capacity (>20% deviation)
+- Missing plant (in reference but not in system output)
+
+## 3.4 Matching Pipeline
+
+<!-- Normalisation: Unicode, diacritics, common abbreviations -->
+<!-- Exact match on canonical name -->
+<!-- Fuzzy match (rapidfuzz, threshold to specify) -->
+<!-- Capacity tolerance (±X%) for disambiguation -->
+<!-- Rules for plant-vs-unit disambiguation -->
+<!-- Output: reconciliation table with match type per entry -->
+<!-- Implemented in Python; reproducible; open-source -->
+
+
+# 4. Experimental Setup
+
+<!-- ~2 pages -->
+
+## 4.1 Systems Under Evaluation
+
+### 4.1.1 Direct LLM Generation (Prompt 1)
+
+<!-- Single-shot CSV generation -->
+<!-- Models: Claude 3.5 Sonnet, GPT-4o, DeepSeek-R1, Llama 3.3 70B, Qwen 2.5 72B, o3-mini, Perplexity Pro -->
+<!-- Same standardised prompt across all models -->
+
+### 4.1.2 Multi-Turn Prompting (Prompt 2 + Relances)
+
+<!-- Structured prompt with expert role, schema, sorting, sourcing instructions -->
+<!-- Three successive "try harder" follow-ups -->
+<!-- Tests on: Claude 3.5 Sonnet, DeepSeek-R1, GPT-4o, Llama 3.3 70B, Qwen 2.5 72B, o3-mini -->
+
+### 4.1.3 RAG Configurations
+
+<!-- Curated RAG: 15 manually selected authoritative documents (PDP7/7A/8, EVN reports, GEM) -->
+<!-- Total: 138.6 kB Markdown, ~63.5k tokens + 3.5k tokens bibliographic references -->
+<!-- Extended RAG: curated + EVN annual reports 2010-2018 -->
+<!-- Multi-turn RAG: RAG + iterative follow-ups -->
+<!-- Models: Claude 3.5 Sonnet, DeepSeek-R1, GPT-4o, o3-mini (medium and high) -->
+
+## 4.2 Evaluation Protocol
+
+<!-- All outputs requested in CSV format -->
+<!-- Normalised through the same pipeline -->
+<!-- Each configuration run once (feasibility study; discuss variance) -->
+<!-- Temperature not controlled (discuss as limitation) -->
+
+
+# 5. Results
+
+<!-- ~2 pages -->
+
+## 5.1 Direct Generation
+
+<!-- TABLE: Model | Prompt 1 (single-shot) | After 4 multi-turn relances -->
+<!-- Key finding: single-shot = 25-40% coverage; multi-turn = up to 65-80% -->
+<!-- Models reveal only ~1/3 of their knowledge on first response -->
+<!-- Correlation between model recency and coverage -->
+<!-- Reasoning models (o3-mini) do NOT perform better; may perform worse due to token allocation -->
+
+## 5.2 Effect of RAG
+
+<!-- TABLE: Model | Without documents | With documents -->
+<!-- Key finding: RAG improves coverage (e.g., Claude: 63→101 with extended RAG + relance) -->
+<!-- RAG and multi-turn are complementary -->
+<!-- Best config: RAG + relance on reasoning model (o3-mini high: 78; DeepSeek-R1: 65) -->
+
+## 5.3 Reconciliation Analysis
+
+<!-- TABLE: Configuration | Exact matches | Approximate | Incorrect | Missing -->
+<!-- From Table 5.2 in report -->
+<!-- Claude baseline: 25 exact, 135 missing -->
+<!-- Claude + RAG + relance: 61 exact, 12 approx, 9 incorrect, 72 missing -->
+<!-- Even best config misses ~45% of reference -->
+
+## 5.4 Coverage–Precision Trade-off
+
+<!-- As coverage increases, precision decreases -->
+<!-- Multi-turn pushes models to generate more, including more errors -->
+<!-- Structural trade-off, not model-specific -->
+
+
+# 6. Error Analysis
+
+<!-- ~1.5 pages -->
+
+## 6.1 Enumeration Failure
+
+<!-- Models fail to systematically traverse tables provided in context -->
+<!-- They summarise rather than enumerate -->
+<!-- Even with explicit instructions, omit plants present in provided documents -->
+<!-- Output length limits compound the problem (4K-8K token responses for a task requiring ~28K tokens) -->
+
+## 6.2 Entity Resolution Errors
+
+<!-- Multiple names for the same plant (Phú Mỹ complex example) -->
+<!-- Transliteration variants not handled -->
+<!-- Plants vs. units vs. complexes conflated -->
+<!-- Double-counting or under-counting -->
+
+## 6.3 Temporal Inconsistency
+
+<!-- Retired plants inconsistently included/excluded -->
+<!-- Cancelled projects from draft plans treated as active -->
+<!-- No mechanism to track status evolution over time -->
+<!-- COD dates from different planning documents contradictory and unreconciled -->
+
+## 6.4 Additional Failure Modes
+
+<!-- Confusion between capacity and production (kW vs kWh) -->
+<!-- Hydroelectric plants listed as thermal (misunderstanding TĐ abbreviation) -->
+<!-- Sourcing: either absent, self-referential ("from provided docs"), or hallucinated -->
+
+
+# 7. Discussion
+
+<!-- ~1.5 pages -->
+
+## 7.1 RAG is Necessary but Insufficient
+
+<!-- RAG addresses knowledge recency and traceability -->
+<!-- But does not solve enumeration, entity resolution, or temporal consistency -->
+<!-- RAG optimised for QA, not for dataset construction -->
+<!-- The gap between "can find information" and "can produce statistics" is structural -->
+
+## 7.2 What Economic Statistics Require
+
+<!-- Statefulness: accumulate knowledge over time, not regenerate from scratch -->
+<!-- Entity resolution and data fusion as explicit pipeline stages -->
+<!-- Provenance tracking at the row/cell level, not just document-level citation -->
+<!-- Ontological alignment (Open Energy Ontology) for consistency -->
+<!-- Human-in-the-loop validation before data enters the knowledge base -->
+
+## 7.3 Implications for AI-Assisted Statistical Systems
+
+<!-- The benchmark reveals that current AI systems do not behave as statistical instruments -->
+<!-- Prompt engineering cannot overcome structural limits -->
+<!-- Need hybrid architectures: LLM for extraction and drafting, structured pipelines for accumulation and validation -->
+<!-- Pointer to agentic architectures (Ha-Duong, 2026 Econom'IA paper; AIRLET project) -->
+
+## 7.4 Limitations of This Study
+
+<!-- Single domain (thermal power plants, Vietnam) — generalisability to be tested -->
+<!-- No repeated runs / variance analysis (feasibility study) -->
+<!-- Temperature not controlled -->
+<!-- Reference dataset itself not error-free -->
+<!-- Models tested in Jan-Feb 2025; rapid progress since then -->
+<!-- Cost and latency not analysed -->
+
+
+# 8. Conclusion
+
+<!-- ~0.5 page -->
+
+We introduced a benchmark for evaluating AI systems on the production of economic statistics. Applied to the inventory of thermal power plants in Vietnam, it reveals:
+
+1. LLMs possess substantial latent knowledge but release only a fraction in single-shot queries.
+2. Multi-turn prompting and RAG are complementary and both improve coverage substantially.
+3. Even the best configurations remain ~45% incomplete relative to an expert reference.
+4. Three structural failure modes—enumeration errors, entity resolution failures, and temporal inconsistency—persist across all approaches.
+
+These results demonstrate that **RAG is a necessary but insufficient component** of a statistical system. Economic statistics require architectures that treat data as first-class objects subject to accumulation, revision, and provenance tracking.
+
+The benchmark is released as open-source code and data to support the evaluation of future AI-assisted statistical systems, including agentic and knowledge-graph-based approaches.
+
+<!-- Code and data: https://github.com/[repo] -->
+
+
+# References
+
+<!-- Key references to include: -->
+<!-- Lewis et al. 2021 — RAG -->
+<!-- Gotzens et al. 2019 — Data quality in power plant databases -->
+<!-- Ha-Duong 2025 — AEDIST technical report (HAL preprint) -->
+<!-- Ha-Duong 2026 — Econom'IA paper (Beyond RAG) -->
+<!-- Ha-Duong 2022 — Wind power dataset Vietnam -->
+<!-- Ha-Duong 2019 — Coal power dataset Vietnam -->
+<!-- Booshehri et al. 2021 — Open Energy Ontology -->
+<!-- GEM 2024 — Global Energy Monitor -->
+<!-- Carlini et al. 2021 — Extracting training data -->
+<!-- Khattab et al. 2023 — DSPy -->


### PR DESCRIPTION
Consolidates AEDIST into one workshop repo, per the `projets/` (editable) vs `papiers/` (frozen outputs, one dir per manuscript, dated dispatch events) rule used by climate-finance-het.

Adds the benchmark manuscript draft (`manuscripts/benchmark/`) and two engineering notes (`docs/`), previously stranded in `papiers/actif/AEDIST benchmark`. That staging directory is now gone; `code/aedist` (disjoint git root, superseded) is archived to `code/attic/aedist-2026-04`.

No code or build change — added files only.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)